### PR TITLE
Move static *_initializer variables from hxx into cxx files and make them const

### DIFF
--- a/lib/src/Base/Common/Catalog.cxx
+++ b/lib/src/Base/Common/Catalog.cxx
@@ -37,6 +37,7 @@ BEGIN_NAMESPACE_OPENTURNS
 static pthread_mutex_t Catalog_InstanceMutex_;
 static Catalog * Catalog_P_instance_ = 0;
 static pthread_once_t Catalog_InstanceMutex_once = PTHREAD_ONCE_INIT;
+static const Catalog_init __Catalog_initializer;
 
 Catalog_init::Catalog_init()
 {

--- a/lib/src/Base/Common/Catalog.hxx
+++ b/lib/src/Base/Common/Catalog.hxx
@@ -95,8 +95,6 @@ struct OT_API Catalog_init
   ~Catalog_init();
 }; /* end struct Catalog_init */
 
-static Catalog_init __Catalog_initializer;
-
 
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Common/IdFactory.cxx
+++ b/lib/src/Base/Common/IdFactory.cxx
@@ -30,6 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 static pthread_once_t IdFactory_InstanceMutex_once = PTHREAD_ONCE_INIT;
 static AtomicInt IdFactory_NextId_;
+static const IdFactory_init __IdFactory_initializer;
 
 
 static void IdFactory_Initialization()

--- a/lib/src/Base/Common/IdFactory.hxx
+++ b/lib/src/Base/Common/IdFactory.hxx
@@ -67,8 +67,6 @@ struct OT_API IdFactory_init
   IdFactory_init();
 }; /* end struct IdFactory_init */
 
-static IdFactory_init __IdFactory_initializer;
-
 END_NAMESPACE_OPENTURNS
 
 #endif /* OPENTURNS_IDFACTORY_HXX */

--- a/lib/src/Base/Common/Log.cxx
+++ b/lib/src/Base/Common/Log.cxx
@@ -30,6 +30,7 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
+static const Log_init __Log_initializer;
 
 
 static inline

--- a/lib/src/Base/Common/Log.hxx
+++ b/lib/src/Base/Common/Log.hxx
@@ -247,8 +247,6 @@ struct OT_API Log_init
   ~Log_init();
 }; /* end struct Log_init */
 
-static Log_init __Log_initializer;
-
 
 END_NAMESPACE_OPENTURNS
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -38,6 +38,7 @@ static const char * XMLTag_value = "value";
 
 static pthread_mutex_t ResourceMap_InstanceMutex_;
 static ResourceMap * ResourceMap_P_instance_ = 0;
+static const ResourceMap_init __ResourceMap_initializer;
 
 ResourceMap_init::ResourceMap_init()
 {

--- a/lib/src/Base/Common/ResourceMap.hxx
+++ b/lib/src/Base/Common/ResourceMap.hxx
@@ -185,7 +185,6 @@ struct OT_API ResourceMap_init
   ResourceMap_init();
   ~ResourceMap_init();
 };
-static ResourceMap_init __ResourceMap_initializer;
 
 /**
  * @fn std::ostream & operator <<(std::ostream & os, const ResourceMap & obj)

--- a/lib/src/Base/Common/TBB.cxx
+++ b/lib/src/Base/Common/TBB.cxx
@@ -35,6 +35,7 @@ BEGIN_NAMESPACE_OPENTURNS
 static pthread_mutex_t TBB_InstanceMutex_;
 static TBB * TBB_P_instance_ = 0;
 static pthread_once_t TBB_InstanceMutex_once = PTHREAD_ONCE_INIT;
+static const TBB_init __TBB_initializer;
 
 #ifdef OPENTURNS_HAVE_TBB
 tbb::task_scheduler_init * TBB_P_scheduler_ = 0;

--- a/lib/src/Base/Common/TBB.hxx
+++ b/lib/src/Base/Common/TBB.hxx
@@ -169,8 +169,6 @@ struct OT_API TBB_init
   ~TBB_init();
 }; /* end class TBB_init */
 
-static TBB_init __TBB_initializer;
-
 END_NAMESPACE_OPENTURNS
 
 #endif /* OPENTURNS_TBB_HXX */


### PR DESCRIPTION
Currently one instance of these variables is created by object files including these
header files.  This is harmless because initialization of the real struct is
protected by pthread_once, but it is annoying when debugging initialization issues
of singleton classes.