### PR TITLE
Argument of Factory constructor is unused

### DIFF
--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ApproximationAlgorithmImplementation);
 
-static Factory<ApproximationAlgorithmImplementation> RegisteredFactory("ApproximationAlgorithmImplementation");
+static const Factory<ApproximationAlgorithmImplementation> RegisteredFactory;
 
 /* Default constructor */
 ApproximationAlgorithmImplementation::ApproximationAlgorithmImplementation()

--- a/lib/src/Base/Algo/CholeskyMethod.cxx
+++ b/lib/src/Base/Algo/CholeskyMethod.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(CholeskyMethod);
 
 
-static Factory<CholeskyMethod> RegisteredFactory("CholeskyMethod");
+static const Factory<CholeskyMethod> RegisteredFactory;
 
 /* Default constructor */
 CholeskyMethod::CholeskyMethod()

--- a/lib/src/Base/Algo/ClassifierImplementation.cxx
+++ b/lib/src/Base/Algo/ClassifierImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ClassifierImplementation);
 
-static Factory<ClassifierImplementation> RegisteredFactory("ClassifierImplementation");
+static const Factory<ClassifierImplementation> RegisteredFactory;
 
 /* Default constructor */
 ClassifierImplementation::ClassifierImplementation()

--- a/lib/src/Base/Algo/CorrectedLeaveOneOut.cxx
+++ b/lib/src/Base/Algo/CorrectedLeaveOneOut.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CorrectedLeaveOneOut);
 
-static Factory<CorrectedLeaveOneOut> RegisteredFactory("CorrectedLeaveOneOut");
+static const Factory<CorrectedLeaveOneOut> RegisteredFactory;
 
 /* Default constructor */
 CorrectedLeaveOneOut::CorrectedLeaveOneOut()

--- a/lib/src/Base/Algo/FFTImplementation.cxx
+++ b/lib/src/Base/Algo/FFTImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FFTImplementation);
 
-static Factory<FFTImplementation> RegisteredFactory("FFTImplementation");
+static const Factory<FFTImplementation> RegisteredFactory;
 
 /* Constructor without parameters */
 FFTImplementation::FFTImplementation()

--- a/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FittingAlgorithmImplementation);
 
-static Factory<FittingAlgorithmImplementation> RegisteredFactory("FittingAlgorithmImplementation");
+static const Factory<FittingAlgorithmImplementation> RegisteredFactory;
 
 /* Default constructor */
 FittingAlgorithmImplementation::FittingAlgorithmImplementation()

--- a/lib/src/Base/Algo/GaussKronrod.cxx
+++ b/lib/src/Base/Algo/GaussKronrod.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GaussKronrod);
 
-static Factory<GaussKronrod> RegisteredFactory("GaussKronrod");
+static const Factory<GaussKronrod> RegisteredFactory;
 
 /* Constructor without parameters */
 GaussKronrod::GaussKronrod()

--- a/lib/src/Base/Algo/GaussKronrodRule.cxx
+++ b/lib/src/Base/Algo/GaussKronrodRule.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GaussKronrodRule);
 
-static Factory<GaussKronrodRule> RegisteredFactory("GaussKronrodRule");
+static const Factory<GaussKronrodRule> RegisteredFactory;
 
 /* Constructor without parameters */
 GaussKronrodRule::GaussKronrodRule()

--- a/lib/src/Base/Algo/IntegrationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/IntegrationAlgorithmImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(IntegrationAlgorithmImplementation);
 
-static Factory<IntegrationAlgorithmImplementation> RegisteredFactory("IntegrationAlgorithmImplementation");
+static const Factory<IntegrationAlgorithmImplementation> RegisteredFactory;
 
 /* Constructor without parameters */
 IntegrationAlgorithmImplementation::IntegrationAlgorithmImplementation()

--- a/lib/src/Base/Algo/IteratedQuadrature.cxx
+++ b/lib/src/Base/Algo/IteratedQuadrature.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(IteratedQuadrature);
 
-static Factory<IteratedQuadrature> RegisteredFactory("IteratedQuadrature");
+static const Factory<IteratedQuadrature> RegisteredFactory;
 
 /* Constructor without parameters */
 IteratedQuadrature::IteratedQuadrature()

--- a/lib/src/Base/Algo/KFold.cxx
+++ b/lib/src/Base/Algo/KFold.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(KFold);
 
 
-static Factory<KFold> RegisteredFactory("KFold");
+static const Factory<KFold> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Algo/KissFFT.cxx
+++ b/lib/src/Base/Algo/KissFFT.cxx
@@ -60,7 +60,7 @@ struct FFTPolicy
 
 CLASSNAMEINIT(KissFFT);
 
-static Factory<KissFFT> RegisteredFactory("KissFFT");
+static const Factory<KissFFT> RegisteredFactory;
 
 /* Constructor with parameters */
 KissFFT::KissFFT()

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LeastSquaresMetaModelSelection);
 
-static Factory<LeastSquaresMetaModelSelection> RegisteredFactory("LeastSquaresMetaModelSelection");
+static const Factory<LeastSquaresMetaModelSelection> RegisteredFactory;
 
 /* Default constructor */
 LeastSquaresMetaModelSelection::LeastSquaresMetaModelSelection()

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LeastSquaresMetaModelSelectionFactory);
 
-static Factory<LeastSquaresMetaModelSelectionFactory> RegisteredFactory("LeastSquaresMetaModelSelectionFactory");
+static const Factory<LeastSquaresMetaModelSelectionFactory> RegisteredFactory;
 
 /* Constructor */
 LeastSquaresMetaModelSelectionFactory::LeastSquaresMetaModelSelectionFactory(const BasisSequenceFactory & fact,

--- a/lib/src/Base/Algo/LeastSquaresMethodImplementation.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMethodImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LeastSquaresMethodImplementation);
 
-static Factory<LeastSquaresMethodImplementation> RegisteredFactory("LeastSquaresMethodImplementation");
+static const Factory<LeastSquaresMethodImplementation> RegisteredFactory;
 
 /* Default constructor */
 LeastSquaresMethodImplementation::LeastSquaresMethodImplementation()

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PenalizedLeastSquaresAlgorithm);
 
-static Factory<PenalizedLeastSquaresAlgorithm> RegisteredFactory("PenalizedLeastSquaresAlgorithm");
+static const Factory<PenalizedLeastSquaresAlgorithm> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PenalizedLeastSquaresAlgorithmFactory);
 
-static Factory<PenalizedLeastSquaresAlgorithmFactory> RegisteredFactory("PenalizedLeastSquaresAlgorithmFactory");
+static const Factory<PenalizedLeastSquaresAlgorithmFactory> RegisteredFactory;
 
 /* Default constructor */
 PenalizedLeastSquaresAlgorithmFactory::PenalizedLeastSquaresAlgorithmFactory(const Bool useNormal)

--- a/lib/src/Base/Algo/QRMethod.cxx
+++ b/lib/src/Base/Algo/QRMethod.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(QRMethod);
 
 
-static Factory<QRMethod> RegisteredFactory("QRMethod");
+static const Factory<QRMethod> RegisteredFactory;
 
 /* Default constructor */
 QRMethod::QRMethod()

--- a/lib/src/Base/Algo/SVDMethod.cxx
+++ b/lib/src/Base/Algo/SVDMethod.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(SVDMethod);
 
 
-static Factory<SVDMethod> RegisteredFactory("SVDMethod");
+static const Factory<SVDMethod> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Common/ComparisonOperatorImplementation.cxx
+++ b/lib/src/Base/Common/ComparisonOperatorImplementation.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComparisonOperatorImplementation);
 
-static Factory<ComparisonOperatorImplementation> RegisteredFactory("ComparisonOperatorImplementation");
+static const Factory<ComparisonOperatorImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComparisonOperatorImplementation::ComparisonOperatorImplementation()

--- a/lib/src/Base/Common/Equal.cxx
+++ b/lib/src/Base/Common/Equal.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Equal);
 
-static Factory<Equal> RegisteredFactory("Equal");
+static const Factory<Equal> RegisteredFactory;
 
 /* Default constructor */
 Equal::Equal()

--- a/lib/src/Base/Common/Greater.cxx
+++ b/lib/src/Base/Common/Greater.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Greater);
 
-static Factory<Greater> RegisteredFactory("Greater");
+static const Factory<Greater> RegisteredFactory;
 
 /* Default constructor */
 Greater::Greater()

--- a/lib/src/Base/Common/GreaterOrEqual.cxx
+++ b/lib/src/Base/Common/GreaterOrEqual.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GreaterOrEqual);
 
-static Factory<GreaterOrEqual> RegisteredFactory("GreaterOrEqual");
+static const Factory<GreaterOrEqual> RegisteredFactory;
 
 /* Default constructor */
 GreaterOrEqual::GreaterOrEqual()

--- a/lib/src/Base/Common/Less.cxx
+++ b/lib/src/Base/Common/Less.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Less);
 
-static Factory<Less> RegisteredFactory("Less");
+static const Factory<Less> RegisteredFactory;
 
 /* Default constructor */
 Less::Less()

--- a/lib/src/Base/Common/LessOrEqual.cxx
+++ b/lib/src/Base/Common/LessOrEqual.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LessOrEqual);
 
-static Factory<LessOrEqual> RegisteredFactory("LessOrEqual");
+static const Factory<LessOrEqual> RegisteredFactory;
 
 /* Default constructor */
 LessOrEqual::LessOrEqual()

--- a/lib/src/Base/Common/PersistentObjectFactory.hxx
+++ b/lib/src/Base/Common/PersistentObjectFactory.hxx
@@ -104,8 +104,18 @@ class Factory
 public:
   /** Constructor
    *
-   * @param className The name of the class the %Factory is bounded to
    * @internal See the CLASSNAME_INIT macro.
+   */
+  Factory()
+  {
+    registerMe(PERSISTENT::GetClassName());
+  }
+
+  /** Constructor
+   *
+   * @param className unused
+   * @internal See the CLASSNAME_INIT macro.
+   * @deprecated
    */
   Factory(const String & /* className */)
   {

--- a/lib/src/Base/Diff/BlendedStep.cxx
+++ b/lib/src/Base/Diff/BlendedStep.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BlendedStep);
 
-static Factory<BlendedStep> RegisteredFactory("BlendedStep");
+static const Factory<BlendedStep> RegisteredFactory;
 
 /* Default constructor */
 BlendedStep::BlendedStep()

--- a/lib/src/Base/Diff/CenteredFiniteDifferenceGradient.cxx
+++ b/lib/src/Base/Diff/CenteredFiniteDifferenceGradient.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CenteredFiniteDifferenceGradient);
 
-static Factory<CenteredFiniteDifferenceGradient> RegisteredFactory("CenteredFiniteDifferenceGradient");
+static const Factory<CenteredFiniteDifferenceGradient> RegisteredFactory;
 
 /* Default constructor */
 CenteredFiniteDifferenceGradient::CenteredFiniteDifferenceGradient() :

--- a/lib/src/Base/Diff/CenteredFiniteDifferenceHessian.cxx
+++ b/lib/src/Base/Diff/CenteredFiniteDifferenceHessian.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CenteredFiniteDifferenceHessian);
 
-static Factory<CenteredFiniteDifferenceHessian> RegisteredFactory("CenteredFiniteDifferenceHessian");
+static const Factory<CenteredFiniteDifferenceHessian> RegisteredFactory;
 
 /* Default constructor */
 CenteredFiniteDifferenceHessian::CenteredFiniteDifferenceHessian()

--- a/lib/src/Base/Diff/ConstantStep.cxx
+++ b/lib/src/Base/Diff/ConstantStep.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConstantStep);
 
-static Factory<ConstantStep> RegisteredFactory("ConstantStep");
+static const Factory<ConstantStep> RegisteredFactory;
 
 /* Default constructor */
 ConstantStep::ConstantStep()

--- a/lib/src/Base/Diff/FiniteDifferenceGradient.cxx
+++ b/lib/src/Base/Diff/FiniteDifferenceGradient.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FiniteDifferenceGradient);
 
-static Factory<FiniteDifferenceGradient> RegisteredFactory("FiniteDifferenceGradient");
+static const Factory<FiniteDifferenceGradient> RegisteredFactory;
 
 /* Default constructor */
 FiniteDifferenceGradient::FiniteDifferenceGradient()

--- a/lib/src/Base/Diff/FiniteDifferenceHessian.cxx
+++ b/lib/src/Base/Diff/FiniteDifferenceHessian.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FiniteDifferenceHessian);
 
-static Factory<FiniteDifferenceHessian> RegisteredFactory("FiniteDifferenceHessian");
+static const Factory<FiniteDifferenceHessian> RegisteredFactory;
 
 /* Default constructor */
 FiniteDifferenceHessian::FiniteDifferenceHessian()

--- a/lib/src/Base/Diff/FiniteDifferenceStepImplementation.cxx
+++ b/lib/src/Base/Diff/FiniteDifferenceStepImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FiniteDifferenceStepImplementation);
 
-static Factory<FiniteDifferenceStepImplementation> RegisteredFactory("FiniteDifferenceStepImplementation");
+static const Factory<FiniteDifferenceStepImplementation> RegisteredFactory;
 
 /* Default constructor */
 FiniteDifferenceStepImplementation::FiniteDifferenceStepImplementation()

--- a/lib/src/Base/Diff/NonCenteredFiniteDifferenceGradient.cxx
+++ b/lib/src/Base/Diff/NonCenteredFiniteDifferenceGradient.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NonCenteredFiniteDifferenceGradient);
 
-static Factory<NonCenteredFiniteDifferenceGradient> RegisteredFactory("NonCenteredFiniteDifferenceGradient");
+static const Factory<NonCenteredFiniteDifferenceGradient> RegisteredFactory;
 
 /* Default constructor */
 NonCenteredFiniteDifferenceGradient::NonCenteredFiniteDifferenceGradient() :

--- a/lib/src/Base/Func/AggregatedNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/AggregatedNumericalMathEvaluationImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AggregatedNumericalMathEvaluationImplementation);
 
-static Factory<AggregatedNumericalMathEvaluationImplementation> RegisteredFactory("AggregatedNumericalMathEvaluationImplementation");
+static const Factory<AggregatedNumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/AggregatedNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/AggregatedNumericalMathGradientImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AggregatedNumericalMathGradientImplementation);
 
-static Factory<AggregatedNumericalMathGradientImplementation> RegisteredFactory("AggregatedNumericalMathGradientImplementation");
+static const Factory<AggregatedNumericalMathGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/AggregatedNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/AggregatedNumericalMathHessianImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AggregatedNumericalMathHessianImplementation);
 
-static Factory<AggregatedNumericalMathHessianImplementation> RegisteredFactory("AggregatedNumericalMathHessianImplementation");
+static const Factory<AggregatedNumericalMathHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/AnalyticalNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathEvaluationImplementation.cxx
@@ -22,7 +22,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AnalyticalNumericalMathEvaluationImplementation);
 
-static Factory<AnalyticalNumericalMathEvaluationImplementation> RegisteredFactory("AnalyticalNumericalMathEvaluationImplementation");
+static const Factory<AnalyticalNumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/AnalyticalNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathGradientImplementation.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AnalyticalNumericalMathGradientImplementation);
 
-static Factory<AnalyticalNumericalMathGradientImplementation> RegisteredFactory("AnalyticalNumericalMathGradientImplementation");
+static const Factory<AnalyticalNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 AnalyticalNumericalMathGradientImplementation::AnalyticalNumericalMathGradientImplementation()

--- a/lib/src/Base/Func/AnalyticalNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathHessianImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AnalyticalNumericalMathHessianImplementation);
 
-static Factory<AnalyticalNumericalMathHessianImplementation> RegisteredFactory("AnalyticalNumericalMathHessianImplementation");
+static const Factory<AnalyticalNumericalMathHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/BasisFactory.cxx
+++ b/lib/src/Base/Func/BasisFactory.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BasisFactory);
 
-static Factory<BasisFactory> RegisteredFactory("BasisFactory");
+static const Factory<BasisFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/BasisImplementation.cxx
+++ b/lib/src/Base/Func/BasisImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BasisImplementation);
 
-static Factory<BasisImplementation> RegisteredFactory("BasisImplementation");
+static const Factory<BasisImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
+++ b/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BasisSequenceFactoryImplementation);
 
-static Factory<BasisSequenceFactoryImplementation> RegisteredFactory("BasisSequenceFactoryImplementation");
+static const Factory<BasisSequenceFactoryImplementation> RegisteredFactory;
 
 /* Default constructor */
 BasisSequenceFactoryImplementation::BasisSequenceFactoryImplementation(const Bool verbose)

--- a/lib/src/Base/Func/BasisSequenceImplementation.cxx
+++ b/lib/src/Base/Func/BasisSequenceImplementation.cxx
@@ -28,14 +28,14 @@ BEGIN_NAMESPACE_OPENTURNS
 
 
 TEMPLATE_CLASSNAMEINIT( PersistentCollection<Indices> );
-static Factory<PersistentCollection<Indices> > RegisteredFactory_PC_I("PersistentCollection<Indices>");
-static Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory_PC_UL("PersistentCollection<UnsignedInteger>");
+static const Factory<PersistentCollection<Indices> > RegisteredFactory_PC_I;
+static const Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory_PC_UL;
 
 
 
 CLASSNAMEINIT(BasisSequenceImplementation);
 
-static Factory<BasisSequenceImplementation> RegisteredFactory_BSI("BasisSequenceImplementation");
+static const Factory<BasisSequenceImplementation> RegisteredFactory_BSI;
 
 /* Default constructor */
 BasisSequenceImplementation::BasisSequenceImplementation()

--- a/lib/src/Base/Func/BoxCoxEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/BoxCoxEvaluationImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BoxCoxEvaluationImplementation);
 
-static Factory<BoxCoxEvaluationImplementation> RegisteredFactory("BoxCoxEvaluationImplementation");
+static const Factory<BoxCoxEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 BoxCoxEvaluationImplementation::BoxCoxEvaluationImplementation()

--- a/lib/src/Base/Func/BoxCoxGradientImplementation.cxx
+++ b/lib/src/Base/Func/BoxCoxGradientImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BoxCoxGradientImplementation);
 
-static Factory<BoxCoxGradientImplementation> RegisteredFactory("BoxCoxGradientImplementation");
+static const Factory<BoxCoxGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 BoxCoxGradientImplementation::BoxCoxGradientImplementation()

--- a/lib/src/Base/Func/BoxCoxHessianImplementation.cxx
+++ b/lib/src/Base/Func/BoxCoxHessianImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BoxCoxHessianImplementation);
 
-static Factory<BoxCoxHessianImplementation> RegisteredFactory("BoxCoxHessianImplementation");
+static const Factory<BoxCoxHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 BoxCoxHessianImplementation::BoxCoxHessianImplementation()

--- a/lib/src/Base/Func/ComposedNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ComposedNumericalMathEvaluationImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComposedNumericalMathEvaluationImplementation);
 
-static Factory<ComposedNumericalMathEvaluationImplementation> RegisteredFactory("ComposedNumericalMathEvaluationImplementation");
+static const Factory<ComposedNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComposedNumericalMathEvaluationImplementation::ComposedNumericalMathEvaluationImplementation(const EvaluationImplementation & p_leftFunction,

--- a/lib/src/Base/Func/ComposedNumericalMathFunction.cxx
+++ b/lib/src/Base/Func/ComposedNumericalMathFunction.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComposedNumericalMathFunction);
 
-static Factory<ComposedNumericalMathFunction> RegisteredFactory("ComposedNumericalMathFunction");
+static const Factory<ComposedNumericalMathFunction> RegisteredFactory;
 
 /* Default constructor */
 ComposedNumericalMathFunction::ComposedNumericalMathFunction()

--- a/lib/src/Base/Func/ComposedNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/ComposedNumericalMathGradientImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComposedNumericalMathGradientImplementation);
 
-static Factory<ComposedNumericalMathGradientImplementation> RegisteredFactory("ComposedNumericalMathGradientImplementation");
+static const Factory<ComposedNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComposedNumericalMathGradientImplementation::ComposedNumericalMathGradientImplementation(const GradientImplementation & p_leftGradient,

--- a/lib/src/Base/Func/ComposedNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/ComposedNumericalMathHessianImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComposedNumericalMathHessianImplementation);
 
-static Factory<ComposedNumericalMathHessianImplementation> RegisteredFactory("ComposedNumericalMathHessianImplementation");
+static const Factory<ComposedNumericalMathHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComposedNumericalMathHessianImplementation::ComposedNumericalMathHessianImplementation(const GradientImplementation & p_leftGradient,

--- a/lib/src/Base/Func/ComputedNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ComputedNumericalMathEvaluationImplementation.cxx
@@ -28,7 +28,7 @@ typedef NumericalMathEvaluationImplementation::CacheType                CacheTyp
 
 CLASSNAMEINIT(ComputedNumericalMathEvaluationImplementation);
 
-static Factory<ComputedNumericalMathEvaluationImplementation> RegisteredFactory("ComputedNumericalMathEvaluationImplementation");
+static const Factory<ComputedNumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ComputedNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/ComputedNumericalMathGradientImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComputedNumericalMathGradientImplementation);
 
-static Factory<ComputedNumericalMathGradientImplementation> RegisteredFactory("ComputedNumericalMathGradientImplementation");
+static const Factory<ComputedNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComputedNumericalMathGradientImplementation::ComputedNumericalMathGradientImplementation(const String & name,

--- a/lib/src/Base/Func/ComputedNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/ComputedNumericalMathHessianImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComputedNumericalMathHessianImplementation);
 
-static Factory<ComputedNumericalMathHessianImplementation> RegisteredFactory("ComputedNumericalMathHessianImplementation");
+static const Factory<ComputedNumericalMathHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComputedNumericalMathHessianImplementation::ComputedNumericalMathHessianImplementation(const String & name,

--- a/lib/src/Base/Func/ConstantBasisFactory.cxx
+++ b/lib/src/Base/Func/ConstantBasisFactory.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConstantBasisFactory);
 
-static Factory<ConstantBasisFactory> RegisteredFactory("ConstantBasisFactory");
+static const Factory<ConstantBasisFactory> RegisteredFactory;
 
 /* Default constructor */
 ConstantBasisFactory::ConstantBasisFactory (const UnsignedInteger inputDimension)

--- a/lib/src/Base/Func/ConstantNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/ConstantNumericalMathGradientImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConstantNumericalMathGradientImplementation);
 
-static Factory<ConstantNumericalMathGradientImplementation> RegisteredFactory("ConstantNumericalMathGradientImplementation");
+static const Factory<ConstantNumericalMathGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ConstantNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/ConstantNumericalMathHessianImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConstantNumericalMathHessianImplementation);
 
-static Factory<ConstantNumericalMathHessianImplementation> RegisteredFactory("ConstantNumericalMathHessianImplementation");
+static const Factory<ConstantNumericalMathHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/DatabaseNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/DatabaseNumericalMathEvaluationImplementation.cxx
@@ -33,7 +33,7 @@ typedef NumericalMathEvaluationImplementation::CacheType                CacheTyp
 
 CLASSNAMEINIT(DatabaseNumericalMathEvaluationImplementation);
 
-static Factory<DatabaseNumericalMathEvaluationImplementation> RegisteredFactory("DatabaseNumericalMathEvaluationImplementation");
+static const Factory<DatabaseNumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/DualLinearCombinationEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/DualLinearCombinationEvaluationImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DualLinearCombinationEvaluationImplementation);
 
-static Factory<DualLinearCombinationEvaluationImplementation> RegisteredFactory("DualLinearCombinationEvaluationImplementation");
+static const Factory<DualLinearCombinationEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/DualLinearCombinationGradientImplementation.cxx
+++ b/lib/src/Base/Func/DualLinearCombinationGradientImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DualLinearCombinationGradientImplementation);
 
-static Factory<DualLinearCombinationGradientImplementation> RegisteredFactory("DualLinearCombinationGradientImplementation");
+static const Factory<DualLinearCombinationGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/DualLinearCombinationHessianImplementation.cxx
+++ b/lib/src/Base/Func/DualLinearCombinationHessianImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DualLinearCombinationHessianImplementation);
 
-static Factory<DualLinearCombinationHessianImplementation> RegisteredFactory("DualLinearCombinationHessianImplementation");
+static const Factory<DualLinearCombinationHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/DynamicalFunctionImplementation.cxx
+++ b/lib/src/Base/Func/DynamicalFunctionImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DynamicalFunctionImplementation);
 
-static Factory<DynamicalFunctionImplementation> RegisteredFactory("DynamicalFunctionImplementation");
+static const Factory<DynamicalFunctionImplementation> RegisteredFactory;
 
 /* Default constructor */
 DynamicalFunctionImplementation::DynamicalFunctionImplementation(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Func/EnumerateFunctionImplementation.cxx
+++ b/lib/src/Base/Func/EnumerateFunctionImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(EnumerateFunctionImplementation);
 
-static Factory<EnumerateFunctionImplementation> RegisteredFactory("EnumerateFunctionImplementation");
+static const Factory<EnumerateFunctionImplementation> RegisteredFactory;
 
 /* Parameter constructor */
 EnumerateFunctionImplementation::EnumerateFunctionImplementation(const UnsignedInteger dimension)

--- a/lib/src/Base/Func/ExpertMixture.cxx
+++ b/lib/src/Base/Func/ExpertMixture.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ExpertMixture);
 
-static Factory<ExpertMixture> RegisteredFactory("ExpertMixture");
+static const Factory<ExpertMixture> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/FiniteBasis.cxx
+++ b/lib/src/Base/Func/FiniteBasis.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FiniteBasis);
 
-static Factory<FiniteBasis> RegisteredFactory("FiniteBasis");
+static const Factory<FiniteBasis> RegisteredFactory;
 
 FiniteBasis::FiniteBasis(const UnsignedInteger size)
   : BasisImplementation()

--- a/lib/src/Base/Func/FunctionalBasisImplementation.cxx
+++ b/lib/src/Base/Func/FunctionalBasisImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FunctionalBasisImplementation);
 
-static Factory<FunctionalBasisImplementation> RegisteredFactory("FunctionalBasisImplementation");
+static const Factory<FunctionalBasisImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/HyperbolicAnisotropicEnumerateFunction.cxx
+++ b/lib/src/Base/Func/HyperbolicAnisotropicEnumerateFunction.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HyperbolicAnisotropicEnumerateFunction);
 
-static Factory<HyperbolicAnisotropicEnumerateFunction> RegisteredFactory("HyperbolicAnisotropicEnumerateFunction");
+static const Factory<HyperbolicAnisotropicEnumerateFunction> RegisteredFactory;
 
 /* Default constructor */
 HyperbolicAnisotropicEnumerateFunction::HyperbolicAnisotropicEnumerateFunction()

--- a/lib/src/Base/Func/IndicatorNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/IndicatorNumericalMathEvaluationImplementation.cxx
@@ -21,7 +21,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(IndicatorNumericalMathEvaluationImplementation);
 
-static Factory<IndicatorNumericalMathEvaluationImplementation> RegisteredFactory("IndicatorNumericalMathEvaluationImplementation");
+static const Factory<IndicatorNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 IndicatorNumericalMathEvaluationImplementation::IndicatorNumericalMathEvaluationImplementation()

--- a/lib/src/Base/Func/InverseBoxCoxEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/InverseBoxCoxEvaluationImplementation.cxx
@@ -19,7 +19,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseBoxCoxEvaluationImplementation);
 
-static Factory<InverseBoxCoxEvaluationImplementation> RegisteredFactory("InverseBoxCoxEvaluationImplementation");
+static const Factory<InverseBoxCoxEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 InverseBoxCoxEvaluationImplementation::InverseBoxCoxEvaluationImplementation()

--- a/lib/src/Base/Func/InverseBoxCoxGradientImplementation.cxx
+++ b/lib/src/Base/Func/InverseBoxCoxGradientImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseBoxCoxGradientImplementation);
 
-static Factory<InverseBoxCoxGradientImplementation> RegisteredFactory("InverseBoxCoxGradientImplementation");
+static const Factory<InverseBoxCoxGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 InverseBoxCoxGradientImplementation::InverseBoxCoxGradientImplementation()

--- a/lib/src/Base/Func/InverseBoxCoxHessianImplementation.cxx
+++ b/lib/src/Base/Func/InverseBoxCoxHessianImplementation.cxx
@@ -20,7 +20,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseBoxCoxHessianImplementation);
 
-static Factory<InverseBoxCoxHessianImplementation> RegisteredFactory("InverseBoxCoxHessianImplementation");
+static const Factory<InverseBoxCoxHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 InverseBoxCoxHessianImplementation::InverseBoxCoxHessianImplementation()

--- a/lib/src/Base/Func/InverseTrendEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/InverseTrendEvaluationImplementation.cxx
@@ -19,7 +19,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseTrendEvaluationImplementation);
 
-static Factory<InverseTrendEvaluationImplementation> RegisteredFactory("InverseTrendEvaluationImplementation");
+static const Factory<InverseTrendEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 InverseTrendEvaluationImplementation::InverseTrendEvaluationImplementation()

--- a/lib/src/Base/Func/InverseTrendTransform.cxx
+++ b/lib/src/Base/Func/InverseTrendTransform.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseTrendTransform);
 
-static Factory<InverseTrendTransform> RegisteredFactory("InverseTrendTransform");
+static const Factory<InverseTrendTransform> RegisteredFactory;
 
 /* Default constructor */
 InverseTrendTransform::InverseTrendTransform()

--- a/lib/src/Base/Func/LAR.cxx
+++ b/lib/src/Base/Func/LAR.cxx
@@ -30,7 +30,7 @@ CLASSNAMEINIT(LAR);
 
 typedef Collection<NumericalScalar>    NumericalScalarCollection;
 
-static Factory<LAR> RegisteredFactory("LAR");
+static const Factory<LAR> RegisteredFactory;
 
 /* Default constructor */
 LAR::LAR(const Bool verbose)

--- a/lib/src/Base/Func/LinearBasisFactory.cxx
+++ b/lib/src/Base/Func/LinearBasisFactory.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearBasisFactory);
 
-static Factory<LinearBasisFactory> RegisteredFactory("LinearBasisFactory");
+static const Factory<LinearBasisFactory> RegisteredFactory;
 
 /* Default constructor */
 LinearBasisFactory::LinearBasisFactory (const UnsignedInteger inputDimension)

--- a/lib/src/Base/Func/LinearCombinationEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/LinearCombinationEvaluationImplementation.cxx
@@ -27,12 +27,12 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<NumericalMathFunction>);
 
-static Factory<PersistentCollection<NumericalMathFunction> > RegisteredFactory_PC_NMF("PersistentCollection<NumericalMathFunction>");
+static const Factory<PersistentCollection<NumericalMathFunction> > RegisteredFactory_PC_NMF;
 
 
 CLASSNAMEINIT(LinearCombinationEvaluationImplementation);
 
-static Factory<LinearCombinationEvaluationImplementation> RegisteredFactory_LCEI("LinearCombinationEvaluationImplementation");
+static const Factory<LinearCombinationEvaluationImplementation> RegisteredFactory_LCEI;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/LinearCombinationGradientImplementation.cxx
+++ b/lib/src/Base/Func/LinearCombinationGradientImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearCombinationGradientImplementation);
 
-static Factory<LinearCombinationGradientImplementation> RegisteredFactory("LinearCombinationGradientImplementation");
+static const Factory<LinearCombinationGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/LinearCombinationHessianImplementation.cxx
+++ b/lib/src/Base/Func/LinearCombinationHessianImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearCombinationHessianImplementation);
 
-static Factory<LinearCombinationHessianImplementation> RegisteredFactory("LinearCombinationHessianImplementation");
+static const Factory<LinearCombinationHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/LinearEnumerateFunction.cxx
+++ b/lib/src/Base/Func/LinearEnumerateFunction.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearEnumerateFunction);
 
-static Factory<LinearEnumerateFunction> RegisteredFactory("LinearEnumerateFunction");
+static const Factory<LinearEnumerateFunction> RegisteredFactory;
 
 
 

--- a/lib/src/Base/Func/LinearNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/LinearNumericalMathEvaluationImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearNumericalMathEvaluationImplementation);
 
-static Factory<LinearNumericalMathEvaluationImplementation> RegisteredFactory("LinearNumericalMathEvaluationImplementation");
+static const Factory<LinearNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 LinearNumericalMathEvaluationImplementation::LinearNumericalMathEvaluationImplementation()

--- a/lib/src/Base/Func/LinearNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/LinearNumericalMathGradientImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LinearNumericalMathGradientImplementation);
 
-static Factory<LinearNumericalMathGradientImplementation> RegisteredFactory("LinearNumericalMathGradientImplementation");
+static const Factory<LinearNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 LinearNumericalMathGradientImplementation::LinearNumericalMathGradientImplementation()

--- a/lib/src/Base/Func/NoNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/NoNumericalMathEvaluationImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NoNumericalMathEvaluationImplementation);
 
-static Factory<NoNumericalMathEvaluationImplementation> RegisteredFactory("NoNumericalMathEvaluationImplementation");
+static const Factory<NoNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 NoNumericalMathEvaluationImplementation::NoNumericalMathEvaluationImplementation()

--- a/lib/src/Base/Func/NoNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/NoNumericalMathGradientImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NoNumericalMathGradientImplementation);
 
-static Factory<NoNumericalMathGradientImplementation> RegisteredFactory("NoNumericalMathGradientImplementation");
+static const Factory<NoNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 NoNumericalMathGradientImplementation::NoNumericalMathGradientImplementation()

--- a/lib/src/Base/Func/NoNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/NoNumericalMathHessianImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NoNumericalMathHessianImplementation);
 
-static Factory<NoNumericalMathHessianImplementation> RegisteredFactory("NoNumericalMathHessianImplementation");
+static const Factory<NoNumericalMathHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 NoNumericalMathHessianImplementation::NoNumericalMathHessianImplementation()

--- a/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
@@ -40,22 +40,22 @@ BEGIN_NAMESPACE_OPENTURNS
 
 typedef NumericalMathEvaluationImplementation::CacheType NumericalMathEvaluationImplementationCache;
 
-static Factory<NumericalMathEvaluationImplementationCache> RegisteredFactory_Cache("Cache<PersistentCollection<NumericalScalar>, PersistentCollection<NumericalScalar>>");
+static const Factory<NumericalMathEvaluationImplementationCache> RegisteredFactory_Cache;
 
 /* These methods are implemented here for the needs of Cache */
 /* We should be careful because they may interfere with other definitions placed elsewhere */
-static Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory_alt1("PersistentCollection<UnsignedInteger>");
+static const Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory_alt1;
 #ifndef OPENTURNS_UNSIGNEDLONG_SAME_AS_UINT64
-static Factory<PersistentCollection<Unsigned64BitsInteger> > RegisteredFactory_alt1b("PersistentCollection<Unsigned64BitsInteger>");
+static const Factory<PersistentCollection<Unsigned64BitsInteger> > RegisteredFactory_alt1b;
 #endif
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<PersistentCollection<NumericalScalar> >);
-static Factory<PersistentCollection<PersistentCollection<NumericalScalar> > > RegisteredFactory_alt2("PersistentCollection<PersistentCollection<NumericalScalar> >");
+static const Factory<PersistentCollection<PersistentCollection<NumericalScalar> > > RegisteredFactory_alt2;
 
 
 CLASSNAMEINIT(NumericalMathEvaluationImplementation);
 
-static Factory<NumericalMathEvaluationImplementation> RegisteredFactory("NumericalMathEvaluationImplementation");
+static const Factory<NumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/NumericalMathFunctionImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathFunctionImplementation.cxx
@@ -47,7 +47,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NumericalMathFunctionImplementation);
 
-static Factory<NumericalMathFunctionImplementation> RegisteredFactory("NumericalMathFunctionImplementation");
+static const Factory<NumericalMathFunctionImplementation> RegisteredFactory;
 
 // Inline documentation for analytical functions
 Bool NumericalMathFunctionImplementation::IsDocumentationInitialized_ = false;

--- a/lib/src/Base/Func/NumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathGradientImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NumericalMathGradientImplementation);
 
-static Factory<NumericalMathGradientImplementation> RegisteredFactory("NumericalMathGradientImplementation");
+static const Factory<NumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 NumericalMathGradientImplementation::NumericalMathGradientImplementation()

--- a/lib/src/Base/Func/NumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathHessianImplementation.cxx
@@ -35,7 +35,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NumericalMathHessianImplementation);
 
-static Factory<NumericalMathHessianImplementation> RegisteredFactory("NumericalMathHessianImplementation");
+static const Factory<NumericalMathHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 NumericalMathHessianImplementation::NumericalMathHessianImplementation()

--- a/lib/src/Base/Func/ParametricEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ParametricEvaluationImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ParametricEvaluationImplementation);
 
-static Factory<ParametricEvaluationImplementation> RegisteredFactory("ParametricEvaluationImplementation");
+static const Factory<ParametricEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ParametricGradientImplementation.cxx
+++ b/lib/src/Base/Func/ParametricGradientImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ParametricGradientImplementation);
 
-static Factory<ParametricGradientImplementation> RegisteredFactory("ParametricGradientImplementation");
+static const Factory<ParametricGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ParametricHessianImplementation.cxx
+++ b/lib/src/Base/Func/ParametricHessianImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ParametricHessianImplementation);
 
-static Factory<ParametricHessianImplementation> RegisteredFactory("ParametricHessianImplementation");
+static const Factory<ParametricHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/PiecewiseHermiteEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/PiecewiseHermiteEvaluationImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PiecewiseHermiteEvaluationImplementation);
 
-static Factory<PiecewiseHermiteEvaluationImplementation> RegisteredFactory("PiecewiseHermiteEvaluationImplementation");
+static const Factory<PiecewiseHermiteEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/PiecewiseLinearEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluationImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PiecewiseLinearEvaluationImplementation);
 
-static Factory<PiecewiseLinearEvaluationImplementation> RegisteredFactory("PiecewiseLinearEvaluationImplementation");
+static const Factory<PiecewiseLinearEvaluationImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ProductNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ProductNumericalMathEvaluationImplementation.cxx
@@ -22,7 +22,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductNumericalMathEvaluationImplementation);
 
-static Factory<ProductNumericalMathEvaluationImplementation> RegisteredFactory("ProductNumericalMathEvaluationImplementation");
+static const Factory<ProductNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 ProductNumericalMathEvaluationImplementation::ProductNumericalMathEvaluationImplementation(const EvaluationImplementation & p_leftEvaluation,

--- a/lib/src/Base/Func/ProductNumericalMathFunction.cxx
+++ b/lib/src/Base/Func/ProductNumericalMathFunction.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductNumericalMathFunction);
 
-static Factory<ProductNumericalMathFunction> RegisteredFactory("ProductNumericalMathFunction");
+static const Factory<ProductNumericalMathFunction> RegisteredFactory;
 
 /* Composition constructor */
 ProductNumericalMathFunction::ProductNumericalMathFunction(const Implementation & p_left,

--- a/lib/src/Base/Func/ProductNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/ProductNumericalMathGradientImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductNumericalMathGradientImplementation);
 
-static Factory<ProductNumericalMathGradientImplementation> RegisteredFactory("ProductNumericalMathGradientImplementation");
+static const Factory<ProductNumericalMathGradientImplementation> RegisteredFactory;
 
 /* Default constructor */
 ProductNumericalMathGradientImplementation::ProductNumericalMathGradientImplementation(const EvaluationImplementation & p_leftEvaluation,

--- a/lib/src/Base/Func/ProductNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/ProductNumericalMathHessianImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductNumericalMathHessianImplementation);
 
-static Factory<ProductNumericalMathHessianImplementation> RegisteredFactory("ProductNumericalMathHessianImplementation");
+static const Factory<ProductNumericalMathHessianImplementation> RegisteredFactory;
 
 /* Default constructor */
 ProductNumericalMathHessianImplementation::ProductNumericalMathHessianImplementation(const EvaluationImplementation & p_leftEvaluation,

--- a/lib/src/Base/Func/ProductPolynomialEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ProductPolynomialEvaluationImplementation.cxx
@@ -26,11 +26,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<UniVariatePolynomial>);
 
-static Factory<PersistentCollection<UniVariatePolynomial> > RegisteredFactory_PC_UVP("PersistentCollection<UniVariatePolynomial>");
+static const Factory<PersistentCollection<UniVariatePolynomial> > RegisteredFactory_PC_UVP;
 
 CLASSNAMEINIT(ProductPolynomialEvaluationImplementation);
 
-static Factory<ProductPolynomialEvaluationImplementation> RegisteredFactory_PPEI("ProductPolynomialEvaluationImplementation");
+static const Factory<ProductPolynomialEvaluationImplementation> RegisteredFactory_PPEI;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ProductPolynomialGradientImplementation.cxx
+++ b/lib/src/Base/Func/ProductPolynomialGradientImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductPolynomialGradientImplementation);
 
-static Factory<ProductPolynomialGradientImplementation> RegisteredFactory("ProductPolynomialGradientImplementation");
+static const Factory<ProductPolynomialGradientImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/ProductPolynomialHessianImplementation.cxx
+++ b/lib/src/Base/Func/ProductPolynomialHessianImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductPolynomialHessianImplementation);
 
-static Factory<ProductPolynomialHessianImplementation> RegisteredFactory("ProductPolynomialHessianImplementation");
+static const Factory<ProductPolynomialHessianImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Func/QuadraticBasisFactory.cxx
+++ b/lib/src/Base/Func/QuadraticBasisFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(QuadraticBasisFactory);
 
-static Factory<QuadraticBasisFactory> RegisteredFactory("QuadraticBasisFactory");
+static const Factory<QuadraticBasisFactory> RegisteredFactory;
 
 /* Default constructor */
 QuadraticBasisFactory::QuadraticBasisFactory (const UnsignedInteger inputDimension)

--- a/lib/src/Base/Func/QuadraticNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/QuadraticNumericalMathEvaluationImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(QuadraticNumericalMathEvaluationImplementation);
 
-static Factory<QuadraticNumericalMathEvaluationImplementation> RegisteredFactory("QuadraticNumericalMathEvaluationImplementation");
+static const Factory<QuadraticNumericalMathEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 QuadraticNumericalMathEvaluationImplementation::QuadraticNumericalMathEvaluationImplementation()

--- a/lib/src/Base/Func/SpatialFunction.cxx
+++ b/lib/src/Base/Func/SpatialFunction.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SpatialFunction);
 
-static Factory<SpatialFunction> RegisteredFactory("SpatialFunction");
+static const Factory<SpatialFunction> RegisteredFactory;
 
 /* Default constructor */
 SpatialFunction::SpatialFunction(const UnsignedInteger meshDimension)

--- a/lib/src/Base/Func/TemporalFunction.cxx
+++ b/lib/src/Base/Func/TemporalFunction.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TemporalFunction);
 
-static Factory<TemporalFunction> RegisteredFactory("TemporalFunction");
+static const Factory<TemporalFunction> RegisteredFactory;
 
 /* Default constructor */
 TemporalFunction::TemporalFunction(const UnsignedInteger meshDimension)

--- a/lib/src/Base/Func/TrendEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/TrendEvaluationImplementation.cxx
@@ -19,7 +19,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TrendEvaluationImplementation);
 
-static Factory<TrendEvaluationImplementation> RegisteredFactory("TrendEvaluationImplementation");
+static const Factory<TrendEvaluationImplementation> RegisteredFactory;
 
 /* Default constructor */
 TrendEvaluationImplementation::TrendEvaluationImplementation()

--- a/lib/src/Base/Func/TrendTransform.cxx
+++ b/lib/src/Base/Func/TrendTransform.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TrendTransform);
 
-static Factory<TrendTransform> RegisteredFactory("TrendTransform");
+static const Factory<TrendTransform> RegisteredFactory;
 
 /* Default constructor */
 TrendTransform::TrendTransform()

--- a/lib/src/Base/Func/UniVariatePolynomialImplementation.cxx
+++ b/lib/src/Base/Func/UniVariatePolynomialImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(UniVariatePolynomialImplementation);
 
-static Factory<UniVariatePolynomialImplementation> RegisteredFactory("UniVariatePolynomialImplementation");
+static const Factory<UniVariatePolynomialImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Geom/DomainImplementation.cxx
+++ b/lib/src/Base/Geom/DomainImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DomainImplementation);
 
-static Factory<DomainImplementation> RegisteredFactory("DomainImplementation");
+static const Factory<DomainImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Geom/Interval.cxx
+++ b/lib/src/Base/Geom/Interval.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Interval);
 
-static Factory<Interval> RegisteredFactory("Interval");
+static const Factory<Interval> RegisteredFactory;
 
 /* Default constructor */
 Interval::Interval(const UnsignedInteger dimension)

--- a/lib/src/Base/Geom/IntervalMesher.cxx
+++ b/lib/src/Base/Geom/IntervalMesher.cxx
@@ -27,7 +27,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(IntervalMesher);
-static Factory<IntervalMesher> RegisteredFactory("IntervalMesher");
+static const Factory<IntervalMesher> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Geom/LevelSet.cxx
+++ b/lib/src/Base/Geom/LevelSet.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LevelSet);
 
-static Factory<LevelSet> RegisteredFactory("LevelSet");
+static const Factory<LevelSet> RegisteredFactory;
 
 /* Default constructor */
 LevelSet::LevelSet(const UnsignedInteger dimension)

--- a/lib/src/Base/Geom/Mesh.cxx
+++ b/lib/src/Base/Geom/Mesh.cxx
@@ -36,7 +36,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Mesh);
 
-static Factory<Mesh> RegisteredFactory("Mesh");
+static const Factory<Mesh> RegisteredFactory;
 
 /* Default constructor */
 Mesh::Mesh(const UnsignedInteger dimension)

--- a/lib/src/Base/Geom/MeshFactoryImplementation.cxx
+++ b/lib/src/Base/Geom/MeshFactoryImplementation.cxx
@@ -27,7 +27,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MeshFactoryImplementation);
-static Factory<MeshFactoryImplementation> RegisteredFactory("MeshFactoryImplementation");
+static const Factory<MeshFactoryImplementation> RegisteredFactory;
 
 /* Default constructor */
 MeshFactoryImplementation::MeshFactoryImplementation()

--- a/lib/src/Base/Geom/RegularGrid.cxx
+++ b/lib/src/Base/Geom/RegularGrid.cxx
@@ -25,7 +25,7 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-static Factory<RegularGrid> RegisteredFactoryTG("RegularGrid");
+static const Factory<RegularGrid> RegisteredFactoryTG;
 
 CLASSNAMEINIT(RegularGrid);
 

--- a/lib/src/Base/Graph/BarPlot.cxx
+++ b/lib/src/Base/Graph/BarPlot.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BarPlot);
 
-static Factory<BarPlot> RegisteredFactory("BarPlot");
+static const Factory<BarPlot> RegisteredFactory;
 
 /* Default constructor */
 BarPlot::BarPlot(const NumericalSample & data,

--- a/lib/src/Base/Graph/Cloud.cxx
+++ b/lib/src/Base/Graph/Cloud.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Cloud);
 
-static Factory<Cloud> RegisteredFactory("Cloud");
+static const Factory<Cloud> RegisteredFactory;
 
 /* Default constructor */
 Cloud::Cloud(const NumericalSample & data,

--- a/lib/src/Base/Graph/Contour.cxx
+++ b/lib/src/Base/Graph/Contour.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Contour);
 
-static Factory<Contour> RegisteredFactory("Contour");
+static const Factory<Contour> RegisteredFactory;
 
 /* Default constructor */
 Contour::Contour(const UnsignedInteger dimX,

--- a/lib/src/Base/Graph/Curve.cxx
+++ b/lib/src/Base/Graph/Curve.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Curve);
 
-static Factory<Curve> RegisteredFactory("Curve");
+static const Factory<Curve> RegisteredFactory;
 
 /* Default constructor */
 Curve::Curve(const String & legend)

--- a/lib/src/Base/Graph/DrawableImplementation.cxx
+++ b/lib/src/Base/Graph/DrawableImplementation.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DrawableImplementation);
 
-static Factory<DrawableImplementation> RegisteredFactory("DrawableImplementation");
+static const Factory<DrawableImplementation> RegisteredFactory;
 
 /* default graphic paramaters */
 

--- a/lib/src/Base/Graph/GraphImplementation.cxx
+++ b/lib/src/Base/Graph/GraphImplementation.cxx
@@ -35,11 +35,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<Drawable>);
 
-static Factory<PersistentCollection<Drawable> > RegisteredFactory1("PersistentCollection<Drawable>");
+static const Factory<PersistentCollection<Drawable> > RegisteredFactory1;
 
 CLASSNAMEINIT(GraphImplementation);
 
-static Factory<GraphImplementation> RegisteredFactory("GraphImplementation");
+static const Factory<GraphImplementation> RegisteredFactory;
 
 Bool GraphImplementation::IsFirstInitialization = true;
 

--- a/lib/src/Base/Graph/Pairs.cxx
+++ b/lib/src/Base/Graph/Pairs.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Pairs);
 
-static Factory<Pairs> RegisteredFactory("Pairs");
+static const Factory<Pairs> RegisteredFactory;
 
 /* Default constructor */
 Pairs::Pairs(const NumericalSample & data,

--- a/lib/src/Base/Graph/Pie.cxx
+++ b/lib/src/Base/Graph/Pie.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Pie);
 
-static Factory<Pie> RegisteredFactory("Pie");
+static const Factory<Pie> RegisteredFactory;
 
 /* Default constructor */
 Pie::Pie(const NumericalPoint & data)

--- a/lib/src/Base/Graph/Polygon.cxx
+++ b/lib/src/Base/Graph/Polygon.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Polygon);
 
-static Factory<Polygon> RegisteredFactory("Polygon");
+static const Factory<Polygon> RegisteredFactory;
 
 /* Default constructor */
 Polygon::Polygon(const String & legend)

--- a/lib/src/Base/Graph/PolygonArray.cxx
+++ b/lib/src/Base/Graph/PolygonArray.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PolygonArray);
 
-static Factory<PolygonArray> RegisteredFactory("PolygonArray");
+static const Factory<PolygonArray> RegisteredFactory;
 
 /* Default constructor */
 PolygonArray::PolygonArray(const String & legend)

--- a/lib/src/Base/Graph/Staircase.cxx
+++ b/lib/src/Base/Graph/Staircase.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Staircase);
 
-static Factory<Staircase> RegisteredFactory("Staircase");
+static const Factory<Staircase> RegisteredFactory;
 
 /* Default constructor */
 Staircase::Staircase()

--- a/lib/src/Base/Optim/AbdoRackwitz/AbdoRackwitz.cxx
+++ b/lib/src/Base/Optim/AbdoRackwitz/AbdoRackwitz.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AbdoRackwitz);
 
-static Factory<AbdoRackwitz> RegisteredFactory("AbdoRackwitz");
+static const Factory<AbdoRackwitz> RegisteredFactory;
 
 /* Default constructor */
 AbdoRackwitz::AbdoRackwitz()

--- a/lib/src/Base/Optim/AbdoRackwitz/AbdoRackwitzSpecificParameters.cxx
+++ b/lib/src/Base/Optim/AbdoRackwitz/AbdoRackwitzSpecificParameters.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AbdoRackwitzSpecificParameters);
 
-static Factory<AbdoRackwitzSpecificParameters> RegisteredFactory("AbdoRackwitzSpecificParameters");
+static const Factory<AbdoRackwitzSpecificParameters> RegisteredFactory;
 
 
 /* Default onstructor */

--- a/lib/src/Base/Optim/BoundConstrainedAlgorithmImplementationResult.cxx
+++ b/lib/src/Base/Optim/BoundConstrainedAlgorithmImplementationResult.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BoundConstrainedAlgorithmImplementationResult);
 
-static Factory<BoundConstrainedAlgorithmImplementationResult> RegisteredFactory("BoundConstrainedAlgorithmImplementationResult");
+static const Factory<BoundConstrainedAlgorithmImplementationResult> RegisteredFactory;
 
 /* Default constructor */
 BoundConstrainedAlgorithmImplementationResult::BoundConstrainedAlgorithmImplementationResult():

--- a/lib/src/Base/Optim/Cobyla/Cobyla.cxx
+++ b/lib/src/Base/Optim/Cobyla/Cobyla.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Cobyla);
 
-static Factory<Cobyla> RegisteredFactory("Cobyla");
+static const Factory<Cobyla> RegisteredFactory;
 
 /* Default constructor */
 Cobyla::Cobyla():

--- a/lib/src/Base/Optim/Cobyla/CobylaSpecificParameters.cxx
+++ b/lib/src/Base/Optim/Cobyla/CobylaSpecificParameters.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CobylaSpecificParameters);
 
-static Factory<CobylaSpecificParameters> RegisteredFactory("CobylaSpecificParameters");
+static const Factory<CobylaSpecificParameters> RegisteredFactory;
 
 
 /* Default with parameters */

--- a/lib/src/Base/Optim/NearestPointAlgorithmImplementation.cxx
+++ b/lib/src/Base/Optim/NearestPointAlgorithmImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NearestPointAlgorithmImplementation);
 
-static Factory<NearestPointAlgorithmImplementation> RegisteredFactory("NearestPointAlgorithmImplementation");
+static const Factory<NearestPointAlgorithmImplementation> RegisteredFactory;
 
 /* Default constructor */
 NearestPointAlgorithmImplementation::NearestPointAlgorithmImplementation() :

--- a/lib/src/Base/Optim/NearestPointAlgorithmImplementationResult.cxx
+++ b/lib/src/Base/Optim/NearestPointAlgorithmImplementationResult.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NearestPointAlgorithmImplementationResult);
 
-static Factory<NearestPointAlgorithmImplementationResult> RegisteredFactory("NearestPointAlgorithmImplementationResult");
+static const Factory<NearestPointAlgorithmImplementationResult> RegisteredFactory;
 
 /* Default constructor */
 NearestPointAlgorithmImplementationResult::NearestPointAlgorithmImplementationResult()

--- a/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
+++ b/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OptimizationProblemImplementation);
 
-static Factory<OptimizationProblemImplementation> RegisteredFactory("OptimizationProblemImplementation");
+static const Factory<OptimizationProblemImplementation> RegisteredFactory;
 
 /* Default constructor */
 OptimizationProblemImplementation::OptimizationProblemImplementation()

--- a/lib/src/Base/Optim/SQP/SQP.cxx
+++ b/lib/src/Base/Optim/SQP/SQP.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SQP);
 
-static Factory<SQP> RegisteredFactory("SQP");
+static const Factory<SQP> RegisteredFactory;
 
 /* Default constructor */
 SQP::SQP():

--- a/lib/src/Base/Optim/SQP/SQPSpecificParameters.cxx
+++ b/lib/src/Base/Optim/SQP/SQPSpecificParameters.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SQPSpecificParameters);
 
-static Factory<SQPSpecificParameters> RegisteredFactory("SQPSpecificParameters");
+static const Factory<SQPSpecificParameters> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Optim/TNC/TNC.cxx
+++ b/lib/src/Base/Optim/TNC/TNC.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TNC);
 
-static Factory<TNC> RegisteredFactory("TNC");
+static const Factory<TNC> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Optim/TNC/TNCSpecificParameters.cxx
+++ b/lib/src/Base/Optim/TNC/TNCSpecificParameters.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TNCSpecificParameters);
 
-static Factory<TNCSpecificParameters> RegisteredFactory("TNCSpecificParameters");
+static const Factory<TNCSpecificParameters> RegisteredFactory;
 
 /* Default with parameters */
 TNCSpecificParameters::TNCSpecificParameters():

--- a/lib/src/Base/Solver/Bisection.cxx
+++ b/lib/src/Base/Solver/Bisection.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Bisection);
 
-static Factory<Bisection> RegisteredFactory("Bisection");
+static const Factory<Bisection> RegisteredFactory;
 
 /* Parameter constructor */
 Bisection::Bisection(const NumericalScalar absoluteError,

--- a/lib/src/Base/Solver/Brent.cxx
+++ b/lib/src/Base/Solver/Brent.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Brent);
 
-static Factory<Brent> RegisteredFactory("Brent");
+static const Factory<Brent> RegisteredFactory;
 
 /* Parameter constructor */
 Brent::Brent(const NumericalScalar absoluteError,

--- a/lib/src/Base/Solver/ODESolverImplementation.cxx
+++ b/lib/src/Base/Solver/ODESolverImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ODESolverImplementation);
 
-static Factory<ODESolverImplementation> RegisteredFactory("ODESolverImplementation");
+static const Factory<ODESolverImplementation> RegisteredFactory;
 
 /* Default constructor */
 ODESolverImplementation::ODESolverImplementation()

--- a/lib/src/Base/Solver/RungeKutta.cxx
+++ b/lib/src/Base/Solver/RungeKutta.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RungeKutta);
 
-static Factory<RungeKutta> RegisteredFactory("RungeKutta");
+static const Factory<RungeKutta> RegisteredFactory;
 
 /* Default constructor */
 RungeKutta::RungeKutta()

--- a/lib/src/Base/Solver/Secant.cxx
+++ b/lib/src/Base/Solver/Secant.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Secant);
 
-static Factory<Secant> RegisteredFactory("Secant");
+static const Factory<Secant> RegisteredFactory;
 
 /* Parameter constructor */
 Secant::Secant(const NumericalScalar absoluteError,

--- a/lib/src/Base/Solver/SolverImplementation.cxx
+++ b/lib/src/Base/Solver/SolverImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SolverImplementation);
 
-static Factory<SolverImplementation> RegisteredFactory("SolverImplementation");
+static const Factory<SolverImplementation> RegisteredFactory;
 
 /** Second parameter constructor */
 SolverImplementation::SolverImplementation(const NumericalScalar absoluteError,

--- a/lib/src/Base/Stat/AbsoluteExponential.cxx
+++ b/lib/src/Base/Stat/AbsoluteExponential.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AbsoluteExponential);
 
-static Factory<AbsoluteExponential> RegisteredFactory("AbsoluteExponential");
+static const Factory<AbsoluteExponential> RegisteredFactory;
 
 
 /* Constructor based on spatial dimension */

--- a/lib/src/Base/Stat/CauchyModel.cxx
+++ b/lib/src/Base/Stat/CauchyModel.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CauchyModel);
 
-static Factory<CauchyModel> RegisteredFactory("CauchyModel");
+static const Factory<CauchyModel> RegisteredFactory;
 
 /* Constructor with parameters */
 CauchyModel::CauchyModel()

--- a/lib/src/Base/Stat/Compact.cxx
+++ b/lib/src/Base/Stat/Compact.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Compact);
 
-static Factory<Compact> RegisteredFactory("Compact");
+static const Factory<Compact> RegisteredFactory;
 
 /* Constructor with parameters */
 Compact::Compact()

--- a/lib/src/Base/Stat/ConfidenceInterval.cxx
+++ b/lib/src/Base/Stat/ConfidenceInterval.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConfidenceInterval);
 
-static Factory<ConfidenceInterval> RegisteredFactory("ConfidenceInterval");
+static const Factory<ConfidenceInterval> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/CovarianceModel.cxx
+++ b/lib/src/Base/Stat/CovarianceModel.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CovarianceModel);
 
-//   static Factory<CovarianceModel> RegisteredFactory("CovarianceModel");
+//   static const Factory<CovarianceModel> RegisteredFactory;
 
 /* Constructor without parameters */
 CovarianceModel::CovarianceModel()

--- a/lib/src/Base/Stat/CovarianceModelFactoryImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelFactoryImplementation.cxx
@@ -27,7 +27,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CovarianceModelFactoryImplementation);
-static Factory<CovarianceModelFactoryImplementation> RegisteredFactory("CovarianceModelFactoryImplementation");
+static const Factory<CovarianceModelFactoryImplementation> RegisteredFactory;
 
 /* Default constructor */
 CovarianceModelFactoryImplementation::CovarianceModelFactoryImplementation()

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CovarianceModelImplementation);
 
-static Factory<CovarianceModelImplementation> RegisteredFactory("CovarianceModelImplementation");
+static const Factory<CovarianceModelImplementation> RegisteredFactory;
 
 /* Dimension-based constructor */
 CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Stat/ExponentialCauchy.cxx
+++ b/lib/src/Base/Stat/ExponentialCauchy.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ExponentialCauchy);
 
-static Factory<ExponentialCauchy> RegisteredFactory("ExponentialCauchy");
+static const Factory<ExponentialCauchy> RegisteredFactory;
 
 /* Constructor with parameters */
 ExponentialCauchy::ExponentialCauchy()

--- a/lib/src/Base/Stat/ExponentialModel.cxx
+++ b/lib/src/Base/Stat/ExponentialModel.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ExponentialModel);
 
-static Factory<ExponentialModel> RegisteredFactory("ExponentialModel");
+static const Factory<ExponentialModel> RegisteredFactory;
 
 /* Constructor from spatial dimension */
 ExponentialModel::ExponentialModel(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
+++ b/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ExponentiallyDampedCosineModel);
 
-static Factory<ExponentiallyDampedCosineModel> RegisteredFactory("ExponentiallyDampedCosineModel");
+static const Factory<ExponentiallyDampedCosineModel> RegisteredFactory;
 
 /* Constructor from spatial dimension */
 ExponentiallyDampedCosineModel::ExponentiallyDampedCosineModel(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Stat/FieldImplementation.cxx
+++ b/lib/src/Base/Stat/FieldImplementation.cxx
@@ -41,11 +41,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<NumericalSample>);
 
-static Factory<PersistentCollection<NumericalSample> > RegisteredFactory1("PersistentCollection<NumericalSample>");
+static const Factory<PersistentCollection<NumericalSample> > RegisteredFactory1;
 
 CLASSNAMEINIT(FieldImplementation);
 
-static Factory<FieldImplementation> RegisteredFactoryFI("FieldImplementation");
+static const Factory<FieldImplementation> RegisteredFactoryFI;
 
 /* Default constructor is private */
 FieldImplementation::FieldImplementation()

--- a/lib/src/Base/Stat/FilteringWindowsImplementation.cxx
+++ b/lib/src/Base/Stat/FilteringWindowsImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FilteringWindowsImplementation);
 
-static Factory<FilteringWindowsImplementation> RegisteredFactory("FilteringWindowsImplementation");
+static const Factory<FilteringWindowsImplementation> RegisteredFactory;
 
 /* Constructor without parameters */
 FilteringWindowsImplementation::FilteringWindowsImplementation()

--- a/lib/src/Base/Stat/Full.cxx
+++ b/lib/src/Base/Stat/Full.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Full);
 
-static Factory<Full> RegisteredFactory("Full");
+static const Factory<Full> RegisteredFactory;
 
 /* Constructor with parameters */
 Full::Full()

--- a/lib/src/Base/Stat/GeneralizedExponential.cxx
+++ b/lib/src/Base/Stat/GeneralizedExponential.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GeneralizedExponential);
 
-static Factory<GeneralizedExponential> RegisteredFactory("GeneralizedExponential");
+static const Factory<GeneralizedExponential> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/Hamming.cxx
+++ b/lib/src/Base/Stat/Hamming.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Hamming);
 
-static Factory<Hamming> RegisteredFactory("Hamming");
+static const Factory<Hamming> RegisteredFactory;
 
 /* Constructor with parameters */
 Hamming::Hamming()

--- a/lib/src/Base/Stat/Hanning.cxx
+++ b/lib/src/Base/Stat/Hanning.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Hanning);
 
-static Factory<Hanning> RegisteredFactory("Hanning");
+static const Factory<Hanning> RegisteredFactory;
 
 /* Constructor with parameters */
 Hanning::Hanning()

--- a/lib/src/Base/Stat/HistoryStrategyImplementation.cxx
+++ b/lib/src/Base/Stat/HistoryStrategyImplementation.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HistoryStrategyImplementation);
 
-static Factory<HistoryStrategyImplementation> RegisteredFactory("HistoryStrategyImplementation");
+static const Factory<HistoryStrategyImplementation> RegisteredFactory;
 
 /* Constructor with parameters */
 HistoryStrategyImplementation::HistoryStrategyImplementation()

--- a/lib/src/Base/Stat/Last.cxx
+++ b/lib/src/Base/Stat/Last.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
  */
 
 CLASSNAMEINIT(Last);
-static Factory<Last> RegisteredFactory("Last");
+static const Factory<Last> RegisteredFactory;
 
 /*Constructor with parameters */
 Last::Last()

--- a/lib/src/Base/Stat/LinearModel.cxx
+++ b/lib/src/Base/Stat/LinearModel.cxx
@@ -32,14 +32,14 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<ConfidenceInterval>);
 
-static Factory<PersistentCollection<ConfidenceInterval> > RegisteredFactory1("PersistentCollection<ConfidenceInterval>");
-static Factory<PersistentCollection<NumericalScalar> > RegisteredFactory2("PersistentCollection<NumericalScalar>");
+static const Factory<PersistentCollection<ConfidenceInterval> > RegisteredFactory1;
+static const Factory<PersistentCollection<NumericalScalar> > RegisteredFactory2;
 
 
 
 CLASSNAMEINIT(LinearModel);
 
-static Factory<LinearModel> RegisteredFactory("LinearModel");
+static const Factory<LinearModel> RegisteredFactory;
 
 /* Default constructor */
 LinearModel::LinearModel()

--- a/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
+++ b/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LowDiscrepancySequenceImplementation);
 
-static Factory<LowDiscrepancySequenceImplementation> RegisteredFactory("LowDiscrepancySequenceImplementation");
+static const Factory<LowDiscrepancySequenceImplementation> RegisteredFactory;
 
 /* Constructor with parameters */
 LowDiscrepancySequenceImplementation::LowDiscrepancySequenceImplementation(const UnsignedInteger dimension) :

--- a/lib/src/Base/Stat/MaternModel.cxx
+++ b/lib/src/Base/Stat/MaternModel.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MaternModel);
 
-static Factory<MaternModel> RegisteredFactory("MaternModel");
+static const Factory<MaternModel> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/NonStationaryCovarianceModelFactory.cxx
+++ b/lib/src/Base/Stat/NonStationaryCovarianceModelFactory.cxx
@@ -31,7 +31,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NonStationaryCovarianceModelFactory);
-static Factory<NonStationaryCovarianceModelFactory> RegisteredFactory("NonStationaryCovarianceModelFactory");
+static const Factory<NonStationaryCovarianceModelFactory> RegisteredFactory;
 
 typedef Collection<CovarianceMatrix>  CovarianceMatrixCollection;
 

--- a/lib/src/Base/Stat/Null.cxx
+++ b/lib/src/Base/Stat/Null.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Null);
 
-static Factory<Null> RegisteredFactory("Null");
+static const Factory<Null> RegisteredFactory;
 /* Constructor with parameters */
 Null::Null()
   : HistoryStrategyImplementation()

--- a/lib/src/Base/Stat/NumericalSampleImplementation.cxx
+++ b/lib/src/Base/Stat/NumericalSampleImplementation.cxx
@@ -54,7 +54,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<NumericalPoint>);
 
-static Factory<PersistentCollection<NumericalPoint> > RegisteredFactory_PC_NP("PersistentCollection<NumericalPoint>");
+static const Factory<PersistentCollection<NumericalPoint> > RegisteredFactory_PC_NP;
 
 NSI_point::NSI_point(NumericalSampleImplementation * p_nsi, const UnsignedInteger index)
   : p_nsi_(p_nsi), index_(index), dimension_(p_nsi->dimension_) {}
@@ -278,7 +278,7 @@ OStream & operator << (OStream & OS, const NSI_const_point & point)
   return OS;
 }
 
-static Factory<NumericalSampleImplementation> RegisteredFactory_NSI("NumericalSampleImplementation");
+static const Factory<NumericalSampleImplementation> RegisteredFactory_NSI;
 
 CLASSNAMEINIT(NumericalSampleImplementation);
 

--- a/lib/src/Base/Stat/ProcessSample.cxx
+++ b/lib/src/Base/Stat/ProcessSample.cxx
@@ -33,11 +33,11 @@ TEMPLATE_CLASSNAMEINIT(PersistentCollection<ProcessSample>);
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<Field>);
 
-static Factory<PersistentCollection<Field> > RegisteredFactory1("PersistentCollection<Field>");
+static const Factory<PersistentCollection<Field> > RegisteredFactory1;
 
 CLASSNAMEINIT(ProcessSample);
 
-static Factory<ProcessSample> RegisteredFactory("ProcessSample");
+static const Factory<ProcessSample> RegisteredFactory;
 
 ProcessSample::ProcessSample()
   : PersistentObject()

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -26,11 +26,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< CovarianceModel >);
 
-static Factory< PersistentCollection< CovarianceModel > > RegisteredFactory1("PersistentCollection< CovarianceModel >");
+static const Factory<PersistentCollection<CovarianceModel> > RegisteredFactory1;
 
 CLASSNAMEINIT(ProductCovarianceModel);
 
-static Factory<ProductCovarianceModel> RegisteredFactory("ProductCovarianceModel");
+static const Factory<ProductCovarianceModel> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/RandomGeneratorState.cxx
+++ b/lib/src/Base/Stat/RandomGeneratorState.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RandomGeneratorState);
 
-static Factory<RandomGeneratorState> RegisteredFactory("RandomGeneratorState");
+static const Factory<RandomGeneratorState> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/SecondOrderModelImplementation.cxx
+++ b/lib/src/Base/Stat/SecondOrderModelImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SecondOrderModelImplementation);
 
-static Factory<SecondOrderModelImplementation> RegisteredFactory("SecondOrderModelImplementation");
+static const Factory<SecondOrderModelImplementation> RegisteredFactory;
 
 /* Constructor without parameters */
 SecondOrderModelImplementation::SecondOrderModelImplementation()

--- a/lib/src/Base/Stat/SobolSequence.cxx
+++ b/lib/src/Base/Stat/SobolSequence.cxx
@@ -28,7 +28,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SobolSequence);
-static Factory<SobolSequence> RegisteredFactory("SobolSequence");
+static const Factory<SobolSequence> RegisteredFactory;
 
 
 const UnsignedInteger    SobolSequence::MaximumNumberOfDimension = 40;

--- a/lib/src/Base/Stat/SpectralModel.cxx
+++ b/lib/src/Base/Stat/SpectralModel.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SpectralModel);
 
-//   static Factory<SpectralModel> RegisteredFactory("SpectralModel");
+//   static const Factory<SpectralModel> RegisteredFactory;
 
 /* Constructor with parameters */
 SpectralModel::SpectralModel()

--- a/lib/src/Base/Stat/SpectralModelFactoryImplementation.cxx
+++ b/lib/src/Base/Stat/SpectralModelFactoryImplementation.cxx
@@ -26,7 +26,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SpectralModelFactoryImplementation);
-static Factory<SpectralModelFactoryImplementation> RegisteredFactory("SpectralModelFactoryImplementation");
+static const Factory<SpectralModelFactoryImplementation> RegisteredFactory;
 
 /* Default constructor */
 SpectralModelFactoryImplementation::SpectralModelFactoryImplementation()

--- a/lib/src/Base/Stat/SpectralModelImplementation.cxx
+++ b/lib/src/Base/Stat/SpectralModelImplementation.cxx
@@ -27,7 +27,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SpectralModelImplementation);
-static Factory<SpectralModelImplementation> RegisteredFactory("SpectralModelImplementation");
+static const Factory<SpectralModelImplementation> RegisteredFactory;
 
 /* Constructor with parameters */
 SpectralModelImplementation::SpectralModelImplementation()

--- a/lib/src/Base/Stat/SphericalModel.cxx
+++ b/lib/src/Base/Stat/SphericalModel.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SphericalModel);
 
-static Factory<SphericalModel> RegisteredFactory("SphericalModel");
+static const Factory<SphericalModel> RegisteredFactory;
 
 /* Constructor from spatial dimension */
 SphericalModel::SphericalModel(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Stat/SquaredExponential.cxx
+++ b/lib/src/Base/Stat/SquaredExponential.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SquaredExponential);
 
-static Factory<SquaredExponential> RegisteredFactory("SquaredExponential");
+static const Factory<SquaredExponential> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Base/Stat/StationaryCovarianceModel.cxx
+++ b/lib/src/Base/Stat/StationaryCovarianceModel.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(StationaryCovarianceModel);
 
-static Factory<StationaryCovarianceModel> RegisteredFactory("StationaryCovarianceModel");
+static const Factory<StationaryCovarianceModel> RegisteredFactory;
 
 /* Constructor with parameters */
 StationaryCovarianceModel::StationaryCovarianceModel(const UnsignedInteger spatialDimension)

--- a/lib/src/Base/Stat/StationaryCovarianceModelFactory.cxx
+++ b/lib/src/Base/Stat/StationaryCovarianceModelFactory.cxx
@@ -29,9 +29,9 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(StationaryCovarianceModelFactory);
-static Factory<StationaryCovarianceModelFactory> RegisteredFactory("StationaryCovarianceModelFactory");
+static const Factory<StationaryCovarianceModelFactory> RegisteredFactory;
 
-static Factory<PersistentCollection<NumericalComplex> > RegisteredFactory2("PersistentCollection<NumericalComplex>");
+static const Factory<PersistentCollection<NumericalComplex> > RegisteredFactory2;
 
 typedef Collection<CovarianceMatrix>  CovarianceMatrixCollection;
 

--- a/lib/src/Base/Stat/TestResult.cxx
+++ b/lib/src/Base/Stat/TestResult.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TestResult);
 
-static Factory< TestResult > RegisteredFactory("TestResult");
+static const Factory< TestResult > RegisteredFactory;
 
 /* Default constructor */
 TestResult::TestResult():

--- a/lib/src/Base/Stat/UserDefinedCovarianceModel.cxx
+++ b/lib/src/Base/Stat/UserDefinedCovarianceModel.cxx
@@ -27,11 +27,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< CovarianceMatrix >);
 
-static Factory< PersistentCollection< CovarianceMatrix > > RegisteredFactory1("PersistentCollection< CovarianceMatrix >");
+static const Factory<PersistentCollection<CovarianceMatrix> > RegisteredFactory1;
 
 CLASSNAMEINIT(UserDefinedCovarianceModel);
 
-static Factory<UserDefinedCovarianceModel> RegisteredFactory("UserDefinedCovarianceModel");
+static const Factory<UserDefinedCovarianceModel> RegisteredFactory;
 
 /* Constructor with parameters */
 UserDefinedCovarianceModel::UserDefinedCovarianceModel()

--- a/lib/src/Base/Stat/UserDefinedSpectralModel.cxx
+++ b/lib/src/Base/Stat/UserDefinedSpectralModel.cxx
@@ -26,11 +26,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< HermitianMatrix >);
-static Factory< PersistentCollection< HermitianMatrix > > RegisteredFactory1("PersistentCollection< HermitianMatrix >");
+static const Factory<PersistentCollection<HermitianMatrix> > RegisteredFactory1;
 
 
 CLASSNAMEINIT(UserDefinedSpectralModel);
-static Factory<UserDefinedSpectralModel> RegisteredFactory("UserDefinedSpectralModel");
+static const Factory<UserDefinedSpectralModel> RegisteredFactory;
 /* Constructor with parameters */
 UserDefinedSpectralModel::UserDefinedSpectralModel()
   : SpectralModelImplementation()

--- a/lib/src/Base/Stat/UserDefinedStationaryCovarianceModel.cxx
+++ b/lib/src/Base/Stat/UserDefinedStationaryCovarianceModel.cxx
@@ -26,11 +26,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 // TEMPLATE_CLASSNAMEINIT(PersistentCollection< CovarianceMatrix >);
-// static Factory< PersistentCollection< CovarianceMatrix > > RegisteredFactory1("PersistentCollection< CovarianceMatrix >");
+// static const Factory<PersistentCollection<CovarianceMatrix> > RegisteredFactory1;
 
 CLASSNAMEINIT(UserDefinedStationaryCovarianceModel);
 
-static Factory<UserDefinedStationaryCovarianceModel> RegisteredFactory("UserDefinedStationaryCovarianceModel");
+static const Factory<UserDefinedStationaryCovarianceModel> RegisteredFactory;
 
 /* Constructor with parameters */
 UserDefinedStationaryCovarianceModel::UserDefinedStationaryCovarianceModel()

--- a/lib/src/Base/Stat/WelchFactory.cxx
+++ b/lib/src/Base/Stat/WelchFactory.cxx
@@ -31,7 +31,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(WelchFactory);
-static Factory<WelchFactory> RegisteredFactory("WelchFactory");
+static const Factory<WelchFactory> RegisteredFactory;
 
 typedef Collection<NumericalComplex> NumericalComplexCollection;
 typedef Collection<HermitianMatrix>  HermitianMatrixCollection;

--- a/lib/src/Base/Type/ComplexMatrixImplementation.cxx
+++ b/lib/src/Base/Type/ComplexMatrixImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(ComplexMatrixImplementation);
 
 
-static Factory<ComplexMatrixImplementation> RegisteredFactory("ComplexMatrixImplementation");
+static const Factory<ComplexMatrixImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComplexMatrixImplementation::ComplexMatrixImplementation()

--- a/lib/src/Base/Type/ComplexTensorImplementation.cxx
+++ b/lib/src/Base/Type/ComplexTensorImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComplexTensorImplementation);
 
-static Factory<ComplexTensorImplementation> RegisteredFactory("ComplexTensorImplementation");
+static const Factory<ComplexTensorImplementation> RegisteredFactory;
 
 /* Default constructor */
 ComplexTensorImplementation::ComplexTensorImplementation()

--- a/lib/src/Base/Type/Description.cxx
+++ b/lib/src/Base/Type/Description.cxx
@@ -25,9 +25,9 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Description);
 
-static Factory<PersistentCollection<String> > RegisteredFactory2("PersistentCollection<String>");
+static const Factory<PersistentCollection<String> > RegisteredFactory2;
 
-static Factory<Description> RegisteredFactory("Description");
+static const Factory<Description> RegisteredFactory;
 
 /* Default constructor */
 Description::Description()

--- a/lib/src/Base/Type/Indices.cxx
+++ b/lib/src/Base/Type/Indices.cxx
@@ -25,7 +25,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Indices);
-static Factory<Indices> RegisteredFactory("Indices");
+static const Factory<Indices> RegisteredFactory;
 
 /* Check that no value is repeated and no value exceed the given bound */
 Bool Indices::check(const UnsignedInteger bound) const

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -36,7 +36,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(MatrixImplementation);
 
 
-static Factory<MatrixImplementation> RegisteredFactory("MatrixImplementation");
+static const Factory<MatrixImplementation> RegisteredFactory;
 
 // All the pivots with a magnitude less than this threshold are considered as zero
 /* Default constructor */

--- a/lib/src/Base/Type/NumericalPoint.cxx
+++ b/lib/src/Base/Type/NumericalPoint.cxx
@@ -30,9 +30,9 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NumericalPoint);
 
-static Factory<PersistentCollection<NumericalScalar> > RegisteredFactory_alt1("PersistentCollection<NumericalScalar>");
+static const Factory<PersistentCollection<NumericalScalar> > RegisteredFactory_alt1;
 
-static Factory<NumericalPoint> RegisteredFactory("NumericalPoint");
+static const Factory<NumericalPoint> RegisteredFactory;
 
 /* Default constructor */
 NumericalPoint::NumericalPoint()

--- a/lib/src/Base/Type/NumericalPointWithDescription.cxx
+++ b/lib/src/Base/Type/NumericalPointWithDescription.cxx
@@ -26,8 +26,8 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(NumericalPointWithDescription);
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<NumericalPointWithDescription>);
 
-static Factory<NumericalPointWithDescription> RegisteredFactory1("NumericalPointWithDescription");
-static Factory<PersistentCollection<NumericalPointWithDescription> > RegisteredFactory2("PersistentCollection<NumericalPointWithDescription>");
+static const Factory<NumericalPointWithDescription> RegisteredFactory1;
+static const Factory<PersistentCollection<NumericalPointWithDescription> > RegisteredFactory2;
 
 /* Default constructor */
 NumericalPointWithDescription::NumericalPointWithDescription()

--- a/lib/src/Base/Type/TensorImplementation.cxx
+++ b/lib/src/Base/Type/TensorImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TensorImplementation);
 
-static Factory<TensorImplementation> RegisteredFactory("TensorImplementation");
+static const Factory<TensorImplementation> RegisteredFactory;
 
 /* Default constructor */
 TensorImplementation::TensorImplementation()

--- a/lib/src/Uncertainty/Algorithm/Analytical/Analytical.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/Analytical.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Analytical);
 
-static Factory< Analytical > RegisteredFactory("Analytical");
+static const Factory< Analytical > RegisteredFactory;
 
 /*
  * @brief  Standard constructor: the class is defined by an optimisation algorithm, a failure event and a physical starting point

--- a/lib/src/Uncertainty/Algorithm/Analytical/AnalyticalResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/AnalyticalResult.cxx
@@ -44,7 +44,7 @@ typedef PersistentCollection<NumericalPointWithDescription> PersistentSensitivit
 
 CLASSNAMEINIT(AnalyticalResult);
 
-static Factory<AnalyticalResult> RegisteredFactory("AnalyticalResult");
+static const Factory<AnalyticalResult> RegisteredFactory;
 
 /*
  * @brief  Standard constructor

--- a/lib/src/Uncertainty/Algorithm/Analytical/FORM.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/FORM.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FORM);
 
-static Factory< FORM > RegisteredFactory("FORM");
+static const Factory< FORM > RegisteredFactory;
 
 /* Default constructor for the save/load mechanism */
 FORM::FORM()

--- a/lib/src/Uncertainty/Algorithm/Analytical/FORMResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/FORMResult.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FORMResult);
 
-static Factory<FORMResult> RegisteredFactory("FORMResult");
+static const Factory<FORMResult> RegisteredFactory;
 
 typedef PersistentCollection<NumericalPointWithDescription> PersistentSensitivity;
 

--- a/lib/src/Uncertainty/Algorithm/Analytical/SORM.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/SORM.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SORM);
 
-static Factory< SORM > RegisteredFactory("SORM");
+static const Factory< SORM > RegisteredFactory;
 
 /* Default constructor for the save/load mechanism */
 SORM::SORM()

--- a/lib/src/Uncertainty/Algorithm/Analytical/SORMResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/SORMResult.cxx
@@ -39,7 +39,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SORMResult);
 
-static Factory<SORMResult> RegisteredFactory("SORMResult");
+static const Factory<SORMResult> RegisteredFactory;
 
 /*
  * @brief  Standard constructor: the class is defined by an optimisation algorithm, a failure event and a physical starting point

--- a/lib/src/Uncertainty/Algorithm/Analytical/StrongMaximumTest.cxx
+++ b/lib/src/Uncertainty/Algorithm/Analytical/StrongMaximumTest.cxx
@@ -37,7 +37,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(StrongMaximumTest);
 
-static Factory< StrongMaximumTest > RegisteredFactory("StrongMaximumTest");
+static const Factory< StrongMaximumTest > RegisteredFactory;
 typedef DistributionImplementation::Implementation                        Implementation;
 typedef DistributionImplementation::InverseIsoProbabilisticTransformation InverseIsoProbabilisticTransformation;
 

--- a/lib/src/Uncertainty/Algorithm/Classification/MixtureClassifier.cxx
+++ b/lib/src/Uncertainty/Algorithm/Classification/MixtureClassifier.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MixtureClassifier);
 
-static Factory<MixtureClassifier> RegisteredFactory("MixtureClassifier");
+static const Factory<MixtureClassifier> RegisteredFactory;
 
 /* Default constructor */
 MixtureClassifier::MixtureClassifier()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AdaptiveStrategyImplementation);
 
-static Factory<AdaptiveStrategyImplementation> RegisteredFactory("AdaptiveStrategyImplementation");
+static const Factory<AdaptiveStrategyImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
@@ -36,7 +36,7 @@ CLASSNAMEINIT(CleaningStrategy);
 
 typedef Collection<NumericalScalar> NumericalScalarCollection;
 
-static Factory<CleaningStrategy> RegisteredFactory("CleaningStrategy");
+static const Factory<CleaningStrategy> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FixedStrategy);
 
-static Factory<FixedStrategy> RegisteredFactory("FixedStrategy");
+static const Factory<FixedStrategy> RegisteredFactory;
 
 /* Default constructor */
 FixedStrategy::FixedStrategy()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -60,7 +60,7 @@ typedef Collection<NumericalMathFunction> NumericalMathFunctionCollection;
 
 CLASSNAMEINIT(FunctionalChaosAlgorithm);
 
-static Factory<FunctionalChaosAlgorithm> RegisteredFactory("FunctionalChaosAlgorithm");
+static const Factory<FunctionalChaosAlgorithm> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
@@ -26,12 +26,12 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-static Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory2("PersistentCollection<UnsignedInteger>");
+static const Factory<PersistentCollection<UnsignedInteger> > RegisteredFactory2;
 
 
 
 CLASSNAMEINIT(FunctionalChaosResult);
-static Factory<FunctionalChaosResult> RegisteredFactory("FunctionalChaosResult");
+static const Factory<FunctionalChaosResult> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(IntegrationStrategy);
 
 
-static Factory<IntegrationStrategy> RegisteredFactory("IntegrationStrategy");
+static const Factory<IntegrationStrategy> RegisteredFactory;
 
 /* Default constructor */
 IntegrationStrategy::IntegrationStrategy()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LeastSquaresStrategy);
 
-static Factory<LeastSquaresStrategy> RegisteredFactory("LeastSquaresStrategy");
+static const Factory<LeastSquaresStrategy> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProjectionStrategyImplementation);
 
-static Factory<ProjectionStrategyImplementation> RegisteredFactory("ProjectionStrategyImplementation");
+static const Factory<ProjectionStrategyImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/SequentialStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/SequentialStrategy.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SequentialStrategy);
 
-static Factory<SequentialStrategy> RegisteredFactory("SequentialStrategy");
+static const Factory<SequentialStrategy> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/KrigingAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/KrigingAlgorithm.cxx
@@ -36,7 +36,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KrigingAlgorithm);
 
-static Factory<KrigingAlgorithm> RegisteredFactory("KrigingAlgorithm");
+static const Factory<KrigingAlgorithm> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/KrigingEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/KrigingEvaluation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(KrigingEvaluation);
 
 
-static Factory<KrigingEvaluation> RegisteredFactory("KrigingEvaluation");
+static const Factory<KrigingEvaluation> RegisteredFactory;
 
 
 /* Constructor with parameters */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/KrigingGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/KrigingGradient.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(KrigingGradient);
 
 
-static Factory<KrigingGradient> RegisteredFactory("KrigingGradient");
+static const Factory<KrigingGradient> RegisteredFactory;
 
 
 /* Constructor with parameters */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/KrigingResult.cxx
@@ -26,7 +26,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KrigingResult);
-static Factory<KrigingResult> RegisteredFactory("KrigingResult");
+static const Factory<KrigingResult> RegisteredFactory;
 
 /* Default constructor */
 KrigingResult::KrigingResult()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelAlgorithm.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MetaModelAlgorithm);
 
-static Factory<MetaModelAlgorithm> RegisteredFactory("MetaModelAlgorithm");
+static const Factory<MetaModelAlgorithm> RegisteredFactory;
 
 /* Default constructor */
 MetaModelAlgorithm::MetaModelAlgorithm()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelResult.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MetaModelResult);
 
-static Factory<MetaModelResult> RegisteredFactory("MetaModelResult");
+static const Factory<MetaModelResult> RegisteredFactory;
 
 /* Default constructor */
 MetaModelResult::MetaModelResult()

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelValidation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelValidation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MetaModelValidation);
 
-static Factory<MetaModelValidation> RegisteredFactory("MetaModelValidation");
+static const Factory<MetaModelValidation> RegisteredFactory;
 
 /* Default constructor */
 MetaModelValidation::MetaModelValidation()

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/CharlierFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/CharlierFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CharlierFactory);
 
-static Factory<CharlierFactory> RegisteredFactory("CharlierFactory");
+static const Factory<CharlierFactory> RegisteredFactory;
 
 
 

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/ChebychevAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/ChebychevAlgorithm.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ChebychevAlgorithm);
 
-static Factory<ChebychevAlgorithm> RegisteredFactory("ChebychevAlgorithm");
+static const Factory<ChebychevAlgorithm> RegisteredFactory;
 
 /* Default constructor */
 ChebychevAlgorithm::ChebychevAlgorithm()

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/GramSchmidtAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/GramSchmidtAlgorithm.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GramSchmidtAlgorithm);
 
-static Factory<GramSchmidtAlgorithm> RegisteredFactory("GramSchmidtAlgorithm");
+static const Factory<GramSchmidtAlgorithm> RegisteredFactory;
 
 /* Default constructor */
 GramSchmidtAlgorithm::GramSchmidtAlgorithm()

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/HermiteFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/HermiteFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HermiteFactory);
 
-static Factory<HermiteFactory> RegisteredFactory("HermiteFactory");
+static const Factory<HermiteFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/JacobiFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/JacobiFactory.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(JacobiFactory);
 
-static Factory<JacobiFactory> RegisteredFactory("JacobiFactory");
+static const Factory<JacobiFactory> RegisteredFactory;
 
 /* Default constructor: (1, 1) order Jacobi polynomial associated with the default Beta() = Beta(2, 4, -1, 1) distribution which is equal to the Epanechnikov distribution */
 JacobiFactory::JacobiFactory()

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/KrawtchoukFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/KrawtchoukFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KrawtchoukFactory);
 
-static Factory<KrawtchoukFactory> RegisteredFactory("KrawtchoukFactory");
+static const Factory<KrawtchoukFactory> RegisteredFactory;
 
 
 

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/LaguerreFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/LaguerreFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LaguerreFactory);
 
-static Factory<LaguerreFactory> RegisteredFactory("LaguerreFactory");
+static const Factory<LaguerreFactory> RegisteredFactory;
 
 
 

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/LegendreFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/LegendreFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LegendreFactory);
 
-static Factory<LegendreFactory> RegisteredFactory("LegendreFactory");
+static const Factory<LegendreFactory> RegisteredFactory;
 
 
 

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/MeixnerFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/MeixnerFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MeixnerFactory);
 
-static Factory<MeixnerFactory> RegisteredFactory("MeixnerFactory");
+static const Factory<MeixnerFactory> RegisteredFactory;
 
 
 

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalFunctionFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalFunctionFactory.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrthogonalFunctionFactory);
 
-static Factory<OrthogonalFunctionFactory> RegisteredFactory("OrthogonalFunctionFactory");
+static const Factory<OrthogonalFunctionFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalProductPolynomialFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalProductPolynomialFactory.cxx
@@ -36,11 +36,11 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<OrthogonalUniVariatePolynomialFamily>);
 
-static Factory<PersistentCollection<OrthogonalUniVariatePolynomialFamily> > RegisteredFactory_PC_OUVPF("PersistentCollection<OrthogonalUniVariatePolynomialFamily>");
+static const Factory<PersistentCollection<OrthogonalUniVariatePolynomialFamily> > RegisteredFactory_PC_OUVPF;
 
 CLASSNAMEINIT(OrthogonalProductPolynomialFactory);
 
-static Factory<OrthogonalProductPolynomialFactory> RegisteredFactory_OPPF("OrthogonalProductPolynomialFactory");
+static const Factory<OrthogonalProductPolynomialFactory> RegisteredFactory_OPPF;
 
 typedef Collection<NumericalPoint> NumericalPointCollection;
 typedef ProductPolynomialEvaluationImplementation::PolynomialCollection PolynomialCollection;

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalUniVariatePolynomial.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalUniVariatePolynomial.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrthogonalUniVariatePolynomial);
 
-static Factory<OrthogonalUniVariatePolynomial> RegisteredFactory("OrthogonalUniVariatePolynomial");
+static const Factory<OrthogonalUniVariatePolynomial> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalUniVariatePolynomialFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthogonalUniVariatePolynomialFactory.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrthogonalUniVariatePolynomialFactory);
 
-static Factory<OrthogonalUniVariatePolynomialFactory> RegisteredFactory("OrthogonalUniVariatePolynomialFactory");
+static const Factory<OrthogonalUniVariatePolynomialFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthonormalizationAlgorithmImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/OrthonormalizationAlgorithmImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrthonormalizationAlgorithmImplementation);
 
-static Factory<OrthonormalizationAlgorithmImplementation> RegisteredFactory("OrthonormalizationAlgorithmImplementation");
+static const Factory<OrthonormalizationAlgorithmImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/OrthogonalBasis/StandardDistributionPolynomialFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/OrthogonalBasis/StandardDistributionPolynomialFactory.cxx
@@ -35,7 +35,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(StandardDistributionPolynomialFactory);
 
-static Factory<StandardDistributionPolynomialFactory> RegisteredFactory("StandardDistributionPolynomialFactory");
+static const Factory<StandardDistributionPolynomialFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/QuadraticCumul/QuadraticCumul.cxx
+++ b/lib/src/Uncertainty/Algorithm/QuadraticCumul/QuadraticCumul.cxx
@@ -34,7 +34,7 @@ typedef Pointer<RandomVectorImplementation> Implementation;
 
 CLASSNAMEINIT(QuadraticCumul);
 
-static Factory<QuadraticCumul> RegisteredFactory("QuadraticCumul");
+static const Factory<QuadraticCumul> RegisteredFactory;
 
 /*
  * @class QuadraticCumul

--- a/lib/src/Uncertainty/Algorithm/Simulation/DirectionalSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/DirectionalSampling.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DirectionalSampling);
 
-static Factory<DirectionalSampling> RegisteredFactory("DirectionalSampling");
+static const Factory<DirectionalSampling> RegisteredFactory;
 
 /* Constructor with parameters */
 DirectionalSampling::DirectionalSampling()

--- a/lib/src/Uncertainty/Algorithm/Simulation/ImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/ImportanceSampling.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ImportanceSampling);
 
-static Factory<ImportanceSampling> RegisteredFactory("ImportanceSampling");
+static const Factory<ImportanceSampling> RegisteredFactory;
 
 /* Constructor with parameters */
 ImportanceSampling::ImportanceSampling()

--- a/lib/src/Uncertainty/Algorithm/Simulation/LHS.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/LHS.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LHS);
 
-static Factory<LHS> RegisteredFactory("LHS");
+static const Factory<LHS> RegisteredFactory;
 
 /* Default constructor */
 LHS::LHS()

--- a/lib/src/Uncertainty/Algorithm/Simulation/MediumSafe.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/MediumSafe.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MediumSafe);
 
-static Factory<MediumSafe> RegisteredFactory("MediumSafe");
+static const Factory<MediumSafe> RegisteredFactory;
 
 /* Constructor with parameters */
 MediumSafe::MediumSafe():

--- a/lib/src/Uncertainty/Algorithm/Simulation/MonteCarlo.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/MonteCarlo.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MonteCarlo);
 
-static Factory<MonteCarlo> RegisteredFactory("MonteCarlo");
+static const Factory<MonteCarlo> RegisteredFactory;
 
 /* Constructor with parameters */
 MonteCarlo::MonteCarlo(const Event & event):

--- a/lib/src/Uncertainty/Algorithm/Simulation/OrthogonalDirection.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/OrthogonalDirection.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrthogonalDirection);
 
-static Factory<OrthogonalDirection> RegisteredFactory("OrthogonalDirection");
+static const Factory<OrthogonalDirection> RegisteredFactory;
 
 /* Default constructor */
 OrthogonalDirection::OrthogonalDirection()

--- a/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalControlledImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalControlledImportanceSampling.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PostAnalyticalControlledImportanceSampling);
 
-static Factory<PostAnalyticalControlledImportanceSampling> RegisteredFactory("PostAnalyticalControlledImportanceSampling");
+static const Factory<PostAnalyticalControlledImportanceSampling> RegisteredFactory;
 
 /* Constructor with parameters */
 PostAnalyticalControlledImportanceSampling::PostAnalyticalControlledImportanceSampling()

--- a/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalImportanceSampling.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PostAnalyticalImportanceSampling);
 
-static Factory<PostAnalyticalImportanceSampling> RegisteredFactory("PostAnalyticalImportanceSampling");
+static const Factory<PostAnalyticalImportanceSampling> RegisteredFactory;
 
 /* Constructor with parameters */
 PostAnalyticalImportanceSampling::PostAnalyticalImportanceSampling()

--- a/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalSimulation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/PostAnalyticalSimulation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PostAnalyticalSimulation);
 
-static Factory<PostAnalyticalSimulation> RegisteredFactory("PostAnalyticalSimulation");
+static const Factory<PostAnalyticalSimulation> RegisteredFactory;
 
 /* Constructor with parameters */
 PostAnalyticalSimulation::PostAnalyticalSimulation()

--- a/lib/src/Uncertainty/Algorithm/Simulation/QuasiMonteCarlo.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/QuasiMonteCarlo.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
  */
 CLASSNAMEINIT(QuasiMonteCarlo);
 
-static Factory<QuasiMonteCarlo> RegisteredFactory("QuasiMonteCarlo");
+static const Factory<QuasiMonteCarlo> RegisteredFactory;
 
 /* Constructor with parameters */
 QuasiMonteCarlo::QuasiMonteCarlo()

--- a/lib/src/Uncertainty/Algorithm/Simulation/QuasiMonteCarloResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/QuasiMonteCarloResult.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(QuasiMonteCarloResult);
 
 
-static Factory<QuasiMonteCarloResult> RegisteredFactory("QuasiMonteCarloResult");
+static const Factory<QuasiMonteCarloResult> RegisteredFactory;
 
 /* Default constructor */
 QuasiMonteCarloResult::QuasiMonteCarloResult()

--- a/lib/src/Uncertainty/Algorithm/Simulation/RandomDirection.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/RandomDirection.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RandomDirection);
 
-static Factory<RandomDirection> RegisteredFactory("RandomDirection");
+static const Factory<RandomDirection> RegisteredFactory;
 
 /* Default constructor */
 RandomDirection::RandomDirection()

--- a/lib/src/Uncertainty/Algorithm/Simulation/RandomizedLHS.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/RandomizedLHS.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RandomizedLHS);
 
-static Factory<RandomizedLHS> RegisteredFactory("RandomizedLHS");
+static const Factory<RandomizedLHS> RegisteredFactory;
 
 /* Default constructor */
 RandomizedLHS::RandomizedLHS():

--- a/lib/src/Uncertainty/Algorithm/Simulation/RandomizedQuasiMonteCarlo.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/RandomizedQuasiMonteCarlo.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
  */
 CLASSNAMEINIT(RandomizedQuasiMonteCarlo);
 
-static Factory<RandomizedQuasiMonteCarlo> RegisteredFactory("RandomizedQuasiMonteCarlo");
+static const Factory<RandomizedQuasiMonteCarlo> RegisteredFactory;
 
 /* Constructor with parameters */
 RandomizedQuasiMonteCarlo::RandomizedQuasiMonteCarlo()

--- a/lib/src/Uncertainty/Algorithm/Simulation/RiskyAndFast.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/RiskyAndFast.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RiskyAndFast);
 
-static Factory<RiskyAndFast> RegisteredFactory("RiskyAndFast");
+static const Factory<RiskyAndFast> RegisteredFactory;
 
 /* Constructor with parameters */
 RiskyAndFast::RiskyAndFast():

--- a/lib/src/Uncertainty/Algorithm/Simulation/RootStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/RootStrategyImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RootStrategyImplementation);
 
-static Factory<RootStrategyImplementation> RegisteredFactory("RootStrategyImplementation");
+static const Factory<RootStrategyImplementation> RegisteredFactory;
 
 /* Default constructor */
 RootStrategyImplementation::RootStrategyImplementation()

--- a/lib/src/Uncertainty/Algorithm/Simulation/SafeAndSlow.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/SafeAndSlow.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SafeAndSlow);
 
-static Factory<SafeAndSlow> RegisteredFactory("SafeAndSlow");
+static const Factory<SafeAndSlow> RegisteredFactory;
 
 /* Constructor with parameters */
 SafeAndSlow::SafeAndSlow():

--- a/lib/src/Uncertainty/Algorithm/Simulation/SamplingStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/SamplingStrategyImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SamplingStrategyImplementation);
 
-static Factory<SamplingStrategyImplementation> RegisteredFactory("SamplingStrategyImplementation");
+static const Factory<SamplingStrategyImplementation> RegisteredFactory;
 
 /* Constructor with parameters */
 SamplingStrategyImplementation::SamplingStrategyImplementation(const UnsignedInteger dimension)

--- a/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Simulation);
 
-static Factory<Simulation> RegisteredFactory("Simulation");
+static const Factory<Simulation> RegisteredFactory;
 
 /** For save/load mechanism */
 Simulation::Simulation(const Bool verbose, const HistoryStrategy & convergenceStrategy)

--- a/lib/src/Uncertainty/Algorithm/Simulation/SimulationResultImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/SimulationResultImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SimulationResultImplementation);
 
-static Factory<SimulationResultImplementation> RegisteredFactory("SimulationResultImplementation");
+static const Factory<SimulationResultImplementation> RegisteredFactory;
 
 /* Default constructor */
 SimulationResultImplementation::SimulationResultImplementation()

--- a/lib/src/Uncertainty/Algorithm/Simulation/SimulationSensitivityAnalysis.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/SimulationSensitivityAnalysis.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(SimulationSensitivityAnalysis);
 
 
-static Factory<SimulationSensitivityAnalysis> RegisteredFactory("SimulationSensitivityAnalysis");
+static const Factory<SimulationSensitivityAnalysis> RegisteredFactory;
 
 /* Default constructor */
 SimulationSensitivityAnalysis::SimulationSensitivityAnalysis()

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MarginalTransformationEvaluation);
 
-static Factory<MarginalTransformationEvaluation> RegisteredFactory("MarginalTransformationEvaluation");
+static const Factory<MarginalTransformationEvaluation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationGradient.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MarginalTransformationGradient);
 
-static Factory<MarginalTransformationGradient> RegisteredFactory("MarginalTransformationGradient");
+static const Factory<MarginalTransformationGradient> RegisteredFactory;
 
 /* ParameterDefault constructor */
 MarginalTransformationGradient::MarginalTransformationGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationHessian.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MarginalTransformationHessian);
 
-static Factory<MarginalTransformationHessian> RegisteredFactory("MarginalTransformationHessian");
+static const Factory<MarginalTransformationHessian> RegisteredFactory;
 
 /* Default constructor */
 MarginalTransformationHessian::MarginalTransformationHessian():

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaEvaluation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalCopulaEvaluation);
 
-static Factory<InverseNatafEllipticalCopulaEvaluation> RegisteredFactory("InverseNatafEllipticalCopulaEvaluation");
+static const Factory<InverseNatafEllipticalCopulaEvaluation> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalCopulaEvaluation::InverseNatafEllipticalCopulaEvaluation()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaGradient.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalCopulaGradient);
 
-static Factory<InverseNatafEllipticalCopulaGradient> RegisteredFactory("InverseNatafEllipticalCopulaGradient");
+static const Factory<InverseNatafEllipticalCopulaGradient> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalCopulaGradient::InverseNatafEllipticalCopulaGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/InverseNatafEllipticalCopulaHessian.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalCopulaHessian);
 
-static Factory<InverseNatafEllipticalCopulaHessian> RegisteredFactory("InverseNatafEllipticalCopulaHessian");
+static const Factory<InverseNatafEllipticalCopulaHessian> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalCopulaHessian::InverseNatafEllipticalCopulaHessian()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaEvaluation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalCopulaEvaluation);
 
-static Factory<NatafEllipticalCopulaEvaluation> RegisteredFactory("NatafEllipticalCopulaEvaluation");
+static const Factory<NatafEllipticalCopulaEvaluation> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalCopulaEvaluation::NatafEllipticalCopulaEvaluation()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaGradient.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalCopulaGradient);
 
-static Factory<NatafEllipticalCopulaGradient> RegisteredFactory("NatafEllipticalCopulaGradient");
+static const Factory<NatafEllipticalCopulaGradient> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalCopulaGradient::NatafEllipticalCopulaGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalCopula/NatafEllipticalCopulaHessian.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalCopulaHessian);
 
-static Factory<NatafEllipticalCopulaHessian> RegisteredFactory("NatafEllipticalCopulaHessian");
+static const Factory<NatafEllipticalCopulaHessian> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalCopulaHessian::NatafEllipticalCopulaHessian()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionEvaluation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalDistributionEvaluation);
 
-static Factory<InverseNatafEllipticalDistributionEvaluation> RegisteredFactory("InverseNatafEllipticalDistributionEvaluation");
+static const Factory<InverseNatafEllipticalDistributionEvaluation> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalDistributionEvaluation::InverseNatafEllipticalDistributionEvaluation()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionGradient.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalDistributionGradient);
 
-static Factory<InverseNatafEllipticalDistributionGradient> RegisteredFactory("InverseNatafEllipticalDistributionGradient");
+static const Factory<InverseNatafEllipticalDistributionGradient> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalDistributionGradient::InverseNatafEllipticalDistributionGradient():

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/InverseNatafEllipticalDistributionHessian.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafEllipticalDistributionHessian);
 
-static Factory<InverseNatafEllipticalDistributionHessian> RegisteredFactory("InverseNatafEllipticalDistributionHessian");
+static const Factory<InverseNatafEllipticalDistributionHessian> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafEllipticalDistributionHessian::InverseNatafEllipticalDistributionHessian():

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionEvaluation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalDistributionEvaluation);
 
-static Factory<NatafEllipticalDistributionEvaluation> RegisteredFactory("NatafEllipticalDistributionEvaluation");
+static const Factory<NatafEllipticalDistributionEvaluation> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalDistributionEvaluation::NatafEllipticalDistributionEvaluation():

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionGradient.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalDistributionGradient);
 
-static Factory<NatafEllipticalDistributionGradient> RegisteredFactory("NatafEllipticalDistributionGradient");
+static const Factory<NatafEllipticalDistributionGradient> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalDistributionGradient::NatafEllipticalDistributionGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafEllipticalDistribution/NatafEllipticalDistributionHessian.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafEllipticalDistributionHessian);
 
-static Factory<NatafEllipticalDistributionHessian> RegisteredFactory("NatafEllipticalDistributionHessian");
+static const Factory<NatafEllipticalDistributionHessian> RegisteredFactory;
 
 /* Default constructor */
 NatafEllipticalDistributionHessian::NatafEllipticalDistributionHessian():

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/InverseNatafIndependentCopulaGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/InverseNatafIndependentCopulaGradient.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafIndependentCopulaGradient);
 
-static Factory<InverseNatafIndependentCopulaGradient> RegisteredFactory("InverseNatafIndependentCopulaGradient");
+static const Factory<InverseNatafIndependentCopulaGradient> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafIndependentCopulaGradient::InverseNatafIndependentCopulaGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/InverseNatafIndependentCopulaHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/InverseNatafIndependentCopulaHessian.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNatafIndependentCopulaHessian);
 
-static Factory<InverseNatafIndependentCopulaHessian> RegisteredFactory("InverseNatafIndependentCopulaHessian");
+static const Factory<InverseNatafIndependentCopulaHessian> RegisteredFactory;
 
 /* Default constructor */
 InverseNatafIndependentCopulaHessian::InverseNatafIndependentCopulaHessian()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaEvaluation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafIndependentCopulaEvaluation);
 
-static Factory<NatafIndependentCopulaEvaluation> RegisteredFactory("NatafIndependentCopulaEvaluation");
+static const Factory<NatafIndependentCopulaEvaluation> RegisteredFactory;
 
 /* Default constructor */
 NatafIndependentCopulaEvaluation::NatafIndependentCopulaEvaluation()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaGradient.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaGradient.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafIndependentCopulaGradient);
 
-static Factory<NatafIndependentCopulaGradient> RegisteredFactory("NatafIndependentCopulaGradient");
+static const Factory<NatafIndependentCopulaGradient> RegisteredFactory;
 
 /* Default constructor */
 NatafIndependentCopulaGradient::NatafIndependentCopulaGradient()

--- a/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaHessian.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/NatafIndependentCopula/NatafIndependentCopulaHessian.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NatafIndependentCopulaHessian);
 
-static Factory<NatafIndependentCopulaHessian> RegisteredFactory("NatafIndependentCopulaHessian");
+static const Factory<NatafIndependentCopulaHessian> RegisteredFactory;
 
 /* Default constructor */
 NatafIndependentCopulaHessian::NatafIndependentCopulaHessian()

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
@@ -40,7 +40,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BoxCoxFactory);
 
-static Factory<BoxCoxFactory> RegisteredFactory("BoxCoxFactory");
+static const Factory<BoxCoxFactory> RegisteredFactory;
 
 /* Constructor with parameters */
 BoxCoxFactory::BoxCoxFactory()

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/TrendFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/TrendFactory.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TrendFactory);
 
-// static Factory<TrendFactory> RegisteredFactory("TrendFactory");
+// static const Factory<TrendFactory> RegisteredFactory;
 
 /* Constructor with parameters */
 TrendFactory::TrendFactory(const BasisSequenceFactory & basisSequenceFactory,

--- a/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/InverseRosenblattEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/InverseRosenblattEvaluation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(InverseRosenblattEvaluation);
 
 
-static Factory<InverseRosenblattEvaluation> RegisteredFactory("InverseRosenblattEvaluation");
+static const Factory<InverseRosenblattEvaluation> RegisteredFactory;
 
 /* Default constructor */
 InverseRosenblattEvaluation::InverseRosenblattEvaluation():

--- a/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/RosenblattEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/RosenblattEvaluation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(RosenblattEvaluation);
 
 
-static Factory<RosenblattEvaluation> RegisteredFactory("RosenblattEvaluation");
+static const Factory<RosenblattEvaluation> RegisteredFactory;
 
 /* Default constructor */
 RosenblattEvaluation::RosenblattEvaluation():

--- a/lib/src/Uncertainty/Bayesian/CalibrationStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Bayesian/CalibrationStrategyImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CalibrationStrategyImplementation);
 
-static Factory<CalibrationStrategyImplementation> RegisteredFactory("CalibrationStrategyImplementation");
+static const Factory<CalibrationStrategyImplementation> RegisteredFactory;
 
 /* Default constructor */
 CalibrationStrategyImplementation::CalibrationStrategyImplementation(const Interval & range,

--- a/lib/src/Uncertainty/Bayesian/MCMC.cxx
+++ b/lib/src/Uncertainty/Bayesian/MCMC.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MCMC);
 
-static Factory<MCMC> RegisteredFactory("MCMC");
+static const Factory<MCMC> RegisteredFactory;
 
 /* Default constructor */
 MCMC::MCMC()

--- a/lib/src/Uncertainty/Bayesian/PosteriorRandomVector.cxx
+++ b/lib/src/Uncertainty/Bayesian/PosteriorRandomVector.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PosteriorRandomVector);
 
-static Factory<PosteriorRandomVector> RegisteredFactory("PosteriorRandomVector");
+static const Factory<PosteriorRandomVector> RegisteredFactory;
 
 /* Default constructor */
 PosteriorRandomVector::PosteriorRandomVector(const Sampler & sampler)

--- a/lib/src/Uncertainty/Bayesian/RandomWalkMetropolisHastings.cxx
+++ b/lib/src/Uncertainty/Bayesian/RandomWalkMetropolisHastings.cxx
@@ -29,12 +29,12 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<CalibrationStrategy>);
-static Factory<PersistentCollection<CalibrationStrategy> > RegisteredFactory2("PersistentCollection<CalibrationStrategy>");
+static const Factory<PersistentCollection<CalibrationStrategy> > RegisteredFactory2;
 
 
 CLASSNAMEINIT(RandomWalkMetropolisHastings);
 
-static Factory<RandomWalkMetropolisHastings> RegisteredFactory("RandomWalkMetropolisHastings");
+static const Factory<RandomWalkMetropolisHastings> RegisteredFactory;
 
 /* Default constructor */
 RandomWalkMetropolisHastings::RandomWalkMetropolisHastings()

--- a/lib/src/Uncertainty/Bayesian/SamplerImplementation.cxx
+++ b/lib/src/Uncertainty/Bayesian/SamplerImplementation.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SamplerImplementation);
 
-static Factory<SamplerImplementation> RegisteredFactory("SamplerImplementation");
+static const Factory<SamplerImplementation> RegisteredFactory;
 
 /* Default constructor */
 SamplerImplementation::SamplerImplementation()

--- a/lib/src/Uncertainty/Distribution/AliMikhailHaqCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/AliMikhailHaqCopula.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(AliMikhailHaqCopula);
 
-static Factory<AliMikhailHaqCopula> RegisteredFactory("AliMikhailHaqCopula");
+static const Factory<AliMikhailHaqCopula> RegisteredFactory;
 
 /* Default constructor */
 AliMikhailHaqCopula::AliMikhailHaqCopula()

--- a/lib/src/Uncertainty/Distribution/Arcsine.cxx
+++ b/lib/src/Uncertainty/Distribution/Arcsine.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Arcsine);
 
-static Factory<Arcsine> RegisteredFactory("Arcsine");
+static const Factory<Arcsine> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(BayesDistribution);
 
-static Factory<BayesDistribution> RegisteredFactory("BayesDistribution");
+static const Factory<BayesDistribution> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Bernoulli.cxx
+++ b/lib/src/Uncertainty/Distribution/Bernoulli.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Bernoulli);
 
-static Factory<Bernoulli> RegisteredFactory("Bernoulli");
+static const Factory<Bernoulli> RegisteredFactory;
 
 /* Default constructor */
 Bernoulli::Bernoulli()

--- a/lib/src/Uncertainty/Distribution/Beta.cxx
+++ b/lib/src/Uncertainty/Distribution/Beta.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Beta);
 
-static Factory<Beta> RegisteredFactory("Beta");
+static const Factory<Beta> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Binomial.cxx
+++ b/lib/src/Uncertainty/Distribution/Binomial.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Binomial);
 
-static Factory<Binomial> RegisteredFactory("Binomial");
+static const Factory<Binomial> RegisteredFactory;
 
 /* Default constructor */
 Binomial::Binomial()

--- a/lib/src/Uncertainty/Distribution/Burr.cxx
+++ b/lib/src/Uncertainty/Distribution/Burr.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Burr);
 
-static Factory<Burr> RegisteredFactory("Burr");
+static const Factory<Burr> RegisteredFactory;
 
 /* Default constructor */
 Burr::Burr()

--- a/lib/src/Uncertainty/Distribution/Chi.cxx
+++ b/lib/src/Uncertainty/Distribution/Chi.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Chi);
 
-static Factory<Chi> RegisteredFactory("Chi");
+static const Factory<Chi> RegisteredFactory;
 
 /* Default constructor */
 Chi::Chi()

--- a/lib/src/Uncertainty/Distribution/ChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/ChiSquare.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ChiSquare);
 
-static Factory<ChiSquare> RegisteredFactory("ChiSquare");
+static const Factory<ChiSquare> RegisteredFactory;
 
 /* Default constructor */
 ChiSquare::ChiSquare()

--- a/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ClaytonCopula);
 
-static Factory<ClaytonCopula> RegisteredFactory("ClaytonCopula");
+static const Factory<ClaytonCopula> RegisteredFactory;
 
 /* Default constructor */
 ClaytonCopula::ClaytonCopula()

--- a/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
@@ -33,11 +33,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<Copula>);
-static Factory<PersistentCollection<Copula> > RegisteredFactory2("PersistentCollection<Copula>");
+static const Factory<PersistentCollection<Copula> > RegisteredFactory2;
 
 CLASSNAMEINIT(ComposedCopula);
 
-static Factory<ComposedCopula> RegisteredFactory("ComposedCopula");
+static const Factory<ComposedCopula> RegisteredFactory;
 
 /* Default constructor */
 ComposedCopula::ComposedCopula()

--- a/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
@@ -44,7 +44,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ComposedDistribution);
 
-static Factory<ComposedDistribution> RegisteredFactory("ComposedDistribution");
+static const Factory<ComposedDistribution> RegisteredFactory;
 
 /* Default constructor */
 ComposedDistribution::ComposedDistribution()

--- a/lib/src/Uncertainty/Distribution/CompositeDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/CompositeDistribution.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CompositeDistribution);
 
-static Factory<CompositeDistribution> RegisteredFactory("CompositeDistribution");
+static const Factory<CompositeDistribution> RegisteredFactory;
 
 /* Default constructor */
 CompositeDistribution::CompositeDistribution()

--- a/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConditionalDistribution);
 
-static Factory<ConditionalDistribution> RegisteredFactory("ConditionalDistribution");
+static const Factory<ConditionalDistribution> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Dirac.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirac.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Dirac);
 
-static Factory<Dirac> RegisteredFactory("Dirac");
+static const Factory<Dirac> RegisteredFactory;
 
 /* Default constructor */
 Dirac::Dirac()

--- a/lib/src/Uncertainty/Distribution/Dirichlet.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirichlet.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Dirichlet);
 
-static Factory<Dirichlet> RegisteredFactory("Dirichlet");
+static const Factory<Dirichlet> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Epanechnikov.cxx
+++ b/lib/src/Uncertainty/Distribution/Epanechnikov.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Epanechnikov);
 
-static Factory<Epanechnikov> RegisteredFactory("Epanechnikov");
+static const Factory<Epanechnikov> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Exponential.cxx
+++ b/lib/src/Uncertainty/Distribution/Exponential.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Exponential);
 
-static Factory<Exponential> RegisteredFactory("Exponential");
+static const Factory<Exponential> RegisteredFactory;
 
 /* Default constructor */
 Exponential::Exponential()

--- a/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FarlieGumbelMorgensternCopula);
 
-static Factory<FarlieGumbelMorgensternCopula> RegisteredFactory("FarlieGumbelMorgensternCopula");
+static const Factory<FarlieGumbelMorgensternCopula> RegisteredFactory;
 
 /* Default constructor */
 FarlieGumbelMorgensternCopula::FarlieGumbelMorgensternCopula()

--- a/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FisherSnedecor);
 
-static Factory<FisherSnedecor> RegisteredFactory("FisherSnedecor");
+static const Factory<FisherSnedecor> RegisteredFactory;
 
 /* Default constructor */
 FisherSnedecor::FisherSnedecor()

--- a/lib/src/Uncertainty/Distribution/FrankCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/FrankCopula.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FrankCopula);
 
-static Factory<FrankCopula> RegisteredFactory("FrankCopula");
+static const Factory<FrankCopula> RegisteredFactory;
 
 /* Default constructor */
 FrankCopula::FrankCopula()

--- a/lib/src/Uncertainty/Distribution/Frechet.cxx
+++ b/lib/src/Uncertainty/Distribution/Frechet.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Frechet);
 
-static Factory<Frechet> RegisteredFactory("Frechet");
+static const Factory<Frechet> RegisteredFactory;
 
 /* Parameters constructor */
 Frechet::Frechet(const NumericalScalar alpha,

--- a/lib/src/Uncertainty/Distribution/Gamma.cxx
+++ b/lib/src/Uncertainty/Distribution/Gamma.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Gamma);
 
-static Factory<Gamma> RegisteredFactory("Gamma");
+static const Factory<Gamma> RegisteredFactory;
 
 /* Default constructor */
 Gamma::Gamma()

--- a/lib/src/Uncertainty/Distribution/GammaMuSigma.cxx
+++ b/lib/src/Uncertainty/Distribution/GammaMuSigma.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GammaMuSigma);
 
-static Factory<GammaMuSigma> RegisteredFactory("GammaMuSigma");
+static const Factory<GammaMuSigma> RegisteredFactory;
 
 /* Default constructor */
 GammaMuSigma::GammaMuSigma()

--- a/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
+++ b/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GeneralizedPareto);
 
-static Factory<GeneralizedPareto> RegisteredFactory("GeneralizedPareto");
+static const Factory<GeneralizedPareto> RegisteredFactory;
 
 /* Default constructor */
 GeneralizedPareto::GeneralizedPareto()

--- a/lib/src/Uncertainty/Distribution/Geometric.cxx
+++ b/lib/src/Uncertainty/Distribution/Geometric.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Geometric);
 
-static Factory<Geometric> RegisteredFactory("Geometric");
+static const Factory<Geometric> RegisteredFactory;
 
 /* Default constructor */
 Geometric::Geometric()

--- a/lib/src/Uncertainty/Distribution/Gumbel.cxx
+++ b/lib/src/Uncertainty/Distribution/Gumbel.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Gumbel);
 
-static Factory<Gumbel> RegisteredFactory("Gumbel");
+static const Factory<Gumbel> RegisteredFactory;
 
 /* Default constructor */
 Gumbel::Gumbel()

--- a/lib/src/Uncertainty/Distribution/GumbelCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/GumbelCopula.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(GumbelCopula);
 
-static Factory<GumbelCopula> RegisteredFactory("GumbelCopula");
+static const Factory<GumbelCopula> RegisteredFactory;
 
 /* Default constructor */
 GumbelCopula::GumbelCopula()

--- a/lib/src/Uncertainty/Distribution/Histogram.cxx
+++ b/lib/src/Uncertainty/Distribution/Histogram.cxx
@@ -29,11 +29,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<HistogramPair>);
-static Factory<PersistentCollection<HistogramPair> > RegisteredFactory("PersistentCollection<HistogramPair>");
+static const Factory<PersistentCollection<HistogramPair> > RegisteredFactory;
 
 CLASSNAMEINIT(Histogram);
 
-static Factory<Histogram> RegisteredFactory_alt("Histogram");
+static const Factory<Histogram> RegisteredFactory_alt;
 
 /* Default constructor */
 Histogram::Histogram()

--- a/lib/src/Uncertainty/Distribution/HistogramPair.cxx
+++ b/lib/src/Uncertainty/Distribution/HistogramPair.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HistogramPair);
 
-static Factory<HistogramPair> RegisteredFactory("HistogramPair");
+static const Factory<HistogramPair> RegisteredFactory;
 
 /* Default constructor */
 HistogramPair::HistogramPair()

--- a/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
@@ -35,7 +35,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(IndependentCopula);
 
-static Factory<IndependentCopula> RegisteredFactory("IndependentCopula");
+static const Factory<IndependentCopula> RegisteredFactory;
 
 /* Default constructor */
 IndependentCopula::IndependentCopula(const UnsignedInteger dimension)

--- a/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseChiSquare);
 
-static Factory<InverseChiSquare> RegisteredFactory("InverseChiSquare");
+static const Factory<InverseChiSquare> RegisteredFactory;
 
 /* Default constructor */
 InverseChiSquare::InverseChiSquare()

--- a/lib/src/Uncertainty/Distribution/InverseGamma.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseGamma.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseGamma);
 
-static Factory<InverseGamma> RegisteredFactory("InverseGamma");
+static const Factory<InverseGamma> RegisteredFactory;
 
 /* Default constructor */
 InverseGamma::InverseGamma()

--- a/lib/src/Uncertainty/Distribution/InverseNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseNormal.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseNormal);
 
-static Factory<InverseNormal> RegisteredFactory("InverseNormal");
+static const Factory<InverseNormal> RegisteredFactory;
 
 /* Default constructor */
 InverseNormal::InverseNormal()

--- a/lib/src/Uncertainty/Distribution/InverseWishart.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseWishart.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(InverseWishart);
 
-static Factory<InverseWishart> RegisteredFactory("InverseWishart");
+static const Factory<InverseWishart> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
@@ -37,7 +37,7 @@ typedef Collection<UnsignedInteger>     UnsignedIntegerCollection;
 
 CLASSNAMEINIT(KPermutationsDistribution);
 
-static Factory<KPermutationsDistribution> RegisteredFactory("KPermutationsDistribution");
+static const Factory<KPermutationsDistribution> RegisteredFactory;
 
 /* Default constructor */
 KPermutationsDistribution::KPermutationsDistribution()

--- a/lib/src/Uncertainty/Distribution/KernelMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelMixture.cxx
@@ -35,7 +35,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KernelMixture);
 
-static Factory<KernelMixture> RegisteredFactory("KernelMixture");
+static const Factory<KernelMixture> RegisteredFactory;
 
 /* Default constructor */
 KernelMixture::KernelMixture()

--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -45,7 +45,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KernelSmoothing);
 
-static Factory<KernelSmoothing> RegisteredFactory("KernelSmoothing");
+static const Factory<KernelSmoothing> RegisteredFactory;
 
 /* Default constructor */
 KernelSmoothing::KernelSmoothing()

--- a/lib/src/Uncertainty/Distribution/Laplace.cxx
+++ b/lib/src/Uncertainty/Distribution/Laplace.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Laplace);
 
-static Factory<Laplace> RegisteredFactory("Laplace");
+static const Factory<Laplace> RegisteredFactory;
 
 /* Default constructor */
 Laplace::Laplace()

--- a/lib/src/Uncertainty/Distribution/LogNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/LogNormal.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LogNormal);
 
-static Factory<LogNormal> RegisteredFactory("LogNormal");
+static const Factory<LogNormal> RegisteredFactory;
 
 /* Default constructor */
 LogNormal::LogNormal()

--- a/lib/src/Uncertainty/Distribution/LogUniform.cxx
+++ b/lib/src/Uncertainty/Distribution/LogUniform.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(LogUniform);
 
-static Factory<LogUniform> RegisteredFactory("LogUniform");
+static const Factory<LogUniform> RegisteredFactory;
 
 /* Default constructor */
 LogUniform::LogUniform()

--- a/lib/src/Uncertainty/Distribution/Logistic.cxx
+++ b/lib/src/Uncertainty/Distribution/Logistic.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Logistic);
 
-static Factory<Logistic> RegisteredFactory("Logistic");
+static const Factory<Logistic> RegisteredFactory;
 
 /* Default constructor */
 Logistic::Logistic()

--- a/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MarginalDistribution);
 
-static Factory<MarginalDistribution> RegisteredFactory("MarginalDistribution");
+static const Factory<MarginalDistribution> RegisteredFactory;
 
 /* Default constructor */
 MarginalDistribution::MarginalDistribution()

--- a/lib/src/Uncertainty/Distribution/MaximumDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumDistribution.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MaximumDistribution);
 
-static Factory<MaximumDistribution> RegisteredFactory("MaximumDistribution");
+static const Factory<MaximumDistribution> RegisteredFactory;
 
 /* Default constructor */
 MaximumDistribution::MaximumDistribution()

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MaximumEntropyOrderStatisticsCopula);
 
-static Factory<MaximumEntropyOrderStatisticsCopula> RegisteredFactory("MaximumEntropyOrderStatisticsCopula");
+static const Factory<MaximumEntropyOrderStatisticsCopula> RegisteredFactory;
 
 /* Default constructor */
 MaximumEntropyOrderStatisticsCopula::MaximumEntropyOrderStatisticsCopula()

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MaximumEntropyOrderStatisticsDistribution);
 
-static Factory<MaximumEntropyOrderStatisticsDistribution> RegisteredFactory("MaximumEntropyOrderStatisticsDistribution");
+static const Factory<MaximumEntropyOrderStatisticsDistribution> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MeixnerDistribution);
 
-static Factory<MeixnerDistribution> RegisteredFactory("MeixnerDistribution");
+static const Factory<MeixnerDistribution> RegisteredFactory;
 
 /* Default constructor */
 MeixnerDistribution::MeixnerDistribution()

--- a/lib/src/Uncertainty/Distribution/MinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/MinCopula.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(MinCopula);
 
-static Factory<MinCopula> RegisteredFactory("MinCopula");
+static const Factory<MinCopula> RegisteredFactory;
 
 /* Default constructor */
 MinCopula::MinCopula(const UnsignedInteger dim)

--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Mixture);
 
-static Factory<Mixture> RegisteredFactory("Mixture");
+static const Factory<Mixture> RegisteredFactory;
 
 /* Default constructor */
 Mixture::Mixture()

--- a/lib/src/Uncertainty/Distribution/Multinomial.cxx
+++ b/lib/src/Uncertainty/Distribution/Multinomial.cxx
@@ -38,7 +38,7 @@ typedef Collection<UnsignedInteger>     UnsignedIntegerCollection;
 
 CLASSNAMEINIT(Multinomial);
 
-static Factory<Multinomial> RegisteredFactory("Multinomial");
+static const Factory<Multinomial> RegisteredFactory;
 
 /* Default constructor */
 Multinomial::Multinomial()

--- a/lib/src/Uncertainty/Distribution/NegativeBinomial.cxx
+++ b/lib/src/Uncertainty/Distribution/NegativeBinomial.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NegativeBinomial);
 
-static Factory<NegativeBinomial> RegisteredFactory("NegativeBinomial");
+static const Factory<NegativeBinomial> RegisteredFactory;
 
 /* Default constructor */
 NegativeBinomial::NegativeBinomial()

--- a/lib/src/Uncertainty/Distribution/NonCentralChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/NonCentralChiSquare.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NonCentralChiSquare);
 
-static Factory<NonCentralChiSquare> RegisteredFactory("NonCentralChiSquare");
+static const Factory<NonCentralChiSquare> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
+++ b/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NonCentralStudent);
 
-static Factory<NonCentralStudent> RegisteredFactory("NonCentralStudent");
+static const Factory<NonCentralStudent> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -40,7 +40,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Normal);
 
-static Factory<Normal> RegisteredFactory("Normal");
+static const Factory<Normal> RegisteredFactory;
 
 /* Constructor for multiD standard normal distribution */
 Normal::Normal(const UnsignedInteger dimension)

--- a/lib/src/Uncertainty/Distribution/NormalCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/NormalCopula.cxx
@@ -40,7 +40,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NormalCopula);
 
-static Factory<NormalCopula> RegisteredFactory("NormalCopula");
+static const Factory<NormalCopula> RegisteredFactory;
 
 /* Default constructor */
 NormalCopula::NormalCopula(const UnsignedInteger dim)

--- a/lib/src/Uncertainty/Distribution/NormalGamma.cxx
+++ b/lib/src/Uncertainty/Distribution/NormalGamma.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(NormalGamma);
 
-static Factory<NormalGamma> RegisteredFactory("NormalGamma");
+static const Factory<NormalGamma> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/OrdinalSumCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/OrdinalSumCopula.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(OrdinalSumCopula);
 
-static Factory<OrdinalSumCopula> RegisteredFactory("OrdinalSumCopula");
+static const Factory<OrdinalSumCopula> RegisteredFactory;
 
 /* Default constructor */
 OrdinalSumCopula::OrdinalSumCopula()

--- a/lib/src/Uncertainty/Distribution/ParametrizedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ParametrizedDistribution.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ParametrizedDistribution);
 
-static Factory<ParametrizedDistribution> RegisteredFactory("ParametrizedDistribution");
+static const Factory<ParametrizedDistribution> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Poisson.cxx
+++ b/lib/src/Uncertainty/Distribution/Poisson.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Poisson);
 
-static Factory<Poisson> RegisteredFactory("Poisson");
+static const Factory<Poisson> RegisteredFactory;
 
 /* Default constructor */
 Poisson::Poisson()

--- a/lib/src/Uncertainty/Distribution/PosteriorDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/PosteriorDistribution.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PosteriorDistribution);
 
-static Factory<PosteriorDistribution> RegisteredFactory("PosteriorDistribution");
+static const Factory<PosteriorDistribution> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/ProductDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ProductDistribution.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProductDistribution);
 
-static Factory<ProductDistribution> RegisteredFactory("ProductDistribution");
+static const Factory<ProductDistribution> RegisteredFactory;
 
 /* Default constructor */
 ProductDistribution::ProductDistribution()

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -43,7 +43,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<Distribution>);
-static Factory<PersistentCollection<Distribution> > RegisteredFactory3("PersistentCollection<Distribution>");
+static const Factory<PersistentCollection<Distribution> > RegisteredFactory3;
 
 
 typedef Collection<Distribution> DistributionCollection;
@@ -53,7 +53,7 @@ typedef Collection<NumericalComplex> NumericalComplexCollection;
 
 CLASSNAMEINIT(RandomMixture);
 
-static Factory<RandomMixture> RegisteredFactory("RandomMixture");
+static const Factory<RandomMixture> RegisteredFactory;
 
 /* Default constructor */
 RandomMixture::RandomMixture(const DistributionCollection & coll,

--- a/lib/src/Uncertainty/Distribution/RatioDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/RatioDistribution.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RatioDistribution);
 
-static Factory<RatioDistribution> RegisteredFactory("RatioDistribution");
+static const Factory<RatioDistribution> RegisteredFactory;
 
 /* Default constructor */
 RatioDistribution::RatioDistribution()

--- a/lib/src/Uncertainty/Distribution/Rayleigh.cxx
+++ b/lib/src/Uncertainty/Distribution/Rayleigh.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Rayleigh);
 
-static Factory<Rayleigh> RegisteredFactory("Rayleigh");
+static const Factory<Rayleigh> RegisteredFactory;
 
 /* Default constructor */
 Rayleigh::Rayleigh()

--- a/lib/src/Uncertainty/Distribution/Rice.cxx
+++ b/lib/src/Uncertainty/Distribution/Rice.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Rice);
 
-static Factory<Rice> RegisteredFactory("Rice");
+static const Factory<Rice> RegisteredFactory;
 
 /* Default constructor */
 Rice::Rice()

--- a/lib/src/Uncertainty/Distribution/Skellam.cxx
+++ b/lib/src/Uncertainty/Distribution/Skellam.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Skellam);
 
-static Factory<Skellam> RegisteredFactory("Skellam");
+static const Factory<Skellam> RegisteredFactory;
 
 /* Default constructor */
 Skellam::Skellam()

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -39,7 +39,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Student);
 
-static Factory<Student> RegisteredFactory("Student");
+static const Factory<Student> RegisteredFactory;
 
 /* Default constructor */
 Student::Student(const NumericalScalar nu,

--- a/lib/src/Uncertainty/Distribution/SubSquareCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/SubSquareCopula.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(SubSquareCopula);
 
-static Factory<SubSquareCopula> RegisteredFactory("SubSquareCopula");
+static const Factory<SubSquareCopula> RegisteredFactory;
 
 /* Default constructor */
 SubSquareCopula::SubSquareCopula()

--- a/lib/src/Uncertainty/Distribution/TracyWidomGOE.cxx
+++ b/lib/src/Uncertainty/Distribution/TracyWidomGOE.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TracyWidomGOE);
 
-static Factory<TracyWidomGOE> RegisteredFactory("TracyWidomGOE");
+static const Factory<TracyWidomGOE> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/TracyWidomGSE.cxx
+++ b/lib/src/Uncertainty/Distribution/TracyWidomGSE.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TracyWidomGSE);
 
-static Factory<TracyWidomGSE> RegisteredFactory("TracyWidomGSE");
+static const Factory<TracyWidomGSE> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/TracyWidomGUE.cxx
+++ b/lib/src/Uncertainty/Distribution/TracyWidomGUE.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TracyWidomGUE);
 
-static Factory<TracyWidomGUE> RegisteredFactory("TracyWidomGUE");
+static const Factory<TracyWidomGUE> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
+++ b/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Trapezoidal);
 
-static Factory<Trapezoidal> RegisteredFactory("Trapezoidal");
+static const Factory<Trapezoidal> RegisteredFactory;
 
 /* Default constructor */
 Trapezoidal::Trapezoidal()

--- a/lib/src/Uncertainty/Distribution/Triangular.cxx
+++ b/lib/src/Uncertainty/Distribution/Triangular.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Triangular);
 
-static Factory<Triangular> RegisteredFactory("Triangular");
+static const Factory<Triangular> RegisteredFactory;
 
 /* Default constructor */
 Triangular::Triangular()

--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TruncatedDistribution);
 
-static Factory<TruncatedDistribution> RegisteredFactory("TruncatedDistribution");
+static const Factory<TruncatedDistribution> RegisteredFactory;
 
 /* Default constructor */
 TruncatedDistribution::TruncatedDistribution()

--- a/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TruncatedNormal);
 
-static Factory<TruncatedNormal> RegisteredFactory("TruncatedNormal");
+static const Factory<TruncatedNormal> RegisteredFactory;
 
 /* Default onstructor */
 TruncatedNormal::TruncatedNormal()

--- a/lib/src/Uncertainty/Distribution/Uniform.cxx
+++ b/lib/src/Uncertainty/Distribution/Uniform.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Uniform);
 
-static Factory<Uniform> RegisteredFactory("Uniform");
+static const Factory<Uniform> RegisteredFactory;
 
 /* Default constructor */
 Uniform::Uniform()

--- a/lib/src/Uncertainty/Distribution/UserDefined.cxx
+++ b/lib/src/Uncertainty/Distribution/UserDefined.cxx
@@ -28,10 +28,10 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<UserDefinedPair>);
-static Factory<PersistentCollection<UserDefinedPair> > RegisteredFactory("PersistentCollection<UserDefinedPair>");
+static const Factory<PersistentCollection<UserDefinedPair> > RegisteredFactory;
 
 CLASSNAMEINIT(UserDefined);
-static Factory<UserDefined> RegisteredFactory_alt2("UserDefined");
+static const Factory<UserDefined> RegisteredFactory_alt2;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/UserDefinedPair.cxx
+++ b/lib/src/Uncertainty/Distribution/UserDefinedPair.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(UserDefinedPair);
 
 
-static Factory<UserDefinedPair> RegisteredFactory("UserDefinedPair");
+static const Factory<UserDefinedPair> RegisteredFactory;
 
 /* Default constructor */
 UserDefinedPair::UserDefinedPair()

--- a/lib/src/Uncertainty/Distribution/VonMises.cxx
+++ b/lib/src/Uncertainty/Distribution/VonMises.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(VonMises);
 
-static Factory<VonMises> RegisteredFactory("VonMises");
+static const Factory<VonMises> RegisteredFactory;
 
 /* Default constructor */
 VonMises::VonMises()

--- a/lib/src/Uncertainty/Distribution/Weibull.cxx
+++ b/lib/src/Uncertainty/Distribution/Weibull.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Weibull);
 
-static Factory<Weibull> RegisteredFactory("Weibull");
+static const Factory<Weibull> RegisteredFactory;
 
 /* Default constructor */
 Weibull::Weibull()

--- a/lib/src/Uncertainty/Distribution/Wishart.cxx
+++ b/lib/src/Uncertainty/Distribution/Wishart.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(Wishart);
 
-static Factory<Wishart> RegisteredFactory("Wishart");
+static const Factory<Wishart> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Distribution/ZipfMandelbrot.cxx
+++ b/lib/src/Uncertainty/Distribution/ZipfMandelbrot.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ZipfMandelbrot);
 
-static Factory<ZipfMandelbrot> RegisteredFactory("ZipfMandelbrot");
+static const Factory<ZipfMandelbrot> RegisteredFactory;
 
 /* Default constructor */
 ZipfMandelbrot::ZipfMandelbrot()

--- a/lib/src/Uncertainty/Model/CompositeRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/CompositeRandomVector.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CompositeRandomVector);
 
-static Factory<CompositeRandomVector> RegisteredFactory("CompositeRandomVector");
+static const Factory<CompositeRandomVector> RegisteredFactory;
 
 /* Standard constructor */
 CompositeRandomVector::CompositeRandomVector()

--- a/lib/src/Uncertainty/Model/ConditionalRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/ConditionalRandomVector.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConditionalRandomVector);
 
-static Factory<ConditionalRandomVector> RegisteredFactory("ConditionalRandomVector");
+static const Factory<ConditionalRandomVector> RegisteredFactory;
 
 /* Default constructor */
 ConditionalRandomVector::ConditionalRandomVector(const Distribution & distribution,

--- a/lib/src/Uncertainty/Model/ConstantRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/ConstantRandomVector.cxx
@@ -30,7 +30,7 @@ typedef Collection<UserDefinedPair>              UserDefinedPairCollection;
 
 CLASSNAMEINIT(ConstantRandomVector);
 
-static Factory<ConstantRandomVector> RegisteredFactory("ConstantRandomVector");
+static const Factory<ConstantRandomVector> RegisteredFactory;
 
 /* Default constructor */
 ConstantRandomVector::ConstantRandomVector(const NumericalPointWithDescription & point)

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -79,7 +79,7 @@ typedef NumericalMathFunctionImplementation::GradientImplementation   GradientIm
 typedef NumericalMathFunctionImplementation::HessianImplementation    HessianImplementation;
 typedef Collection<Distribution>                                      DistributionCollection;
 
-static Factory<DistributionImplementation> RegisteredFactory("DistributionImplementation");
+static const Factory<DistributionImplementation> RegisteredFactory;
 
 /* Default constructor */
 DistributionImplementation::DistributionImplementation()

--- a/lib/src/Uncertainty/Model/DistributionParametersImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionParametersImplementation.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DistributionParametersImplementation);
 
-// static Factory<DistributionParametersImplementation> RegisteredFactory("DistributionParametersImplementation");
+// static const Factory<DistributionParametersImplementation> RegisteredFactory;
 
 /* Default constructor */
 DistributionParametersImplementation::DistributionParametersImplementation()

--- a/lib/src/Uncertainty/Model/EllipticalDistribution.cxx
+++ b/lib/src/Uncertainty/Model/EllipticalDistribution.cxx
@@ -37,7 +37,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(EllipticalDistribution);
 
-static Factory<EllipticalDistribution> RegisteredFactory("EllipticalDistribution");
+static const Factory<EllipticalDistribution> RegisteredFactory;
 
 /* Default constructor */
 EllipticalDistribution::EllipticalDistribution()

--- a/lib/src/Uncertainty/Model/EventDomainImplementation.cxx
+++ b/lib/src/Uncertainty/Model/EventDomainImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(EventDomainImplementation);
 
-static Factory<EventDomainImplementation> RegisteredFactory("EventDomainImplementation");
+static const Factory<EventDomainImplementation> RegisteredFactory;
 /* Default constructor */
 EventDomainImplementation::EventDomainImplementation()
   : CompositeRandomVector()

--- a/lib/src/Uncertainty/Model/EventProcess.cxx
+++ b/lib/src/Uncertainty/Model/EventProcess.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(EventProcess);
 
-static Factory<EventProcess> RegisteredFactory("EventProcess");
+static const Factory<EventProcess> RegisteredFactory;
 
 /* Default constructor */
 EventProcess::EventProcess()

--- a/lib/src/Uncertainty/Model/EventRandomVectorImplementation.cxx
+++ b/lib/src/Uncertainty/Model/EventRandomVectorImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(EventRandomVectorImplementation);
 
-static Factory<EventRandomVectorImplementation> RegisteredFactory("EventRandomVectorImplementation");
+static const Factory<EventRandomVectorImplementation> RegisteredFactory;
 
 /* Default constructor */
 EventRandomVectorImplementation::EventRandomVectorImplementation()

--- a/lib/src/Uncertainty/Model/FunctionalChaosRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/FunctionalChaosRandomVector.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FunctionalChaosRandomVector);
 
-static Factory<FunctionalChaosRandomVector> RegisteredFactory("FunctionalChaosRandomVector");
+static const Factory<FunctionalChaosRandomVector> RegisteredFactory;
 
 /* Default constructor */
 FunctionalChaosRandomVector::FunctionalChaosRandomVector(const FunctionalChaosResult & functionalChaosResult)

--- a/lib/src/Uncertainty/Model/KrigingRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/KrigingRandomVector.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(KrigingRandomVector);
 
-static Factory<KrigingRandomVector> RegisteredFactory("KrigingRandomVector");
+static const Factory<KrigingRandomVector> RegisteredFactory;
 
 /* Default constructor */
 KrigingRandomVector::KrigingRandomVector(const KrigingResult & krigingResult,

--- a/lib/src/Uncertainty/Model/ProcessImplementation.cxx
+++ b/lib/src/Uncertainty/Model/ProcessImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ProcessImplementation);
 
-static Factory<ProcessImplementation> RegisteredFactory("ProcessImplementation");
+static const Factory<ProcessImplementation> RegisteredFactory;
 
 /* Default constructor */
 ProcessImplementation::ProcessImplementation()

--- a/lib/src/Uncertainty/Model/RandomVectorImplementation.cxx
+++ b/lib/src/Uncertainty/Model/RandomVectorImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RandomVectorImplementation);
 
-static Factory<RandomVectorImplementation> RegisteredFactory("RandomVectorImplementation");
+static const Factory<RandomVectorImplementation> RegisteredFactory;
 
 /* Default constructor */
 RandomVectorImplementation::RandomVectorImplementation()

--- a/lib/src/Uncertainty/Model/SklarCopula.cxx
+++ b/lib/src/Uncertainty/Model/SklarCopula.cxx
@@ -40,7 +40,7 @@ typedef NumericalMathFunctionImplementation::HessianImplementation    HessianImp
 
 CLASSNAMEINIT(SklarCopula);
 
-static Factory<SklarCopula> RegisteredFactory("SklarCopula");
+static const Factory<SklarCopula> RegisteredFactory;
 
 /* Default constructor */
 SklarCopula::SklarCopula()

--- a/lib/src/Uncertainty/Model/UsualRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/UsualRandomVector.cxx
@@ -25,7 +25,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(UsualRandomVector);
 
-static Factory<UsualRandomVector> RegisteredFactory("UsualRandomVector");
+static const Factory<UsualRandomVector> RegisteredFactory;
 
 /* Default constructor */
 UsualRandomVector::UsualRandomVector(const Distribution & distribution)

--- a/lib/src/Uncertainty/Process/ARMA.cxx
+++ b/lib/src/Uncertainty/Process/ARMA.cxx
@@ -33,7 +33,7 @@ typedef Collection< NumericalComplex >         NumericalComplexCollection;
 
 CLASSNAMEINIT(ARMA);
 
-static Factory<ARMA> RegisteredFactory("ARMA");
+static const Factory<ARMA> RegisteredFactory;
 
 ARMA::ARMA()
   : ProcessImplementation()

--- a/lib/src/Uncertainty/Process/ARMACoefficients.cxx
+++ b/lib/src/Uncertainty/Process/ARMACoefficients.cxx
@@ -26,10 +26,10 @@ BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< ARMACoefficients >);
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< SquareMatrix >);
-static Factory< PersistentCollection< SquareMatrix > > RegisteredFactory1("PersistentCollection<SquareMatrix>");
+static const Factory<PersistentCollection<SquareMatrix> > RegisteredFactory1;
 
 CLASSNAMEINIT(ARMACoefficients);
-static Factory<ARMACoefficients> RegisteredFactory("ARMACoefficients");
+static const Factory<ARMACoefficients> RegisteredFactory;
 
 /* Default constructor */
 ARMACoefficients::ARMACoefficients(const UnsignedInteger & size,

--- a/lib/src/Uncertainty/Process/ARMAFactoryImplementation.cxx
+++ b/lib/src/Uncertainty/Process/ARMAFactoryImplementation.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ARMAFactoryImplementation);
 
-static Factory<ARMAFactoryImplementation> RegisteredFactory("ARMAFactoryImplementation");
+static const Factory<ARMAFactoryImplementation> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Process/ARMALikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Process/ARMALikelihoodFactory.cxx
@@ -37,7 +37,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ARMALikelihoodFactory);
 
-static Factory<ARMALikelihoodFactory> RegisteredFactory("ARMALikelihoodFactory");
+static const Factory<ARMALikelihoodFactory> RegisteredFactory;
 
 static int modifiedCholeskyDecomposition(SquareMatrix &matrix,
     NumericalScalar epsilon);

--- a/lib/src/Uncertainty/Process/ARMAState.cxx
+++ b/lib/src/Uncertainty/Process/ARMAState.cxx
@@ -25,7 +25,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ARMAState);
-static Factory<ARMAState> RegisteredFactory("ARMAState");
+static const Factory<ARMAState> RegisteredFactory;
 
 /* Default constructor */
 ARMAState::ARMAState()

--- a/lib/src/Uncertainty/Process/AggregatedProcess.cxx
+++ b/lib/src/Uncertainty/Process/AggregatedProcess.cxx
@@ -29,8 +29,8 @@ BEGIN_NAMESPACE_OPENTURNS
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< Process >);
 CLASSNAMEINIT(AggregatedProcess);
 
-static Factory<AggregatedProcess> RegisteredFactory("AggregatedProcess");
-static Factory< PersistentCollection< Process > > RegisteredFactory1("PersistentCollection<Process>");
+static const Factory<AggregatedProcess> RegisteredFactory;
+static const Factory<PersistentCollection<Process> > RegisteredFactory1;
 
 AggregatedProcess::AggregatedProcess()
   : ProcessImplementation()

--- a/lib/src/Uncertainty/Process/CompositeProcess.cxx
+++ b/lib/src/Uncertainty/Process/CompositeProcess.cxx
@@ -28,7 +28,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(CompositeProcess);
 
-static Factory<CompositeProcess> RegisteredFactory("CompositeProcess");
+static const Factory<CompositeProcess> RegisteredFactory;
 
 CompositeProcess::CompositeProcess()
   : ProcessImplementation()

--- a/lib/src/Uncertainty/Process/ConditionedNormalProcess.cxx
+++ b/lib/src/Uncertainty/Process/ConditionedNormalProcess.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(ConditionedNormalProcess);
 
-static Factory<ConditionedNormalProcess> RegisteredFactory("ConditionedNormalProcess");
+static const Factory<ConditionedNormalProcess> RegisteredFactory;
 
 ConditionedNormalProcess::ConditionedNormalProcess()
   : TemporalNormalProcess()

--- a/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
+++ b/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(FunctionalBasisProcess);
 
-static Factory<FunctionalBasisProcess> RegisteredFactory("FunctionalBasisProcess");
+static const Factory<FunctionalBasisProcess> RegisteredFactory;
 
 /* Standard constructor */
 FunctionalBasisProcess::FunctionalBasisProcess()

--- a/lib/src/Uncertainty/Process/RandomWalk.cxx
+++ b/lib/src/Uncertainty/Process/RandomWalk.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(RandomWalk);
 
-static Factory<RandomWalk> RegisteredFactory("RandomWalk");
+static const Factory<RandomWalk> RegisteredFactory;
 
 /* Standard constructor */
 RandomWalk::RandomWalk()

--- a/lib/src/Uncertainty/Process/SpectralNormalProcess.cxx
+++ b/lib/src/Uncertainty/Process/SpectralNormalProcess.cxx
@@ -29,11 +29,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection< TriangularComplexMatrix >);
-static Factory< PersistentCollection< TriangularComplexMatrix > > RegisteredFactory1("PersistentCollection< TriangularComplexMatrix >");
+static const Factory<PersistentCollection<TriangularComplexMatrix> > RegisteredFactory1;
 
 CLASSNAMEINIT(SpectralNormalProcess);
 
-static Factory<SpectralNormalProcess> RegisteredFactory("SpectralNormalProcess");
+static const Factory<SpectralNormalProcess> RegisteredFactory;
 
 SpectralNormalProcess::SpectralNormalProcess()
   : ProcessImplementation()

--- a/lib/src/Uncertainty/Process/TemporalNormalProcess.cxx
+++ b/lib/src/Uncertainty/Process/TemporalNormalProcess.cxx
@@ -34,7 +34,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(TemporalNormalProcess);
 
-static Factory<TemporalNormalProcess> RegisteredFactory("TemporalNormalProcess");
+static const Factory<TemporalNormalProcess> RegisteredFactory;
 
 TemporalNormalProcess::TemporalNormalProcess()
   : ProcessImplementation()

--- a/lib/src/Uncertainty/Process/WhiteNoise.cxx
+++ b/lib/src/Uncertainty/Process/WhiteNoise.cxx
@@ -29,7 +29,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(WhiteNoise);
 
-static Factory<WhiteNoise> RegisteredFactory("WhiteNoise");
+static const Factory<WhiteNoise> RegisteredFactory;
 
 /* Standard constructor */
 WhiteNoise::WhiteNoise()

--- a/lib/src/Uncertainty/Process/WhittleFactory.cxx
+++ b/lib/src/Uncertainty/Process/WhittleFactory.cxx
@@ -34,11 +34,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 TEMPLATE_CLASSNAMEINIT(PersistentCollection<WhittleFactoryState>);
-static Factory<PersistentCollection<WhittleFactoryState> > RegisteredFactory2("PersistentCollection<WhittleFactoryState>");
+static const Factory<PersistentCollection<WhittleFactoryState> > RegisteredFactory2;
 
 CLASSNAMEINIT(WhittleFactory);
 
-static Factory<WhittleFactory> RegisteredFactory("WhittleFactory");
+static const Factory<WhittleFactory> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/Process/WhittleFactoryState.cxx
+++ b/lib/src/Uncertainty/Process/WhittleFactoryState.cxx
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(WhittleFactoryState);
 
-static Factory<WhittleFactoryState> RegisteredFactory("WhittleFactoryState");
+static const Factory<WhittleFactoryState> RegisteredFactory;
 
 
 /* Default constructor */

--- a/lib/src/Uncertainty/StatTests/DickeyFullerTest.cxx
+++ b/lib/src/Uncertainty/StatTests/DickeyFullerTest.cxx
@@ -32,7 +32,7 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(DickeyFullerTest);
-static Factory<DickeyFullerTest> RegisteredFactory("DickeyFullerTest");
+static const Factory<DickeyFullerTest> RegisteredFactory;
 
 
 /* Default constructor */

--- a/python/src/PythonDistributionImplementation.cxx
+++ b/python/src/PythonDistributionImplementation.cxx
@@ -33,7 +33,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PythonDistributionImplementation);
 
-static Factory<PythonDistributionImplementation> RegisteredFactory("PythonDistributionImplementation");
+static const Factory<PythonDistributionImplementation> RegisteredFactory;
 
 
 

--- a/python/src/PythonDynamicalFunctionImplementation.cxx
+++ b/python/src/PythonDynamicalFunctionImplementation.cxx
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PythonDynamicalFunctionImplementation);
 
-static Factory<PythonDynamicalFunctionImplementation> RegisteredFactory("PythonDynamicalFunctionImplementation");
+static const Factory<PythonDynamicalFunctionImplementation> RegisteredFactory;
 
 /* Default constructor */
 PythonDynamicalFunctionImplementation::PythonDynamicalFunctionImplementation()

--- a/python/src/PythonNumericalMathEvaluationImplementation.cxx
+++ b/python/src/PythonNumericalMathEvaluationImplementation.cxx
@@ -35,7 +35,7 @@ typedef NumericalMathEvaluationImplementation::CacheType                CacheTyp
 
 CLASSNAMEINIT(PythonNumericalMathEvaluationImplementation);
 
-static Factory<PythonNumericalMathEvaluationImplementation> RegisteredFactory("PythonNumericalMathEvaluationImplementation");
+static const Factory<PythonNumericalMathEvaluationImplementation> RegisteredFactory;
 
 
 

--- a/python/src/PythonNumericalMathGradientImplementation.cxx
+++ b/python/src/PythonNumericalMathGradientImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PythonNumericalMathGradientImplementation);
 
-static Factory<PythonNumericalMathGradientImplementation> RegisteredFactory("PythonNumericalMathGradientImplementation");
+static const Factory<PythonNumericalMathGradientImplementation> RegisteredFactory;
 
 
 

--- a/python/src/PythonNumericalMathHessianImplementation.cxx
+++ b/python/src/PythonNumericalMathHessianImplementation.cxx
@@ -30,7 +30,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PythonNumericalMathHessianImplementation);
 
-static Factory<PythonNumericalMathHessianImplementation> RegisteredFactory("PythonNumericalMathHessianImplementation");
+static const Factory<PythonNumericalMathHessianImplementation> RegisteredFactory;
 
 
 

--- a/python/src/PythonRandomVectorImplementation.cxx
+++ b/python/src/PythonRandomVectorImplementation.cxx
@@ -31,7 +31,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(PythonRandomVectorImplementation);
 
-static Factory<PythonRandomVectorImplementation> RegisteredFactory("PythonRandomVectorImplementation");
+static const Factory<PythonRandomVectorImplementation> RegisteredFactory;
 
 
 


### PR DESCRIPTION
Mark previous constructor as @deprecated, and create a new one
without argument.

Update all classes to call the new constructor.
Make static Factory objects as const, since they are not modified.