### PR TITLE
Rewrite singleton classes Catalog, Log, ResourceMap and TBB

### DIFF
--- a/lib/src/Base/Common/Catalog.cxx
+++ b/lib/src/Base/Common/Catalog.cxx
@@ -93,6 +93,12 @@ MutexLockSingleton<Catalog> Catalog::GetInstance()
   return *Catalog_P_instance_;
 }
 
+/* Get the list of keys */
+std::vector<String> Catalog::GetKeys()
+{
+  return GetInstance().lock().getKeys();
+}
+
 
 /* Get the factory from its name */
 const PersistentObjectFactory & Catalog::Get(const String & factoryName)
@@ -110,6 +116,17 @@ const PersistentObjectFactory & Catalog::get(const String & factoryName) const
   return *(it->second);
 }
 
+
+/* Get the list of keys */
+std::vector<String> Catalog::getKeys() const
+{
+  std::vector<String> keys;
+  for(CatalogType::const_iterator it = catalog_.begin(); it != catalog_.end(); ++it)
+  {
+    keys.push_back(it->first);
+  }
+  return keys;
+}
 
 /* Add a new factory to the catalog */
 void Catalog::Add(const String & factoryName, const PersistentObjectFactory * p_factory)

--- a/lib/src/Base/Common/Catalog.hxx
+++ b/lib/src/Base/Common/Catalog.hxx
@@ -23,6 +23,7 @@
 
 #include <map>         // for std::map
 #include "OTprivate.hxx"
+#include "MutexLock.hxx"
 
 
 BEGIN_NAMESPACE_OPENTURNS
@@ -44,17 +45,10 @@ class PersistentObjectFactory;
 
 class OT_API Catalog
 {
-private:
-
-  /** These methods allocate and free storage */
-  static void Release();
-  static void Initialize();
-
-
 public:
 
   /** Return the catalog as a singleton */
-  static Catalog & GetInstance();
+  static MutexLockSingleton<Catalog> GetInstance();
 
   /** Return the catalog as a singleton */
   static void Add(const String & factoryName, const PersistentObjectFactory * p_factory);
@@ -94,8 +88,6 @@ struct OT_API Catalog_init
   Catalog_init();
   ~Catalog_init();
 }; /* end struct Catalog_init */
-
-static Catalog_init __Catalog_initializer;
 
 
 

--- a/lib/src/Base/Common/Catalog.hxx
+++ b/lib/src/Base/Common/Catalog.hxx
@@ -46,9 +46,10 @@ class PersistentObjectFactory;
 class OT_API Catalog
 {
 public:
-
+#ifndef SWIG
   /** Return the catalog as a singleton */
   static MutexLockSingleton<Catalog> GetInstance();
+#endif
 
   /** Return the catalog as a singleton */
   static void Add(const String & factoryName, const PersistentObjectFactory * p_factory);

--- a/lib/src/Base/Common/Catalog.hxx
+++ b/lib/src/Base/Common/Catalog.hxx
@@ -22,6 +22,7 @@
 #define OPENTURNS_CATALOG_HXX
 
 #include <map>         // for std::map
+#include <vector>
 #include "OTprivate.hxx"
 #include "MutexLock.hxx"
 
@@ -57,6 +58,8 @@ public:
   /** Get the factory by name */
   static const PersistentObjectFactory & Get(const String & factoryName);
 
+  /** Get the list of keys */
+  static std::vector<String> GetKeys();
 
   /** Destructor */
   ~Catalog();
@@ -79,6 +82,9 @@ private:
 
   /** Get the factory by name */
   const PersistentObjectFactory & get(const String & factoryName) const;
+
+  /** Get the list of keys */
+  std::vector<String> getKeys() const;
 
   friend struct Catalog_init; /* friendship for static member initialization */
 }; /* end class Catalog */

--- a/lib/src/Base/Common/IdFactory.cxx
+++ b/lib/src/Base/Common/IdFactory.cxx
@@ -27,41 +27,11 @@
 BEGIN_NAMESPACE_OPENTURNS
 
 
-
-static pthread_once_t IdFactory_InstanceMutex_once = PTHREAD_ONCE_INIT;
-static AtomicInt IdFactory_NextId_;
-
-
-static void IdFactory_Initialization()
-{
-  // Nothing to do
-}
-
-
-IdFactory_init::IdFactory_init()
-{
-  int rc = pthread_once( &IdFactory_InstanceMutex_once, IdFactory_Initialization );
-  if (rc != 0)
-  {
-    perror("IdFactory_init::IdFactory_init once Initialization failed");
-    exit(1);
-  }
-}
-
-
-/* Default constructor */
-IdFactory::IdFactory()
-{
-  // Nothing to do
-}
-
-
 /* Id accessor */
 Id IdFactory::BuildId()
 {
-  return IdFactory_NextId_.fetchAndAdd( 1 );
+  static AtomicInt IdFactory_NextId;
+  return IdFactory_NextId.fetchAndAdd( 1 );
 }
-
-
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Common/IdFactory.hxx
+++ b/lib/src/Base/Common/IdFactory.hxx
@@ -52,22 +52,12 @@ public:
    */
   static Id BuildId();
 
-
 private:
-
-  /** Default constructor */
+  /** Disable default constructors */
   IdFactory();
-
-  friend struct IdFactory_init;
+  IdFactory(const IdFactory& other);
+  IdFactory & operator=(const IdFactory& other);
 }; /* class IdFactory */
-
-/** This struct initializes all static members of IdFactory */
-struct OT_API IdFactory_init
-{
-  IdFactory_init();
-}; /* end struct IdFactory_init */
-
-static IdFactory_init __IdFactory_initializer;
 
 END_NAMESPACE_OPENTURNS
 

--- a/lib/src/Base/Common/Log.hxx
+++ b/lib/src/Base/Common/Log.hxx
@@ -26,6 +26,7 @@
 #include "OTprivate.hxx"
 #include "AtomicFunctions.hxx"
 #include "TTY.hxx"
+#include "MutexLock.hxx"
 
 
 #define LOGDEBUG(st)   do { if (OT::Log::HasDebug()  ) OT::Log::Debug(st);   } while(0)
@@ -67,9 +68,8 @@ public:
   typedef unsigned long Severity;
 
 private:
-  static Log & GetInstance();
-  static void Initialization();
-  static void Release();
+  /** GetInstance gives a locked access to the singleton */
+  static MutexLockSingleton<Log> GetInstance();
 
 public:
 
@@ -246,8 +246,6 @@ struct OT_API Log_init
   Log_init();
   ~Log_init();
 }; /* end struct Log_init */
-
-static Log_init __Log_initializer;
 
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Common/Log.hxx
+++ b/lib/src/Base/Common/Log.hxx
@@ -68,11 +68,12 @@ public:
   typedef unsigned long Severity;
 
 private:
+#ifndef SWIG
   /** GetInstance gives a locked access to the singleton */
   static MutexLockSingleton<Log> GetInstance();
+#endif
 
 public:
-
   /** Those flags should be ORed */
   static const Severity DBG;
   static const Severity WRAPPER;

--- a/lib/src/Base/Common/MutexLock.hxx
+++ b/lib/src/Base/Common/MutexLock.hxx
@@ -69,7 +69,33 @@ public:
 
 }; /* class MutexLock */
 
-END_NAMESPACE_OPENTURNS
+template<class T>
+class MutexLockSingleton
+{
+  T & singleton_;
+  MutexLock lock_;
 
+public:
+  // Default constructor, defined by client classes
+  MutexLockSingleton( T & singleton ) throw();
+  // Default copy-constructor
+  MutexLockSingleton( const MutexLockSingleton<T> & other ) : singleton_(other.singleton_), lock_(other.lock_) {}
+
+private:
+  // Disable copy-assignment
+  MutexLockSingleton& operator=( const MutexLockSingleton<T> & other );
+
+public:
+  /** @copydoc Object::__repr__() const */
+  String __repr__() const { return singleton_.__repr__(); }
+
+#ifndef SWIG
+  T & lock() throw() { return singleton_; }
+  const T & lock() const throw() { return singleton_; }
+#endif
+
+}; /* class MutexLockSingleton */
+
+END_NAMESPACE_OPENTURNS
 
 #endif /* OPENTURNS_MUTEXLOCK_HXX */

--- a/lib/src/Base/Common/ResourceMap.hxx
+++ b/lib/src/Base/Common/ResourceMap.hxx
@@ -32,27 +32,6 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-/** Forward declaration */
-class ResourceMap;
-
-class OT_API ResourceMapInstance
-{
-  ResourceMap & rm_;
-  MutexLock lock_;
-
-public:
-  ResourceMapInstance( ResourceMap & rm ) throw();
-  ResourceMapInstance( const ResourceMapInstance & other );
-
-  /** @copydoc Object::__repr__() const */
-  String __repr__() const;
-
-#ifndef SWIG
-  ResourceMap & lock() throw();
-  const ResourceMap & lock() const throw();
-#endif
-}; // end class ResourceMapInstance
-
 /**
  * @class ResourceMap
  * @brief Defines a catalog containing all default values used by OpenTURNS
@@ -65,11 +44,8 @@ public:
 class OT_API ResourceMap
 {
 public:
-  /** Since ResourceMap is a singleton, GetInstance gives access to the object */
-  static ResourceMapInstance GetInstance();
-private:
-  static void Release();
-  static void Initialize();
+  /** GetInstance gives a locked access to the singleton */
+  static MutexLockSingleton<ResourceMap> GetInstance();
 
 public:
   /** Get a value in the map */
@@ -185,7 +161,6 @@ struct OT_API ResourceMap_init
   ResourceMap_init();
   ~ResourceMap_init();
 };
-static ResourceMap_init __ResourceMap_initializer;
 
 /**
  * @fn std::ostream & operator <<(std::ostream & os, const ResourceMap & obj)
@@ -197,9 +172,9 @@ static ResourceMap_init __ResourceMap_initializer;
  * Operator << converts the ResourceMap object to an output stream
  * so it is easy to show the content of the resourceMap.
  */
-OT_API std::ostream & operator <<(std::ostream & os, const ResourceMapInstance & obj);
+OT_API std::ostream & operator <<(std::ostream & os, const MutexLockSingleton<ResourceMap> & obj);
 #ifndef SWIG
-OT_API OStream & operator <<(OStream & OS, const ResourceMapInstance & obj);
+OT_API OStream & operator <<(OStream & OS, const MutexLockSingleton<ResourceMap> & obj);
 #endif
 
 

--- a/lib/src/Base/Common/ResourceMap.hxx
+++ b/lib/src/Base/Common/ResourceMap.hxx
@@ -44,10 +44,11 @@ BEGIN_NAMESPACE_OPENTURNS
 class OT_API ResourceMap
 {
 public:
+#ifndef SWIG
   /** GetInstance gives a locked access to the singleton */
   static MutexLockSingleton<ResourceMap> GetInstance();
+#endif
 
-public:
   /** Get a value in the map */
   static String Get(String key);
   static Bool GetAsBool(String key);
@@ -172,8 +173,8 @@ struct OT_API ResourceMap_init
  * Operator << converts the ResourceMap object to an output stream
  * so it is easy to show the content of the resourceMap.
  */
-OT_API std::ostream & operator <<(std::ostream & os, const MutexLockSingleton<ResourceMap> & obj);
 #ifndef SWIG
+OT_API std::ostream & operator <<(std::ostream & os, const MutexLockSingleton<ResourceMap> & obj);
 OT_API OStream & operator <<(OStream & OS, const MutexLockSingleton<ResourceMap> & obj);
 #endif
 

--- a/lib/src/Base/Common/TBB.cxx
+++ b/lib/src/Base/Common/TBB.cxx
@@ -28,13 +28,14 @@
 #include "OTthread.hxx"
 
 #include "TBB.hxx"
+#include "ResourceMap.hxx"
 
 
 BEGIN_NAMESPACE_OPENTURNS
 
 static pthread_mutex_t TBB_InstanceMutex_;
 static TBB * TBB_P_instance_ = 0;
-static pthread_once_t TBB_InstanceMutex_once = PTHREAD_ONCE_INIT;
+static const TBB_init initializer_TBB;
 
 #ifdef OPENTURNS_HAVE_TBB
 tbb::task_scheduler_init * TBB_P_scheduler_ = 0;
@@ -43,54 +44,29 @@ tbb::task_scheduler_init * TBB_P_scheduler_ = 0;
 
 TBB_init::TBB_init()
 {
-  int rc = pthread_once( &TBB_InstanceMutex_once, TBB::Initialization );
-  if (rc != 0)
+  if (!TBB_P_instance_)
   {
-    perror("TBB_init::TBB_init once Initialization failed");
-    exit(1);
-  }
-}
-
-TBB_init::~TBB_init()
-{
-  TBB::Release();
-}
-
-
-void TBB::Initialization()
-{
 #ifndef OT_MUTEXINIT_NOCHECK
-  pthread_mutexattr_t attr;
-  pthread_mutexattr_init( &attr );
-  //pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_NORMAL );
-  pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_ERRORCHECK );
-  //pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_RECURSIVE );
-  int rc = pthread_mutex_init( &TBB_InstanceMutex_, &attr );
-  if (rc != 0)
-  {
-    perror("TBB::Initialization mutex initialization failed");
-    exit(1);
-  }
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init( &attr );
+    pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_ERRORCHECK );
+    pthread_mutex_init( &TBB_InstanceMutex_, &attr );
 #else
-  pthread_mutex_init( &TBB_InstanceMutex_, NULL );
+    pthread_mutex_init( &TBB_InstanceMutex_, NULL );
 #endif
-#ifdef BOGUS_PTHREAD_LIBRARY
-  TBB_P_instance_ = 0;
-#else
-  TBB_P_instance_ = new TBB;
+    TBB_P_instance_ = new TBB;
+  }
 #ifdef OPENTURNS_HAVE_TBB
   UnsignedInteger nbThreads = ResourceMap::GetAsUnsignedInteger( "parallel-threads" );
   TBB_P_scheduler_ = new tbb::task_scheduler_init( nbThreads );
 #endif /* OPENTURNS_HAVE_TBB */
-#endif /* BOGUS_PTHREAD_LIBRARY */
-  // std::atexit( TBB::Release );
 }
 
-
-void TBB::Release()
+TBB_init::~TBB_init()
 {
   delete TBB_P_instance_;
   TBB_P_instance_ = 0;
+  pthread_mutex_destroy( &TBB_InstanceMutex_);
 #ifdef OPENTURNS_HAVE_TBB
   delete TBB_P_scheduler_;
   TBB_P_scheduler_ = 0;

--- a/lib/src/Base/Common/TBB.hxx
+++ b/lib/src/Base/Common/TBB.hxx
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include "OTprivate.hxx"
 #include "OTconfig.hxx"
-#include "ResourceMap.hxx" // ensures correct static initialization order
+#include "MutexLock.hxx"
 
 #ifdef OPENTURNS_HAVE_TBB
 #ifdef OPENTURNS_TBB_NO_IMPLICIT_LINKAGE
@@ -124,16 +124,6 @@ public:
     BlockedRange(const tbb::blocked_range<T> & range) : tbb::blocked_range<T>(range) {}
   };
 
-private:
-
-  /** Start the machinery of multithreading */
-  static void Initialization();
-
-  /** End the machinery of multithreading */
-  static void Release();
-
-public:
-
   template <typename BODY>
   static inline
   void ParallelFor( UnsignedInteger from, UnsignedInteger to, const BODY & body, std::size_t gs = 1 )
@@ -168,8 +158,6 @@ struct OT_API TBB_init
   TBB_init();
   ~TBB_init();
 }; /* end class TBB_init */
-
-static TBB_init __TBB_initializer;
 
 END_NAMESPACE_OPENTURNS
 

--- a/lib/src/Base/Common/TBB.hxx
+++ b/lib/src/Base/Common/TBB.hxx
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include "OTprivate.hxx"
 #include "OTconfig.hxx"
-#include "MutexLock.hxx"
 
 #ifdef OPENTURNS_HAVE_TBB
 #ifdef OPENTURNS_TBB_NO_IMPLICIT_LINKAGE

--- a/lib/test/t_Catalog_std.cxx
+++ b/lib/test/t_Catalog_std.cxx
@@ -29,20 +29,8 @@ int main(int argc, char *argv[])
   TESTPREAMBLE;
   OStream fullprint(std::cout);
 
-  try
-  {
-
-    // Create a Catalog Object
-    fullprint << Catalog::GetInstance().__repr__() << std::endl;
-  }
-  catch (FileOpenException & ex)
-  {
-    std::cerr << ex << std::endl;
-    return ExitCode::Error;
-  }
-
-
-
+  // Create a Catalog Object
+  fullprint << Catalog::GetInstance().__repr__() << std::endl;
 
   return ExitCode::Success;
 }

--- a/lib/test/t_ResourceMap_std.cxx
+++ b/lib/test/t_ResourceMap_std.cxx
@@ -29,23 +29,10 @@ int main(int argc, char *argv[])
   TESTPREAMBLE;
   OStream fullprint(std::cout);
 
-  try
-  {
+  // Create a ResourceMap Object
+  fullprint << ResourceMap::GetInstance() << std::endl;
 
-    // Create a ResourceMap Object
-    fullprint << ResourceMap::GetInstance() << std::endl;
-
-    fullprint << "Extract from ResourceMap : R-executable-command -> " << ResourceMap::Get("R-executable-command") << std::endl;
-
-  }
-  catch (FileOpenException & ex)
-  {
-    std::cerr << ex << std::endl;
-    return ExitCode::Error;
-  }
-
-
-
+  fullprint << "Extract from ResourceMap : R-executable-command -> " << ResourceMap::Get("R-executable-command") << std::endl;
 
   return ExitCode::Success;
 }

--- a/python/src/ResourceMap.i
+++ b/python/src/ResourceMap.i
@@ -10,8 +10,6 @@
 
 %nodefaultctor ResourceMap;
 
-%ignore OT::ResourceMap::GetInstance;
-
 %include ResourceMap.hxx
 
 namespace OT {

--- a/python/src/common_module.i
+++ b/python/src/common_module.i
@@ -31,6 +31,7 @@
 %include TTY.i
 %include Log.i
 %include Path.i
+%include Catalog.i
 %include ResourceMap.i
 %include ComparisonOperatorImplementation.i
 %include ComparisonOperator.i

--- a/python/test/t_Catalog_std.py
+++ b/python/test/t_Catalog_std.py
@@ -5,10 +5,7 @@ from openturns import *
 
 TESTPREAMBLE()
 
-try:
-    catalog = Catalog.GetInstance()
-    print(catalog)
-
-except:
-    import sys
-    print("t_Catalog_std.py", sys.exc_info()[0], sys.exc_info()[1])
+print("Catalog={")
+for key in Catalog.GetKeys():
+    print("  %s," % key)
+print("}")

--- a/python/test/t_ResourceMap_std.py
+++ b/python/test/t_ResourceMap_std.py
@@ -5,11 +5,9 @@ from openturns import *
 
 TESTPREAMBLE()
 
-try:
-    resourceMap = ResourceMap.GetInstance()
-    print(resourceMap)
-    print("Extract from ResourceMap : R-executable-command -> ",
-          resourceMap.get("R-executable-command"))
-except:
-    import sys
-    print("t_ResourceMap_std.py", sys.exc_info()[0], sys.exc_info()[1])
+print("ResourceMap={")
+for key in ResourceMap.GetKeys():
+    print("  %s => %s," % (key, ResourceMap.Get(key)))
+print("}")
+print("Extract from ResourceMap : R-executable-command -> ",
+      ResourceMap.Get("R-executable-command"))


### PR DESCRIPTION
Singletons are challenging in C++, it is very hard to have a thread-safe implementation which takes into account dependencies between singletons.

Current code does not work as expected, we had issues on Windows when loading an Excel plug-in because ResourceMap was not initialized. Current code is difficult to read and debug, mostly because singleton builders (`*_init` structs defined along singletons) are initialized in header files and thus duplicated in each object file.

We propose here a simpler pattern: a `MutexLockSingleton` template class is declared in `MutexLock.hxx`, it is modelled after `ResourceMapInstance`. `Catalog`, `Log`, `ResourceMap` and `TBB` are rewritten to use it. 

A static builder is defined in implementation files, and a second one in `GetInstance()`.  There are no threading issues because static variables are instantiated during library load, before user code.  The second builder ensures that initialization order does not matter.

It is not clear whether problems reported above are fixed by this commit, but at least it should be simpler to follow singleton constructions.
