### PR TITLE
Increase NP typecheck priority

### DIFF
--- a/python/src/NumericalPoint.i
+++ b/python/src/NumericalPoint.i
@@ -28,7 +28,7 @@
 %template(NumericalPointPersistentCollection)  OT::PersistentCollection<OT::NumericalPoint>;
 
 
-#define OT_TYPECHECK_NUMERICALPOINT 5
+#define OT_TYPECHECK_NUMERICALPOINT 4
 
 %typemap(in) const NumericalPoint & ($1_basetype temp) {
   if (SWIG_IsOK(SWIG_ConvertPtr($input, (void **) &$1, $1_descriptor, 0)))


### PR DESCRIPTION
Fixes swig warning 509 about NP/NS overloads for various methods after wrappers removal.
```
[0m/home/travis/build/openturns/openturns/lib/src/Base/Geom/Mesh.hxx:84: Warning 509: Overloaded method OT::Mesh::getNearestVertexIndex(OT::NumericalSample const &) const effectively ignored,
/home/travis/build/openturns/openturns/lib/src/Base/Geom/Mesh.hxx:78: Warning 509: as it is shadowed by OT::Mesh::getNearestVertexIndex(OT::NumericalPoint const &) const.
```

See discussion in https://github.com/openturns/openturns/pull/19

I chosed to increase the NP priority instead of NS remembering this: http://trac.openturns.org/changeset/2261
Also Field has this set to 3.

