### PR TITLE
Minor update in CovarianceModelImplementation

### DIFF
--- a/lib/src/Base/Stat/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.hxx
@@ -79,10 +79,10 @@ public:
                                        const NumericalPoint & t) const;
   // Special case for 1D model
   virtual NumericalScalar computeAsScalar (const NumericalScalar s,
-      const NumericalScalar t) const;
+                                           const NumericalScalar t) const;
 
   virtual NumericalScalar computeAsScalar (const NumericalPoint & s,
-      const NumericalPoint & t) const;
+                                           const NumericalPoint & t) const;
 
   virtual CovarianceMatrix operator() (const NumericalScalar tau) const;
   virtual CovarianceMatrix operator() (const NumericalPoint & tau) const;
@@ -110,20 +110,20 @@ public:
   virtual Bool isDiagonal() const;
 
   /** Amplitude accessors */
-  NumericalPoint getAmplitude() const;
-  void setAmplitude(const NumericalPoint & amplitude);
+  virtual NumericalPoint getAmplitude() const;
+  virtual void setAmplitude(const NumericalPoint & amplitude);
 
   /** Scale accessors */
   virtual NumericalPoint getScale() const;
   virtual void setScale(const NumericalPoint & scale);
 
   /** Spatial correlation accessors */
-  CorrelationMatrix getSpatialCorrelation() const;
-  void setSpatialCorrelation(const CorrelationMatrix & correlation);
+  virtual CorrelationMatrix getSpatialCorrelation() const;
+  virtual void setSpatialCorrelation(const CorrelationMatrix & correlation);
 
   /** Nugget factor accessor */
-  void setNuggetFactor(const NumericalScalar nuggetFactor);
-  NumericalScalar getNuggetFactor() const;
+  virtual void setNuggetFactor(const NumericalScalar nuggetFactor);
+  virtual NumericalScalar getNuggetFactor() const;
 
   /** Parameters accessor */
   virtual void setParameters(const NumericalPoint & parameters);

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -121,6 +121,20 @@ OT_CovarianceModel_discretize_doc
 %feature("docstring") OT::CovarianceModelImplementation::discretizeRow
 OT_CovarianceModel_discretizeRow_doc
 
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_getAmplitude_doc
+"Get the amplitude parameter of the covariance function.
+
+Returns
+-------
+amplitude : :class:`~openturns.NumericalPoint`
+    The amplitude parameter used in the covariance function."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::getAmplitde
+OT_CovarianceModel_getAmplitude_doc
+
 // ---------------------------------------------------------------------
 
 %define OT_CovarianceModel_getDimension_doc
@@ -147,6 +161,46 @@ parameters : :class:`~openturns.NumericalPointWithDescription`
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::getParameters
 OT_CovarianceModel_getParameters_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_getScale_doc
+"Get the scale parameter of the covariance function.
+
+Returns
+-------
+scale : :class:`~openturns.NumericalPoint`
+    The scale parameter used in the covariance function."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::getScale
+OT_CovarianceModel_getScale_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_getSpatialCorrelation_doc
+"Get the spatial correlation matrix of the covariance function.
+
+Returns
+-------
+spatialCorrelation : :class:`~openturns.CorrelationMatrix`
+    Correlation matrix :math:`\mat{R} \in \mathcal{M}_{dimension \times dimension}([-1, 1])`."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::getSpatialCorrelation
+OT_CovarianceModel_getSpatialCorrelation_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_getSpatialDimension_doc
+"Get the spatial dimension of the covariance function.
+
+Returns
+-------
+spatialDimension : int
+    SpatialDimension of the *CovarianceModel*."
+
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::getSpatialDimension
+OT_CovarianceModel_getSpatialDimension_doc
 
 // ---------------------------------------------------------------------
 
@@ -205,6 +259,33 @@ OT_CovarianceModel_partialGradient_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_CovarianceModel_setAmplitude_doc
+"Set the amplitude parameter of the covariance function.
+
+Parameters
+----------
+amplitude : :class:`~openturns.NumericalPoint`
+    The amplitude parameter to be used in the covariance function."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::setAmplitde
+OT_CovarianceModel_setAmplitude_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_setScale_doc
+"Set the scale parameter of the covariance function.
+
+Parameters
+----------
+scale : :class:`~openturns.NumericalPoint`
+    The scale parameter to be used in the covariance function.
+    It should be of size dimension."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::setScale
+OT_CovarianceModel_setScale_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_CovarianceModel_setParameters_doc
 "Set the parameters of the covariance function.
 
@@ -217,3 +298,17 @@ parameters : :class:`~openturns.NumericalPointWithDescription`
 %feature("docstring") OT::CovarianceModelImplementation::setParameters
 OT_CovarianceModel_setParameters_doc
 
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_setSpatialCorrelation_doc
+"Set the spatial correlation matrix of the covariance function.
+
+Parameters
+----------
+spatialCorrelation : :class:`~openturns.CorrelationMatrix`
+    Correlation matrix :math:`\mat{R} \in \mathcal{M}_{dimension \times dimension}([-1, 1])`."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::setSpatialCorrelation
+OT_CovarianceModel_setSpatialCorrelation_doc
+
+// ---------------------------------------------------------------------

--- a/python/src/CovarianceModel_doc.i.in
+++ b/python/src/CovarianceModel_doc.i.in
@@ -10,13 +10,27 @@ OT_CovarianceModel_discretize_doc
 OT_CovarianceModel_discretizeRow_doc
 %feature("docstring") OT::CovarianceModel::getDimension
 OT_CovarianceModel_getDimension_doc
+%feature("docstring") OT::CovarianceModel::getAmplitude
+OT_CovarianceModel_getAmplitude_doc
+%feature("docstring") OT::CovarianceModel::getScale
+OT_CovarianceModel_getScale_doc
 %feature("docstring") OT::CovarianceModel::getParameters
 OT_CovarianceModel_getParameters_doc
+%feature("docstring") OT::CovarianceModel::getSpatialCorrelation
+OT_CovarianceModel_getSpatialCorrelation_doc
+%feature("docstring") OT::CovarianceModel::getSpatialDimension
+OT_CovarianceModel_getSpatialDimension_doc
 %feature("docstring") OT::CovarianceModel::isDiagonal
 OT_CovarianceModel_isDiagonal_doc
 %feature("docstring") OT::CovarianceModel::isStationary
 OT_CovarianceModel_isStationary_doc
 %feature("docstring") OT::CovarianceModel::partialGradient
 OT_CovarianceModel_partialGradient_doc
+%feature("docstring") OT::CovarianceModel::setAmplitude
+OT_CovarianceModel_setAmplitude_doc
+%feature("docstring") OT::CovarianceModel::setScale
+OT_CovarianceModel_setScale_doc
 %feature("docstring") OT::CovarianceModel::setParameters
 OT_CovarianceModel_setParameters_doc
+%feature("docstring") OT::CovarianceModel::setSpatialCorrelation
+OT_CovarianceModel_setSpatialCorrelation_doc

--- a/python/src/ExponentialModel_doc.i.in
+++ b/python/src/ExponentialModel_doc.i.in
@@ -19,7 +19,7 @@ scale : sequence of float
 spatialCorrelation : :class:`~openturns.CorrelationMatrix`
     Correlation matrix :math:`\mat{R} \in \mathcal{M}_{d \times d}([-1, 1])`.
 spatialCovariance : :class:`~openturns.CovarianceMatrix`
-    Correlation matrix :math:`C^{stat} \in \mathcal{M}_{d \times d}([-1, 1])`.
+    Covariance matrix :math:`C^{stat} \in \mathcal{M}_{+}^{*}(\Rset^d)`.
 
 Notes
 -----


### PR DESCRIPTION
All methods of the implementation class should be declared as virtual. Indeed some of these methods might be redefined by derived classes