### PR TITLE
Avoid infinite loops in several distribution factories

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
  * Enhanced print of samples
 
 === Bug fixes ===
+ * #796 (Beta distribution: if sample contains Inf, freeze on getSample)
  * #798 (Error message misstyping (Gamma distribution))
 
 == 1.6 release (2015-08-14) == #release-1.6

--- a/lib/src/Uncertainty/Distribution/BetaFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/BetaFactory.cxx
@@ -19,6 +19,7 @@
  *
  */
 #include "BetaFactory.hxx"
+#include "SpecFunc.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -65,7 +66,8 @@ Beta BetaFactory::buildAsBeta(const NumericalSample & sample) const
   const NumericalScalar a(xMin - std::abs(xMin) / (2.0 + size));
   const NumericalScalar xMax(sample.getMax()[0]);
   const NumericalScalar b(xMax + std::abs(xMax) / (2.0 + size));
-  if (a >= b) throw InvalidArgumentException(HERE) << "Error: can build a Beta distribution only if a < b, here a=" << a << " and b=" << b;
+  // Check that 1.) a and b are not NaN, 2.) a < b, 3.) b is not +Inf
+  if (!(a < b) || SpecFunc::IsInf(b)) throw InvalidArgumentException(HERE) << "Error: can build a Beta distribution only if a < b, here a=" << a << " and b=" << b;
   const NumericalScalar mean(sample.computeMean()[0]);
   const NumericalScalar sigma(sample.computeStandardDeviationPerComponent()[0]);
   const NumericalScalar t((b - mean) * (mean - a) / (sigma * sigma) - 1.0);

--- a/lib/src/Uncertainty/Distribution/BinomialFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/BinomialFactory.cxx
@@ -72,7 +72,7 @@ Binomial BinomialFactory::buildAsBinomial(const NumericalSample & sample) const
     const NumericalScalar x(sample[i][0]);
     const int iX(static_cast<int>(round(x)));
     // The sample must be made of nonnegative integral values
-    if (std::abs(x - iX) > supportEpsilon || (iX < 0)) throw InvalidArgumentException(HERE) << "Error: can build a Binomial distribution only from a sample made of nonnegative integers, here x=" << x;
+    if (!(std::abs(x - iX) <= supportEpsilon) || (iX < 0)) throw InvalidArgumentException(HERE) << "Error: can build a Binomial distribution only from a sample made of nonnegative integers, here x=" << x;
     // Update the upper bound
     if (iX > static_cast<const int>(upperBound)) upperBound = iX;
     var = i * var / (i + 1.0) + (1.0 - 1.0 / (i + 1.0)) * (mean - x) * (mean - x) / (i + 1.0);

--- a/lib/src/Uncertainty/Distribution/GammaFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/GammaFactory.cxx
@@ -19,6 +19,7 @@
  *
  */
 #include "GammaFactory.hxx"
+#include "SpecFunc.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -64,7 +65,7 @@ Gamma GammaFactory::buildAsGamma(const NumericalSample & sample) const
   const NumericalScalar gamma(xMin - std::abs(xMin) / (2.0 + size));
   const NumericalScalar mu(sample.computeMean()[0]);
   const NumericalScalar sigma(sample.computeStandardDeviationPerComponent()[0]);
-  if (sigma <= 0.0) throw InvalidArgumentException(HERE) << "Error: can build a Gamma distribution only if sigma > 0, here sigma=" << sigma;
+  if (!(sigma > 0.0) || SpecFunc::IsInf(sigma)) throw InvalidArgumentException(HERE) << "Error: can build a Gamma distribution only if sigma > 0, here sigma=" << sigma;
   NumericalScalar lambda((mu - gamma) / sigma);
   const NumericalScalar k(lambda * lambda);
   lambda /= sigma;

--- a/lib/src/Uncertainty/Distribution/PoissonFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/PoissonFactory.cxx
@@ -69,7 +69,7 @@ Poisson PoissonFactory::buildAsPoisson(const NumericalSample & sample) const
     if ((x != trunc(x)) || (x < 0.0)) throw InvalidArgumentException(HERE) << "Error: can build a Poisson distribution only from a sample with integer components >= 0, here sample[" << i << "][0]=" << x;
     lambda += x;
   }
-  if (lambda <= 0.0) throw InvalidArgumentException(HERE) << "Error: can build a poisson distribution only if lambda > 0, here lambda=" << lambda;
+  if (!(lambda > 0.0) || SpecFunc::IsInf(lambda)) throw InvalidArgumentException(HERE) << "Error: can build a poisson distribution only if lambda > 0, here lambda=" << lambda;
   Poisson result(lambda / size);
   result.setDescription(sample.getDescription());
   return result;


### PR DESCRIPTION
When these factories are called with invalid values (either NaN or Inf),
getSample() loops forever.
Fix http://trac.openturns.org/ticket/796