### PR TITLE
Native compilation on OS X

### DIFF
--- a/lib/src/Base/Common/OSS.hxx
+++ b/lib/src/Base/Common/OSS.hxx
@@ -272,13 +272,6 @@ public:
   OSS_iterator&
   operator=(const _Tp& value)
   {
-#ifdef __GNUC__
-#if ( GCC_VERSION >= 30400 )
-    __glibcxx_requires_cond(_M_stream != 0,
-                            _M_message(__gnu_debug::__msg_output_ostream)
-                            ._M_iterator(*this));
-#endif
-#endif
     if (_UnaryPredicate()(value))
     {
       if (!_M_first) *_M_stream << _M_string;

--- a/lib/src/Base/Common/OStream.cxx
+++ b/lib/src/Base/Common/OStream.cxx
@@ -166,7 +166,7 @@ OStream & operator << (OStream & OS, std::ios_base & (*manip)(std::ios_base &))
   return OS;
 }
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
 
 OStream & operator << (OStream & OS, std::_Setw manip)
 {
@@ -209,6 +209,7 @@ OStream & operator << (OStream & OS, std::_Setfill<char> manip)
   OS.getStream() << manip;
   return OS;
 }
+
 #endif
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Common/OStream.hxx
+++ b/lib/src/Base/Common/OStream.hxx
@@ -118,6 +118,26 @@ inline OStream & operator << (OStream & OS, std::_Fillobj<T> manip)
   return OS;
 }
 
+#elif defined(__clang__) && defined(_LIBCPP_VERSION)
+inline OStream & operator << (OStream & OS, std::__1::__iom_t6 manip)
+{
+  OS.getStream() << manip;
+  return OS;
+}
+
+template <typename T>
+inline OStream & operator << (OStream & OS, std::__1::__iom_t4<T> manip)
+{
+  OS.getStream() << manip;
+  return OS;
+}
+
+
+inline OStream & operator << (OStream & OS, std::__1::__iom_t5 manip)
+{
+    OS.getStream() << manip;
+    return OS;
+}
 #elif defined(__GNUC__)
 
 OT_API

--- a/python/test/t_coupling_tools.py
+++ b/python/test/t_coupling_tools.py
@@ -558,7 +558,9 @@ def check_execute():
     # ensure previous print is print before following command output
     sys.stdout.flush()
 
-    if 'win' not in sys.platform:
+    # Care with -darwin systems
+
+    if ('darwin' in sys.platform) or ('win' not in sys.platform):
         coupling_tools.execute('/bin/ls /bin/kill')
         coupling_tools.execute('echo "hi"', is_shell=True)
         coupling_tools.execute('echo "hi"', is_shell=True,


### PR DESCRIPTION
We update the library API to let the compilation on Debian & OS X systems using clang/libc++

Indeed, native compilation on OS X system uses the last ones as Mac OS X 10.9+ no longer uses GCC/libstdc++. In that case, dependencies such as muParser & tbb are naturally linked to libc++ (using packager like MacPort/Homebrew or ot-superbuild for example)

Following pull request will focus on a detail "How to install with OS X" 

