### PR TITLE
Support infix operator for matrix multiplication (PEP465)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
  * Deprecated (AbdoRackwitz|Cobyla|SQP|TNC)SpecificParameters classes
 
 === Python module ===
+ * Support infix operator for matrix multiplication (PEP465)
 
 === Miscellaneous ===
  * Enhanced print of samples

--- a/python/src/ComplexMatrix.i
+++ b/python/src/ComplexMatrix.i
@@ -53,5 +53,9 @@ namespace OT {
   
   ComplexMatrix __truediv__(NumericalComplex s) { return (*self) / s; }
   
+  ComplexMatrix __matmul__(const ComplexMatrix & other) { return *self * other; }
+
+  ComplexMatrix __matmul__(const Matrix & other) { return *self * other; }
+
 } // ComplexMatrix
 } // OT

--- a/python/src/Matrix.i
+++ b/python/src/Matrix.i
@@ -334,5 +334,7 @@ namespace OT {
     
   Matrix __truediv__(const NumericalScalar s) { return (*self) / s; }
 
+  Matrix __matmul__(const Matrix & other) { return *self * other; }
+
 } // Matrix
 } // OT


### PR DESCRIPTION
http://legacy.python.org/dev/peps/pep-0465/