### PR TITLE
Unset VonMises parallel flag

### DIFF
--- a/lib/src/Uncertainty/Distribution/VonMises.cxx
+++ b/lib/src/Uncertainty/Distribution/VonMises.cxx
@@ -43,6 +43,7 @@ VonMises::VonMises()
   // This call also call update and computeRange()
   setKappa(1.0);
   setDimension(1);
+  setParallel(false);
   computeRange();
 }
 
@@ -60,6 +61,7 @@ VonMises::VonMises(const NumericalScalar mu,
   setMu(mu);
   setKappa(kappa);
   setDimension(1);
+  setParallel(false);
   computeRange();
 }
 


### PR DESCRIPTION
There is bug with VonMises when computeCDF is called on a sample with TBB enabled.
The bug can be exposed while looping several thousands times the kolmogorov test in t_VonMises_std as its occurs randomly:
```
for(int iter = 0; iter < 1e6; ++ iter)
  {
    // Test basic functionnalities
    checkClassWithClassName<TestObject>();

    // Instanciate one distribution object
    VonMises distribution(-0.5, 1.5);
    fullprint << "Distribution " << distribution << std::endl;
    std::cout << "Distribution " << distribution << std::endl;

    // Is this distribution elliptical ?
    fullprint << "Elliptical = " << (distribution.isElliptical() ? "true" : "false") << std::endl;

    // Is this distribution continuous ?
    fullprint << "Continuous = " << (distribution.isContinuous() ? "true" : "false") << std::endl;

    // Test for realization of distribution
    NumericalPoint oneRealization = distribution.getRealization();
    fullprint << "oneRealization=" << oneRealization << std::endl;

    // Test for sampling
    UnsignedInteger size = 10000;
//     NumericalSample oneSample = distribution.getSample( size );
//     fullprint << "oneSample first=" << oneSample[0] << " last=" << oneSample[size - 1] << std::endl;
//     fullprint << "mean=" << oneSample.computeMean() << std::endl;
//     fullprint << "covariance=" << oneSample.computeCovariance() << std::endl;
    size = 100;
    RandomGenerator::SetSeed(0);
    for (UnsignedInteger i = 0; i < 2; ++i)
    {
      fullprint << "Kolmogorov test for the generator, sample size=" << size << " is " << (FittingTest::Kolmogorov(distribution.getSample(size), distribution).getBinaryQualityMeasure() ? "accepted" : "rejected") << std::endl;
      size *= 10;
    }
}
```

I suspect DistributionImplementation::computeGaussNodesAndWeights cannot be run in parallel :
```
#0  __memmove_ssse3_back () at ../sysdeps/x86_64/multiarch/memcpy-ssse3-back.S:169
#1  0x00007ffff70c3bdf in OT::PersistentCollection<double>::operator=(OT::PersistentCollection<double> const&) () at /usr/include/c++/4.8/bits/stl_algobase.h:372
#2  0x00007ffff74979ef in OT::DistributionImplementation::computeGaussNodesAndWeights() const () at /home/schueller/projects/openturns/schueller/lib/src/Base/Type/NumericalPoint.hxx:37
#3  0x00007ffff74864b2 in OT::DistributionImplementation::getGaussNodesAndWeights(OT::NumericalPoint&) const () at /home/schueller/projects/openturns/schueller/lib/src/Uncertainty/Model/DistributionImplementation.cxx:2275
#4  0x00007ffff7488d41 in OT::DistributionImplementation::computeProbabilityContinuous(OT::Interval const&) const () at /home/schueller/projects/openturns/schueller/lib/src/Uncertainty/Model/DistributionImplementation.cxx:726
#5  0x00007ffff74c6702 in OT::ContinuousDistribution::computeCDF(OT::NumericalPoint const&) const () at /home/schueller/projects/openturns/schueller/lib/src/Uncertainty/Model/ContinuousDistribution.cxx:123
#6  0x00007ffff74bf3d8 in void tbb::interface6::internal::partition_type_base<tbb::interface6::internal::auto_partition_type>::execute<tbb::interface6::internal::start_for<tbb::blocked_range<unsigned long>, OT::ComputeCDFPolicy, tbb::auto_partitioner>, tbb::blocked_range<unsigned long> >(tbb::interface6::internal::start_for<tbb::blocked_range<unsigned long>, OT::ComputeCDFPolicy, tbb::auto_partitioner>&, tbb::blocked_range<unsigned long>&) ()
    at /home/schueller/projects/openturns/schueller/lib/src/Uncertainty/Model/DistributionImplementation.cxx:564
#7  0x00007ffff74bf839 in tbb::interface6::internal::start_for<tbb::blocked_range<unsigned long>, OT::ComputeCDFPolicy, tbb::auto_partitioner>::execute() () at /usr/include/tbb/parallel_for.h:116
#8  0x00007ffff539e242 in ?? () from /usr/lib/libtbb.so.2
#9  0x00007ffff539a09d in ?? () from /usr/lib/libtbb.so.2
#10 0x00007ffff539954b in ?? () from /usr/lib/libtbb.so.2
#11 0x00007ffff539708f in ?? () from /usr/lib/libtbb.so.2
#12 0x00007ffff53972c9 in ?? () from /usr/lib/libtbb.so.2
#13 0x00007ffff4917e9a in start_thread (arg=0x7fffdaafa700) at pthread_create.c:308
#14 0x00007ffff66f238d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:112
#15 0x0000000000000000 in ?? ()
```
Thoughts, @regislebrun ?