### PR TITLE
Rename CovarianceModel::setParameters into CovarianceModel::setParameter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@
  * Removed CovarianceModel::getParameters
  * Added CovarianceModel::getParameter
  * Added CovarianceModel::getParameterDescription
+ * Moved CovarianceModel::setParameters to CovarianceModel::setParameter
 
 === Python module ===
  * Support infix operator for matrix multiplication (PEP465)

--- a/lib/src/Base/Stat/CovarianceModel.cxx
+++ b/lib/src/Base/Stat/CovarianceModel.cxx
@@ -31,7 +31,7 @@ CLASSNAMEINIT(CovarianceModel);
 
 //   static const Factory<CovarianceModel> RegisteredFactory;
 
-/* Constructor without parameters */
+/* Constructor without parameter */
 CovarianceModel::CovarianceModel()
   : TypedInterfaceObject<CovarianceModelImplementation>(new ExponentialModel())
 {
@@ -205,10 +205,10 @@ void CovarianceModel::setNuggetFactor(const NumericalScalar nuggetFactor)
 }
 
 /* Parameters accessor */
-void CovarianceModel::setParameters(const NumericalPoint& parameters)
+void CovarianceModel::setParameter(const NumericalPoint& parameter)
 {
   copyOnWrite();
-  getImplementation()->setParameters(parameters);
+  getImplementation()->setParameter(parameter);
 }
 
 NumericalPoint CovarianceModel::getParameter() const

--- a/lib/src/Base/Stat/CovarianceModel.hxx
+++ b/lib/src/Base/Stat/CovarianceModel.hxx
@@ -40,7 +40,7 @@ public:
 
   typedef CovarianceModelImplementation::Implementation    Implementation;
 
-  /** Default constructor without parameters */
+  /** Default constructor without parameter */
   CovarianceModel();
 
   /** Copy constructors */
@@ -113,7 +113,7 @@ public:
   NumericalScalar getNuggetFactor() const;
 
   /** Parameters accessor */
-  void setParameters(const NumericalPoint & parameters);
+  void setParameter(const NumericalPoint & parameter);
   NumericalPoint getParameter() const;
   Description getParameterDescription() const;
 

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -50,7 +50,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteg
   updateSpatialCovariance();
 }
 
-/* Constructor with parameters */
+/* Constructor with parameter */
 CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteger spatialDimension,
                                                              const NumericalPoint & amplitude,
                                                              const NumericalPoint & scale)
@@ -71,7 +71,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteg
   updateSpatialCovariance();
 }
 
-/** Standard constructor with amplitude and scale parameters parameters */
+/** Standard constructor with amplitude and scale parameter parameter */
 CovarianceModelImplementation::CovarianceModelImplementation(const NumericalPoint & amplitude,
                                                              const NumericalPoint & scale)
  : PersistentObject()
@@ -111,7 +111,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteg
   setSpatialCorrelation(spatialCorrelation);
 }
 
-/** Standard constructor with amplitude, scale and spatial correlation parameters parameters */
+/** Standard constructor with amplitude, scale and spatial correlation parameter parameter */
 CovarianceModelImplementation::CovarianceModelImplementation(const NumericalPoint & amplitude,
                                                              const NumericalPoint & scale,
                                                              const CorrelationMatrix & spatialCorrelation)
@@ -162,7 +162,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteg
   } // !isDiagonal
 }
 
-/** Standard constructor with scale and spatial covariance parameters parameters */
+/** Standard constructor with scale and spatial covariance parameter parameter */
 CovarianceModelImplementation::CovarianceModelImplementation(const NumericalPoint & scale,
                                                              const CovarianceMatrix & spatialCovariance)
  : PersistentObject()
@@ -514,25 +514,25 @@ void CovarianceModelImplementation::setNuggetFactor(const NumericalScalar nugget
 }
 
 /* Parameters accessor */
-void CovarianceModelImplementation::setParameters(const NumericalPoint & parameters)
+void CovarianceModelImplementation::setParameter(const NumericalPoint & parameter)
 {
   // Default parameter setter
-  // By convention, the first points corresponds to scale parameters
-  // it follows amplitude parameters
-  if (parameters.getDimension() != spatialDimension_ + 1)
-    throw InvalidArgumentException(HERE) << "In CovarianceModelImplementation::setParameters: parameters dimension should be " << spatialDimension_ + dimension_
-                                         << "(got " << parameters.getDimension() << ")";
+  // By convention, the first points corresponds to scale parameter
+  // it follows amplitude parameter
+  if (parameter.getDimension() != spatialDimension_ + 1)
+    throw InvalidArgumentException(HERE) << "In CovarianceModelImplementation::setParameter: parameter dimension should be " << spatialDimension_ + dimension_
+                                         << "(got " << parameter.getDimension() << ")";
   NumericalPoint scale(spatialDimension_);
   NumericalPoint amplitude(dimension_);
-  for (UnsignedInteger j = 0; j < spatialDimension_; ++j) scale[j] = parameters[j];
-  for (UnsignedInteger j = 0; j < dimension_; ++j) amplitude[j] = parameters[spatialDimension_ + j];
+  for (UnsignedInteger j = 0; j < spatialDimension_; ++j) scale[j] = parameter[j];
+  for (UnsignedInteger j = 0; j < dimension_; ++j) amplitude[j] = parameter[spatialDimension_ + j];
   setScale(scale);
   setAmplitude(amplitude);
 }
 
 NumericalPoint CovarianceModelImplementation::getParameter() const
 {
-  // Convention : scale parameters + amplitude parameters
+  // Convention : scale parameter + amplitude parameter
   NumericalPoint result(getScale());
   result.add(getAmplitude());
   // return result
@@ -541,7 +541,7 @@ NumericalPoint CovarianceModelImplementation::getParameter() const
 
 Description CovarianceModelImplementation::getParameterDescription() const
 {
-  // Convention : scale parameters + amplitude parameters
+  // Convention : scale parameter + amplitude parameter
   Description description(spatialDimension_ + dimension_);
   for (UnsignedInteger j = 0; j < spatialDimension_; ++j)
   {

--- a/lib/src/Base/Stat/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.hxx
@@ -47,32 +47,32 @@ public:
   /** Dimension-based constructor */
   explicit CovarianceModelImplementation(const UnsignedInteger spatialDimension = 1);
 
-  /** Standard constructor with amplitude and scale parameters parameters */
+  /** Standard constructor with amplitude and scale parameter parameter */
   CovarianceModelImplementation(const UnsignedInteger spatialDimension,
                                 const NumericalPoint & amplitude,
                                 const NumericalPoint & scale);
 
-  /** Standard constructor with amplitude and scale parameters parameters */
+  /** Standard constructor with amplitude and scale parameter parameter */
   CovarianceModelImplementation(const NumericalPoint & amplitude,
                                 const NumericalPoint & scale);
 
-  /** Standard constructor with amplitude, scale and spatial correlation parameters parameters */
+  /** Standard constructor with amplitude, scale and spatial correlation parameter parameter */
   CovarianceModelImplementation(const UnsignedInteger spatialDimension,
                                 const NumericalPoint & amplitude,
                                 const NumericalPoint & scale,
                                 const CorrelationMatrix & spatialCorrelation);
 
-  /** Standard constructor with amplitude, scale and spatial correlation parameters parameters */
+  /** Standard constructor with amplitude, scale and spatial correlation parameter parameter */
   CovarianceModelImplementation(const NumericalPoint & amplitude,
                                 const NumericalPoint & scale,
                                 const CorrelationMatrix & spatialCorrelation);
 
-  /** Standard constructor with scale and spatial covariance parameters parameters */
+  /** Standard constructor with scale and spatial covariance parameter parameter */
   CovarianceModelImplementation(const UnsignedInteger spatialDimension,
                                 const NumericalPoint & scale,
                                 const CovarianceMatrix & spatialCovariance);
 
-  /** Standard constructor with scale and spatial covariance parameters parameters */
+  /** Standard constructor with scale and spatial covariance parameter parameter */
   CovarianceModelImplementation(const NumericalPoint & scale,
                                 const CovarianceMatrix & spatialCovariance);
 
@@ -151,7 +151,7 @@ public:
   virtual NumericalScalar getNuggetFactor() const;
 
   /** Parameters accessor */
-  virtual void setParameters(const NumericalPoint & parameters);
+  virtual void setParameter(const NumericalPoint & parameter);
   virtual NumericalPoint getParameter() const;
   virtual Description getParameterDescription() const;
 

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -161,7 +161,7 @@ Matrix ProductCovarianceModel::partialGradient(const NumericalPoint & s,
 }
 
 /* Parameters accessor */
-void ProductCovarianceModel::setParameters(const NumericalPoint & parameters)
+void ProductCovarianceModel::setParameter(const NumericalPoint & parameters)
 {
   const UnsignedInteger parametersDimension(getParameter().getDimension());
   if (parameters.getDimension() != parametersDimension) throw InvalidArgumentException(HERE) << "Error: parameters dimension should be 1 (got " << parameters.getDimension() << ")";
@@ -173,7 +173,7 @@ void ProductCovarianceModel::setParameters(const NumericalPoint & parameters)
     NumericalPoint atomParameters(atomParametersDimension);
     std::copy(parameters.begin() + start, parameters.begin() + stop, atomParameters.begin());
     start = stop;
-    collection_[i].setParameters(atomParameters);
+    collection_[i].setParameter(atomParameters);
   }
 }
 

--- a/lib/src/Base/Stat/ProductCovarianceModel.hxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.hxx
@@ -66,7 +66,7 @@ public:
   virtual Implementation getMarginal(const UnsignedInteger index) const;
 
   /** Parameters accessor */
-  void setParameters(const NumericalPoint & parameters);
+  void setParameter(const NumericalPoint & parameters);
   NumericalPoint getParameter() const;
   Description getParameterDescription() const;
 

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -387,7 +387,7 @@ OT_CovarianceModel_set_nugget_factor_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_CovarianceModel_setParameters_doc
+%define OT_CovarianceModel_setParameter_doc
 "Set the parameters of the covariance function.
 
 Returns
@@ -398,8 +398,8 @@ parameters : :class:`~openturns.NumericalPointWithDescription`
     The parameters should be of size (spatialDim + dim) : it sets the spatialDim first elements to scale
     and the dim following to amplitude."
 %enddef
-%feature("docstring") OT::CovarianceModelImplementation::setParameters
-OT_CovarianceModel_setParameters_doc
+%feature("docstring") OT::CovarianceModelImplementation::setParameter
+OT_CovarianceModel_setParameter_doc
 
 // ---------------------------------------------------------------------
 

--- a/python/src/CovarianceModel_doc.i.in
+++ b/python/src/CovarianceModel_doc.i.in
@@ -40,8 +40,8 @@ OT_CovarianceModel_setAmplitude_doc
 OT_CovarianceModel_setScale_doc
 %feature("docstring") OT::CovarianceModel::setNuggetFactor
 OT_CovarianceModel_set_nugget_factor_doc
-%feature("docstring") OT::CovarianceModel::setParameters
-OT_CovarianceModel_setParameters_doc
+%feature("docstring") OT::CovarianceModel::setParameter
+OT_CovarianceModel_setParameter_doc
 %feature("docstring") OT::CovarianceModel::setSpatialCorrelation
 OT_CovarianceModel_setSpatialCorrelation_doc
 %feature("docstring") OT::CovarianceModel::operator()


### PR DESCRIPTION
The PR completes  #50 
It renames CovarianceModel::setParameters into CovarianceModel::setParameter