### PR TITLE
Improved the symmetry check in MatrixImplementation

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -193,6 +193,7 @@
 
   <!-- OT::MatrixImplementation parameters -->
   <MatrixImplementation-DefaultSmallPivot value="1.0e-7"     />
+  <MatrixImplementation-SymmetryThreshold value="1.0e-12"    />
 
   <!-- OT::BurrFactory parameters -->
   <BurrFactory-AbsolutePrecision value="1e-12" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -459,7 +459,8 @@ void ResourceMap::loadDefaultConfiguration()
   setAsUnsignedInteger( "ComplexTensor-size-visible-in-str-from", 6 );
 
   // MatrixImplementation parameters //
-  setAsNumericalScalar( "MatrixImplementation-DefaultSmallPivot", 1.0e-7 );
+  setAsNumericalScalar( "MatrixImplementation-DefaultSmallPivot", 1.0e-7  );
+  setAsNumericalScalar( "MatrixImplementation-SymmetryThreshold", 1.0e-12 );
 
   // BurrFactory parameters //
   setAsNumericalScalar( "BurrFactory-AbsolutePrecision", 1.0e-12 );

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -520,11 +520,12 @@ Bool MatrixImplementation::operator == (const MatrixImplementation & rhs) const
 
 Bool MatrixImplementation::isSymmetric() const
 {
+  const NumericalScalar epsilon(ResourceMap::GetAsNumericalScalar("MatrixImplementation-SymmetryThreshold"));
   if ( nbRows_ == nbColumns_ )
   {
     for ( UnsignedInteger i = 1; i < nbRows_; ++ i )
       for ( UnsignedInteger j = 0; j < i; ++ j )
-        if ( this->operator[](convertPosition(i, j)) != operator[](convertPosition(j, i)) )
+        if ( std::abs(this->operator[](convertPosition(i, j)) - operator[](convertPosition(j, i))) > epsilon)
           return false;
     return true;
   }


### PR DESCRIPTION
Due to rounding errors, sometimes a symmetric matrix (obtained ie as L^tCL with C symmetric) is not exactly symmetric due to rounding errors. A more permissive check is needed in order to enforce the symmetry of the result in Python.