### PR TITLE
Extend WelchFactory to time grid with non-zero start

### DIFF
--- a/lib/src/Base/Stat/WelchFactory.cxx
+++ b/lib/src/Base/Stat/WelchFactory.cxx
@@ -123,7 +123,7 @@ UserDefinedSpectralModel * WelchFactory::build(const ProcessSample & sample) con
   const RegularGrid timeGrid(sample.getTimeGrid());
   const UnsignedInteger N(timeGrid.getN());
   const NumericalScalar timeStep(timeGrid.getStep());
-  const NumericalScalar T(timeGrid.getEnd());
+  const NumericalScalar T(timeGrid.getEnd() - timeGrid.getStart());
   // Preprocessing: the scaling factor, including the tappering window
   NumericalComplexCollection alpha(N);
   const NumericalScalar factor(timeStep / sqrt(sampleSize * T));


### PR DESCRIPTION
The WelchFactory class made the implicit assumption that the time grid associated to the given process sample was starting from 0, resulting in a wrong estimation if it was not the case. Now, it is fixed.