### PR TITLE
Restore Distribution::setParametersCollection(NP)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,9 @@
  * Replaced KrigingAlgorithm::[gs]etOptimizer methods by KrigingAlgorithm::[gs]etOptimizationSolver
  * Removed ConfidenceInterval class
  * Removed draw method to CovarianceModel
+ * Added Distribution::[sg]etParameter parameter value accessors
+ * Added Distribution::getParameterDescription parameter description accessor
+ * Deprecated method Distribution::setParametersCollection(NP)
  * Removed CovarianceModel::getParameters
  * Added CovarianceModel::getParameter
  * Added CovarianceModel::getParameterDescription

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
 Remove deprecated AbdoRackwitz|Cobyla|SQP::[gs]etLevelFunction|[gs]etLevelValue
 Remove deprecated (AbdoRackwitz|Cobyla|SQP|TNC)SpecificParameters classes
 Remove deprecated OptimizationSolverImplementation::[sg]etMaximumIterationsNumber methods
+Remove deprecated Distribution::setParametersCollection(NP) method

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -892,6 +892,12 @@ void Distribution::setParametersCollection(const NumericalPointCollection & para
   getImplementation()->setParametersCollection(parametersCollection);
 }
 
+void Distribution::setParametersCollection(const NumericalPoint & parameter)
+{
+  copyOnWrite();
+  getImplementation()->setParametersCollection(parameter);
+}
+
 /* Parameters value accessor */
 void Distribution::setParameter(const NumericalPoint & parameters)
 {

--- a/lib/src/Uncertainty/Model/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/Distribution.hxx
@@ -416,6 +416,8 @@ public:
   NumericalPointWithDescriptionCollection getParametersCollection() const;
   void setParametersCollection(const NumericalPointWithDescriptionCollection & parametersCollection);
   void setParametersCollection(const NumericalPointCollection & parametersCollection);
+  /** @deprecated */
+  void setParametersCollection(const NumericalPoint & parameter);
 
   /** Parameters value accessor */
   virtual NumericalPoint getParameter() const;

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -3128,6 +3128,12 @@ void DistributionImplementation::setParametersCollection(const NumericalPointCol
   setParameter(newParameters);
 }
 
+void DistributionImplementation::setParametersCollection(const NumericalPoint & parameter)
+{
+  Log::Info(OSS() << "DistributionImplementation::setParametersCollection(NP) is deprecated.");
+  setParameter(parameter);
+}
+
 /* Parameters value accessor */
 NumericalPoint DistributionImplementation::getParameter() const
 {

--- a/lib/src/Uncertainty/Model/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.hxx
@@ -519,6 +519,8 @@ public:
   virtual NumericalPointWithDescriptionCollection getParametersCollection() const;
   virtual void setParametersCollection(const NumericalPointWithDescriptionCollection & parametersCollection);
   virtual void setParametersCollection(const NumericalPointCollection & parametersCollection);
+  /** @deprecated */
+  void setParametersCollection(const NumericalPoint & parameter);
 
   /** Parameters value accessor */
   virtual NumericalPoint getParameter() const;


### PR DESCRIPTION
It is violently removed by #53.