### PR TITLE
Improved the numerical stability and accuracy of ClaytonCopula

### DIFF
--- a/lib/src/Uncertainty/Model/ContinuousDistribution.cxx
+++ b/lib/src/Uncertainty/Model/ContinuousDistribution.cxx
@@ -65,14 +65,18 @@ NumericalPoint ContinuousDistribution::computeDDF(const NumericalPoint & point) 
   const UnsignedInteger dimension(getDimension());
   NumericalPoint ddf(dimension);
   const NumericalScalar h(std::pow(pdfEpsilon_, 1.0 / 3.0));
-  const NumericalScalar idenom(1.0 / (2.0 * h));
+  LOGINFO(OSS() << "h=" << h);
   for (UnsignedInteger i = 0; i < dimension; ++i)
   {
     NumericalPoint left(point);
     left[i] += h;
     NumericalPoint right(point);
     right[i] -= h;
-    ddf[i] = (computePDF(left) - computePDF(right)) * idenom;
+    const NumericalScalar denom(left[i] - right[i]);
+    const NumericalScalar pdfLeft(computePDF(left));
+    const NumericalScalar pdfRight(computePDF(right));
+    ddf[i] = (pdfLeft - pdfRight) / denom;
+    LOGINFO(OSS() << "left=" << left << ", right=" << right << ", pdfLeft=" << pdfLeft << ", pdfRight=" << pdfRight);
   }
   return ddf;
 }

--- a/lib/test/t_ClaytonCopula_std.cxx
+++ b/lib/test/t_ClaytonCopula_std.cxx
@@ -71,8 +71,8 @@ int main(int argc, char *argv[])
     NumericalScalar pointPDF = copula.computePDF( point );
     NumericalScalar pointCDF = copula.computeCDF( point );
     fullprint << "point= " << point
-              << " ddf=" << pointDDF
-              << " ddf (FD)=" << copula.ContinuousDistribution::computeDDF(point)
+              << " ddf=" << pointDDF.__str__()
+              << " ddf (FD)=" << copula.ContinuousDistribution::computeDDF(point).__str__()
               << " pdf=" << pointPDF
               << " cdf=" << pointCDF
               << std::endl;
@@ -116,6 +116,33 @@ int main(int argc, char *argv[])
     fullprint << "margins quantile=" << quantile << std::endl;
     fullprint << "margins CDF(quantile)=" << margins.computeCDF(quantile) << std::endl;
     fullprint << "margins realization=" << margins.getRealization() << std::endl;
+
+    // Additional tests for PDF/CDF in extreme cases
+    NumericalSample points(0, 2);
+    points.add(NumericalPoint(2, 1.0e-12));
+    points.add(NumericalPoint(2, 1.0e-7));
+    points.add(NumericalPoint(2, 0.1));
+    points.add(NumericalPoint(2, 0.5));
+    points.add(NumericalPoint(2, 0.1));
+    points.add(NumericalPoint(2, 0.1));
+    points.add(NumericalPoint(2, 0.1));
+
+    NumericalPoint thetas;
+    thetas.add(1.0e-12);
+    thetas.add(0.9e-8);
+    thetas.add(1.1e-8);
+    thetas.add(-0.99);
+    thetas.add(9.9e1);
+    thetas.add(1.1e2);
+    thetas.add(1.0e5);
+    for (UnsignedInteger i = 0; i < thetas.getSize(); ++i)
+    {
+      NumericalPoint x(points[i]);
+      ClaytonCopula copula(thetas[i]);
+      fullprint << copula.__str__() << std::endl;
+      fullprint << "PDF(" << x.__str__() << ")=" << std::setprecision(12) << copula.computePDF(x) << std::endl;
+      fullprint << "CDF(" << x.__str__() << ")=" << std::setprecision(12) << copula.computeCDF(x) << std::endl;
+    }
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_ClaytonCopula_std.expout
+++ b/lib/test/t_ClaytonCopula_std.expout
@@ -8,7 +8,7 @@ oneRealization=class=NumericalPoint name=Unnamed dimension=2 values=[0.629877,0.
 oneSample=class=NumericalSample name=a clayton copula implementation=class=NumericalSampleImplementation name=a clayton copula size=10 dimension=2 description=[marginal 1,marginal 2] data=[[0.135276,0.0526823],[0.347057,0.895953],[0.92068,0.794201],[0.0632061,0.0551566],[0.714382,0.621802],[0.373767,0.583326],[0.883503,0.65348],[0.92851,0.935197],[0.684575,0.88113],[0.359802,0.865943]]
 anotherSample mean=class=NumericalPoint name=Unnamed dimension=2 values=[0.502777,0.50134]
 anotherSample covariance=class=CovarianceMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.0845153,0.0628988,0.0628988,0.0838004]
-point= class=NumericalPoint name=Unnamed dimension=2 values=[0.2,0.2] ddf=class=NumericalPoint name=Unnamed dimension=2 values=[-8.01112,-8.01112] ddf (FD)=class=NumericalPoint name=Unnamed dimension=2 values=[-8.01111,-8.01111] pdf=3.3879 cdf=0.152117
+point= class=NumericalPoint name=Unnamed dimension=2 values=[0.2,0.2] ddf=[-8.01112,-8.01112] ddf (FD)=[-8.01111,-8.01111] pdf=3.3879 cdf=0.152117
 Quantile=class=NumericalPoint name=Unnamed dimension=2 values=[0.618165,0.618165]
 CDF(quantile)=0.5
 covariance=class=CovarianceMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.08333,0.06184,0.06184,0.08333]
@@ -32,3 +32,24 @@ margins CDF=0.190662
 margins quantile=class=NumericalPoint name=Unnamed dimension=2 values=[0.973879,0.973879]
 margins CDF(quantile)=0.95
 margins realization=class=NumericalPoint name=Unnamed dimension=2 values=[0.243714,0.761003]
+ClaytonCopula(theta = 1e-12)
+PDF([1e-12,1e-12])=1.00000000071
+CDF([1e-12,1e-12])=1.00000000076e-24
+ClaytonCopula(theta = 9e-09)
+PDF([1e-07,1e-07])=1.00000205701
+CDF([1e-07,1e-07])=1.00000233814e-14
+ClaytonCopula(theta = 1.1e-08)
+PDF([0.1,0.1])=1.00000001866
+CDF([0.1,0.1])=0.0100000005832
+ClaytonCopula(theta = -0.99)
+PDF([0.5,0.5])=1.38641895688
+CDF([0.5,0.5])=0.00661510662812
+ClaytonCopula(theta = 99)
+PDF([0.1,0.1])=248.255741658
+CDF([0.1,0.1])=0.0993022966632
+ClaytonCopula(theta = 110)
+PDF([0.1,0.1])=275.756876477
+CDF([0.1,0.1])=0.099371847379
+ClaytonCopula(theta = 100000)
+PDF([0.1,0.1])=250000.767121
+CDF([0.1,0.1])=0.0999993068552

--- a/python/test/t_ClaytonCopula_std.expout
+++ b/python/test/t_ClaytonCopula_std.expout
@@ -29,3 +29,24 @@ margins CDF=0.190662
 margins quantile= class=NumericalPoint name=Unnamed dimension=2 values=[0.973879,0.973879]
 margins CDF(qantile)=0.950000
 margins realization= class=NumericalPoint name=Unnamed dimension=2 values=[0.243714,0.761003]
+ClaytonCopula(theta = 1e-12)
+PDF( [1e-12,1e-12] )=1.000000000709e+00
+CDF( [1e-12,1e-12] )=1.000000000763e-24
+ClaytonCopula(theta = 9e-09)
+PDF( [1e-07,1e-07] )=1.000002057013e+00
+CDF( [1e-07,1e-07] )=1.000002338139e-14
+ClaytonCopula(theta = 1.1e-08)
+PDF( [0.1,0.1] )=1.000000018664e+00
+CDF( [0.1,0.1] )=1.000000058321e-02
+ClaytonCopula(theta = -0.99)
+PDF( [0.5,0.5] )=1.386418956876e+00
+CDF( [0.5,0.5] )=6.615106628117e-03
+ClaytonCopula(theta = 99)
+PDF( [0.1,0.1] )=2.482557416581e+02
+CDF( [0.1,0.1] )=9.930229666324e-02
+ClaytonCopula(theta = 110)
+PDF( [0.1,0.1] )=2.757568764767e+02
+CDF( [0.1,0.1] )=9.937184737898e-02
+ClaytonCopula(theta = 100000)
+PDF( [0.1,0.1] )=2.500007671207e+05
+CDF( [0.1,0.1] )=9.999930685522e-02

--- a/python/test/t_ClaytonCopula_std.py
+++ b/python/test/t_ClaytonCopula_std.py
@@ -77,6 +77,22 @@ try:
     print("margins CDF(qantile)=%.6f" % margins.computeCDF(quantile))
     print("margins realization=", repr(margins.getRealization()))
 
+    # Additional tests for PDF/CDF in extreme cases
+    # We focus on the main diagonal as it is the most challenging computation
+    points = [[1.0e-12] * 2, [1.0e-7] * 2, [0.1] * 2,
+              [0.5] * 2, [0.1] * 2, [0.1] * 2, [0.1] * 2]
+
+    thetas = [1.0e-12, 0.9e-8, 1.1e-8, -0.99, 9.9e1, 1.1e2, 1.0e5]
+    c_py = list()
+    C_py = list()
+    for i in range(len(thetas)):
+        x = NumericalPoint(points[i])
+        copula = ClaytonCopula(thetas[i])
+        print(copula)
+        c_py.append(copula.computePDF(x))
+        C_py.append(copula.computeCDF(x))
+        print("PDF(", x, ")=%.12e" % c_py[i])
+        print("CDF(", x, ")=%.12e" % C_py[i])
 except:
     import sys
-    print("t_NormalCopula_std.py", sys.exc_info()[0], sys.exc_info()[1])
+    print("t_ClaytonCopula_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
This copula has a CDF/PDF and a random generator badly conditioned for large values of theta (the limit of this copula is the Min copula, which is singular), leading to overflows when implemented naively, and suffers from cancellation for theta close to zero (the limit being the independent copula). The previous implementation was not robust enough to handle these cases with full accuracy.