### PR TITLE
Remove python tests encoding tags

### DIFF
--- a/python/src/coupling_tools.py
+++ b/python/src/coupling_tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #                                               -*- Python -*-
 #
 # @brief Gives functions that help coupling against external code,

--- a/python/test/t_Burr_std.py
+++ b/python/test/t_Burr_std.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 from openturns import *

--- a/python/test/t_ChiFactory_std.py
+++ b/python/test/t_ChiFactory_std.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: iso-8859-15 -*-
 
 from __future__ import print_function
 from openturns import *

--- a/python/test/t_Chi_std.py
+++ b/python/test/t_Chi_std.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: iso-8859-15 -*-
 
 from __future__ import print_function
 from openturns import *

--- a/python/test/t_GeneralizedPareto_std.py
+++ b/python/test/t_GeneralizedPareto_std.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 from openturns import *

--- a/python/test/t_Rice_std.py
+++ b/python/test/t_Rice_std.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: iso-8859-15 -*-
 
 from __future__ import print_function
 from openturns import *

--- a/python/test/t_coupling_tools.py
+++ b/python/test/t_coupling_tools.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from openturns import coupling_tools
 import os


### PR DESCRIPTION
Python 3.5 throws an exception on windows:
SyntaxError: encoding problem: iso-8859-15