### PR TITLE
Rewrite the Fortran language check

### DIFF
--- a/lib/include/CMakeLists.txt
+++ b/lib/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 #                                               -*- cmake -*-
 
-if (CMAKE_Fortran_COMPILER)
+if (CMAKE_Fortran_COMPILER_WORKS)
   # workaround for bug #0014358
   if (CMAKE_VERSION VERSION_LESS 2.8.13 AND NOT DEFINED FortranCInterface_EXE)
     set (FortranCInterface_EXE ${CMAKE_BINARY_DIR}/CMakeFiles/FortranCInterface/FortranCInterface${CMAKE_EXECUTABLE_SUFFIX})


### PR DESCRIPTION
This allows to set CMAKE_Fortran_COMPILER through the mingw toolchain file
while not triggering fortran language specifics if not needed.