### PR TITLE
Fix empty range segfault in drawDiscreteCDF

### DIFF
--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2828,6 +2828,7 @@ Graph DistributionImplementation::drawDiscreteCDF(const NumericalScalar xMin,
   const NumericalSample support(getSupport(Interval(xMin, xMax)));
   const NumericalSample gridY(computeCDF(support));
   const UnsignedInteger size(support.getSize());
+  if (size == 0) throw InvalidArgumentException(HERE) << "empty range (" << xMin << ", " << xMax << ")" << ", support is (" << getSupport().getMin()[0] << ", " << getSupport().getMax()[0] << ")";
   const String xName(getDescription()[0]);
   Graph graphCDF(title, xName, "CDF", true, "topleft");
   NumericalSample data(size + 2, 2);


### PR DESCRIPTION
When the range of drawDiscreteCDF is disjoint from the support
the size variable is zero and leads to a segfault:

import numpy as np
import openturns as ot
mysample1 = np.arange(0,10,0.1)
mysample = np.split(mysample1,len(mysample1))
myCDF = ot.VisualTest_DrawEmpiricalCDF(mysample,10,100)