### PR TITLE
Improved the draw() method of Field

### DIFF
--- a/lib/src/Base/Stat/FieldImplementation.cxx
+++ b/lib/src/Base/Stat/FieldImplementation.cxx
@@ -372,6 +372,15 @@ Mesh FieldImplementation::asDeformedMesh() const
 /* Draw a marginal of the Field */
 Graph FieldImplementation::draw() const
 {
+  // Specific drawing method for bidimensional fields indexed by a scalar
+  if ((getSpatialDimension() == 1) && (getDimension() == 2))
+    {
+      const String title(OSS() << getName());
+      Graph graph(title, description_[0], description_[1], true, "");
+      const Curve curveSerie(getValues());
+      graph.add(curveSerie);
+      return graph;
+    }
   return drawMarginal(0, false);
 }
 


### PR DESCRIPTION
Now, for fields with spatial dimension 1 and with dimension 2, the default draw() method plots the second output as a function of the first output.