### PR TITLE
Fix duplicate contour levels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,7 @@
  * #804 (no IntervalMesher documentation content)
  * #805 (Python segfault in computeSilvermanBandwidth)
  * #808 (Index check of SymmetricTensor fails when embedded within a PythonFunction)
+ * #812 (Sphinx documentation build error)
 
 == 1.6 release (2015-08-14) == #release-1.6
 

--- a/lib/src/Base/Graph/Contour.cxx
+++ b/lib/src/Base/Graph/Contour.cxx
@@ -245,6 +245,7 @@ void Contour::buildDefaultLevels(const UnsignedInteger number)
   const UnsignedInteger size(data_.getSize());
   levels_ = NumericalPoint(number);
   for (UnsignedInteger i = 0; i < number; ++i) levels_[i] = sortedData[static_cast<UnsignedInteger>(size * (i + 0.5) / number)][0];
+  levels_.erase(std::unique(levels_.begin(), levels_.end()), levels_.end());
 }
 
 /* Build default labels by taking the level values */


### PR DESCRIPTION
Fixes the default BayesDistribution pdf graph with uniform
distributions with matplotlib.

Matplotlib 1.5.1 now turns this into an error:
https://github.com/matplotlib/matplotlib/pull/5485