### PR TITLE
Use NSI_const_iterator in ReductionFunctor 

### DIFF
--- a/lib/src/Base/Stat/NumericalSampleImplementation.cxx
+++ b/lib/src/Base/Stat/NumericalSampleImplementation.cxx
@@ -925,7 +925,8 @@ struct ReductionFunctor
 
   void operator() (const TBB::BlockedRange<UnsignedInteger> & r)
   {
-    for (UnsignedInteger i = r.begin(); i != r.end(); ++i) op_.inplace_op( accumulator_, nsi_[i] );
+    NSI_const_iterator it = nsi_.begin() + r.begin();
+    for (UnsignedInteger i = r.begin(); i != r.end(); ++i, ++it) op_.inplace_op( accumulator_, *it );
   }
 
   void join(const ReductionFunctor & other)


### PR DESCRIPTION
Otherwise TBB overhead may impact performance.

I wrote a benchmark to compare timings for current implementation based on TBB, and a naive one:
```
size=       1 dim=       1 size*dim=        1:    meanTBB=2.704e-05 (*)meanSeq=1.488e-06 (*)varTBB=3.200e-07    varSeq=3.320e-07
size=       1 dim=      10 size*dim=       10:    meanTBB=4.076e-06 (*)meanSeq=4.780e-07    varTBB=1.900e-07 (*)varSeq=1.580e-07
size=       1 dim=     100 size*dim=      100:    meanTBB=4.253e-06 (*)meanSeq=1.118e-06 (*)varTBB=1.570e-07    varSeq=1.890e-07
size=       1 dim=    1000 size*dim=     1000:    meanTBB=1.021e-05 (*)meanSeq=7.029e-06    varTBB=2.510e-07 (*)varSeq=1.610e-07
size=       1 dim=   10000 size*dim=    10000:    meanTBB=1.137e-04 (*)meanSeq=9.377e-05    varTBB=4.080e-07 (*)varSeq=1.380e-07
size=       1 dim=  100000 size*dim=   100000:    meanTBB=1.239e-03 (*)meanSeq=9.938e-04    varTBB=1.113e-06 (*)varSeq=3.310e-07
size=      10 dim=       1 size*dim=       10:    meanTBB=9.063e-05 (*)meanSeq=6.330e-07    varTBB=1.091e-05 (*)varSeq=9.110e-07
size=      10 dim=      10 size*dim=      100:    meanTBB=7.226e-06 (*)meanSeq=9.530e-07    varTBB=9.100e-06 (*)varSeq=1.681e-06
size=      10 dim=     100 size*dim=     1000:    meanTBB=1.211e-05 (*)meanSeq=5.468e-06    varTBB=2.075e-05 (*)varSeq=1.075e-05
size=      10 dim=    1000 size*dim=    10000:    meanTBB=6.075e-05 (*)meanSeq=4.794e-05    varTBB=1.408e-04 (*)varSeq=1.016e-04
size=      10 dim=   10000 size*dim=   100000:    meanTBB=5.475e-04 (*)meanSeq=5.022e-04    varTBB=1.466e-03 (*)varSeq=1.076e-03
size=      10 dim=  100000 size*dim=  1000000: (*)meanTBB=5.532e-03    meanSeq=7.457e-03    varTBB=1.599e-02 (*)varSeq=1.155e-02
size=     100 dim=       1 size*dim=      100:    meanTBB=1.921e-04 (*)meanSeq=1.414e-06    varTBB=9.416e-04 (*)varSeq=2.670e-06
size=     100 dim=      10 size*dim=     1000:    meanTBB=4.700e-04 (*)meanSeq=6.035e-06    varTBB=9.389e-04 (*)varSeq=1.111e-05
size=     100 dim=     100 size*dim=    10000:    meanTBB=5.006e-04 (*)meanSeq=4.946e-05    varTBB=9.786e-04 (*)varSeq=9.920e-05
size=     100 dim=    1000 size*dim=   100000:    meanTBB=6.669e-04 (*)meanSeq=4.690e-04    varTBB=1.339e-03 (*)varSeq=9.894e-04
size=     100 dim=   10000 size*dim=  1000000: (*)meanTBB=2.923e-03    meanSeq=7.839e-03 (*)varTBB=5.857e-03    varSeq=1.038e-02
size=     100 dim=  100000 size*dim= 10000000: (*)meanTBB=1.945e-02    meanSeq=4.765e-02 (*)varTBB=5.902e-02    varSeq=1.045e-01
size=    1000 dim=       1 size*dim=     1000:    meanTBB=8.467e-05 (*)meanSeq=8.367e-06    varTBB=6.673e-05 (*)varSeq=1.658e-05
size=    1000 dim=      10 size*dim=    10000:    meanTBB=1.485e-04 (*)meanSeq=5.164e-05    varTBB=1.160e-04 (*)varSeq=1.015e-04
size=    1000 dim=     100 size*dim=   100000:    meanTBB=6.884e-04 (*)meanSeq=4.966e-04 (*)varTBB=9.319e-04    varSeq=9.636e-04
size=    1000 dim=    1000 size*dim=  1000000: (*)meanTBB=2.028e-03    meanSeq=4.717e-03 (*)varTBB=8.161e-03    varSeq=1.025e-02
size=    1000 dim=   10000 size*dim= 10000000: (*)meanTBB=1.000e-02    meanSeq=4.724e-02 (*)varTBB=2.321e-02    varSeq=1.031e-01
size=    1000 dim=  100000 size*dim=100000000: (*)meanTBB=1.661e-01    meanSeq=4.764e-01 (*)varTBB=4.289e-01    varSeq=1.044e+00
size=   10000 dim=       1 size*dim=    10000:    meanTBB=1.050e-04 (*)meanSeq=7.788e-05    varTBB=2.816e-04 (*)varSeq=1.558e-04
size=   10000 dim=      10 size*dim=   100000: (*)meanTBB=3.558e-04    meanSeq=4.754e-04 (*)varTBB=8.762e-04    varSeq=9.935e-04
size=   10000 dim=     100 size*dim=  1000000: (*)meanTBB=3.326e-03    meanSeq=4.981e-03 (*)varTBB=9.937e-03    varSeq=9.986e-03
size=   10000 dim=    1000 size*dim= 10000000: (*)meanTBB=1.535e-02    meanSeq=4.742e-02 (*)varTBB=2.304e-02    varSeq=1.010e-01
size=   10000 dim=   10000 size*dim=100000000: (*)meanTBB=1.172e-01    meanSeq=4.749e-01 (*)varTBB=2.222e-01    varSeq=1.037e+00
size=  100000 dim=       1 size*dim=   100000: (*)meanTBB=3.709e-04    meanSeq=7.581e-04 (*)varTBB=9.976e-04    varSeq=1.556e-03
size=  100000 dim=      10 size*dim=  1000000: (*)meanTBB=1.401e-03    meanSeq=4.953e-03 (*)varTBB=4.094e-03    varSeq=1.033e-02
size=  100000 dim=     100 size*dim= 10000000: (*)meanTBB=9.568e-03    meanSeq=4.978e-02 (*)varTBB=2.199e-02    varSeq=9.985e-02
size=  100000 dim=    1000 size*dim=100000000: (*)meanTBB=9.568e-02    meanSeq=4.774e-01 (*)varTBB=2.049e-01    varSeq=1.033e+00
```

Based on these timings, I propose to use sequential implementation when size*dimension < 1e4.  This threshold is not very important, we should only make sure that very small samples do not use TBB.