### PR TITLE
Pythondistribution parallel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,8 +29,9 @@
 
 === Bug fixes ===
  * #813 (Error when multiplying a Matrix by a SymmetricMatrix)
+ * #820 (Python distribution fails randomly when computing the PDF over a sample)
  * #822 (Incorect Matrix / point operations with cast)
-  
+
 == 1.7 release (2016-01-27) == #release-1.7
 
 === Library ===

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -746,7 +746,7 @@ void ResourceMap::loadDefaultConfiguration()
   setAsUnsignedInteger( "DistributionImplementation-DefaultIntegrationNodesNumber", 255 );
   setAsUnsignedInteger( "DistributionImplementation-DefaultLevelNumber", 10 );
   setAsUnsignedInteger( "DistributionImplementation-DefaultQuantileCacheSize", 128 );
-  setAsBool("DistributionImplementation-Parallel", false);
+  setAsBool("DistributionImplementation-Parallel", true);
   setAsUnsignedInteger( "DistributionImplementation-CharacteristicFunctionBlockMax", 20 );
   setAsUnsignedInteger( "DistributionImplementation-CharacteristicFunctionNMax", 1000000 );
 

--- a/python/src/PythonDistributionImplementation.cxx
+++ b/python/src/PythonDistributionImplementation.cxx
@@ -51,6 +51,9 @@ PythonDistributionImplementation::PythonDistributionImplementation(PyObject * py
   : DistributionImplementation(),
     pyObj_(pyObject)
 {
+  // Python memory management is not thread-safe
+  setParallel(false);
+  
   Py_XINCREF( pyObj_ );
 
   if ( !PyObject_HasAttrString( pyObj_, const_cast<char *>("computeCDF") ) ) throw InvalidArgumentException(HERE) << "Error: the given object does not have a computeCDF() method.";


### PR DESCRIPTION
Python memory management is not thread-safe and parallelization
cannot be used to wrap the callbacks.