### PR TITLE
Fix NMEvaluation::::getParameterDimension

### DIFF
--- a/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
@@ -388,7 +388,7 @@ UnsignedInteger NumericalMathEvaluationImplementation::getOutputDimension() cons
 /* Accessor for input point dimension */
 UnsignedInteger NumericalMathEvaluationImplementation::getParameterDimension() const
 {
-  return parameter_.getDimension();
+  return getParameter().getDimension();
 }
 
 /* Get the i-th marginal function */


### PR DESCRIPTION
to use the virtual getParameter method if redefined in inherited classes