### PR TITLE
Fix compilation of Python bindings

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_target (generate_docstrings)
 
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
 
-include_directories (${INTERNAL_INCLUDE_DIRS})
+include_directories (BEFORE ${INTERNAL_INCLUDE_DIRS})
 include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 
 set (OPENTURNS_PYTHON_MODULES)


### PR DESCRIPTION
Swig adds several -I flags to c++ command line option, in particular
-I/usr/include on Debian.  If OpenTURNS had already been installed
into /usr/include, headers are then taken from /usr/include/openturns
and not from source directory.
Pass BEFORE option to CMake include_directories() command to ensure
that correct header files are being used.