### PR TITLE
Allow partial copy constructor of NumericalSample

### DIFF
--- a/lib/src/Base/Stat/NumericalSample.cxx
+++ b/lib/src/Base/Stat/NumericalSample.cxx
@@ -533,7 +533,7 @@ NumericalScalar NumericalSample::computeEmpiricalCDF(const NumericalPoint & poin
 
 /*
  * Get the position of a point in the sample.
- * Returns size+1 if the point does not belong to the sample.
+ * Returns size if the point does not belong to the sample.
  */
 UnsignedInteger NumericalSample::find(const NumericalPoint & point) const
 {

--- a/lib/src/Base/Stat/NumericalSample.cxx
+++ b/lib/src/Base/Stat/NumericalSample.cxx
@@ -100,6 +100,15 @@ NumericalSample::NumericalSample(const UnsignedInteger size,
   // Nothing to do
 }
 
+/* Partial copy constructor */
+NumericalSample::NumericalSample(const NumericalSample other,
+                                 const UnsignedInteger first,
+                                 const UnsignedInteger last)
+  : TypedInterfaceObject<NumericalSampleImplementation>(new NumericalSampleImplementation(*other.getImplementation(), other.getImplementation()->begin()+first, other.getImplementation()->begin()+last))
+{
+  // Nothing to do
+}
+
 /* Constructor from a collection of NumericalPoint */
 NumericalSample::NumericalSample(const Collection<NumericalPoint> & coll)
   : TypedInterfaceObject<NumericalSampleImplementation>(new NumericalSampleImplementation(coll))

--- a/lib/src/Base/Stat/NumericalSampleImplementation.cxx
+++ b/lib/src/Base/Stat/NumericalSampleImplementation.cxx
@@ -554,7 +554,7 @@ NumericalSampleImplementation::NumericalSampleImplementation(const Collection<In
 }
 
 /* Partial copy constructor */
-NumericalSampleImplementation::NumericalSampleImplementation(const NumericalSampleImplementation & other, iterator first, iterator last)
+NumericalSampleImplementation::NumericalSampleImplementation(const NumericalSampleImplementation & other, const_iterator first, const_iterator last)
   : PersistentObject()
   , size_(last - first)
   , dimension_(other.getDimension())

--- a/lib/src/Base/Stat/openturns/NumericalSample.hxx
+++ b/lib/src/Base/Stat/openturns/NumericalSample.hxx
@@ -78,6 +78,11 @@ public:
   NumericalSample(const UnsignedInteger size,
                   const NumericalPoint & point);
 
+  /** Partial copy constructor */
+  NumericalSample(const NumericalSample other,
+                  const UnsignedInteger first,
+                  const UnsignedInteger last);
+
 #ifndef SWIG
   /** Constructor from a collection of NumericalPoint */
   NumericalSample(const Collection<NumericalPoint> & coll);

--- a/lib/src/Base/Stat/openturns/NumericalSample.hxx
+++ b/lib/src/Base/Stat/openturns/NumericalSample.hxx
@@ -265,7 +265,7 @@ public:
 
   /**
    * Get the position of a point in the sample.
-   * Returns size+1 if the point does not belong to the sample.
+   * Returns size if the point does not belong to the sample.
    */
   UnsignedInteger find(const NumericalPoint & point) const;
 

--- a/lib/src/Base/Stat/openturns/NumericalSampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/NumericalSampleImplementation.hxx
@@ -514,8 +514,8 @@ public:
 
   /** Partial copy constructor */
   NumericalSampleImplementation(const NumericalSampleImplementation & other,
-                                iterator first,
-                                iterator last);
+                                const_iterator first,
+                                const_iterator last);
 
   inline iterator begin()
   {

--- a/lib/test/t_NumericalSample_std.cxx
+++ b/lib/test/t_NumericalSample_std.cxx
@@ -142,6 +142,9 @@ int main(int argc, char *argv[])
     sample3.erase(pos);
     fullprint << "sample3=" << sample3 << std::endl;
 
+    // Partial copy constructor containing sample2[4:7]
+    NumericalSample sample4(sample2, 4, 8);
+    fullprint << "sample4=" << sample4 << std::endl;
 
   }
   catch (TestFailed & ex)

--- a/lib/test/t_NumericalSample_std.expout
+++ b/lib/test/t_NumericalSample_std.expout
@@ -18,3 +18,4 @@ sample3=class=NumericalSample name=Unnamed implementation=class=NumericalSampleI
 sample3=class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=6 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[-1000,-2000,-3000]]
 sample3=class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=7 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[-1000,-2000,-3000],[1000,2000,3000]]
 sample3=class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=6 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000]]
+sample4=class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=4 dimension=2 data=[[10,20],[11,21],[10,20],[10,20]]

--- a/python/src/NumericalSample_doc.i.in
+++ b/python/src/NumericalSample_doc.i.in
@@ -740,10 +740,10 @@ Examples
 
 Parameters
 ----------
-f : int, :math:`0 \leq f < n`
+f : int, :math:`0 \leq f < m`
     The index of the first point to erase.
-l : int, :math:`f < l < n`, optional
-    The index of the last point to erase.
+l : int, :math:`f < l \leq m`, optional
+    The index after the last point to erase.
     Default uses `l = f + 1` and only removes `sample[f]`.
 Returns
 -------
@@ -808,7 +808,7 @@ point : sequence of float
 Returns
 -------
 index : int,
-    Returns :math:`n` if the point does not belong to the sample.
+    Returns :math:`m` if the point does not belong to the sample.
 
 Examples
 --------

--- a/python/src/NumericalSample_doc.i.in
+++ b/python/src/NumericalSample_doc.i.in
@@ -1,6 +1,13 @@
 %feature("docstring") OT::NumericalSample
 "Sample of real vectors.
 
+Available constructors:
+    NumericalSample(*size, dim*)
+
+    NumericalSample(*size, point*)
+
+    NumericalSample(*other, first, last*)
+
 Parameters
 ----------
 size : int, :math:`m > 0`, optional
@@ -12,6 +19,12 @@ dimension : int, :math:`n > 0`, optional
 point : :class:`~openturns.NumericalPoint` or flat (1d) array, list or tuple of floats, optional
     The point that will be repeated along the sample.
     Default creates a sample filled with zeros (null vectors).
+other : :class:`~openturns.NumericalSample`
+    The sample contains points to copy.
+first : int, :math:`0 \leq first < m`
+    The index of the first point to copy.
+last : int, :math:`first < last \leq m`, optional
+    The index after the last point to copy.
 
 See Also
 --------

--- a/python/test/t_NumericalSample_std.expout
+++ b/python/test/t_NumericalSample_std.expout
@@ -7,4 +7,4 @@ sample3= class=NumericalSample name=Unnamed implementation=class=NumericalSample
 sample3= class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=6 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[-1000,-2000,-3000]]
 sample3= class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=7 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[-1000,-2000,-3000],[1000,2000,3000]]
 sample3= class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=6 dimension=3 data=[[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000],[1000,2000,3000]]
-sample4= class=NumericalSample name=Sample1 implementation=class=NumericalSampleImplementation name=Sample1 size=3 dimension=2 description=[a0,a1] data=[[10,20],[11,21],[1000,2000]]
+sample4= class=NumericalSample name=Unnamed implementation=class=NumericalSampleImplementation name=Unnamed size=4 dimension=2 data=[[10,20],[11,21],[10,20],[10,20]]

--- a/python/test/t_NumericalSample_std.py
+++ b/python/test/t_NumericalSample_std.py
@@ -82,8 +82,8 @@ try:
     sample3.erase(pos)
     print("sample3=", repr(sample3))
 
-    # Copy a sample
-    sample4 = NumericalSample(sample1)
+    # Partial copy constructor containing sample2[4:7]
+    sample4 = NumericalSample(sample2, 4, 8)
     print("sample4=", repr(sample4))
 
 except:


### PR DESCRIPTION
Modify partial copy constructor of NumericalSampleImplementation to also work on const objects.
Fix typos in NumericalSample comments and docstrings.