### PR TITLE
Fixed a bug in GaussProductExperiment introduced in PR#222

### DIFF
--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
@@ -79,6 +79,10 @@ private:
   // Compute the tensor product nodes and weights
   void computeNodesAndWeights();
 
+  // Distribution and marginal degrees accessor
+  void setDistributionAndMarginalDegrees(const Distribution & distribution,
+					 const Indices & marginalDegrees);
+
   // Marginal orthogonal univariate polynomial family collection
   OrthogonalUniVariatePolynomialFamilyCollection collection_;
 


### PR DESCRIPTION
The bug is due to the incremental way an attribute is built during the construction of the object, which is reused when the distribution underlying this weighted experiment is changed. The reset of the attribute was missing.