### PR TITLE
Fix TruncatedDistribution::setParameter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@
  * #820 (Python distribution fails randomly when computing the PDF over a sample)
  * #822 (Incorect Matrix / point operations with cast)
  * #824 (Confusing behavior of NumericalSample::sort)
+ * #837 (TruncatedDistribution::setParameter segfaults)
 
 == 1.7 release (2016-01-27) == #release-1.7
 

--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -343,7 +343,7 @@ void TruncatedDistribution::setParameter(const NumericalPoint & parameter)
 {
   const UnsignedInteger parametersSize = distribution_.getParameterDimension();
   if (parameter.getSize() != parametersSize + 4) throw InvalidArgumentException(HERE) << "Error: expected " << parametersSize + 4 << " values, got " << parameter.getSize();
-  NumericalPoint newParameters;
+  NumericalPoint newParameters(parametersSize);
   std::copy(parameter.begin(), parameter.begin() + parametersSize, newParameters.begin());
   Distribution newDistribution(distribution_);
   newDistribution.setParameter(newParameters);

--- a/lib/test/t_TruncatedDistribution_std.cxx
+++ b/lib/test/t_TruncatedDistribution_std.cxx
@@ -50,76 +50,84 @@ int main(int argc, char *argv[])
     distribution[2] = TruncatedDistribution(Normal(2.0, 1.5), 4.0, TruncatedDistribution::UPPER);
     for (UnsignedInteger testCase = 0; testCase < 3; ++testCase)
     {
-      fullprint << "Distribution " << distribution[testCase] << std::endl;
-      std::cout << "Distribution " << distribution[testCase] << std::endl;
+      TruncatedDistribution distributionTestCase(distribution[testCase]);
+      fullprint << "Distribution " << distributionTestCase << std::endl;
+      std::cout << "Distribution " << distributionTestCase << std::endl;
 
       // Is this distribution elliptical ?
-      fullprint << "Elliptical = " << (distribution[testCase].isElliptical() ? "true" : "false") << std::endl;
+      fullprint << "Elliptical = " << (distributionTestCase.isElliptical() ? "true" : "false") << std::endl;
 
       // Is this distribution continuous ?
-      fullprint << "Continuous = " << (distribution[testCase].isContinuous() ? "true" : "false") << std::endl;
+      fullprint << "Continuous = " << (distributionTestCase.isContinuous() ? "true" : "false") << std::endl;
 
       // Test for realization of distribution
-      NumericalPoint oneRealization = distribution[testCase].getRealization();
+      NumericalPoint oneRealization = distributionTestCase.getRealization();
       fullprint << "oneRealization=" << oneRealization << std::endl;
 
       // Test for sampling
       UnsignedInteger size = 10000;
-      NumericalSample oneSample = distribution[testCase].getSample( size );
+      NumericalSample oneSample = distributionTestCase.getSample( size );
       fullprint << "oneSample first=" << oneSample[0] << " last=" << oneSample[size - 1] << std::endl;
       fullprint << "mean=" << oneSample.computeMean() << std::endl;
       fullprint << "covariance=" << oneSample.computeCovariance() << std::endl;
 
       // Define a point
-      NumericalPoint point( distribution[testCase].getDimension(), 2.5 );
+      NumericalPoint point( distributionTestCase.getDimension(), 2.5 );
       fullprint << "Point= " << point << std::endl;
 
       // Show PDF and CDF of point
-      NumericalPoint DDF = distribution[testCase].computeDDF( point );
+      NumericalPoint DDF = distributionTestCase.computeDDF( point );
       fullprint << "ddf      =" << DDF << std::endl;
       fullprint << "ddf (ref)=" << referenceDistribution[testCase].computeDDF(point) << std::endl;
-      NumericalScalar PDF = distribution[testCase].computePDF( point );
+      NumericalScalar PDF = distributionTestCase.computePDF( point );
       fullprint << "pdf      =" << PDF << std::endl;
       fullprint << "pdf (ref)=" << referenceDistribution[testCase].computePDF(point) << std::endl;
-      NumericalScalar CDF = distribution[testCase].computeCDF( point );
+      NumericalScalar CDF = distributionTestCase.computeCDF( point );
       fullprint << "cdf      =" << CDF << std::endl;
       fullprint << "cdf (ref)=" << referenceDistribution[testCase].computeCDF(point) << std::endl;
-      NumericalPoint PDFgr = distribution[testCase].computePDFGradient( point );
+      NumericalPoint PDFgr = distributionTestCase.computePDFGradient( point );
       fullprint << "pdf gradient      =" << clean(PDFgr) << std::endl;
       fullprint << "pdf gradient (ref)=" << clean(referenceDistribution[testCase].computePDFGradient(point)) << std::endl;
-      NumericalPoint CDFgr = distribution[testCase].computeCDFGradient( point );
+      NumericalPoint CDFgr = distributionTestCase.computeCDFGradient( point );
       fullprint << "cdf gradient      =" << clean(CDFgr) << std::endl;
       fullprint << "cdf gradient (ref)=" << clean(referenceDistribution[testCase].computeCDFGradient(point)) << std::endl;
-      NumericalPoint quantile = distribution[testCase].computeQuantile( 0.95 );
+      NumericalPoint quantile = distributionTestCase.computeQuantile( 0.95 );
       fullprint << "quantile      =" << quantile << std::endl;
       fullprint << "quantile (ref)=" << referenceDistribution[testCase].computeQuantile( 0.95 ) << std::endl;
-      fullprint << "cdf(quantile)=" << distribution[testCase].computeCDF(quantile) << std::endl;
-      NumericalPoint mean = distribution[testCase].getMean();
+      fullprint << "cdf(quantile)=" << distributionTestCase.computeCDF(quantile) << std::endl;
+      NumericalPoint mean = distributionTestCase.getMean();
       fullprint << "mean      =" << mean << std::endl;
       fullprint << "mean (ref)=" << referenceDistribution[testCase].getMean() << std::endl;
-      NumericalPoint standardDeviation = distribution[testCase].getStandardDeviation();
+      NumericalPoint standardDeviation = distributionTestCase.getStandardDeviation();
       fullprint << "standard deviation      =" << standardDeviation << std::endl;
       fullprint << "standard deviation (ref)=" << referenceDistribution[testCase].getStandardDeviation() << std::endl;
-      NumericalPoint skewness = distribution[testCase].getSkewness();
+      NumericalPoint skewness = distributionTestCase.getSkewness();
       fullprint << "skewness      =" << skewness << std::endl;
       fullprint << "skewness (ref)=" << referenceDistribution[testCase].getSkewness() << std::endl;
-      NumericalPoint kurtosis = distribution[testCase].getKurtosis();
+      NumericalPoint kurtosis = distributionTestCase.getKurtosis();
       fullprint << "kurtosis      =" << kurtosis << std::endl;
       fullprint << "kurtosis (ref)=" << referenceDistribution[testCase].getKurtosis() << std::endl;
-      CovarianceMatrix covariance = distribution[testCase].getCovariance();
+      CovarianceMatrix covariance = distributionTestCase.getCovariance();
       fullprint << "covariance      =" << covariance << std::endl;
       fullprint << "covariance (ref)=" << referenceDistribution[testCase].getCovariance() << std::endl;
-      TruncatedDistribution::NumericalPointWithDescriptionCollection parameters = distribution[testCase].getParametersCollection();
+      TruncatedDistribution::NumericalPointWithDescriptionCollection parameters = distributionTestCase.getParametersCollection();
       fullprint << "parameters      =" << parameters << std::endl;
       fullprint << "parameters (ref)=" << referenceDistribution[testCase].getParametersCollection() << std::endl;
-      for (UnsignedInteger i = 0; i < 6; ++i) fullprint << "standard moment n=" << i << ", value=" << distribution[testCase].getStandardMoment(i) << std::endl;
-      fullprint << "Standard representative=" << distribution[testCase].getStandardRepresentative()->__str__() << std::endl;
+      for (UnsignedInteger i = 0; i < 6; ++i) fullprint << "standard moment n=" << i << ", value=" << distributionTestCase.getStandardMoment(i) << std::endl;
+      fullprint << "Standard representative=" << distributionTestCase.getStandardRepresentative()->__str__() << std::endl;
 
       // Specific to this distribution
-      NumericalScalar lowerBound(distribution[testCase].getLowerBound());
+      NumericalScalar lowerBound(distributionTestCase.getLowerBound());
       fullprint << "lowerBound=" << lowerBound << std::endl;
-      NumericalScalar upperBound(distribution[testCase].getUpperBound());
+      NumericalScalar upperBound(distributionTestCase.getUpperBound());
       fullprint << "upperBound=" << upperBound << std::endl;
+
+      // Get/Set parameter
+      NumericalPoint parameter(distributionTestCase.getParameter());
+      fullprint << "Distribution parameters      =" << parameter.__str__() << std::endl;
+      parameter[0] = 1.0;
+      distributionTestCase.setParameter(parameter);
+      fullprint << "Distribution after setParameter =" << distributionTestCase.getParameter().__str__() << std::endl;
 
     }
   }

--- a/lib/test/t_TruncatedDistribution_std.expout
+++ b/lib/test/t_TruncatedDistribution_std.expout
@@ -41,6 +41,8 @@ standard moment n=5, value=class=NumericalPoint name=Unnamed dimension=1 values=
 Standard representative=TruncatedDistribution(Normal(mu = 2, sigma = 1.5), a = 1, b = 4)
 lowerBound=1
 upperBound=4
+Distribution parameters      =[2,1.5,1,1,1,4]
+Distribution after setParameter =[1,1.5,1,1,1,4]
 Distribution class=TruncatedDistribution name=TruncatedDistribution distribution=class=Normal name=Normal dimension=1 mean=class=NumericalPoint name=Unnamed dimension=1 values=[2] sigma=class=NumericalPoint name=Unnamed dimension=1 values=[1.5] correlationMatrix=class=CorrelationMatrix dimension=1 implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[1] lowerBound=1 finiteLowerBound=true upperBound=13.4759 finiteUpperBound=false thresholdRealization=0.5
 Distribution TruncatedDistribution(Normal(mu = 2, sigma = 1.5), a = 1, b = +inf)
 Elliptical = false
@@ -84,6 +86,8 @@ standard moment n=5, value=class=NumericalPoint name=Unnamed dimension=1 values=
 Standard representative=TruncatedDistribution(Normal(mu = 2, sigma = 1.5), a = 1, b = +inf)
 lowerBound=1
 upperBound=13.4759
+Distribution parameters      =[2,1.5,1,1,0,13.4759]
+Distribution after setParameter =[1,1.5,1,1,0,12.4759]
 Distribution class=TruncatedDistribution name=TruncatedDistribution distribution=class=Normal name=Normal dimension=1 mean=class=NumericalPoint name=Unnamed dimension=1 values=[2] sigma=class=NumericalPoint name=Unnamed dimension=1 values=[1.5] correlationMatrix=class=CorrelationMatrix dimension=1 implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[1] lowerBound=-9.47594 finiteLowerBound=false upperBound=4 finiteUpperBound=true thresholdRealization=0.5
 Distribution TruncatedDistribution(Normal(mu = 2, sigma = 1.5), a = -inf, b = 4)
 Elliptical = false
@@ -127,3 +131,5 @@ standard moment n=5, value=class=NumericalPoint name=Unnamed dimension=1 values=
 Standard representative=TruncatedDistribution(Normal(mu = 2, sigma = 1.5), a = -inf, b = 4)
 lowerBound=-9.47594
 upperBound=4
+Distribution parameters      =[2,1.5,0,-9.47594,1,4]
+Distribution after setParameter =[1,1.5,0,-10.4759,1,4]


### PR DESCRIPTION
The TruncatedDistribution::setParameter method currently crashes due to a bad allocation (cf  http://trac.openturns.org/ticket/837)
This PR fixes this issue.