### PR TITLE
Avoid bind method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,9 +35,10 @@
 === Python module ===
 
 === Miscellaneous ===
- * Improved the computeCDF() method of Normal 
- * Add HarrisonMcCabe, BreuschPagan and DurbinWatson tests to test homoskedasticity, autocorrelation of linear regression residuals 
+ * Improved the computeCDF() method of Normal
+ * Add HarrisonMcCabe, BreuschPagan and DurbinWatson tests to test homoskedasticity, autocorrelation of linear regression residuals
  * Add two samples Kolmogorov test
+ * Improved the speed of many algorithms based on method binding
 
 === Bug fixes ===
  * #813 (Error when multiplying a Matrix by a SymmetricMatrix)

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
@@ -26,9 +26,9 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/OrderStatisticsMarginalChecker.hxx"
 #include "openturns/Uniform.hxx"
-#include "openturns/MethodBoundNumericalMathEvaluationImplementation.hxx"
 #include "openturns/GaussKronrod.hxx"
 #include "openturns/Brent.hxx"
+#include "openturns/MethodBoundNumericalMathEvaluationImplementation.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 

--- a/lib/src/Uncertainty/Distribution/openturns/AliMikhailHaqCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/AliMikhailHaqCopula.hxx
@@ -83,9 +83,11 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/openturns/ClaytonCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/ClaytonCopula.hxx
@@ -84,9 +84,11 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/openturns/ComposedCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/ComposedCopula.hxx
@@ -102,12 +102,15 @@ public:
   Implementation getMarginal(const Indices & indices) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   virtual NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   virtual NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   virtual NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Parameters value and description accessor */

--- a/lib/src/Uncertainty/Distribution/openturns/ComposedDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/ComposedDistribution.hxx
@@ -118,9 +118,11 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Get the standard deviation of the distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/Dirichlet.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Dirichlet.hxx
@@ -97,12 +97,15 @@ public:
   NumericalPoint getTheta() const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Get the i-th marginal distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/FarlieGumbelMorgensternCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FarlieGumbelMorgensternCopula.hxx
@@ -80,9 +80,11 @@ public:
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Parameters value accessors */

--- a/lib/src/Uncertainty/Distribution/openturns/FrankCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FrankCopula.hxx
@@ -83,9 +83,11 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/openturns/GumbelCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/GumbelCopula.hxx
@@ -83,9 +83,11 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/openturns/IndependentCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/IndependentCopula.hxx
@@ -96,12 +96,15 @@ public:
   virtual NumericalScalar computeConditionalDDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   virtual NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   virtual NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   virtual NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Get the isoprobabilistic transformation */

--- a/lib/src/Uncertainty/Distribution/openturns/MaximumEntropyOrderStatisticsDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MaximumEntropyOrderStatisticsDistribution.hxx
@@ -98,12 +98,15 @@ public:
   NumericalScalar computeCDFOld(const NumericalPoint & point) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Get the i-th marginal distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/Multinomial.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Multinomial.hxx
@@ -72,14 +72,17 @@ public:
   NumericalScalar computeCDF(const NumericalPoint & point) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q,
       const NumericalPoint & y) const;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Normal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Normal.hxx
@@ -99,12 +99,15 @@ public:
       const Bool tail = false) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Get the i-th marginal distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/NormalCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/NormalCopula.hxx
@@ -97,14 +97,17 @@ public:
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q,
       const NumericalPoint & y) const;
 

--- a/lib/src/Uncertainty/Distribution/openturns/OrdinalSumCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/OrdinalSumCopula.hxx
@@ -104,12 +104,15 @@ public:
   Implementation getMarginal(const Indices & indices) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   virtual NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   virtual NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   virtual NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Parameters value and description accessor */

--- a/lib/src/Uncertainty/Distribution/openturns/Student.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Student.hxx
@@ -93,12 +93,15 @@ public:
       const Bool tail = false) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const;
 
   /** Get the i-th marginal distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/SubSquareCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/SubSquareCopula.hxx
@@ -68,14 +68,17 @@ public:
   NumericalScalar computeCDF(const NumericalPoint & point) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q,
       const NumericalPoint & y) const;
 

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -308,6 +308,13 @@ NumericalPoint Distribution::getCenteredMoment(const UnsignedInteger n) const
   return getImplementation()->getCenteredMoment(n);
 }
 
+/* Get the shifted moments of the distribution */
+NumericalPoint Distribution::getShiftedMoment(const UnsignedInteger n,
+					      const NumericalPoint & shift) const
+{
+  return getImplementation()->getShiftedMoment(n, shift);
+}
+
 /* Get the covariance of the distribution */
 CovarianceMatrix Distribution::getCovariance() const
 {

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -711,14 +711,29 @@ NumericalScalar Distribution::computeConditionalPDF(const NumericalScalar x, con
   return getImplementation()->computeConditionalPDF(x, y);
 }
 
+NumericalPoint Distribution::computeConditionalPDF(const NumericalPoint & x, const NumericalSample & y) const
+{
+  return getImplementation()->computeConditionalPDF(x, y);
+}
+
 /* Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
 NumericalScalar Distribution::computeConditionalCDF(const NumericalScalar x, const NumericalPoint & y) const
 {
   return getImplementation()->computeConditionalCDF(x, y);
 }
 
+NumericalPoint Distribution::computeConditionalCDF(const NumericalPoint & x, const NumericalSample & y) const
+{
+  return getImplementation()->computeConditionalCDF(x, y);
+}
+
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
 NumericalScalar Distribution::computeConditionalQuantile(const NumericalScalar q, const NumericalPoint & y) const
+{
+  return getImplementation()->computeConditionalQuantile(q, y);
+}
+
+NumericalPoint Distribution::computeConditionalQuantile(const NumericalPoint & q, const NumericalSample & y) const
 {
   return getImplementation()->computeConditionalQuantile(q, y);
 }

--- a/lib/src/Uncertainty/Model/openturns/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/Distribution.hxx
@@ -326,14 +326,20 @@ public:
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
   virtual NumericalScalar computeConditionalPDF(const NumericalScalar x,
       const NumericalPoint & y) const;
+  virtual NumericalPoint computeConditionalPDF(const NumericalPoint & x,
+      const NumericalSample & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
   virtual NumericalScalar computeConditionalCDF(const NumericalScalar x,
       const NumericalPoint & y) const;
+  virtual NumericalPoint computeConditionalCDF(const NumericalPoint & x,
+      const NumericalSample & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
   virtual NumericalScalar computeConditionalQuantile(const NumericalScalar q,
       const NumericalPoint & y) const;
+  virtual NumericalPoint computeConditionalQuantile(const NumericalPoint & q,
+      const NumericalSample & y) const;
 
   /** Get the isoprobabilist transformation */
   IsoProbabilisticTransformation getIsoProbabilisticTransformation() const;

--- a/lib/src/Uncertainty/Model/openturns/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/Distribution.hxx
@@ -236,6 +236,10 @@ public:
   /** Get the centered moments about the mean of the distribution */
   NumericalPoint getCenteredMoment(const UnsignedInteger n) const;
 
+  /** Get the shifted moments of the distribution */
+  NumericalPoint getShiftedMoment(const UnsignedInteger n,
+				  const NumericalPoint & shift) const;
+
   /** Inverse of the Cholesky factor of the covariance matrix accessor */
   TriangularMatrix getInverseCholesky() const;
 

--- a/lib/src/Uncertainty/Model/openturns/SklarCopula.hxx
+++ b/lib/src/Uncertainty/Model/openturns/SklarCopula.hxx
@@ -87,14 +87,17 @@ public:
                                  const Bool tail = false) const;
 
   /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalPDF;
   NumericalScalar computeConditionalPDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalCDF;
   NumericalScalar computeConditionalCDF(const NumericalScalar x,
                                         const NumericalPoint & y) const;
 
   /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using CopulaImplementation::computeConditionalQuantile;
   NumericalScalar computeConditionalQuantile(const NumericalScalar q,
       const NumericalPoint & y) const;
 

--- a/lib/test/t_KernelMixture_std.cxx
+++ b/lib/test/t_KernelMixture_std.cxx
@@ -113,6 +113,33 @@ int main(int argc, char *argv[])
     fullprint << "quantile=" << quantile << std::endl;
     fullprint << "quantile (ref)=" << distributionRef.computeQuantile( 0.95 ) << std::endl;
     fullprint << "cdf(quantile)=" << distribution.computeCDF(quantile) << std::endl;
+    NumericalPoint x(3);
+    x[0] = 1.1;
+    x[1] = 1.6;
+    x[2] = 2.2;
+    NumericalPoint q(3);
+    q[0] = 0.1;
+    q[1] = 0.3;
+    q[2] = 0.7;
+    NumericalSample y(3, 1);
+    y[0][0] = -0.5;
+    y[1][0] =  0.5;
+    y[2][0] =  1.5;
+
+    NumericalScalar condCDF(distribution.computeConditionalCDF(x[0], y[0]));
+    fullprint << "cond. cdf=" << condCDF << std::endl;
+    NumericalPoint condCDFs(distribution.computeConditionalCDF(x, y));
+    fullprint << "cond. cdf (vect)=" << condCDFs << std::endl;
+    NumericalScalar condPDF(distribution.computeConditionalPDF(x[0], y[0]));
+    fullprint << "cond. pdf=" << condPDF << std::endl;
+    NumericalPoint condPDFs(distribution.computeConditionalPDF(x, y));
+    fullprint << "cond. pdf (vect)=" << condPDFs << std::endl;
+    NumericalScalar condQuantile(distribution.computeConditionalQuantile(q[0], y[0]));
+    fullprint << "cond. quantile=" << condQuantile << std::endl;
+    NumericalPoint condQuantiles(distribution.computeConditionalQuantile(q, y));
+    fullprint << "cond. quantile (vect)=" << condQuantiles << std::endl;
+    fullprint << "cond. cdf(cond. quantile)=" << distribution.computeConditionalCDF(condQuantiles, y) << std::endl;
+
     NumericalPoint mean = distribution.getMean();
     fullprint << "mean=" << mean << std::endl;
     fullprint << "mean (ref)=" << distributionRef.getMean() << std::endl;

--- a/lib/test/t_KernelMixture_std.expout
+++ b/lib/test/t_KernelMixture_std.expout
@@ -25,6 +25,13 @@ log characteristic function=(-2.36595,1.5)
 quantile=class=NumericalPoint name=Unnamed dimension=3 values=[6.05991,7.07458,4.66827]
 quantile (ref)=class=NumericalPoint name=Unnamed dimension=3 values=[6.05991,7.07458,4.66827]
 cdf(quantile)=0.95
+cond. cdf=0.615836
+cond. cdf (vect)=class=NumericalPoint name=Unnamed dimension=3 values=[0.615836,0.657634,0.707868]
+cond. pdf=0.123311
+cond. pdf (vect)=class=NumericalPoint name=Unnamed dimension=3 values=[0.123311,0.118288,0.110573]
+cond. quantile=-3.77006
+cond. quantile (vect)=class=NumericalPoint name=Unnamed dimension=3 values=[-3.77006,-1.28752,2.12927]
+cond. cdf(cond. quantile)=class=NumericalPoint name=Unnamed dimension=3 values=[0.1,0.3,0.7]
 mean=class=NumericalPoint name=Unnamed dimension=3 values=[1.5,0.5,2]
 mean (ref)=class=NumericalPoint name=Unnamed dimension=3 values=[1.5,0.5,2]
 covariance=class=CovarianceMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[4.66667,0.666667,0.666667,0.666667,9.66667,0.666667,0.666667,0.666667,1.66667]

--- a/python/src/Distribution.i
+++ b/python/src/Distribution.i
@@ -32,7 +32,7 @@ class PythonDistribution(object):
         return self.__dim
 
     def computeCDF(self, X):
-        raise RuntimeError('You must define a method computePDF(x) -> cdf, where cdf is a float')
+        raise RuntimeError('You must define a method computeCDF(x) -> cdf, where cdf is a float')
 
 
 class SciPyDistribution(PythonDistribution):

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -781,7 +781,7 @@ n_points : int
 Returns
 -------
 graph : :class:`~openturns.Graph`
-    A graphical representation of the requested margin's CDF.
+    A graphical representation of the CDF of the requested margin.
 
 See Also
 --------
@@ -825,7 +825,7 @@ n_points : int
 Returns
 -------
 graph : :class:`~openturns.Graph`
-    A graphical representation of the requested margin's PDF.
+    A graphical representation of the PDF of the requested margin.
 
 See Also
 --------
@@ -1074,7 +1074,7 @@ OT_Distribution_getCDFEpsilon_doc
 Parameters
 ----------
 k : int
-    The centered moment's order.
+    The order of the centered moment.
 
 Returns
 -------
@@ -1099,6 +1099,39 @@ OT_Distribution_getCenteredMoment_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_Distribution_getShiftedMoment_doc
+"Accessor to the componentwise shifted moments.
+
+Parameters
+----------
+k : int
+    The order of the shifted moment.
+shift : sequence of float
+    The shift of the moment.
+
+Returns
+-------
+m : :class:`~openturns.NumericalPoint`
+    Componentwise centered moment of order :math:`k`.
+
+Notes
+-----
+The moments are centered with respect to the given shift :\math:`\vect{s}`:
+
+.. math::
+
+    \vect{m}^{(k)}_0 = \Tr{\left(\Expect{\left(X_i - s_i\right)^k},
+                                 \quad i = 1, \ldots, n\right)}
+
+See Also
+--------
+getMoment, getCenteredMoment"
+%enddef
+%feature("docstring") OT::DistributionImplementation::getShiftedMoment
+OT_Distribution_getShiftedMoment_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_Distribution_getCholesky_doc
 "Accessor to the Cholesky factor of the covariance matrix.
 
@@ -1117,12 +1150,12 @@ OT_Distribution_getCholesky_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getCopula_doc
-"Accessor to the distribution's copula.
+"Accessor to the copula of the distribution.
 
 Returns
 -------
 C : :class:`~openturns.Distribution`
-    Distribution's copula.
+    Copula of the distribution.
 
 See Also
 --------
@@ -1151,7 +1184,7 @@ Sigma : :class:`~openturns.CovarianceMatrix`
 
 Notes
 -----
-The covariance is the second-order standard moment. It is defined as:
+The covariance is the second-order centered moment. It is defined as:
 
 .. math::
 
@@ -1170,7 +1203,7 @@ OT_Distribution_getCovariance_doc
 Returns
 -------
 description : :class:`~openturns.Description`
-    Description of the distribution's components.
+    Description of the components of the distribution.
 
 See Also
 --------
@@ -1182,7 +1215,7 @@ OT_Distribution_getDescription_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getDimension_doc
-"Accessor to the distribution's dimension.
+"Accessor to the dimension of the distribution.
 
 Returns
 -------
@@ -1361,7 +1394,7 @@ k : :class:`~openturns.NumericalPoint`
 
 Notes
 -----
-The kurtosis is the fourth-order standard moment:
+The kurtosis is the fourth-order centered moment standardized by the standard deviation:
 
 .. math::
 
@@ -1427,7 +1460,7 @@ OT_Distribution_getMean_doc
 Parameters
 ----------
 k : int
-    The moment's order.
+    The order of the moment.
 
 Returns
 -------
@@ -1461,7 +1494,7 @@ OT_Distribution_getPDFEpsilon_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getParametersCollection_doc
-"Accessor to the distribution's parameters.
+"Accessor to the parameter of the distribution.
 
 Returns
 -------
@@ -1474,7 +1507,7 @@ OT_Distribution_getParametersCollection_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_setParameter_doc
-"Accessor to the distribution's parameter.
+"Accessor to the parameter of the distribution.
 
 Parameters
 ----------
@@ -1487,7 +1520,7 @@ OT_Distribution_setParameter_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getParameter_doc
-"Accessor to the distribution's parameter.
+"Accessor to the parameter of the distribution.
 
 Returns
 -------
@@ -1500,7 +1533,7 @@ OT_Distribution_getParameter_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getParameterDescription_doc
-"Accessor to the distribution's parameter description.
+"Accessor to the parameter description of the distribution.
 
 Returns
 -------
@@ -1571,7 +1604,7 @@ OT_Distribution_getPositionIndicator_doc
 Returns
 -------
 range : :class:`~openturns.Interval`
-    Distribution's range.
+    Range of the distribution.
 
 Notes
 -----
@@ -1611,7 +1644,7 @@ OT_Distribution_getRealization_doc
 Returns
 -------
 r : float
-    Distribution's roughness.
+    Roughness of the distribution.
 
 Notes
 -----
@@ -1659,7 +1692,7 @@ OT_Distribution_getSample_doc
 Returns
 -------
 shape : :class:`~openturns.CorrelationMatrix`
-    Shape matrix of the distribution's elliptical copula.
+    Shape matrix of the elliptical copula of a distribution.
 
 Notes
 -----
@@ -1684,7 +1717,7 @@ d : :class:`~openturns.NumericalPoint`
 
 Notes
 -----
-The skewness is the third-order standard moment:
+The skewness is the third-order centered moment standardized by the standard deviation:
 
 .. math::
 
@@ -1773,7 +1806,7 @@ OT_Distribution_getStandardDistribution_doc
 Parameters
 ----------
 k : int
-    The standard moment's order.
+    The order of the standard moment.
 
 Returns
 -------
@@ -1782,19 +1815,11 @@ m : :class:`~openturns.NumericalPoint`
 
 Notes
 -----
-Standard moments are centered with respect to the first-order moment and
-normalized with respect to the standard deviation:
-
-.. math::
-
-    \overline{\vect{m}}^{(k)}_0 =
-        \Tr{\left(\Expect{\left(\frac{X_i - \mu_i}
-                                     {\sigma_i}\right)^k},
-        \quad i = 1, \ldots, n\right)}
+Standard moments are the raw moments of the standard representative of the parametric family of distributions.
 
 See Also
 --------
-getMean, getStandardDeviation"
+getStandardRepresentative"
 %enddef
 %feature("docstring") OT::DistributionImplementation::getStandardMoment
 OT_Distribution_getStandardMoment_doc
@@ -1811,8 +1836,7 @@ std_repr_dist : :class:`~openturns.Distribution`
 
 Notes
 -----
-The standard representative distribution is the one associated with the
-standard moments."
+The standard representative distribution is defined on a distribution by distribution basis, most of the time by scaling the distribution with bounded support to :math:`[0,1]` or by standardizing (ie zero mean, unit variance) the distributions with unbounded support. It is the member of the family for which orthonormal polynomials will be built using generic algorithms of orthonormalization."
 %enddef
 %feature("docstring") OT::DistributionImplementation::getStandardRepresentative
 OT_Distribution_getStandardRepresentative_doc
@@ -1820,22 +1844,21 @@ OT_Distribution_getStandardRepresentative_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_getSupport_doc
-"Accessor to the distribution's support.
+"Accessor to the support of the distribution.
 
 Parameters
 ----------
 interval : :class:`~openturns.Interval`
-    An interval to intersect with the distribution's support.
+    An interval to intersect with the support of the discrete part of the distribution.
 
 Returns
 -------
 support : :class:`~openturns.Interval`
-    The intersection of the distribution's support with the given `interval`.
+    The intersection of the support of the discrete part of the distribution with the given `interval`.
 
 Notes
 -----
-The mathematical support :math:`\supp{\vect{X}}` of the distribution is
-the interval (or collection of intervals) where the PDF is non-zero.
+The mathematical support :math:`\supp{\vect{X}}` of the discrete part of a distribution is the collection of points with nonzero probability.
 
 This is yet implemented for discrete distributions only.
 
@@ -1862,7 +1885,7 @@ OT_Distribution_getProbabilities_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_hasEllipticalCopula_doc
-"Test whether the distribution's copula is elliptical or not.
+"Test whether the copula of the distribution is elliptical or not.
 
 Returns
 -------
@@ -1879,7 +1902,7 @@ OT_Distribution_hasEllipticalCopula_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_hasIndependentCopula_doc
-"Test whether the distribution's copula is independent.
+"Test whether the copula of the distribution is the independent one.
 
 Returns
 -------
@@ -1981,7 +2004,7 @@ OT_Distribution_isIntegral_doc
 Parameters
 ----------
 description : sequence of str
-    Description of the distribution's components."
+    Description of the components of the distribution."
 %enddef
 %feature("docstring") OT::DistributionImplementation::setDescription
 OT_Distribution_setDescription_doc
@@ -1989,7 +2012,7 @@ OT_Distribution_setDescription_doc
 // ---------------------------------------------------------------------
 
 %define OT_Distribution_setParametersCollection_doc
-"Accessor to the distribution's parameters.
+"Accessor to the parameter of the distribution.
 
 Parameters
 ----------

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -126,15 +126,15 @@ OT_Distribution_computeComplementaryCDF_doc
 
 Parameters
 ----------
-Xn : float
+Xn : float, sequence of float
     Conditional CDF input (last component).
-Xcond : sequence of float with dimension :math:`n-1`
+Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
     Conditionning values for the other components.
 
 Returns
 -------
-F : float
-    Conditional CDF value at input `Xn`, `Xcond`.
+F : float, sequence of float
+    Conditional CDF value(s) at input `Xn`, `Xcond`.
 
 Notes
 -----
@@ -185,15 +185,15 @@ Conditional PDF of the last component with respect to the other fixed components
 
 Parameters
 ----------
-Xn : float
+Xn : float, sequence of float
     Conditional PDF input (last component).
-Xcond : sequence of float with dimension :math:`n-1`
+Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
     Conditionning values for the other components.
 
 Returns
 -------
-f : float
-    Conditional PDF value at input `Xn`, `Xcond`.
+F : float, sequence of float
+    Conditional PDF value(s) at input `Xn`, `Xcond`.
 
 See Also
 --------
@@ -211,9 +211,9 @@ Conditional quantile with respect to the other fixed components.
 
 Parameters
 ----------
-p : float, :math:`0 < p < 1`
+p : float, sequence of float, :math:`0 < p < 1`
     Conditional quantile function input.
-Xcond : sequence of float with dimension :math:`n-1`
+Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
     Conditionning values for the other components.
 
 Returns

--- a/python/src/Distribution_doc.i.in
+++ b/python/src/Distribution_doc.i.in
@@ -66,6 +66,8 @@ OT_Distribution_drawQuantile_doc
 OT_Distribution_getCDFEpsilon_doc
 %feature("docstring") OT::Distribution::getCenteredMoment
 OT_Distribution_getCenteredMoment_doc
+%feature("docstring") OT::Distribution::getShiftedMoment
+OT_Distribution_getShiftedMoment_doc
 %feature("docstring") OT::Distribution::getCholesky
 OT_Distribution_getCholesky_doc
 %feature("docstring") OT::Distribution::getCopula

--- a/python/src/GraphImplementation_doc.i.in
+++ b/python/src/GraphImplementation_doc.i.in
@@ -88,10 +88,10 @@ OT_Graph_getDrawable_doc
 
 Parameters
 ----------
-index : int
-    Position of the Drawable.
 drawable : :class:`~openturns.Drawable`
-    Drawable included in the Graph."
+    Drawable included in the Graph.
+index : int
+    Position of the Drawable."
 %enddef
 %feature("docstring") OT::GraphImplementation::setDrawable
 OT_Graph_setDrawable_doc

--- a/python/test/t_KernelMixture_std.expout
+++ b/python/test/t_KernelMixture_std.expout
@@ -22,6 +22,13 @@ cdf (ref)=0.081759
 quantile= class=NumericalPoint name=Unnamed dimension=3 values=[6.05991,7.07458,4.66827]
 quantile (ref)= class=NumericalPoint name=Unnamed dimension=3 values=[6.05991,7.07458,4.66827]
 cdf(quantile)=0.950000
+cond. cdf=0.615836
+cond. cdf (vect)= [0.615836,0.657634,0.707868]
+cond. pdf=0.123311
+cond. pdf (vect)= [0.123311,0.118288,0.110573]
+cond. quantile=-3.77006
+cond. quantile (vect)= [-3.77006,-1.28752,2.12927]
+cond. cdf(cond. quantile)= [0.1,0.3,0.7]
 mean= class=NumericalPoint name=Unnamed dimension=3 values=[1.5,0.5,2]
 mean (ref)= class=NumericalPoint name=Unnamed dimension=3 values=[1.5,0.5,2]
 covariance= class=CovarianceMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[4.66667,0.666667,0.666667,0.666667,9.66667,0.666667,0.666667,0.666667,1.66667]

--- a/python/test/t_KernelMixture_std.py
+++ b/python/test/t_KernelMixture_std.py
@@ -98,6 +98,24 @@ try:
     print("quantile=", repr(quantile))
     print("quantile (ref)=", repr(distributionRef.computeQuantile(0.95)))
     print("cdf(quantile)=%.6f" % distribution.computeCDF(quantile))
+    x = [1.1, 1.6, 2.2]
+    q = [0.1, 0.3, 0.7]
+    y = [[-0.5], [0.5], [1.5]]
+
+    condCDF = distribution.computeConditionalCDF(x[0], y[0])
+    print("cond. cdf=%.6f" % condCDF)
+    condCDFs = distribution.computeConditionalCDF(x, y)
+    print("cond. cdf (vect)=", condCDFs)
+    condPDF = distribution.computeConditionalPDF(x[0], y[0])
+    print("cond. pdf=%.6f" % condPDF)
+    condPDFs = distribution.computeConditionalPDF(x, y)
+    print("cond. pdf (vect)=", condPDFs)
+    condQuantile = distribution.computeConditionalQuantile(q[0], y[0])
+    print("cond. quantile=%.5f" % condQuantile)
+    condQuantiles = distribution.computeConditionalQuantile(q, y)
+    print("cond. quantile (vect)=", condQuantiles)
+    print("cond. cdf(cond. quantile)=", distribution.computeConditionalCDF(condQuantiles, y))
+
     mean = distribution.getMean()
     print("mean=", repr(mean))
     print("mean (ref)=", repr(distributionRef.getMean()))


### PR DESCRIPTION
+Changed the method binding to speed-up computations in DistributionImplementation:
Switched from the use of the general method binding to a specific binding to speed-up the computation of conditional CDF, following a very good idea of Denis Barbier.
+Made the getShiftedMoment() method visible in Distribution
+Added a vectorized version of some methods in Distribution
It concerns the following methods: computeConditionalPDF(), computeConditionalCDF() and computeConditionalQuantile().
The key point is to reuse the marginal distributions involved in these computations, as there extraction can be costly. These versions should be overloaded on a specific multivariate distribution/copula basis, not yet done.
+Improved the documentation of Distribution
Added the documentation of the getShiftedMoment() method, fixed some typos and the description of standard moments which was wrong.
