### PR TITLE
Fix a segfault in CovarianceModelImplementation::discretizeHMatrix

### DIFF
--- a/lib/src/Base/Stat/openturns/HMatrixImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/HMatrixImplementation.hxx
@@ -197,8 +197,8 @@ private:
 class CovarianceAssemblyFunction : public HMatrixRealAssemblyFunction
 {
 private:
-  const CovarianceModel & covarianceModel_;
-  const NumericalSample & vertices_;
+  const CovarianceModel covarianceModel_;
+  const NumericalSample vertices_;
   const UnsignedInteger covarianceDimension_;
   const double epsilon_;
 
@@ -225,8 +225,8 @@ public:
 class CovarianceBlockAssemblyFunction : public HMatrixTensorRealAssemblyFunction
 {
 private:
-  const CovarianceModel & covarianceModel_;
-  const NumericalSample & vertices_;
+  const CovarianceModel covarianceModel_;
+  const NumericalSample vertices_;
   const double epsilon_;
   CovarianceMatrix epsilonId_;
 


### PR DESCRIPTION
CovarianceModelImplementation::discretizeHMatrix contains this snippet:
```
  if (dimension_ == 1)
  {
    CovarianceAssemblyFunction simple(*this, vertices, nuggetFactor);
    covarianceHMatrix.assemble(simple, 'L');
  }
```

In fact, `*this` is converted into a local `CovarianceModel` variable,
and `CovarianceAssemblyFunction::covarianceModel_` is a reference to
this local variable.  When exiting from `CovarianceAssemblyFunction`
constructor, this local variable is destroyed, but `covarianceModel_`
is still referencing it and `covarianceHMatrix.assemble()` crashes.

Also remove reference for vertices too, in order to be safe.