### PR TITLE
Level set bounds

### DIFF
--- a/lib/src/Base/Geom/openturns/LevelSet.hxx
+++ b/lib/src/Base/Geom/openturns/LevelSet.hxx
@@ -73,9 +73,11 @@ public:
   void setLevel(const NumericalScalar level);
 
   /** Lower bound of the bounding box */
+  void setLowerBound(const NumericalPoint & bound);
   NumericalPoint getLowerBound() const;
 
   /** Upper bound of the bounding box */
+  void setUpperBound(const NumericalPoint & bound);
   NumericalPoint getUpperBound() const;
 
   /** String converter */
@@ -90,12 +92,23 @@ public:
 
 private:
 
+  /** Compute the lower bound using optimization */
+  void computeLowerBound() const;
+
+  /** Compute the upper bound using optimization */
+  void computeUpperBound() const;
+
   /** Function defining the level set*/
   NumericalMathFunction function_;
 
   /** Level defining the level set */
   NumericalScalar level_;
 
+  /** Lower bound of the bounding box */
+  mutable NumericalPoint lowerBound_;
+
+  /** Upper bound of the bounding box */
+  mutable NumericalPoint upperBound_;
 }; /* class LevelSet */
 
 END_NAMESPACE_OPENTURNS

--- a/python/src/LevelSet_doc.i.in
+++ b/python/src/LevelSet_doc.i.in
@@ -169,3 +169,23 @@ Examples
 >>> import openturns as ot
 >>> levelSet = ot.LevelSet()
 >>> levelSet.setLevel(3.0)"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LevelSet::setLowerBound
+"Set the lower bound of the bounding box.
+
+Parameters
+----------
+bound : sequence of floats
+    Lower bound of the bounding box of the level set. It allows to clip the level set."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LevelSet::setUpperBound
+"Set the upper bound of the bounding box.
+
+Parameters
+----------
+bound : sequence of floats
+    Upper bound of the bounding box of the level set. It allows to clip the level set."


### PR DESCRIPTION
Improved LevelSet:
Now the user can specify a bounding box by using the setLowerBound()/setUpperBound() methods. The level set is cliped by this bounding box, ie the contains() method will return false as soon as the given point is outside of the user-defined bounding box.

Improved KarhunenLoeveQuadratureFactory:
Now it fully support multidimensional covariance models. It is also more verbose.