### PR TITLE
Make ot.PythonFunction (optionally) distributed with multiprocessing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ individual contributors:
     Antoine Dumas <dumas@phimeca.com>
     Aurelie Ladier <ladier@phimeca.com>
     Denis Barbier <barbier@imacs.polytechnique.fr>
+    Felipe Aguirre Martinez <aguirre@phimeca.com>
     Ivan Dutka-Malen <ivan.dutka-malen@edf.fr>
     Julien Schueller <schueller@phimeca.com>
     Mathieu Lapointe <lapointe@phimeca.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@
  * Deprecated LAR in favor of LARS
 
 === Python module ===
+ * Add the possibility to distribute PythonFunction calls with multiprocessing
 
 === Miscellaneous ===
  * Improved the computeCDF() method of Normal

--- a/python/test/t_NumericalMathFunction_python.expout
+++ b/python/test/t_NumericalMathFunction_python.expout
@@ -37,6 +37,13 @@ exec_sample only on a sample
 0 : [ 200 ]
 1 : [ 202 ]
 2 : [ 204 ]
+distributed exec only on a point
+[200]
+distributed exec only on a sample
+    [ y0  ]
+0 : [ 200 ]
+1 : [ 202 ]
+2 : [ 204 ]
 gradient
 [[  1 ]
  [ -1 ]]

--- a/python/test/t_NumericalMathFunction_python.py
+++ b/python/test/t_NumericalMathFunction_python.py
@@ -124,6 +124,15 @@ myFunc = PythonFunction(2, 1, func_sample=a_exec_sample)
 outSample = myFunc(a_sample)
 print(outSample)
 
+print('distributed exec only on a point')
+myFunc = PythonFunction(2, 1, a_exec, n_cpus=-1)
+outSample = myFunc([100., 100.])
+print(outSample)
+
+print('distributed exec only on a sample')
+myFunc = PythonFunction(2, 1, a_exec, n_cpus=-1)
+outSample = myFunc(a_sample)
+print(outSample)
 
 def a_grad(X):
     # wrong but allows to verify

--- a/python/test/t_NumericalMathFunction_python.py
+++ b/python/test/t_NumericalMathFunction_python.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from openturns import *
+import sys
 
 TESTPREAMBLE()
 
@@ -125,12 +126,12 @@ outSample = myFunc(a_sample)
 print(outSample)
 
 print('distributed exec only on a point')
-myFunc = PythonFunction(2, 1, a_exec, n_cpus=-1)
+myFunc = PythonFunction(2, 1, a_exec, n_cpus=None if sys.platform.startswith('win') else -1)
 outSample = myFunc([100., 100.])
 print(outSample)
 
 print('distributed exec only on a sample')
-myFunc = PythonFunction(2, 1, a_exec, n_cpus=-1)
+myFunc = PythonFunction(2, 1, a_exec, n_cpus=None if sys.platform.startswith('win') else -1)
 outSample = myFunc(a_sample)
 print(outSample)
 


### PR DESCRIPTION
This pull request adds the optional argument `n_cpus` to PythonFunction. If it is set, it distributes `func` with multiprocessing on the number of cpus specified by `n_cpus`. If `n_cpus=-1`, it uses all the cores of the machine. if `n_cpus=1`, it does nothing. If `n_cpus` and `func_sample` are both given as arguments, `n_cpus` will be ignored and samples will be handled by `func_sample`.

This function is limited to distributing `func` calls on the machine you are working on. More advanced distribution techniques will be develloped for [otwrapy.Parallelizer](http://felipeam86.github.io/otwrapy/_generated/otwrapy.Parallelizer.html#otwrapy.Parallelizer)
