### PR TITLE
Fixed BernsteinCopulaFactory

### DIFF
--- a/lib/src/Uncertainty/Distribution/BernsteinCopulaFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/BernsteinCopulaFactory.cxx
@@ -104,7 +104,10 @@ Distribution BernsteinCopulaFactory::build(const NumericalSample & sample,
   BernsteinCopulaFactoryPolicy policy(empiricalCopulaSample, binNumber, atomsMixture);
   LOGINFO("BernsteinCopulaFactory - Create the resulting Bernstein copula");
   TBB::ParallelFor( 0, size, policy );
-  return Mixture(atomsMixture);
+  Mixture result(atomsMixture);
+  // Here we know that the mixture is a copula even if none of its atoms is.
+  result.isCopula_ = true;
+  return result;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -218,6 +218,7 @@ void Mixture::setDistributionCollectionWithWeights(const DistributionCollection 
   // Second loop, keep only the atoms with a significant weight and update the sum
   weightSum = 0.0;
   distributionCollection_ = DistributionCollection(0);
+  isCopula_ = true;
   for(UnsignedInteger i = 0; i < size; ++i)
   {
     NumericalScalar w(weights[i]);
@@ -232,6 +233,7 @@ void Mixture::setDistributionCollectionWithWeights(const DistributionCollection 
       atom.setWeight(w);
       distributionCollection_.add(atom);
       weightSum += w;
+      isCopula_ = isCopula_ && atom.isCopula();
     }
   }
 
@@ -523,14 +525,6 @@ Mixture::NumericalPointWithDescriptionCollection Mixture::getParametersCollectio
   parameters[size].setName("dependence");
   return parameters;
 } // getParametersCollection
-
-/* Check if the distribution is elliptical */
-Bool Mixture::isCopula() const
-{
-  const UnsignedInteger size(distributionCollection_.getSize());
-  for (UnsignedInteger i = 0; i < size; ++i) if (!distributionCollection_[i].isCopula()) return false;
-  return true;
-}
 
 /* Check if the distribution is elliptical */
 Bool Mixture::isElliptical() const

--- a/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
@@ -37,6 +37,10 @@ class OT_API Mixture
   : public DistributionImplementation
 {
   CLASSNAME;
+  // Make the BernsteinCopulaFactory class a friend of Mixture as it has to 
+  // set the isCopula_ attribute directly
+  friend class BernsteinCopulaFactory;
+
 public:
 
   /** A type for distribution collection */
@@ -113,9 +117,6 @@ public:
 
   /** Parameters value and description accessor */
   NumericalPointWithDescriptionCollection getParametersCollection() const;
-
-  /** Check if the distribution is a copula */
-  Bool isCopula() const;
 
   /** Check if the distribution is elliptical */
   Bool isElliptical() const;

--- a/lib/src/Uncertainty/Model/CopulaImplementation.cxx
+++ b/lib/src/Uncertainty/Model/CopulaImplementation.cxx
@@ -39,7 +39,8 @@ CLASSNAMEINIT(CopulaImplementation);
 CopulaImplementation::CopulaImplementation()
   : ContinuousDistribution()
 {
-  // Nothing to do
+  // Set the flag isCopula_ here to avoid warnings on the initialization order
+  isCopula_ = true;
 }
 
 /* Virtual constructor */
@@ -281,12 +282,6 @@ CopulaImplementation::Implementation CopulaImplementation::getMarginal(const Uns
 CopulaImplementation::Implementation CopulaImplementation::getCopula() const
 {
   return clone();
-}
-
-/* Check if the copula is a copula */
-Bool CopulaImplementation::isCopula() const
-{
-  return true;
 }
 
 /* Compute the mathematical and numerical range of the copula.

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -106,6 +106,7 @@ DistributionImplementation::DistributionImplementation()
   , range_(Interval(1.0, -1.0))
   , description_(1)
   , isParallel_(ResourceMap::GetAsBool("DistributionImplementation-Parallel"))
+  , isCopula_(false)
   , isInitializedCF_(false)
   , pdfGrid_(0)
 {
@@ -2390,7 +2391,7 @@ Bool DistributionImplementation::isElliptical() const
 /* Check if the distribution is a copula */
 Bool DistributionImplementation::isCopula() const
 {
-  return false;
+  return isCopula_;
 }
 
 /* Check if the distribution is continuous */
@@ -3242,6 +3243,7 @@ void DistributionImplementation::save(Advocate & adv) const
   adv.saveAttribute( "weight_", weight_ );
   adv.saveAttribute( "range_", range_ );
   adv.saveAttribute( "description_", description_ );
+  adv.saveAttribute( "isCopula_", isCopula_ );
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -3260,6 +3262,7 @@ void DistributionImplementation::load(Advocate & adv)
   adv.loadAttribute( "weight_", weight_ );
   adv.loadAttribute( "range_", range_ );
   adv.loadAttribute( "description_", description_ );
+  adv.loadAttribute( "isCopula_", isCopula_ );
 }
 
 /* Transformation of distributions by usual functions */

--- a/lib/src/Uncertainty/Model/openturns/CopulaImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/CopulaImplementation.hxx
@@ -74,9 +74,6 @@ public:
   /** Get the copula */
   Implementation getCopula() const;
 
-  /** Check if the copula is a copula */
-  Bool isCopula() const;
-
   /** String converter */
   String __repr__() const;
 

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -946,6 +946,9 @@ protected:
   /** Use parallelism */
   Bool isParallel_;
 
+  /** Flag to tell if the distribution is indeed a copula */
+  Bool isCopula_;
+
   /** Data for characteristic function computation */
   mutable Bool isInitializedCF_;
 


### PR DESCRIPTION
The BernsteinCopulaFactory class produces a Mixture which is a copula but it cannot be deduced from the individual properties of the atoms in the mixture.