### PR TITLE
Make C cobyla function private

### DIFF
--- a/lib/src/Base/Optim/Cobyla/Cobyla.cxx
+++ b/lib/src/Base/Optim/Cobyla/Cobyla.cxx
@@ -126,7 +126,7 @@ void Cobyla::run()
    * extern int cobyla(int n, int m, double *x, double rhobeg, double rhoend,
    *  int message, int *maxfun, cobyla_function *calcfc, void *state);
    */
-  int returnCode(cobyla(n, m, &x[0], rhoBeg_, rhoEnd, message, &maxFun, Cobyla::ComputeObjectiveAndConstraint, (void*) this));
+  int returnCode(ot_cobyla(n, m, &x[0], rhoBeg_, rhoEnd, message, &maxFun, Cobyla::ComputeObjectiveAndConstraint, (void*) this));
 
   // Update the result
   UnsignedInteger size(evaluationInputHistory_.getSize());

--- a/lib/src/Base/Optim/Cobyla/algocobyla.c
+++ b/lib/src/Base/Optim/Cobyla/algocobyla.c
@@ -69,7 +69,7 @@ static int trstlp(int *n, int *m, double *a, double *b, double *rho,
 
 /* ------------------------------------------------------------------------ */
 
-int cobyla(int n, int m, double *x, double rhobeg, double rhoend, int iprint,
+int ot_cobyla(int n, int m, double *x, double rhobeg, double rhoend, int iprint,
            int *maxfun, cobyla_function *calcfc, void *state)
 {
   int icon, isim, isigb, idatm, iveta, isimi, ivsig, iwork, ia, idx, mpp, rc;

--- a/lib/src/Base/Optim/Cobyla/algocobyla.h
+++ b/lib/src/Base/Optim/Cobyla/algocobyla.h
@@ -110,7 +110,7 @@ typedef int cobyla_function(int n, int m, double *x, double *f, double *con,
  * The cobyla function returns a code defined in the cobyla_rc enum.
  *
  */
-extern int cobyla(int n, int m, double *x, double rhobeg, double rhoend,
+extern int ot_cobyla(int n, int m, double *x, double rhobeg, double rhoend,
                   int message, int *maxfun, cobyla_function *calcfc, void *state);
 
 END_C_DECLS

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
@@ -25,7 +25,6 @@
 #include "openturns/Field.hxx"
 #include "openturns/BoxCoxEvaluationImplementation.hxx"
 #include "openturns/SpecFunc.hxx"
-#include "algocobyla.h"
 #include "openturns/Log.hxx"
 #include "openturns/BoxCoxTransform.hxx"
 #include "openturns/InverseBoxCoxTransform.hxx"

--- a/lib/src/Uncertainty/Process/ARMALikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Process/ARMALikelihoodFactory.cxx
@@ -25,7 +25,6 @@
 #include "openturns/Exception.hxx"
 #include "openturns/ARMACoefficients.hxx"
 #include "openturns/SpecFunc.hxx"
-#include "algocobyla.h"
 #include "openturns/Log.hxx"
 #include "openturns/Normal.hxx"
 #include "openturns/WhittleFactory.hxx"

--- a/lib/src/Uncertainty/Process/WhittleFactory.cxx
+++ b/lib/src/Uncertainty/Process/WhittleFactory.cxx
@@ -25,7 +25,6 @@
 #include "openturns/ARMACoefficients.hxx"
 #include "openturns/UserDefinedSpectralModel.hxx"
 #include "openturns/SpecFunc.hxx"
-#include "algocobyla.h"
 #include "openturns/Log.hxx"
 #include "openturns/Normal.hxx"
 #include "openturns/UniVariatePolynomial.hxx"


### PR DESCRIPTION
Another cobyla function is provided by NLopt.
On Windows with MSVC, linking fails with this error:
```
  nlopt.lib(cobyla.obj) : error LNK2005: cobyla already defined in algocobyla.obj
```
Since this function is needed only by Cobyla.cxx, we can embed it into Cobyla.cxx with few adjustements so that algocobyla.c compiles with a C++ compiler.

An alternative would be to rename cobyla into ot_cobyla, I can do that if requested.
