### PR TITLE
Use CMake instead of autotools in travis/nlopt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,7 @@ install:
 # use latest nlopt
   - git clone https://github.com/stevengj/nlopt.git
   - pushd nlopt
-  - ./autogen.sh --no-configure
-  - ./configure --prefix=$HOME/.local --enable-maintainer-mode --enable-shared
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_PYTHON=OFF -DBUILD_OCTAVE=OFF -DBUILD_GUILE=OFF -DCMAKE_MACOSX_RPATH=ON
   - make -j2
   - make install
   - popd


### PR DESCRIPTION
nlopt does not support autotools anymore since the integration of https://github.com/stevengj/nlopt/pull/49