### PR TITLE
Bug fixes

### DIFF
--- a/lib/src/Base/Func/LinearNumericalMathFunction.cxx
+++ b/lib/src/Base/Func/LinearNumericalMathFunction.cxx
@@ -41,7 +41,8 @@ LinearNumericalMathFunction::LinearNumericalMathFunction(const NumericalPoint & 
 /* Comparison operator */
 Bool LinearNumericalMathFunction::operator ==(const LinearNumericalMathFunction & other) const
 {
-  return true;
+  if (this == &other) return true;
+  return *getImplementation() == *other.getImplementation();
 }
 
 /* String converter */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -1609,7 +1609,8 @@ NumericalScalar DistributionImplementation::computeConditionalCDF(const Numerica
   const NumericalScalar xMax(conditionedDistribution->getRange().getUpperBound()[conditioningDimension]);
   if (x >= xMax) return 1.0;
   // Numerical integration with respect to x
-  if (p_conditionalPDFWrapper_.isNull()) p_conditionalPDFWrapper_ = new ConditionalPDFWrapper(conditionedDistribution);
+  // Here we recreate a ConditionalPDFWrapper only if none has been created or if the parameter dimension has changed
+  if (p_conditionalPDFWrapper_.isNull() || (p_conditionalPDFWrapper_->getParameter().getDimension() != y.getDimension())) p_conditionalPDFWrapper_ = new ConditionalPDFWrapper(conditionedDistribution);
   p_conditionalPDFWrapper_->setParameter(y);
   GaussKronrod algo;
   const NumericalPoint value(algo.integrate(p_conditionalPDFWrapper_, Interval(xMin, x)));
@@ -1642,7 +1643,8 @@ NumericalPoint DistributionImplementation::computeConditionalCDF(const Numerical
   const NumericalScalar xMin(conditionedDistribution->getRange().getLowerBound()[conditioningDimension]);
   const NumericalScalar xMax(conditionedDistribution->getRange().getUpperBound()[conditioningDimension]);
   NumericalPoint result(size);
-  if (p_conditionalPDFWrapper_.isNull()) p_conditionalPDFWrapper_ = new ConditionalPDFWrapper(conditionedDistribution);
+  // Here we recreate a ConditionalPDFWrapper only if none has been created or if the parameter dimension has changed
+  if (p_conditionalPDFWrapper_.isNull() || (p_conditionalPDFWrapper_->getParameter().getDimension() != y.getDimension())) p_conditionalPDFWrapper_ = new ConditionalPDFWrapper(conditionedDistribution);
   GaussKronrod algo;
   for (UnsignedInteger i = 0; i < size; ++i)
     if (pdfConditioning[i][0] > 0.0)
@@ -1675,7 +1677,7 @@ NumericalPoint DistributionImplementation::computeConditionalQuantile(const Nume
   const UnsignedInteger size(q.getDimension());
   for (UnsignedInteger i = 0; i < size; ++i)
   {
-    if ((q[i] < 0.0) || (q[i] > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
+    if ((q[i] < 0.0) || (q[i] > 1.0)) throw InvalidArgumentException(HERE) << "Error: point=" << i << ", cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
   }
   // Special case for no conditioning or independent copula
   if ((conditioningDimension == 0) || (hasIndependentCopula()))
@@ -1684,7 +1686,8 @@ NumericalPoint DistributionImplementation::computeConditionalQuantile(const Nume
   const NumericalScalar xMin(range_.getLowerBound()[conditioningDimension]);
   const NumericalScalar xMax(range_.getUpperBound()[conditioningDimension]);
   NumericalPoint result(size);
-  if (p_conditionalCDFWrapper_.isNull()) p_conditionalCDFWrapper_ = new ConditionalCDFWrapper(this);
+  // Here we recreate a ConditionalCDFWrapper only if none has been created or if the parameter dimension has changed
+  if (p_conditionalCDFWrapper_.isNull() || (p_conditionalCDFWrapper_->getParameter().getDimension() != y.getDimension())) p_conditionalCDFWrapper_ = new ConditionalCDFWrapper(this);
   for (UnsignedInteger i = 0; i < size; ++i)
   {
     p_conditionalCDFWrapper_->setParameter(y[i]);

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -877,6 +877,11 @@ protected:
       y_ = parameters;
     }
 
+    NumericalPoint getParameter() const
+    {
+      return y_;
+    }
+
     UnsignedInteger getInputDimension() const
     {
       return 1;
@@ -915,6 +920,11 @@ protected:
     void setParameter(const NumericalPoint & parameters)
     {
       y_ = parameters;
+    }
+
+    NumericalPoint getParameter() const
+    {
+      return y_;
     }
 
     UnsignedInteger getInputDimension() const


### PR DESCRIPTION
1) Fixed comparison operator in LinearNumericalMathFunction.

2) Fixed a bug in DistributionImplementation
+ The generic implementations of the computeConditionalCDF() and computeConditionalQuantile() methods were wrong when dimension > 1 due to a reuse of a wrapper.

3) Fixed a bug in JacobiFactory
+ In the case where alpha+beta+1 == 0, the last recurrence coefficient for n == 1 was equal to NaN due to a 0/0 term.
