### PR TITLE
Set Sobol positve default boostrap size

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -176,7 +176,7 @@
   <!-- OT::SensitivityAlgorithm parameters -->
   <MartinezSensitivityAlgorithm-UseAsymptoticInterval value="0" />
   <SobolIndicesAlgorithm-DefaultBlockSize value="1" />
-  <SobolIndicesAlgorithm-DefaultBootstrapSize value="0" />
+  <SobolIndicesAlgorithm-DefaultBootstrapSize value="100" />
   <SobolIndicesAlgorithm-DefaultBootstrapConfidenceLevel value="0.95" />
 
   <!-- OT::FAST parameters -->

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -444,7 +444,7 @@ void ResourceMap::loadDefaultConfiguration()
   // SensitivityAlgorithm parameters //
   setAsBool( "MartinezSensitivityAlgorithm-UseAsymptoticInterval", false );
   setAsUnsignedInteger( "SobolIndicesAlgorithm-DefaultBlockSize", 1 );
-  setAsUnsignedInteger( "SobolIndicesAlgorithm-DefaultBootstrapSize", 0 );
+  setAsUnsignedInteger( "SobolIndicesAlgorithm-DefaultBootstrapSize", 100 );
   setAsNumericalScalar( "SobolIndicesAlgorithm-DefaultBootstrapConfidenceLevel", 0.95 );
 
   // FAST parameters //


### PR DESCRIPTION
otherwise the confidence interval length is null