### PR TITLE
Add copy constructor for {Symmetric,Hermitian}Matrix

### DIFF
--- a/lib/src/Base/Type/HermitianMatrix.cxx
+++ b/lib/src/Base/Type/HermitianMatrix.cxx
@@ -55,6 +55,14 @@ HermitianMatrix::HermitianMatrix(const Implementation & i)
   // Nothing to do
 }
 
+/* Copy constructor, added to solve glitches with inheritance */
+HermitianMatrix::HermitianMatrix(const HermitianMatrix & h)
+  : SquareComplexMatrix(static_cast<const SquareComplexMatrix &>(h))
+  , hasBeenHermitianized_(false)
+{
+  // Nothing to do
+}
+
 /* String converter */
 String HermitianMatrix::__repr__() const
 {

--- a/lib/src/Base/Type/SymmetricMatrix.cxx
+++ b/lib/src/Base/Type/SymmetricMatrix.cxx
@@ -50,6 +50,13 @@ SymmetricMatrix::SymmetricMatrix(const MatrixImplementation & i)
   // Nothing to do
 }
 
+/* Copy constructor, added to solve glitches with inheritance */
+SymmetricMatrix::SymmetricMatrix(const SymmetricMatrix & s)
+  : SquareMatrix(static_cast<const SquareMatrix &>(s))
+  , hasBeenSymmetrized_(false)
+{
+  // Nothing to do
+}
 
 /* Constructor with size (dim, which is the same for nbRows_ and nbColumns_ )*/
 SymmetricMatrix::SymmetricMatrix(const UnsignedInteger dim)

--- a/lib/src/Base/Type/openturns/HermitianMatrix.hxx
+++ b/lib/src/Base/Type/openturns/HermitianMatrix.hxx
@@ -64,6 +64,9 @@ public:
   /** Constructor with implementation */
   HermitianMatrix(const Implementation & i);
 
+  /** Copy constructor, added to solve glitches with inheritance */
+  HermitianMatrix(const HermitianMatrix & h);
+
   /** String converter */
   String __repr__() const;
   String __str__(const String & offset = "") const;

--- a/lib/src/Base/Type/openturns/SymmetricMatrix.hxx
+++ b/lib/src/Base/Type/openturns/SymmetricMatrix.hxx
@@ -55,6 +55,9 @@ public:
   /** Constructor with implementation */
   SymmetricMatrix(const MatrixImplementation & i);
 
+  /** Copy constructor, added to solve glitches with inheritance */
+  SymmetricMatrix(const SymmetricMatrix & s);
+
   /** Constructor with size (dim, which is the same for nbRows_ and nbColumns_) */
   explicit SymmetricMatrix(const UnsignedInteger dim);
 #if 0


### PR DESCRIPTION
In order to fix Trac ticket 822 (PR#187), four constructors had been added:

  ComplexMatrix(const HermitianMatrix & hermitian);
  Matrix(const SymmetricMatrix & symmetric);
  SquareComplexMatrix(const HermitianMatrix & hermitian);
  SquareMatrix(const SymmetricMatrix & symmetric);

But they introduce some glitches.  Consider this C++ file:
========================= test.cxx =================================
  #include <iostream>

  inline void print_msg(const char* msg) { std::cout << msg << std::endl; }

  class Derived;

  class Base {
  public:
      Base() { print_msg("Base()"); }
      Base(const Derived & a) { print_msg("Base(const Derived &)"); }
      Base(const Base & a) { print_msg("Base(const Base &)"); }
  };
  class Derived: public Base {
  public:
      Derived() { print_msg("Derived()"); }
  };

  int main(void)
  {
      std::cout << "create a" << std::endl;
      Derived a;
      std::cout << "create b" << std::endl;
      Derived b(a);
  }
====================================================================

On Linux with g++ 5.3.1, output is
  create a
  Base()
  Derived()
  create b
  Base(const Base &)

But on Windows with Visual 2010, output is
  create a
  Base()
  Derived()
  create b
  Base(const Derived &)

And thus on Windows, when writing
  HermitianMatrix a;
  HermitianMatrix b(a);
copy constructor calls ComplexMatrix(const HermitianMatrix&) and matrix
is hermitianized.

In order to have the same result, explicit copy constructor for derived
classes are added.