### PR TITLE
Conditional include of headers

### DIFF
--- a/lib/include/OTconfig.h.in
+++ b/lib/include/OTconfig.h.in
@@ -63,10 +63,6 @@
 /* Support for regular expression library */
 #cmakedefine OPENTURNS_HAVE_LIBXML2
 
-/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
-   to 0 otherwise. */
-#cmakedefine HAVE_MALLOC
-
 /* Define to 1 if you have the <math.h> header file. */
 #cmakedefine OPENTURNS_HAVE_MATH_H
 

--- a/lib/include/installed-OTconfig.h.in
+++ b/lib/include/installed-OTconfig.h.in
@@ -21,9 +21,6 @@
 /* Support for regular expression library */
 #cmakedefine OPENTURNS_HAVE_LIBXML2
 
-/* Define to 1 if you have the <malloc.h> header file. */
-#cmakedefine OPENTURNS_HAVE_MALLOC_H
-
 /* Define to 1 if you have the <pthread.h> header file. */
 #cmakedefine OPENTURNS_HAVE_PTHREAD_H
 

--- a/lib/src/Base/Common/Os.cxx
+++ b/lib/src/Base/Common/Os.cxx
@@ -25,13 +25,23 @@
 #include "openturns/OSS.hxx"
 #include "openturns/ResourceMap.hxx" // For ResourceMap
 
+// include OTConfig that defines OPENTURNS_HAVE_XXX
+#include "openturns/OTconfig.hxx"
+
 #ifdef OPENTURNS_HAVE_UNISTD_H
 # include <unistd.h>  // for rmdir, unlink
 #endif
 
 #include <cstdlib>   // for system(3)
-#include <sys/types.h>            // for stat
-#include <sys/stat.h>             // for stat
+
+#ifdef OPENTURNS_HAVE_SYS_TYPES_H
+# include <sys/types.h>            // for stat
+#endif
+
+#ifdef OPENTURNS_HAVE_SYS_STAT_H
+# include <sys/stat.h>             // for stat
+#endif
+
 #include <fcntl.h>
 #ifndef WIN32
 #include <ftw.h>       // for stat(2)

--- a/lib/src/Base/Common/Path.cxx
+++ b/lib/src/Base/Common/Path.cxx
@@ -31,10 +31,22 @@
 #define mkdir(p)  _mkdir(p)
 #endif /* _MSC_VER */
 #endif /* WIN32 */
-#include <sys/types.h>            // for stat
-#include <sys/stat.h>             // for stat
-#include <unistd.h>               // for stat
+
+// Include OTConfig that defines OPENTURNS_HAVE_XXX
+// It also defines INSTALL_PATH, SYSCONFIG_PATH, DATA_PATH, OPENTURNS_HOME_ENV_VAR
+
 #include "openturns/OTconfig.hxx"
+
+#ifdef OPENTURNS_HAVE_SYS_TYPES_H
+# include <sys/types.h>            // for stat
+#endif
+#ifdef OPENTURNS_HAVE_SYS_STAT_H
+# include <sys/stat.h>             // for stat
+#endif
+#ifdef OPENTURNS_HAVE_UNISTD_H
+# include <unistd.h>  // for stat
+#endif
+
 #include "openturns/OTthread.hxx"
 #include "openturns/OSS.hxx"
 #include "openturns/Path.hxx"


### PR DESCRIPTION
In Os/Path, unistd.h, sys/types.h and sys/stat.h are systematically included (for rmdir, unlink, stat)

We should first check that OPENTURNS_HAVE_XXX variables are defined to include these last ones.