### PR TITLE
Add Os::IsDirectory, IsFile

### DIFF
--- a/lib/src/Base/Common/openturns/Os.hxx
+++ b/lib/src/Base/Common/openturns/Os.hxx
@@ -77,6 +77,10 @@ public:
    */
   static int ExecuteCommand(const String & command);
 
+  static Bool IsDirectory(const String & fileName);
+
+  static Bool IsFile(const String & fileName);
+
 private:
 
   /** Default constructor */


### PR DESCRIPTION
In particular use IsFile in Path::FindFileByNameInDirectoryList
instead of just 'stat' to check for a regular file.
This allows to work around what seems a bug compiling on conda/osx
with libcpp where this function returns a directory.