### PR TITLE
Remove LINK_PYTHON_LIBRARY option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,13 @@ option (USE_LIBXML2                  "Use LibXml2 for XML support"              
 option (USE_R                        "Use R for graph output support"                                        ON)
 option (USE_OPENMP                   "Use OpenMP for multithreading"                                         OFF)
 option (USE_BOOST                    "Use Boost for distribution computation"                                ON)
-option (USE_SPHINX                    "Use sphinx for documentation"                                          ON)
-option (USE_DOXYGEN                   "Use Doxygen for API documentation"                                     ON)
+option (USE_SPHINX                   "Use sphinx for documentation"                                          ON)
+option (USE_DOXYGEN                  "Use Doxygen for API documentation"                                     ON)
 option (USE_NLOPT                    "Use NLopt for additional optimization algorithms"                      ON)
 option (USE_COTIRE                   "Use cotire for unity builds"                                           OFF)
 
 option (BUILD_PYTHON                 "Build the python module for the library"                               ON)
 option (BUILD_VALIDATION             "Build the validation files of the library"                             ON)
-option (LINK_PYTHON_LIBRARY          "Link python modules against python library"                            ON)
 option (BUILD_SHARED_LIBS            "Build shared libraries"                                                ON)
 
 if (MSVC)

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -73,7 +73,6 @@ cmake-configure-%:
             -DLIB_VERSION=0.9.0 \
             -DOPENTURNS_SYSCONFIG_PATH:PATH=/etc/openturns-1.7 \
             -DINSTALL_DESTDIR:PATH=$(CURDIR)/debian/tmp \
-            -DLINK_PYTHON_LIBRARY:BOOL=OFF \
             -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python$* \
             -DPYTHON_INCLUDE_DIR:PATH=$$(python$*-config --includes | sed -e 's/ .*//' -e 's/^-I//') \
             -DPYTHON_INCLUDE_DIR2:PATH=$$(python$*-config --includes | sed -e 's/ .*//' -e 's/^-I//') \

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -56,10 +56,6 @@ macro (ot_add_python_module MODULENAME SOURCEFILE)
   add_dependencies (${SWIG_MODULE_${MODULENAME}_REAL_NAME} generate_swig_runtime generate_docstrings)
   swig_link_libraries (${MODULENAME} OT)
 
-  if (LINK_PYTHON_LIBRARY)
-    swig_link_libraries (${MODULENAME} ${PYTHON_LIBRARIES})
-  endif ()
-
   set_target_properties (${SWIG_MODULE_${MODULENAME}_REAL_NAME} PROPERTIES NO_SONAME ON)
 
   if (USE_COTIRE)


### PR DESCRIPTION
Doesn't seem to be needed anywhere.