### PR TITLE
Generalize WeightedExperiment::generateWithWeights

### DIFF
--- a/lib/src/Base/Experiments/Axial.cxx
+++ b/lib/src/Base/Experiments/Axial.cxx
@@ -57,7 +57,7 @@ Axial * Axial::clone() const
 }
 
 /* Experiment plane generation */
-NumericalSample Axial::generate()
+NumericalSample Axial::generate() const
 {
   /* Dimension of the realizations */
   const UnsignedInteger dimension = center_.getDimension();

--- a/lib/src/Base/Experiments/Box.cxx
+++ b/lib/src/Base/Experiments/Box.cxx
@@ -64,7 +64,7 @@ Box * Box::clone() const
 /* Experiment plane generation
    The box [0, 1]^n is uniformly sampled in each dimension
    levels counts the number of interior points in each dimension */
-NumericalSample Box::generate()
+NumericalSample Box::generate() const
 {
   const UnsignedInteger dimension = levels_.getDimension();
   Indices bounds(dimension);

--- a/lib/src/Base/Experiments/Composite.cxx
+++ b/lib/src/Base/Experiments/Composite.cxx
@@ -58,7 +58,7 @@ Composite * Composite::clone() const
 }
 
 /* Experiment plane generation */
-NumericalSample Composite::generate()
+NumericalSample Composite::generate() const
 {
   /* Dimension of the realizations */
   const UnsignedInteger dimension = center_.getDimension();

--- a/lib/src/Base/Experiments/Experiment.cxx
+++ b/lib/src/Base/Experiments/Experiment.cxx
@@ -63,7 +63,7 @@ void Experiment::setImplementation(const Implementation & p_implementation)
 }
 
 /* Sample generation */
-NumericalSample Experiment::generate()
+NumericalSample Experiment::generate() const
 {
   return getImplementation()->generate();
 }

--- a/lib/src/Base/Experiments/ExperimentImplementation.cxx
+++ b/lib/src/Base/Experiments/ExperimentImplementation.cxx
@@ -49,7 +49,7 @@ String ExperimentImplementation::__repr__() const
 }
 
 /* Sample generation */
-NumericalSample ExperimentImplementation::generate()
+NumericalSample ExperimentImplementation::generate() const
 {
   throw NotYetImplementedException(HERE) << "In ExperimentImplementation::generate()";
 }

--- a/lib/src/Base/Experiments/Factorial.cxx
+++ b/lib/src/Base/Experiments/Factorial.cxx
@@ -57,7 +57,7 @@ Factorial * Factorial::clone() const
 }
 
 /* Experiment plane generation */
-NumericalSample Factorial::generate()
+NumericalSample Factorial::generate() const
 {
   /* Dimension of the realizations */
   const UnsignedInteger dimension = center_.getDimension();

--- a/lib/src/Base/Experiments/openturns/Axial.hxx
+++ b/lib/src/Base/Experiments/openturns/Axial.hxx
@@ -54,7 +54,7 @@ public:
   virtual Axial * clone() const;
 
   /** Experiment plane generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** String converter */
   virtual String __repr__() const;

--- a/lib/src/Base/Experiments/openturns/Box.hxx
+++ b/lib/src/Base/Experiments/openturns/Box.hxx
@@ -53,7 +53,7 @@ public:
   /** Experiment plane generation :
    *  The box [0, 1]^n is uniformly sampled in each dimension
    */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** String converter */
   virtual String __repr__() const;

--- a/lib/src/Base/Experiments/openturns/Composite.hxx
+++ b/lib/src/Base/Experiments/openturns/Composite.hxx
@@ -54,7 +54,7 @@ public:
   virtual Composite * clone() const;
 
   /** Experiment plane generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** String converter */
   virtual String __repr__() const;

--- a/lib/src/Base/Experiments/openturns/Experiment.hxx
+++ b/lib/src/Base/Experiments/openturns/Experiment.hxx
@@ -54,7 +54,7 @@ public:
   virtual String __repr__() const;
 
   /** Sample generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** Implementation accessor */
   void setImplementation(const Implementation & p_implementation);

--- a/lib/src/Base/Experiments/openturns/ExperimentImplementation.hxx
+++ b/lib/src/Base/Experiments/openturns/ExperimentImplementation.hxx
@@ -54,7 +54,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
 protected:
 

--- a/lib/src/Base/Experiments/openturns/Factorial.hxx
+++ b/lib/src/Base/Experiments/openturns/Factorial.hxx
@@ -55,7 +55,7 @@ public:
   virtual Factorial * clone() const;
 
   /** Experiment plane generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** String converter */
   virtual String __repr__() const;

--- a/lib/src/Base/Stat/FaureSequence.cxx
+++ b/lib/src/Base/Stat/FaureSequence.cxx
@@ -66,7 +66,7 @@ void FaureSequence::initialize(const UnsignedInteger dimension)
 }
 
 /* Generate a pseudo-random vector of independant numbers uniformly distributed over [0, 1[ */
-NumericalPoint FaureSequence::generate()
+NumericalPoint FaureSequence::generate() const
 {
   NumericalPoint realization(dimension_);
   // First, compute the decomposition of seed_ in base modulus_
@@ -161,7 +161,7 @@ void FaureSequence::computeInitialBinomialCoefficients()
 }
 
 /* Update the binomial coefficients table by adding one column to the triangular array */
-void FaureSequence::updateBinomialCoefficients()
+void FaureSequence::updateBinomialCoefficients() const
 {
   // Here, we assume that the coefficient table has already been initialized and stores the values associated with logSeed-1
   UnsignedInteger previousIndex2 = coefficients_.getSize() - logSeed_ + 1;

--- a/lib/src/Base/Stat/HaltonSequence.cxx
+++ b/lib/src/Base/Stat/HaltonSequence.cxx
@@ -54,7 +54,7 @@ void HaltonSequence::initialize(const UnsignedInteger dimension)
 }
 
 /* Generate a pseudo-random vector of independant numbers uniformly distributed over [0, 1[ */
-NumericalPoint HaltonSequence::generate()
+NumericalPoint HaltonSequence::generate() const
 {
   NumericalPoint realization(dimension_);
   // Loop over the components

--- a/lib/src/Base/Stat/HaselgroveSequence.cxx
+++ b/lib/src/Base/Stat/HaselgroveSequence.cxx
@@ -63,7 +63,7 @@ void HaselgroveSequence::initialize(const UnsignedInteger dimension)
 }
 
 /* Generate a pseudo-random vector of independant numbers uniformly distributed over [0, 1[ */
-NumericalPoint HaselgroveSequence::generate()
+NumericalPoint HaselgroveSequence::generate() const
 {
   NumericalPoint realization(dimension_);
   // Loop over the components

--- a/lib/src/Base/Stat/LowDiscrepancySequence.cxx
+++ b/lib/src/Base/Stat/LowDiscrepancySequence.cxx
@@ -73,14 +73,14 @@ UnsignedInteger LowDiscrepancySequence::getDimension() const
 
 
 /* Generate a sample of pseudo-random vectors of numbers uniformly distributed over [0, 1) */
-NumericalPoint LowDiscrepancySequence::generate()
+NumericalPoint LowDiscrepancySequence::generate() const
 {
   return getImplementation()->generate();
 }
 
 
 /* Generate a sample of pseudo-random vectors of numbers uniformly distributed over [0, 1) */
-NumericalSample LowDiscrepancySequence::generate(const UnsignedInteger size)
+NumericalSample LowDiscrepancySequence::generate(const UnsignedInteger size) const
 {
   return getImplementation()->generate(size);
 }

--- a/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
+++ b/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
@@ -65,14 +65,14 @@ UnsignedInteger LowDiscrepancySequenceImplementation::getDimension() const
 
 
 /* Generate a low discrepancy vector of numbers uniformly distributed over [0, 1) */
-NumericalPoint LowDiscrepancySequenceImplementation::generate()
+NumericalPoint LowDiscrepancySequenceImplementation::generate() const
 {
   throw NotYetImplementedException(HERE) << "In LowDiscrepancySequenceImplementation::generate()";
 }
 
 
 /* Generate a sample of pseudo-random vectors of numbers uniformly distributed over [0, 1) */
-NumericalSample LowDiscrepancySequenceImplementation::generate(const UnsignedInteger size)
+NumericalSample LowDiscrepancySequenceImplementation::generate(const UnsignedInteger size) const
 {
   NumericalSample sequenceSample(size, dimension_);
   for(UnsignedInteger i = 0; i < size ; ++i) sequenceSample[i] = generate();

--- a/lib/src/Base/Stat/ReverseHaltonSequence.cxx
+++ b/lib/src/Base/Stat/ReverseHaltonSequence.cxx
@@ -55,7 +55,7 @@ void ReverseHaltonSequence::initialize(const UnsignedInteger dimension)
 
 /* Generate a pseudo-random vector of independant numbers uniformly distributed over [0, 1[
    See Bart Vandewoestyne, Ronald Cools, "Good permutations for deterministic scrambled Halton sequences in terms of L2-discrepancy", Journal of Computational and Applied Mathematics, 189, 341-361 (2006) */
-NumericalPoint ReverseHaltonSequence::generate()
+NumericalPoint ReverseHaltonSequence::generate() const
 {
   NumericalPoint realization(dimension_);
   // Loop over the components

--- a/lib/src/Base/Stat/SobolSequence.cxx
+++ b/lib/src/Base/Stat/SobolSequence.cxx
@@ -166,7 +166,7 @@ void SobolSequence::initialize(const UnsignedInteger dimension)
 
 
 /* Generate a pseudo-random vector of independant numbers uniformly distributed over [0, 1[ */
-NumericalPoint SobolSequence::generate()
+NumericalPoint SobolSequence::generate() const
 {
   // initialize a point with values 2^-MaximumBase2Logarithm
   NumericalPoint sequencePoint(dimension_, Epsilon);

--- a/lib/src/Base/Stat/openturns/FaureSequence.hxx
+++ b/lib/src/Base/Stat/openturns/FaureSequence.hxx
@@ -47,7 +47,7 @@ public:
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1[ */
   using LowDiscrepancySequenceImplementation::generate;
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** String converter */
   String __repr__() const;
@@ -63,10 +63,10 @@ private:
   void computeInitialBinomialCoefficients();
 
   /** Update the binomial table by adding one column to the triangular array */
-  void updateBinomialCoefficients();
+  void updateBinomialCoefficients() const;
 
   /** Binomial for the generation of the sequence */
-  Unsigned64BitsIntegerPersistentCollection coefficients_;
+  mutable Unsigned64BitsIntegerPersistentCollection coefficients_;
 
   /** Modulus of the sequence, i.e. least prime number greater or equal to the dimension */
   Unsigned64BitsInteger modulus_;
@@ -75,13 +75,13 @@ private:
   NumericalScalar modulusInverse_;
 
   /** Current seed into the sequence */
-  Unsigned64BitsInteger seed_;
+  mutable Unsigned64BitsInteger seed_;
 
   /** Next value of the seed that needs a coefficient update */
-  Unsigned64BitsInteger seedBound_;
+  mutable Unsigned64BitsInteger seedBound_;
 
   /** Number of digits of the seed in base the modulus */
-  UnsignedInteger logSeed_;
+  mutable UnsignedInteger logSeed_;
 
 }; /* class FaureSequence */
 

--- a/lib/src/Base/Stat/openturns/HaltonSequence.hxx
+++ b/lib/src/Base/Stat/openturns/HaltonSequence.hxx
@@ -47,7 +47,7 @@ public:
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1[ */
   using LowDiscrepancySequenceImplementation::generate;
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** String converter */
   String __repr__() const;
@@ -65,7 +65,7 @@ private:
   Unsigned64BitsIntegerPersistentCollection base_;
 
   /** Current seed into the sequence */
-  Unsigned64BitsInteger seed_;
+  mutable Unsigned64BitsInteger seed_;
 
 }; /* class HaltonSequence */
 

--- a/lib/src/Base/Stat/openturns/HaselgroveSequence.hxx
+++ b/lib/src/Base/Stat/openturns/HaselgroveSequence.hxx
@@ -50,7 +50,7 @@ public:
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1[ */
   using LowDiscrepancySequenceImplementation::generate;
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** String converter */
   String __repr__() const;
@@ -62,7 +62,7 @@ private:
   NumericalPoint base_;
 
   /** Current seed into the sequence */
-  Unsigned64BitsInteger seed_;
+  mutable Unsigned64BitsInteger seed_;
 
 }; /* class HaselgroveSequence */
 

--- a/lib/src/Base/Stat/openturns/LowDiscrepancySequence.hxx
+++ b/lib/src/Base/Stat/openturns/LowDiscrepancySequence.hxx
@@ -57,10 +57,10 @@ public:
   UnsignedInteger getDimension() const;
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1) */
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** Generate a sample of pseudo-random vectors of numbers uniformly distributed over [0, 1) */
-  NumericalSample generate(const UnsignedInteger size);
+  NumericalSample generate(const UnsignedInteger size) const;
 
   /** Compute the star discrepancy of a sample uniformly distributed over [0, 1) */
   NumericalScalar computeStarDiscrepancy(const NumericalSample & sample) const;

--- a/lib/src/Base/Stat/openturns/LowDiscrepancySequenceImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/LowDiscrepancySequenceImplementation.hxx
@@ -57,10 +57,10 @@ public:
   UnsignedInteger getDimension() const;
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1) */
-  virtual NumericalPoint generate();
+  virtual NumericalPoint generate() const;
 
   /** Generate a sample of pseudo-random vectors of numbers uniformly distributed over [0, 1) */
-  virtual NumericalSample generate(const UnsignedInteger size);
+  virtual NumericalSample generate(const UnsignedInteger size) const;
 
   /** Compute the star discrepancy of a sample uniformly distributed over [0, 1) */
   static NumericalScalar ComputeStarDiscrepancy(const NumericalSample & sample);

--- a/lib/src/Base/Stat/openturns/ReverseHaltonSequence.hxx
+++ b/lib/src/Base/Stat/openturns/ReverseHaltonSequence.hxx
@@ -47,7 +47,7 @@ public:
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1[ */
   using LowDiscrepancySequenceImplementation::generate;
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** String converter */
   String __repr__() const;
@@ -63,7 +63,7 @@ private:
   Unsigned64BitsIntegerPersistentCollection base_;
 
   /** Current seed into the sequence */
-  Unsigned64BitsInteger seed_;
+  mutable Unsigned64BitsInteger seed_;
 
 }; /* class ReverseHaltonSequence */
 

--- a/lib/src/Base/Stat/openturns/SobolSequence.hxx
+++ b/lib/src/Base/Stat/openturns/SobolSequence.hxx
@@ -66,7 +66,7 @@ public:
 
   /** Generate a quasi-random vector of numbers uniformly distributed over [0, 1[ */
   using LowDiscrepancySequenceImplementation::generate;
-  NumericalPoint generate();
+  NumericalPoint generate() const;
 
   /** String converter */
   String __repr__() const;
@@ -80,10 +80,10 @@ public:
 protected:
   /** The numbers used to generate the sequence */
   Unsigned64BitsIntegerPersistentCollection base_;
-  Unsigned64BitsIntegerPersistentCollection coefficients_;
+  mutable Unsigned64BitsIntegerPersistentCollection coefficients_;
 
   /** Current seed */
-  Unsigned64BitsInteger seed_;
+  mutable Unsigned64BitsInteger seed_;
 
 private:
   /** return 2^n */

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/BootstrapExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/BootstrapExperiment.cxx
@@ -60,8 +60,9 @@ String BootstrapExperiment::__repr__() const
 }
 
 /* Sample generation */
-NumericalSample BootstrapExperiment::generate()
+NumericalSample BootstrapExperiment::generateWithWeights(NumericalPoint & weights)
 {
+  weights = NumericalPoint(size_, 1.0 / size_);
   return distribution_.getSample(size_);
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/BootstrapExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/BootstrapExperiment.cxx
@@ -60,7 +60,7 @@ String BootstrapExperiment::__repr__() const
 }
 
 /* Sample generation */
-NumericalSample BootstrapExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample BootstrapExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   weights = NumericalPoint(size_, 1.0 / size_);
   return distribution_.getSample(size_);

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/FixedExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/FixedExperiment.cxx
@@ -40,8 +40,8 @@ FixedExperiment::FixedExperiment()
 FixedExperiment::FixedExperiment(const NumericalSample & sample)
   : WeightedExperimentImplementation(UserDefined(sample), sample.getSize())
   , sample_(sample)
+  , weights_(sample.getSize(), 1.0 / sample.getSize())
 {
-  // Nothing to do
 }
 
 /* Constructor with parameters */
@@ -49,9 +49,8 @@ FixedExperiment::FixedExperiment(const NumericalSample & sample,
                                  const NumericalPoint & weights)
   : WeightedExperimentImplementation(UserDefined(sample, weights), sample.getSize())
   , sample_(sample)
+  , weights_(weights)
 {
-  // Add the weights to the upper level class
-  weights_ = weights;
 }
 
 /* Virtual constructor */
@@ -78,8 +77,9 @@ void FixedExperiment::setDistribution(const Distribution & distribution)
 }
 
 /* Sample generation */
-NumericalSample FixedExperiment::generate()
+NumericalSample FixedExperiment::generateWithWeights(NumericalPoint & weights)
 {
+  weights = weights_;
   return sample_;
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/FixedExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/FixedExperiment.cxx
@@ -77,7 +77,7 @@ void FixedExperiment::setDistribution(const Distribution & distribution)
 }
 
 /* Sample generation */
-NumericalSample FixedExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample FixedExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   weights = weights_;
   return sample_;

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/GaussProductExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/GaussProductExperiment.cxx
@@ -103,7 +103,7 @@ void GaussProductExperiment::setDistribution(const Distribution & distribution)
 }
 
 /* Sample generation */
-NumericalSample GaussProductExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample GaussProductExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   if (!isAlreadyComputedNodesAndWeights_) computeNodesAndWeights();
   weights = weights_;
@@ -129,6 +129,14 @@ void GaussProductExperiment::setDistributionAndMarginalDegrees(const Distributio
   // Set the marginal degrees here then the distribution with checks
   marginalDegrees_ = marginalDegrees;
   setDistribution(distribution);
+
+  const UnsignedInteger dimension = distribution_.getDimension();
+  size_ = 1;
+  for (UnsignedInteger i = 0; i < dimension; ++ i)
+  {
+    const UnsignedInteger dI = marginalDegrees_[i];
+    size_ *= dI;
+  }
 }
 
 Indices GaussProductExperiment::getMarginalDegrees() const
@@ -137,19 +145,17 @@ Indices GaussProductExperiment::getMarginalDegrees() const
 }
 
 /* Compute the tensor product nodes and weights */
-void GaussProductExperiment::computeNodesAndWeights()
+void GaussProductExperiment::computeNodesAndWeights() const
 {
   const UnsignedInteger dimension = distribution_.getDimension();
   // Build the integration nodes and weights
   // First, get the marginal nodes and weights
   NumericalPointCollection marginalNodes(dimension);
   NumericalPointCollection marginalWeights(dimension);
-  size_ = 1;
   for (UnsignedInteger i = 0; i < dimension; ++i)
   {
     const UnsignedInteger dI = marginalDegrees_[i];
     marginalNodes[i] = collection_[i].getNodesAndWeights(dI, marginalWeights[i]);
-    size_ *= dI;
   }
   // Second, multiplex everything
   nodes_ = NumericalSample(size_, dimension);

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/GaussProductExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/GaussProductExperiment.cxx
@@ -103,9 +103,10 @@ void GaussProductExperiment::setDistribution(const Distribution & distribution)
 }
 
 /* Sample generation */
-NumericalSample GaussProductExperiment::generate()
+NumericalSample GaussProductExperiment::generateWithWeights(NumericalPoint & weights)
 {
   if (!isAlreadyComputedNodesAndWeights_) computeNodesAndWeights();
+  weights = weights_;
   return nodes_;
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/ImportanceSamplingExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/ImportanceSamplingExperiment.cxx
@@ -81,7 +81,7 @@ String ImportanceSamplingExperiment::__repr__() const
 }
 
 /* Sample generation with weights */
-NumericalSample ImportanceSamplingExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample ImportanceSamplingExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   NumericalSample result(size_, distribution_.getDimension());
   result.setDescription(distribution_.getDescription());

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/ImportanceSamplingExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/ImportanceSamplingExperiment.cxx
@@ -85,21 +85,14 @@ NumericalSample ImportanceSamplingExperiment::generateWithWeights(NumericalPoint
 {
   NumericalSample result(size_, distribution_.getDimension());
   result.setDescription(distribution_.getDescription());
-  weights_ = NumericalPoint(size_);
+  weights = NumericalPoint(size_);
   for (UnsignedInteger i = 0; i < size_; ++i)
   {
     result[i] = importanceDistribution_.getRealization();
-    weights_[i] = distribution_.computePDF(result[i]) / importanceDistribution_.computePDF(result[i]);
+    weights[i] = distribution_.computePDF(result[i]) / importanceDistribution_.computePDF(result[i]);
   }
-  weights = weights_;
   return result;
 }
 
-/* Sample generation */
-NumericalSample ImportanceSamplingExperiment::generate()
-{
-  NumericalPoint tmp(0);
-  return generateWithWeights(tmp);
-}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/LHSExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/LHSExperiment.cxx
@@ -102,7 +102,7 @@ String LHSExperiment::__str__(const String & offset) const
 }
 
 /* Sample generation */
-NumericalSample LHSExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample LHSExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   const UnsignedInteger dimension = distribution_.getDimension();
   // To insure that the shuffle has been initialized

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/LHSExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/LHSExperiment.cxx
@@ -102,7 +102,7 @@ String LHSExperiment::__str__(const String & offset) const
 }
 
 /* Sample generation */
-NumericalSample LHSExperiment::generate()
+NumericalSample LHSExperiment::generateWithWeights(NumericalPoint & weights)
 {
   const UnsignedInteger dimension = distribution_.getDimension();
   // To insure that the shuffle has been initialized
@@ -119,6 +119,7 @@ NumericalSample LHSExperiment::generate()
       sample[index][component] = marginals_[component].computeQuantile(xi)[0];
     }
   }
+  weights = NumericalPoint(size_, 1.0 / size_);
   return sample;
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/LowDiscrepancyExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/LowDiscrepancyExperiment.cxx
@@ -143,7 +143,7 @@ void LowDiscrepancyExperiment::setRestart(const Bool restart)
 }
 
 /* Sample generation */
-NumericalSample LowDiscrepancyExperiment::generate()
+NumericalSample LowDiscrepancyExperiment::generateWithWeights(NumericalPoint & weights)
 {
   // In-place transformation to reduce memory consumption
   NumericalSample sample(sequence_.generate(size_));
@@ -151,6 +151,7 @@ NumericalSample LowDiscrepancyExperiment::generate()
   const UnsignedInteger dimension = marginals_.getSize();
   for (UnsignedInteger i = 0; i < size_; ++ i)
     for (UnsignedInteger j = 0; j < dimension; ++ j) sample[i][j] = marginals_[j].computeQuantile(sample[i][j])[0];
+  weights = NumericalPoint(size_, 1.0 / size_);
   return sample;
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/LowDiscrepancyExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/LowDiscrepancyExperiment.cxx
@@ -143,7 +143,7 @@ void LowDiscrepancyExperiment::setRestart(const Bool restart)
 }
 
 /* Sample generation */
-NumericalSample LowDiscrepancyExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample LowDiscrepancyExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   // In-place transformation to reduce memory consumption
   NumericalSample sample(sequence_.generate(size_));

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/MonteCarloExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/MonteCarloExperiment.cxx
@@ -66,7 +66,7 @@ String MonteCarloExperiment::__repr__() const
 }
 
 /* Sample generation */
-NumericalSample MonteCarloExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample MonteCarloExperiment::generateWithWeights(NumericalPoint & weights) const
 {
   weights = NumericalPoint(size_, 1.0 / size_);
   return distribution_.getSample(size_);

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/MonteCarloExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/MonteCarloExperiment.cxx
@@ -66,8 +66,9 @@ String MonteCarloExperiment::__repr__() const
 }
 
 /* Sample generation */
-NumericalSample MonteCarloExperiment::generate()
+NumericalSample MonteCarloExperiment::generateWithWeights(NumericalPoint & weights)
 {
+  weights = NumericalPoint(size_, 1.0 / size_);
   return distribution_.getSample(size_);
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperiment.cxx
@@ -78,23 +78,20 @@ UnsignedInteger WeightedExperiment::getSize() const
 /* Here is the interface that all derived class must implement */
 
 /* Sample generation */
-NumericalSample WeightedExperiment::generate()
+NumericalSample WeightedExperiment::generate() const
 {
-  copyOnWrite();
   return getImplementation()->generate();
 }
 
 /* Sample generation with weights*/
-NumericalSample WeightedExperiment::generateWithWeights(NumericalPoint & weights)
+NumericalSample WeightedExperiment::generateWithWeights(NumericalPoint & weights) const
 {
-  copyOnWrite();
   return getImplementation()->generateWithWeights(weights);
 }
 
 /* Weight accessor */
-NumericalPoint WeightedExperiment::getWeight()
+NumericalPoint WeightedExperiment::getWeight() const
 {
-  copyOnWrite();
   return getImplementation()->getWeight();
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperiment.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperiment.cxx
@@ -92,8 +92,9 @@ NumericalSample WeightedExperiment::generateWithWeights(NumericalPoint & weights
 }
 
 /* Weight accessor */
-NumericalPoint WeightedExperiment::getWeight() const
+NumericalPoint WeightedExperiment::getWeight()
 {
+  copyOnWrite();
   return getImplementation()->getWeight();
 }
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperimentImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperimentImplementation.cxx
@@ -103,20 +103,20 @@ UnsignedInteger WeightedExperimentImplementation::getSize() const
 }
 
 /* Sample generation */
-NumericalSample WeightedExperimentImplementation::generate()
+NumericalSample WeightedExperimentImplementation::generate() const
 {
   NumericalPoint weights;
   return generateWithWeights(weights);
 }
 
 /* Sample generation with weights */
-NumericalSample WeightedExperimentImplementation::generateWithWeights(NumericalPoint & weights)
+NumericalSample WeightedExperimentImplementation::generateWithWeights(NumericalPoint & weights) const
 {
   throw NotYetImplementedException(HERE) << "In WeightedExperimentImplementation::generateWithWeights()";
 }
 
 /* Weight accessor */
-NumericalPoint WeightedExperimentImplementation::getWeight()
+NumericalPoint WeightedExperimentImplementation::getWeight() const
 {
   Log::Warn(OSS() << "WeightedExperimentImplementation::getWeight is deprecated.");
   NumericalPoint weights;

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperimentImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/WeightedExperimentImplementation.cxx
@@ -33,21 +33,19 @@ CLASSNAMEINIT(WeightedExperimentImplementation);
 
 
 /* Default constructor */
-WeightedExperimentImplementation::WeightedExperimentImplementation():
-  ExperimentImplementation(),
-  distribution_(),
-  size_(ResourceMap::GetAsUnsignedInteger("WeightedExperiment-DefaultSize")),
-  weights_(ResourceMap::GetAsUnsignedInteger("WeightedExperiment-DefaultSize" ), 1.0 / ResourceMap::GetAsUnsignedInteger("WeightedExperiment-DefaultSize"))
+WeightedExperimentImplementation::WeightedExperimentImplementation()
+  : ExperimentImplementation()
+  , distribution_()
+  , size_(ResourceMap::GetAsUnsignedInteger("WeightedExperiment-DefaultSize"))
 {
   // Nothing to do
 }
 
 /* Constructor with parameters */
-WeightedExperimentImplementation::WeightedExperimentImplementation(const UnsignedInteger size):
-  ExperimentImplementation(),
-  distribution_(),
-  size_(0),
-  weights_(0)
+WeightedExperimentImplementation::WeightedExperimentImplementation(const UnsignedInteger size)
+  : ExperimentImplementation()
+  , distribution_()
+  , size_(0)
 {
   // Check if the size is valid
   setSize(size);
@@ -55,11 +53,10 @@ WeightedExperimentImplementation::WeightedExperimentImplementation(const Unsigne
 
 /* Constructor with parameters */
 WeightedExperimentImplementation::WeightedExperimentImplementation(const Distribution & distribution,
-    const UnsignedInteger size):
-  ExperimentImplementation(),
-  distribution_(distribution),
-  size_(0),
-  weights_(0)
+    const UnsignedInteger size)
+  : ExperimentImplementation()
+  , distribution_(distribution)
+  , size_(0)
 {
   // Check if the size is valid
   setSize(size);
@@ -98,7 +95,6 @@ void WeightedExperimentImplementation::setSize(const UnsignedInteger size)
 {
   if (size == 0) throw InvalidArgumentException(HERE) << "Error: the size must be > 0.";
   size_ = size;
-  weights_ = NumericalPoint(size_, 1.0 / size_);
 }
 
 UnsignedInteger WeightedExperimentImplementation::getSize() const
@@ -109,21 +105,23 @@ UnsignedInteger WeightedExperimentImplementation::getSize() const
 /* Sample generation */
 NumericalSample WeightedExperimentImplementation::generate()
 {
-  throw NotYetImplementedException(HERE) << "In WeightedExperimentImplementation::generate()";
+  NumericalPoint weights;
+  return generateWithWeights(weights);
 }
 
 /* Sample generation with weights */
 NumericalSample WeightedExperimentImplementation::generateWithWeights(NumericalPoint & weights)
 {
-  const NumericalSample sample(generate());
-  weights = weights_;
-  return sample;
+  throw NotYetImplementedException(HERE) << "In WeightedExperimentImplementation::generateWithWeights()";
 }
 
 /* Weight accessor */
-NumericalPoint WeightedExperimentImplementation::getWeight() const
+NumericalPoint WeightedExperimentImplementation::getWeight()
 {
-  return weights_;
+  Log::Warn(OSS() << "WeightedExperimentImplementation::getWeight is deprecated.");
+  NumericalPoint weights;
+  generateWithWeights(weights);
+  return weights;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/BootstrapExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/BootstrapExperiment.hxx
@@ -54,8 +54,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/BootstrapExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/BootstrapExperiment.hxx
@@ -54,7 +54,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/FixedExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/FixedExperiment.hxx
@@ -61,7 +61,7 @@ public:
   void setDistribution(const Distribution & distribution);
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/FixedExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/FixedExperiment.hxx
@@ -61,14 +61,14 @@ public:
   void setDistribution(const Distribution & distribution);
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
 protected:
 
 private:
   // The fixed sample that will be returned at each call
   NumericalSample sample_;
+  NumericalPoint weights_;
 
 }; /* class FixedExperiment */
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
@@ -63,7 +63,7 @@ public:
   virtual String __repr__() const;
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
   /** Marginal degrees accessor */
   void setMarginalDegrees(const Indices & marginalDegrees);
@@ -76,7 +76,7 @@ protected:
 
 private:
   // Compute the tensor product nodes and weights
-  void computeNodesAndWeights();
+  void computeNodesAndWeights() const;
 
   // Distribution and marginal degrees accessor
   void setDistributionAndMarginalDegrees(const Distribution & distribution,
@@ -89,8 +89,8 @@ private:
   Indices marginalDegrees_;
 
   // Integration nodes; weights
-  NumericalSample nodes_;
-  NumericalPoint weights_;
+  mutable NumericalSample nodes_;
+  mutable NumericalPoint weights_;
 
   // Flag to manage the computation of nodes and weights
   mutable Bool isAlreadyComputedNodesAndWeights_;

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/GaussProductExperiment.hxx
@@ -63,8 +63,7 @@ public:
   virtual String __repr__() const;
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
   /** Marginal degrees accessor */
   void setMarginalDegrees(const Indices & marginalDegrees);
@@ -89,8 +88,9 @@ private:
   // Marginal degrees
   Indices marginalDegrees_;
 
-  // Integration nodes
+  // Integration nodes; weights
   NumericalSample nodes_;
+  NumericalPoint weights_;
 
   // Flag to manage the computation of nodes and weights
   mutable Bool isAlreadyComputedNodesAndWeights_;

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/ImportanceSamplingExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/ImportanceSamplingExperiment.hxx
@@ -63,7 +63,6 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generate();
   NumericalSample generateWithWeights(NumericalPoint & weights);
 
 protected:

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/ImportanceSamplingExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/ImportanceSamplingExperiment.hxx
@@ -63,7 +63,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LHSExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LHSExperiment.hxx
@@ -66,7 +66,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
   /** Shuffle the cells. */
   static Matrix ComputeShuffle(const UnsignedInteger dimension,

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LHSExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LHSExperiment.hxx
@@ -66,8 +66,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
   /** Shuffle the cells. */
   static Matrix ComputeShuffle(const UnsignedInteger dimension,

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LowDiscrepancyExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LowDiscrepancyExperiment.hxx
@@ -80,8 +80,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LowDiscrepancyExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/LowDiscrepancyExperiment.hxx
@@ -80,7 +80,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/MonteCarloExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/MonteCarloExperiment.hxx
@@ -58,8 +58,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  using WeightedExperimentImplementation::generate;
-  NumericalSample generate();
+  NumericalSample generateWithWeights(NumericalPoint & weights);
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/MonteCarloExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/MonteCarloExperiment.hxx
@@ -58,7 +58,7 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  NumericalSample generateWithWeights(NumericalPoint & weights);
+  NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
 protected:
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperiment.hxx
@@ -69,8 +69,9 @@ public:
   /** Sample generation with weights*/
   virtual NumericalSample generateWithWeights(NumericalPoint & weights);
 
-  /** Weight accessor */
-  virtual NumericalPoint getWeight() const;
+  /** Weight accessor 
+   * @deprecated */
+  virtual NumericalPoint getWeight();
 
 } ; /* class WeightedExperiment */
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperiment.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperiment.hxx
@@ -64,14 +64,14 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** Sample generation with weights*/
-  virtual NumericalSample generateWithWeights(NumericalPoint & weights);
+  virtual NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
   /** Weight accessor 
    * @deprecated */
-  virtual NumericalPoint getWeight();
+  virtual NumericalPoint getWeight() const;
 
 } ; /* class WeightedExperiment */
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperimentImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperimentImplementation.hxx
@@ -74,17 +74,17 @@ public:
   /** Sample generation with weights*/
   virtual NumericalSample generateWithWeights(NumericalPoint & weights);
 
-  /** Weight accessor */
-  virtual NumericalPoint getWeight() const;
+  /** Weight accessor
+   * @deprecated */
+  virtual NumericalPoint getWeight();
 
 protected:
 
   /** Distribution that defines the weights of the experiment */
   Distribution distribution_;
+
   /** The size of the sample to be generated */
   UnsignedInteger size_;
-  /** The weights associated with the sample for numerical integration */
-  NumericalPoint weights_;
 
 }; /* class WeightedExperimentImplementation */
 

--- a/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperimentImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/WeightedExperiments/openturns/WeightedExperimentImplementation.hxx
@@ -69,14 +69,14 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Sample generation */
-  virtual NumericalSample generate();
+  virtual NumericalSample generate() const;
 
   /** Sample generation with weights*/
-  virtual NumericalSample generateWithWeights(NumericalPoint & weights);
+  virtual NumericalSample generateWithWeights(NumericalPoint & weights) const;
 
   /** Weight accessor
    * @deprecated */
-  virtual NumericalPoint getWeight();
+  virtual NumericalPoint getWeight() const;
 
 protected:
 


### PR DESCRIPTION
All weighted experiment to implement generateWithWeights
generate is calling generateWithWeights
getWeight is deprecated
Fixes http://trac.openturns.org/ticket/840