### PR TITLE
Fix Python bindings for HMatrix::compressionRatio

### DIFF
--- a/python/src/HMatrix.i
+++ b/python/src/HMatrix.i
@@ -5,6 +5,7 @@
 %}
 
 %template(HMatrixImplementationTypedInterfaceObject) OT::TypedInterfaceObject<OT::HMatrixImplementation>;
+%template(pairlonglong) std::pair< size_t, size_t >;
 
 %include openturns/HMatrix.hxx
 


### PR DESCRIPTION
Without this change, swig is confused:
```
 >>> cov.compressionRatio()
 <Swig Object of type 'std::pair< size_t,size_t > *' at 0x11bb13180>
```
With this change:
```
 >>> cov.compressionRatio()
 (36L, 36L)
```