### PR TITLE
Allow to change TBB threads number at runtime

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,7 @@
  * Shortened ResourceMap keys to not contain 'Implementation'
 
 === Bug fixes ===
+ * #535 (parallel-threads option cannot be changed at runtime with TBB)
  * #565 (The SensitivityAnalysis class manages only one single output.)
  * #604 (Bug concerning the NonCentralStudent distribution)
  * #698 (KernelSmoothing() as a factory)

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -19,7 +19,6 @@
  *
  */
 #include <unistd.h>                 // for sysconf
-#include <string.h>                 // for strdup
 #include "openturns/OTthread.hxx"
 #include "openturns/OTconfig.hxx"
 #include "openturns/OSS.hxx"

--- a/lib/src/Base/Common/TBB.cxx
+++ b/lib/src/Base/Common/TBB.cxx
@@ -42,6 +42,28 @@ tbb::task_scheduler_init * TBB_P_scheduler_ = 0;
 #endif /* OPENTURNS_HAVE_TBB */
 
 
+void TBB::SetNumberOfThreads(const UnsignedInteger numberOfThreads)
+{
+#ifdef OPENTURNS_HAVE_TBB
+  delete TBB_P_scheduler_;
+  TBB_P_scheduler_ = new tbb::task_scheduler_init(numberOfThreads);
+#endif
+}
+
+void TBB::Enable()
+{
+  const UnsignedInteger nbThreads = ResourceMap::GetAsUnsignedInteger("parallel-threads");
+  SetNumberOfThreads(nbThreads);
+}
+
+
+void TBB::Disable()
+{
+  SetNumberOfThreads(1);
+}
+
+
+
 TBB_init::TBB_init()
 {
   if (!TBB_P_instance_)
@@ -56,10 +78,7 @@ TBB_init::TBB_init()
 #endif
     TBB_P_instance_ = new TBB;
   }
-#ifdef OPENTURNS_HAVE_TBB
-  UnsignedInteger nbThreads = ResourceMap::GetAsUnsignedInteger( "parallel-threads" );
-  TBB_P_scheduler_ = new tbb::task_scheduler_init( nbThreads );
-#endif /* OPENTURNS_HAVE_TBB */
+  TBB::Enable();
 }
 
 TBB_init::~TBB_init()

--- a/lib/src/Base/Common/openturns/TBB.hxx
+++ b/lib/src/Base/Common/openturns/TBB.hxx
@@ -114,6 +114,7 @@ public:
   struct Split {};
 #endif /* OPENTURNS_HAVE_TBB */
 
+#ifndef SWIG // swig 1.3.40 fails to parse this
   template <typename T>
   struct BlockedRange : public tbb::blocked_range<T>
   {
@@ -122,6 +123,7 @@ public:
     BlockedRange(value_type from, value_type to, size_type gs = 1) : tbb::blocked_range<T>(from, to, gs) {}
     BlockedRange(const tbb::blocked_range<T> & range) : tbb::blocked_range<T>(range) {}
   };
+#endif // SWIG
 
   template <typename BODY>
   static inline
@@ -144,12 +146,15 @@ public:
     tbb::parallel_sort( first, last );
   }
 
+  static void Enable();
+  static void Disable();
+
 private:
+  static void SetNumberOfThreads(const UnsignedInteger numberOfThreads);
 
-  friend struct TBB_init; /* friendship for static member initialization */
+  friend struct TBB_init;
+
 }; /* end class TBB */
-
-
 
 /** This struct initializes all static members of TBB */
 struct OT_API TBB_init

--- a/python/doc/user_manual/configuration.rst
+++ b/python/doc/user_manual/configuration.rst
@@ -18,8 +18,8 @@ OPENTURNS_HOME
 OPENTURNS_LOG_SEVERITY
     The default severity of logs, see the :class:`~openturns.Log` class.
 
-OpenTURNS environment checking and filesystem manipulation
-==========================================================
+Environment checking and filesystem manipulation
+================================================
 
 .. autosummary::
     :toctree: _generated/
@@ -54,3 +54,13 @@ Resource catalog
     :template: class.rst_t
 
     ResourceMap
+
+Threading configuration
+=======================
+
+.. autosummary::
+    :toctree: _generated/
+    :template: function.rst_t
+
+    TBB_Enable
+    TBB_Disable

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -86,6 +86,7 @@ ot_add_python_module(common common_module.i
                       OTtypes.i
                       OTexceptions.i
                       Memory.i
+                      TBB.i TBB_doc.i.in
                       Object.i Object_doc.i.in
                       PersistentObject.i PersistentObject_doc.i.in
                       Study.i Study_doc.i.in

--- a/python/src/TBB.i
+++ b/python/src/TBB.i
@@ -1,0 +1,14 @@
+// SWIG file TBB.i
+
+%{
+#include "openturns/TBB.hxx"
+%}
+
+%include TBB_doc.i
+
+%ignore OT::TBB::Split;
+%ignore OT::TBB_init;
+
+%nodefaultctor TBB;
+
+%include openturns/TBB.hxx

--- a/python/src/TBB_doc.i.in
+++ b/python/src/TBB_doc.i.in
@@ -1,0 +1,15 @@
+%feature("docstring") OT::TBB
+"Threading parameters."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::TBB::Enable
+"Enable threading.
+
+The number of threads is the value associated to the `parallel-threads` key
+in :class:`~openturns.ResourceMap`."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::TBB::Disable
+"Disable threading."

--- a/python/src/common_module.i
+++ b/python/src/common_module.i
@@ -15,6 +15,7 @@
 
 /* Base/Common */
 %include Memory.i
+%include TBB.i
 %include Object.i
 %include PersistentObject.i
 %include SharedPointer.i


### PR DESCRIPTION
Added TBB::SetNumberOfThreads which is called in ResourceMap::SetAsUnsignedInteger.

This can be used to get a deterministic behavior of KrigingAlgorithm with normalization enabled.