### PR TITLE
Distribution::computeLogPDF gradient method and application in MaximumLikelihoodFactory

### DIFF
--- a/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
@@ -142,6 +142,32 @@ NumericalScalar FisherSnedecor::computeLogPDF(const NumericalPoint & point) cons
   return normalizationFactor_ + (0.5 * d1_ - 1.0) * std::log(x) - 0.5 * (d1_ + d2_) * log1p(d1_ * x / d2_);
 }
 
+NumericalPoint FisherSnedecor::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  const NumericalScalar x = point[0];
+  NumericalPoint logPdfGradient(2, 0.0);
+  if (!(x > 0.0)) return logPdfGradient;
+  const NumericalScalar d1xd2 = d1_ * x + d2_;
+  // First derivate the normlizationFactor as function of d1_, d2_ (see expression above in LogPDF)
+  // As the term is a combinations of LnBeta(d1/2, d2/2) := log(Beta(d1/2, d2/2), dLnBeta = dBeta/Beta
+  // As dBeta(x,y) = B(x,y) * (DiGamma(X) - DiGamma(x+y)) (see  https://en.wikipedia.org/wiki/Beta_function#Derivatives)
+  // it follows that d(LnBeta(x,y)) = dBeta(x,y) / Beta(x,y) = DiGamma(X) - DiGamma(x+y)
+  logPdfGradient[0] = 0.5 * ( std::log(d1_ / d2_)  + 1.0 - SpecFunc::DiGamma(0.5 * d1_) + SpecFunc::DiGamma(0.5 * d1_ + 0.5 * d2_) );
+  logPdfGradient[1] = 0.5 * (-d1_  / d2_ - SpecFunc::DiGamma(0.5 * d2_) + SpecFunc::DiGamma(0.5 * d1_ + 0.5 * d2_) );
+  // Second part is less complex
+  logPdfGradient[0] += 0.5 * (std::log(x) - log1p(d1_ * x / d2_) - (d1_ + d2_) * x / d1xd2);
+  logPdfGradient[1] += 0.5 * (-log1p(d1_ * x / d2_) + (d1_  + d2_) * (d1_ * x  / d2_) / d1xd2);
+  return logPdfGradient;
+}
+
+NumericalPoint FisherSnedecor::computePDFGradient(const NumericalPoint & point) const
+{
+  // PDF(x) =  exp(LogPDF(x)) thus PDF(x)' = LogPDF(x)' * exp(LogPDF(x))
+  NumericalPoint PdfGradient(computeLogPDFGradient(point));
+  NumericalScalar pdf = computePDF(point);
+  return PdfGradient * pdf;
+}
+
 /* Get the CDF of the distribution */
 NumericalScalar FisherSnedecor::computeCDF(const NumericalPoint & point) const
 {

--- a/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
@@ -227,6 +227,12 @@ public:
     // parallelization handeled by distribution::computeLogPDFGradient
     const NumericalPoint logPdfGradient = distribution.computeLogPDFGradient(sample_).computeMean();
     result = MatrixImplementation(getInputDimension(), 1, logPdfGradient);
+    // Check about this
+    // Gradient should be 0 for knownParameters
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
+    {
+      result(knownParameterIndices_[j], 0) = 0.0;
+    }
     return result;
   }
 

--- a/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
@@ -32,6 +32,9 @@
 #include "openturns/CenteredFiniteDifferenceGradient.hxx"
 #include "openturns/Normal.hxx"
 #include "openturns/TNC.hxx"
+#include "openturns/Matrix.hxx"
+#include "openturns/NumericalMathEvaluationImplementation.hxx"
+#include "openturns/NumericalMathGradientImplementation.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -82,78 +85,157 @@ String MaximumLikelihoodFactory::__str__(const String & offset) const
   return this->getClassName();
 }
 
-
-/* Here is the interface that all derived class must implement */
-
-
-struct MaximumLikelihoodFactoryLogLikelihood
+class LogLikelihoodEvaluation : public NumericalMathEvaluationImplementation
 {
-  MaximumLikelihoodFactoryLogLikelihood(const NumericalSample & sample,
+public:
+  LogLikelihoodEvaluation(const NumericalSample & sample,
                                         const Distribution & distribution,
                                         const NumericalPoint & knownParameterValues,
                                         const Indices & knownParameterIndices,
                                         const Bool & isParallel)
-    : sample_(sample)
+    : NumericalMathEvaluationImplementation()
+    , sample_(sample)
     , distribution_(distribution)
     , knownParameterValues_(knownParameterValues)
     , knownParameterIndices_(knownParameterIndices)
-    , isParallel_(isParallel)
   {
-    // Nothing to do
+    distribution_.getImplementation()->setParallel(isParallel);
   }
 
-  NumericalScalar computeLogLikelihood(const NumericalPoint & parameter) const
+  LogLikelihoodEvaluation * clone() const
+  {
+    return new LogLikelihoodEvaluation(*this);
+  }
+
+  UnsignedInteger getInputDimension() const
+  {
+    return distribution_.getParameterDimension();
+  }
+
+  UnsignedInteger getOutputDimension() const
+  {
+    return 1;
+  }
+
+  Description getInputDescription() const
+  {
+    return Description::BuildDefault(getInputDimension(), "theta");
+  }
+
+  Description getOutputDescription() const
+  {
+    return Description(1, "lh");
+  }
+
+  Description getDescription() const
+  {
+    Description description(getInputDescription());
+    description.add(getOutputDescription());
+    return description;
+  }
+
+  NumericalPoint operator() (const NumericalPoint & parameter) const
   {
     NumericalScalar result = 0.0;
-    try
+    NumericalPoint effectiveParameter(parameter);
+    UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
     {
-      NumericalPoint effectiveParameter(parameter);
-      UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
-      for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
-      {
-        effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
-      }
-      Distribution distribution(distribution_);
-      distribution.setParameter(effectiveParameter);
-
-      if (isParallel_)
-      {
-        const NumericalScalar logLikelihood = distribution.computeLogPDF(sample_).computeMean()[0];
-        result = SpecFunc::IsNormal(logLikelihood) ? logLikelihood : -SpecFunc::MaxNumericalScalar;
-      } // Parallel computeLogPDF
-      else
-      {
-        const UnsignedInteger size = sample_.getSize();
-        for (UnsignedInteger i = 0; i < size; ++ i)
-        {
-          const NumericalScalar logPdf = distribution.computeLogPDF(sample_[i]);
-          if (logPdf == -SpecFunc::MaxNumericalScalar)
-          {
-            result = -SpecFunc::MaxNumericalScalar;
-            break;
-          }
-          else
-          {
-            result += logPdf;
-          }
-        } // Loop over the realizations
-	result /= size;
-      } // Sequential computeLogPDF
-    } // try
-    catch (...)
-    {
-      result = -SpecFunc::MaxNumericalScalar;
+      effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
     }
+    Distribution distribution(distribution_);
+    distribution.setParameter(effectiveParameter);
+    // Take into account the mean over sample
+    // Parallelization (evaluation over a sample) is handeled by distribution_
+    const NumericalScalar logLikelihood = distribution.computeLogPDF(sample_).computeMean()[0];
+    result = SpecFunc::IsNormal(logLikelihood) ? logLikelihood : SpecFunc::LogMinNumericalScalar;
+    return NumericalPoint(1, result);
+  }
+
+private:
+  NumericalSample sample_;
+  Distribution distribution_;
+  NumericalPoint knownParameterValues_;
+  Indices knownParameterIndices_;
+};
+
+class LogLikelihoodGradient : public NumericalMathGradientImplementation
+{
+public:
+  LogLikelihoodGradient(const NumericalSample & sample,
+                                        const Distribution & distribution,
+                                        const NumericalPoint & knownParameterValues,
+                                        const Indices & knownParameterIndices,
+                                        const Bool & isParallel)
+    : NumericalMathGradientImplementation()
+    , sample_(sample)
+    , distribution_(distribution)
+    , knownParameterValues_(knownParameterValues)
+    , knownParameterIndices_(knownParameterIndices)
+  {
+    distribution_.getImplementation()->setParallel(isParallel);
+  }
+
+  LogLikelihoodGradient * clone() const
+  {
+    return new LogLikelihoodGradient(*this);
+  }
+
+  UnsignedInteger getInputDimension() const
+  {
+    return distribution_.getParameterDimension();
+  }
+
+  UnsignedInteger getOutputDimension() const
+  {
+    return 1;
+  }
+
+  Description getInputDescription() const
+  {
+    return Description::BuildDefault(getInputDimension(), "theta");
+  }
+
+  Description getOutputDescription() const
+  {
+    return Description(1, "lhG");
+  }
+
+  Description getDescription() const
+  {
+    Description description(getInputDescription());
+    description.add(getOutputDescription());
+    return description;
+  }
+
+  Matrix gradient(const NumericalPoint & parameter) const
+  {
+    // Define conditionned distribution
+    NumericalPoint effectiveParameter(parameter);
+    UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
+    {
+      effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
+    }
+    Distribution distribution(distribution_);
+    distribution.setParameter(effectiveParameter);
+    // Evaluate the gradient
+    // Matrix result
+    MatrixImplementation result(parameter.getSize(), 1);
+    const UnsignedInteger size = sample_.getSize();
+    // Compute sum(LogPDFGraident(sample)) ~> size * mean
+    // parallelization handeled by distribution::computeLogPDFGradient
+    const NumericalPoint logPdfGradient = distribution.computeLogPDFGradient(sample_).computeMean();
+    result = MatrixImplementation(getInputDimension(), 1, logPdfGradient);
     return result;
   }
 
-  const NumericalSample & sample_;
-  const Distribution distribution_;
-  const NumericalPoint knownParameterValues_;
-  const Indices knownParameterIndices_;
-  const Bool isParallel_;
+private:
+  NumericalSample sample_;
+  Distribution distribution_;
+  NumericalPoint knownParameterValues_;
+  Indices knownParameterIndices_;
 };
-
 
 NumericalPoint MaximumLikelihoodFactory::buildParameter(const NumericalSample & sample) const
 {
@@ -161,11 +243,13 @@ NumericalPoint MaximumLikelihoodFactory::buildParameter(const NumericalSample & 
   if (sample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: can build a distribution only from a sample of dimension 1, here dimension=" << sample.getDimension();
 
   UnsignedInteger parameterDimension = distribution_.getParameterDimension();
-  MaximumLikelihoodFactoryLogLikelihood logLikelihoodWrapper(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
-
-  NumericalMathFunction logLikelihood(bindMethod<MaximumLikelihoodFactoryLogLikelihood, NumericalScalar, NumericalPoint>(logLikelihoodWrapper, &MaximumLikelihoodFactoryLogLikelihood::computeLogLikelihood, parameterDimension, 1));
+  // Define NumericalMathEvaluation using the LogLikelihoodEvaluation wrapper
+  LogLikelihoodEvaluation logLikelihoodWrapper(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
+  NumericalMathFunction logLikelihood(logLikelihoodWrapper.clone());
+  // Define NumericalMathGradient using the LogLikelihoodEvaluation wrapper
+  LogLikelihoodGradient logLikelihoodWrapperGradient(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
   CenteredFiniteDifferenceGradient gradient(ResourceMap::GetAsNumericalScalar("MaximumLikelihoodFactory-GradientStep"), logLikelihood.getEvaluation());
-  logLikelihood.setGradient(gradient);
+  logLikelihood.setGradient(logLikelihoodWrapperGradient.clone());
   OptimizationProblem problem(problem_);
   problem.setMinimization(false);
   problem.setObjective(logLikelihood);

--- a/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
+++ b/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
@@ -218,6 +218,37 @@ NumericalPoint Trapezoidal::computePDFGradient(const NumericalPoint & point) con
   return pdfGradient;
 }
 
+/* Get the logPDFGradient of the distribution */
+NumericalPoint Trapezoidal::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  if (point.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=1, here dimension=" << point.getDimension();
+
+  const NumericalScalar x = point[0];
+  NumericalPoint logPdfGradient(4, 0.0);
+  if ((a_ < x) && (x < b_))
+  {
+    logPdfGradient[0] = h_ / 2.0 - 1.0 / (x - a_) + 1.0 / (b_ - a_);
+    logPdfGradient[1] = h_ / 2.0 - 1.0 / (b_ - a_);
+    logPdfGradient[2] = -h_ / 2.0;
+    logPdfGradient[3] = -h_ / 2.0;
+  }
+  else if ((b_ <= x) && (x <= c_))
+  {
+    logPdfGradient[0] =  h_ / 2.0;
+    logPdfGradient[1] =  h_ / 2.0;
+    logPdfGradient[2] = -h_ / 2.0;
+    logPdfGradient[3] = -h_ / 2.0;
+  }
+  else if ((c_ < x) && (x < d_))
+  {
+    logPdfGradient[0] = h_ / 2.0;
+    logPdfGradient[1] = h_ / 2.0;
+    logPdfGradient[2] = -h_ / 2.0 + 1.0 / (d_ - c_);
+    logPdfGradient[3] = -h_ / 2.0 + 1.0 / (d_ - x) - 1.0 / (d_ - c_);
+  }
+  return logPdfGradient;
+}
+
 
 /* Get the CDFGradient of the distribution */
 NumericalPoint Trapezoidal::computeCDFGradient(const NumericalPoint & point) const

--- a/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
@@ -336,6 +336,27 @@ NumericalPoint TruncatedNormal::computePDFGradient(const NumericalPoint & point)
   return pdfGradient;
 }
 
+/* Get the LogPDFGradient of the distribution */
+NumericalPoint TruncatedNormal::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  if (point.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "In TruncatedNormal::computeLogPDFGradient, the given point must have dimension=1, here dimension=" << point.getDimension();
+
+  const NumericalScalar x = point[0];
+  NumericalPoint logPdfGradient(getParameterDimension());
+  if (!(x > a_) || !(x < b_)) return logPdfGradient;
+  const NumericalScalar iSigma = 1.0 / sigma_;
+  const NumericalScalar xNorm = (x - mu_) * iSigma;
+  const NumericalScalar aNorm = (a_ - mu_) * iSigma;
+  const NumericalScalar bNorm = (b_ - mu_) * iSigma;
+  const NumericalScalar iDenom = normalizationFactor_ * iSigma;
+  logPdfGradient[0] = xNorm * iSigma +  iDenom * (phiBNorm_ - phiANorm_);
+  logPdfGradient[1] = iSigma * ( -1.0 + xNorm * xNorm ) + iDenom * (phiBNorm_ * bNorm - phiANorm_ * aNorm);
+  logPdfGradient[2] = phiANorm_ * iDenom;
+  logPdfGradient[3] = - phiBNorm_ * iDenom;
+  return logPdfGradient;
+}
+
 /* Get the CDFGradient of the distribution */
 NumericalPoint TruncatedNormal::computeCDFGradient(const NumericalPoint & point) const
 {

--- a/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
@@ -69,6 +69,14 @@ public:
   using ContinuousDistribution::computeLogPDF;
   NumericalScalar computeLogPDF(const NumericalPoint & point) const;
 
+  // LogPDFGradient
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
+  // PDFGradient
+  using ContinuousDistribution::computePDFGradient;
+  NumericalPoint computePDFGradient(const NumericalPoint & point) const;
+
   /** Get the CDF of the distribution, i.e. P(X <= point) = CDF(point) */
   using ContinuousDistribution::computeCDF;
   NumericalScalar computeCDF(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
@@ -85,6 +85,10 @@ public:
   using ContinuousDistribution::computePDFGradient;
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
 
+  /** Get the gradient of the logPDF w.r.t the parameters of the distribution */
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
   /** Get the gradient of the CDF w.r.t the parameters of the distribution */
   using ContinuousDistribution::computeCDFGradient;
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
@@ -102,6 +102,10 @@ public:
   using ContinuousDistribution::computePDFGradient;
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
 
+  /** Get the LogPDFGradient of the TruncatedNormal distribution */
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
   /** Get the CDFGradient of the TruncatedNormal distribution */
   using ContinuousDistribution::computeCDFGradient;
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -573,6 +573,18 @@ NumericalSample Distribution::computePDFGradient(const NumericalSample & sample)
   return getImplementation()->computePDFGradient(sample);
 }
 
+/* Get the logPDF gradient of the distribution */
+NumericalPoint Distribution::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  return getImplementation()->computeLogPDFGradient(point);
+}
+
+NumericalSample Distribution::computeLogPDFGradient(const NumericalSample & sample) const
+{
+  return getImplementation()->computeLogPDFGradient(sample);
+}
+
+
 /* Get the CDF gradient of the distribution */
 NumericalPoint Distribution::computeCDFGradient(const NumericalPoint & point) const
 {

--- a/lib/src/Uncertainty/Model/openturns/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/Distribution.hxx
@@ -204,6 +204,10 @@ public:
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
   NumericalSample computePDFGradient(const NumericalSample & sample) const;
 
+  /** Get the log(PDFgradient) of the distribution */
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+  NumericalSample computeLogPDFGradient(const NumericalSample & sample) const;
+
   /** Get the CDF gradient of the distribution */
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
   NumericalSample computeCDFGradient(const NumericalSample & sample) const;

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -276,7 +276,16 @@ public:
   /** Get the PDF gradient of the distribution */
   virtual NumericalPoint computePDFGradient(const NumericalPoint & point) const;
   virtual NumericalSample computePDFGradient(const NumericalSample & inSample) const;
-public:
+
+  /** Get the logPDF gradient of the distribution */
+  virtual NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+  virtual NumericalSample computeLogPDFGradient(const NumericalSample & inSample) const;
+
+protected:
+  virtual NumericalSample computeLogPDFGradientSequential(const NumericalSample & sample) const;
+  virtual NumericalSample computeLogPDFGradientParallel(const NumericalSample & sample) const;
+
+ public:
   /** Get the CDF gradient of the distribution */
   virtual NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
   virtual NumericalSample computeCDFGradient(const NumericalSample & inSample) const;

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -465,6 +465,25 @@ OT_Distribution_computeLogPDF_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_Distribution_computeLogPDFGradient_doc
+"Compute the gradient of the log probability density function.
+
+Parameters
+----------
+X : sequence of float
+    PDF input.
+
+Returns
+-------
+dfdtheta : :class:`~openturns.NumericalPoint`
+    Partial derivatives of the logPDF with respect to the distribution
+    parameters at input `X`."
+%enddef
+%feature("docstring") OT::DistributionImplementation::computeLogPDFGradient
+OT_Distribution_computeLogPDFGradient_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_Distribution_computePDF_doc
 "Compute the probability density function.
 

--- a/python/src/Distribution_doc.i.in
+++ b/python/src/Distribution_doc.i.in
@@ -50,6 +50,8 @@ OT_Distribution_computeUnilateralConfidenceInterval_doc
 OT_Distribution_computeUnilateralConfidenceIntervalWithMarginalProbability_doc
 %feature("docstring") OT::Distribution::computeLogPDF
 OT_Distribution_computeLogPDF_doc
+%feature("docstring") OT::Distribution::computeLogPDFGradient
+OT_Distribution_computeLogPDFGradient_doc
 %feature("docstring") OT::Distribution::computePDF
 OT_Distribution_computePDF_doc
 %feature("docstring") OT::Distribution::computePDFGradient

--- a/python/test/t_TruncatedNormal_std.expout
+++ b/python/test/t_TruncatedNormal_std.expout
@@ -17,6 +17,8 @@ cdf=0.743877
 ccdf=0.256123
 pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
 pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
+log-pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
+log-pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
 cdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 cdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 quantile= class=NumericalPoint name=Unnamed dimension=1 values=[1.79498]

--- a/python/test/t_TruncatedNormal_std.py
+++ b/python/test/t_TruncatedNormal_std.py
@@ -69,6 +69,7 @@ try:
     print("cdf=%.6f" % CDF)
     CCDF = distribution.computeComplementaryCDF(point)
     print("ccdf=%.6f" % CCDF)
+
     PDFgr = distribution.computePDFGradient(point)
     print("pdf gradient     =", repr(PDFgr))
     # by the finite difference technique
@@ -82,6 +83,21 @@ try:
     PDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computePDF(point) -
                   TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computePDF(point)) / (2.0 * eps)
     print("pdf gradient (FD)=", repr(PDFgrFD))
+
+    # derivative of the logPDF with regards the parameters of the distribution
+    logPDFgr = distribution.computeLogPDFGradient(point)
+    print("log-pdf gradient     =", repr(logPDFgr))
+    # by the finite difference technique
+    logPDFgrFD = NumericalPoint(4)
+    logPDFgrFD[0] = (TruncatedNormal(distribution.getMu() + eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu() - eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[1] = (TruncatedNormal(distribution.getMu(), distribution.getSigma() + eps, distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma() - eps, distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[2] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() + eps, distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() - eps, distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computeLogPDF(point)) / (2.0 * eps)
+    print("log-pdf gradient (FD)=", repr(logPDFgrFD))
 
     # derivative of the PDF with regards the parameters of the distribution
     CDFgr = distribution.computeCDFGradient(point)


### PR DESCRIPTION
This PR implements a generic Distribution::computeLogPDFGradient (defined as PDFGradient/PDF)
The objective is to use the method as an exact gradient when maximizing the log-likelihood function for estimating distribution's parameters in MaximumLikelihoodFactoryLogLikelihood. 

Indeed this class provides a buildParameter method which purpose is to maximize the log-likelihood function previously defined as bind method function (+ difference finite gradient). We rework the internal structure "MaximumLikelihoodFactoryLogLikelihood" as follows:
- It inherits now from NumericalMathEvaluationImplementation;
- It implements the operator() (reuse the computeLogLikelihood method)
- A gradient wrapper is added (maps Distribution::computeLogPDFGradient)
  Thus we get the function and is exact gradient for the evaluation.

Note that here the separation between NumericalMathEvaluationImplementation and NumericalMathGradientImplementation is required as some optimization algorithms require explicitely the gradientImplementation and not only the gradient operator.

Finally to fix/speed up some tests, we implement specific computeLogPDFGradient to TruncatedNormal and Fisher-Snedecor
