### PR TITLE
MaximumLikelihoodFactory enhancements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@
   * Removed deprecated method WeightedExperiment::getWeight
   * Removed deprecated method DistributionFactory::build(NumericalSample, CovarianceMatrix&)
   * Removed deprecated distributions alternative parameters constructors, accessors
+  * Added a generic implementation of the computeLogPDFGradient() method in the DistributionImplementation class.
 
 === Python module ===
 

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -286,9 +286,6 @@
   <LogNormalFactory-ResidualPrecision value="1e-12" />
   <LogNormalFactory-MaximumIteration  value="50"    />
 
-  <!-- MaximumLikelihoodFactory parameters -->
-  <MaximumLikelihoodFactory-GradientStep value="1.0e-5" />
-
   <!-- Meixner parameters -->
   <MeixnerDistribution-CDFIntegrationNodesNumber value="32" />
   <MeixnerDistribution-CDFDiscretization value="10000" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -553,9 +553,6 @@ void ResourceMap::loadDefaultConfiguration()
   setAsNumericalScalar( "LogNormalFactory-ResidualPrecision", 1.0e-12 );
   setAsUnsignedInteger( "LogNormalFactory-MaximumIteration", 50 );
 
-  // MaximumLikelihoodFactory parameters //
-  setAsNumericalScalar( "MaximumLikelihoodFactory-GradientStep", 1.0e-5 );
-
   // Meixner parameters //
   setAsUnsignedInteger( "MeixnerDistribution-CDFIntegrationNodesNumber", 32 );
   setAsUnsignedInteger( "MeixnerDistribution-CDFDiscretization", 10000 );

--- a/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
@@ -29,10 +29,12 @@
 #include "openturns/Os.hxx"
 #include "openturns/SpecFunc.hxx"
 #include "openturns/MethodBoundNumericalMathEvaluationImplementation.hxx"
-#include "openturns/CenteredFiniteDifferenceGradient.hxx"
 #include "openturns/Normal.hxx"
 #include "openturns/TNC.hxx"
 #include "openturns/PersistentObjectFactory.hxx"
+#include "openturns/Matrix.hxx"
+#include "openturns/NumericalMathEvaluationImplementation.hxx"
+#include "openturns/NumericalMathGradientImplementation.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -85,78 +87,178 @@ String MaximumLikelihoodFactory::__str__(const String & offset) const
   return this->getClassName();
 }
 
-
-/* Here is the interface that all derived class must implement */
-
-
-struct MaximumLikelihoodFactoryLogLikelihood
+class LogLikelihoodEvaluation : public NumericalMathEvaluationImplementation
 {
-  MaximumLikelihoodFactoryLogLikelihood(const NumericalSample & sample,
+public:
+  LogLikelihoodEvaluation(const NumericalSample & sample,
                                         const Distribution & distribution,
                                         const NumericalPoint & knownParameterValues,
                                         const Indices & knownParameterIndices,
                                         const Bool & isParallel)
-    : sample_(sample)
+    : NumericalMathEvaluationImplementation()
+    , sample_(sample)
     , distribution_(distribution)
     , knownParameterValues_(knownParameterValues)
     , knownParameterIndices_(knownParameterIndices)
-    , isParallel_(isParallel)
   {
-    // Nothing to do
+    distribution_.getImplementation()->setParallel(isParallel);
   }
 
-  NumericalScalar computeLogLikelihood(const NumericalPoint & parameter) const
+  LogLikelihoodEvaluation * clone() const
+  {
+    return new LogLikelihoodEvaluation(*this);
+  }
+
+  UnsignedInteger getInputDimension() const
+  {
+    return distribution_.getParameterDimension();
+  }
+
+  UnsignedInteger getOutputDimension() const
+  {
+    return 1;
+  }
+
+  Description getInputDescription() const
+  {
+    return Description::BuildDefault(getInputDimension(), "theta");
+  }
+
+  Description getOutputDescription() const
+  {
+    return Description(1, "lh");
+  }
+
+  Description getDescription() const
+  {
+    Description description(getInputDescription());
+    description.add(getOutputDescription());
+    return description;
+  }
+
+  NumericalPoint operator() (const NumericalPoint & parameter) const
   {
     NumericalScalar result = 0.0;
-    try
+    NumericalPoint effectiveParameter(parameter);
+    UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
     {
-      NumericalPoint effectiveParameter(parameter);
-      UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
-      for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
-      {
-        effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
-      }
-      Distribution distribution(distribution_);
-      distribution.setParameter(effectiveParameter);
+      effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
+    }
+    Distribution distribution(distribution_);
+    distribution.setParameter(effectiveParameter);
+    // Take into account the mean over sample
+    // Parallelization (evaluation over a sample) is handeled by distribution_
+    const NumericalSample logPdfSample = distribution.computeLogPDF(sample_);
+    NumericalScalar logPdf = SpecFunc::LogMinNumericalScalar;
+    if (distribution.getImplementation()->isParallel())
+        logPdf = logPdfSample.computeMean()[0];
+    else
+    {
+      const UnsignedInteger size = sample_.getSize();
+      for (UnsignedInteger k = 0; k < size; ++k)
+        logPdf += logPdfSample(k, 0) / size;
+    }
+    result = SpecFunc::IsNormal(logPdf) ? logPdf : SpecFunc::LogMinNumericalScalar;
+    return NumericalPoint(1, result);
+  }
 
-      if (isParallel_)
-      {
-        const NumericalScalar logLikelihood = distribution.computeLogPDF(sample_).computeMean()[0];
-        result = SpecFunc::IsNormal(logLikelihood) ? logLikelihood : -SpecFunc::MaxNumericalScalar;
-      } // Parallel computeLogPDF
-      else
-      {
-        const UnsignedInteger size = sample_.getSize();
-        for (UnsignedInteger i = 0; i < size; ++ i)
-        {
-          const NumericalScalar logPdf = distribution.computeLogPDF(sample_[i]);
-          if (logPdf == -SpecFunc::MaxNumericalScalar)
-          {
-            result = -SpecFunc::MaxNumericalScalar;
-            break;
-          }
-          else
-          {
-            result += logPdf;
-          }
-        } // Loop over the realizations
-	result /= size;
-      } // Sequential computeLogPDF
-    } // try
-    catch (...)
+private:
+  NumericalSample sample_;
+  Distribution distribution_;
+  NumericalPoint knownParameterValues_;
+  Indices knownParameterIndices_;
+};
+
+class LogLikelihoodGradient : public NumericalMathGradientImplementation
+{
+public:
+  LogLikelihoodGradient(const NumericalSample & sample,
+                        const Distribution & distribution,
+                        const NumericalPoint & knownParameterValues,
+                        const Indices & knownParameterIndices,
+                        const Bool & isParallel)
+    : NumericalMathGradientImplementation()
+    , sample_(sample)
+    , distribution_(distribution)
+    , knownParameterValues_(knownParameterValues)
+    , knownParameterIndices_(knownParameterIndices)
+  {
+    distribution_.getImplementation()->setParallel(isParallel);
+  }
+
+  LogLikelihoodGradient * clone() const
+  {
+    return new LogLikelihoodGradient(*this);
+  }
+
+  UnsignedInteger getInputDimension() const
+  {
+    return distribution_.getParameterDimension();
+  }
+
+  UnsignedInteger getOutputDimension() const
+  {
+    return 1;
+  }
+
+  Description getInputDescription() const
+  {
+    return Description::BuildDefault(getInputDimension(), "theta");
+  }
+
+  Description getOutputDescription() const
+  {
+    return Description(1, "lhG");
+  }
+
+  Description getDescription() const
+  {
+    Description description(getInputDescription());
+    description.add(getOutputDescription());
+    return description;
+  }
+
+  Matrix gradient(const NumericalPoint & parameter) const
+  {
+    // Define conditionned distribution
+    NumericalPoint effectiveParameter(parameter);
+    UnsignedInteger knownParametersSize = knownParameterIndices_.getSize();
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
     {
-      result = -SpecFunc::MaxNumericalScalar;
+      effectiveParameter[knownParameterIndices_[j]] = knownParameterValues_[j];
+    }
+    Distribution distribution(distribution_);
+    distribution.setParameter(effectiveParameter);
+    // Matrix result
+    MatrixImplementation result(parameter.getSize(), 1);
+    // Evaluate the gradient
+    const NumericalSample logPdfGradientSample( distribution.computeLogPDFGradient(sample_));
+    NumericalPoint logPdfGradient(distribution_.getParameterDimension(), SpecFunc::LogMinNumericalScalar);
+    if (distribution.getImplementation()->isParallel())
+        logPdfGradient = logPdfGradientSample.computeMean();
+    else
+    {
+      const UnsignedInteger size = sample_.getSize();
+      for (UnsignedInteger k = 0; k < size; ++k)
+        logPdfGradient += logPdfGradientSample[k] / size;
+    }
+    // Result as Matrix
+    result = MatrixImplementation(getInputDimension(), 1, logPdfGradient);
+    // Gradient should be 0 for knownParameters
+    for (UnsignedInteger j = 0; j < knownParametersSize; ++ j)
+    {
+      result(knownParameterIndices_[j], 0) = 0.0;
     }
     return result;
   }
 
-  const NumericalSample & sample_;
-  const Distribution distribution_;
-  const NumericalPoint knownParameterValues_;
-  const Indices knownParameterIndices_;
-  const Bool isParallel_;
+private:
+  NumericalSample sample_;
+  Distribution distribution_;
+  NumericalPoint knownParameterValues_;
+  Indices knownParameterIndices_;
 };
-
 
 NumericalPoint MaximumLikelihoodFactory::buildParameter(const NumericalSample & sample) const
 {
@@ -164,11 +266,14 @@ NumericalPoint MaximumLikelihoodFactory::buildParameter(const NumericalSample & 
   if (sample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: can build a distribution only from a sample of dimension 1, here dimension=" << sample.getDimension();
 
   UnsignedInteger parameterDimension = distribution_.getParameterDimension();
-  MaximumLikelihoodFactoryLogLikelihood logLikelihoodWrapper(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
+  // Define NumericalMathEvaluation using the LogLikelihoodEvaluation wrapper
+  LogLikelihoodEvaluation logLikelihoodWrapper(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
+  NumericalMathFunction logLikelihood(logLikelihoodWrapper.clone());
+  // Define NumericalMathGradient using the LogLikelihoodEvaluation wrapper
+  LogLikelihoodGradient logLikelihoodGradientWrapper(sample, distribution_, knownParameterValues_, knownParameterIndices_, isParallel_);
+  logLikelihood.setGradient(logLikelihoodGradientWrapper.clone());
 
-  NumericalMathFunction logLikelihood(bindMethod<MaximumLikelihoodFactoryLogLikelihood, NumericalScalar, NumericalPoint>(logLikelihoodWrapper, &MaximumLikelihoodFactoryLogLikelihood::computeLogLikelihood, parameterDimension, 1));
-  CenteredFiniteDifferenceGradient gradient(ResourceMap::GetAsNumericalScalar("MaximumLikelihoodFactory-GradientStep"), logLikelihood.getEvaluation());
-  logLikelihood.setGradient(gradient);
+  // Define optimisation problem
   OptimizationProblem problem(problem_);
   problem.setMinimization(false);
   problem.setObjective(logLikelihood);

--- a/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
+++ b/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
@@ -218,6 +218,37 @@ NumericalPoint Trapezoidal::computePDFGradient(const NumericalPoint & point) con
   return pdfGradient;
 }
 
+/* Get the logPDFGradient of the distribution */
+NumericalPoint Trapezoidal::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  if (point.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=1, here dimension=" << point.getDimension();
+
+  const NumericalScalar x = point[0];
+  NumericalPoint logPdfGradient(4, 0.0);
+  if ((a_ < x) && (x < b_))
+  {
+    logPdfGradient[0] = h_ / 2.0 - 1.0 / (x - a_) + 1.0 / (b_ - a_);
+    logPdfGradient[1] = h_ / 2.0 - 1.0 / (b_ - a_);
+    logPdfGradient[2] = -h_ / 2.0;
+    logPdfGradient[3] = -h_ / 2.0;
+  }
+  else if ((b_ <= x) && (x <= c_))
+  {
+    logPdfGradient[0] =  h_ / 2.0;
+    logPdfGradient[1] =  h_ / 2.0;
+    logPdfGradient[2] = -h_ / 2.0;
+    logPdfGradient[3] = -h_ / 2.0;
+  }
+  else if ((c_ < x) && (x < d_))
+  {
+    logPdfGradient[0] = h_ / 2.0;
+    logPdfGradient[1] = h_ / 2.0;
+    logPdfGradient[2] = -h_ / 2.0 + 1.0 / (d_ - c_);
+    logPdfGradient[3] = -h_ / 2.0 + 1.0 / (d_ - x) - 1.0 / (d_ - c_);
+  }
+  return logPdfGradient;
+}
+
 
 /* Get the CDFGradient of the distribution */
 NumericalPoint Trapezoidal::computeCDFGradient(const NumericalPoint & point) const

--- a/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
@@ -336,6 +336,27 @@ NumericalPoint TruncatedNormal::computePDFGradient(const NumericalPoint & point)
   return pdfGradient;
 }
 
+/* Get the LogPDFGradient of the distribution */
+NumericalPoint TruncatedNormal::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  if (point.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "In TruncatedNormal::computeLogPDFGradient, the given point must have dimension=1, here dimension=" << point.getDimension();
+
+  const NumericalScalar x = point[0];
+  NumericalPoint logPdfGradient(getParameterDimension());
+  if (!(x > a_) || !(x < b_)) return logPdfGradient;
+  const NumericalScalar iSigma = 1.0 / sigma_;
+  const NumericalScalar xNorm = (x - mu_) * iSigma;
+  const NumericalScalar aNorm = (a_ - mu_) * iSigma;
+  const NumericalScalar bNorm = (b_ - mu_) * iSigma;
+  const NumericalScalar iDenom = normalizationFactor_ * iSigma;
+  logPdfGradient[0] = xNorm * iSigma +  iDenom * (phiBNorm_ - phiANorm_);
+  logPdfGradient[1] = iSigma * ( -1.0 + xNorm * xNorm ) + iDenom * (phiBNorm_ * bNorm - phiANorm_ * aNorm);
+  logPdfGradient[2] = phiANorm_ * iDenom;
+  logPdfGradient[3] = - phiBNorm_ * iDenom;
+  return logPdfGradient;
+}
+
 /* Get the CDFGradient of the distribution */
 NumericalPoint TruncatedNormal::computeCDFGradient(const NumericalPoint & point) const
 {

--- a/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
@@ -69,6 +69,14 @@ public:
   using ContinuousDistribution::computeLogPDF;
   NumericalScalar computeLogPDF(const NumericalPoint & point) const;
 
+  // LogPDFGradient
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
+  // PDFGradient
+  using ContinuousDistribution::computePDFGradient;
+  NumericalPoint computePDFGradient(const NumericalPoint & point) const;
+
   /** Get the CDF of the distribution, i.e. P(X <= point) = CDF(point) */
   using ContinuousDistribution::computeCDF;
   NumericalScalar computeCDF(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
@@ -85,6 +85,10 @@ public:
   using ContinuousDistribution::computePDFGradient;
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
 
+  /** Get the gradient of the logPDF w.r.t the parameters of the distribution */
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
   /** Get the gradient of the CDF w.r.t the parameters of the distribution */
   using ContinuousDistribution::computeCDFGradient;
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
@@ -102,6 +102,10 @@ public:
   using ContinuousDistribution::computePDFGradient;
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
 
+  /** Get the LogPDFGradient of the TruncatedNormal distribution */
+  using ContinuousDistribution::computeLogPDFGradient;
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+
   /** Get the CDFGradient of the TruncatedNormal distribution */
   using ContinuousDistribution::computeCDFGradient;
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -573,6 +573,18 @@ NumericalSample Distribution::computePDFGradient(const NumericalSample & sample)
   return getImplementation()->computePDFGradient(sample);
 }
 
+/* Get the logPDF gradient of the distribution */
+NumericalPoint Distribution::computeLogPDFGradient(const NumericalPoint & point) const
+{
+  return getImplementation()->computeLogPDFGradient(point);
+}
+
+NumericalSample Distribution::computeLogPDFGradient(const NumericalSample & sample) const
+{
+  return getImplementation()->computeLogPDFGradient(sample);
+}
+
+
 /* Get the CDF gradient of the distribution */
 NumericalPoint Distribution::computeCDFGradient(const NumericalPoint & point) const
 {

--- a/lib/src/Uncertainty/Model/openturns/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/Distribution.hxx
@@ -204,6 +204,10 @@ public:
   NumericalPoint computePDFGradient(const NumericalPoint & point) const;
   NumericalSample computePDFGradient(const NumericalSample & sample) const;
 
+  /** Get the log(PDFgradient) of the distribution */
+  NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+  NumericalSample computeLogPDFGradient(const NumericalSample & sample) const;
+
   /** Get the CDF gradient of the distribution */
   NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
   NumericalSample computeCDFGradient(const NumericalSample & sample) const;

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -276,7 +276,16 @@ public:
   /** Get the PDF gradient of the distribution */
   virtual NumericalPoint computePDFGradient(const NumericalPoint & point) const;
   virtual NumericalSample computePDFGradient(const NumericalSample & inSample) const;
-public:
+
+  /** Get the logPDF gradient of the distribution */
+  virtual NumericalPoint computeLogPDFGradient(const NumericalPoint & point) const;
+  virtual NumericalSample computeLogPDFGradient(const NumericalSample & inSample) const;
+
+protected:
+  virtual NumericalSample computeLogPDFGradientSequential(const NumericalSample & sample) const;
+  virtual NumericalSample computeLogPDFGradientParallel(const NumericalSample & sample) const;
+
+ public:
   /** Get the CDF gradient of the distribution */
   virtual NumericalPoint computeCDFGradient(const NumericalPoint & point) const;
   virtual NumericalSample computeCDFGradient(const NumericalSample & inSample) const;

--- a/lib/test/t_FisherSnedecor_std.cxx
+++ b/lib/test/t_FisherSnedecor_std.cxx
@@ -98,26 +98,30 @@ int main(int argc, char *argv[])
     fullprint << "characteristic function=" << CF << std::endl;
     NumericalComplex LCF = distribution.computeLogCharacteristicFunction( point[0] );
     fullprint << "log characteristic function=" << LCF << std::endl;
-    // NumericalPoint PDFgr = distribution.computePDFGradient( point );
-    // fullprint << "pdf gradient     =" << PDFgr << std::endl;
-    // NumericalPoint PDFgrFD(3);
-    // PDFgrFD[0] = (FisherSnedecor(distribution.getA() + eps, distribution.getM(), distribution.getB()).computePDF(point) -
-    //               FisherSnedecor(distribution.getA() - eps, distribution.getM(), distribution.getB()).computePDF(point)) / (2.0 * eps);
-    // PDFgrFD[1] = (FisherSnedecor(distribution.getA(), distribution.getM() + eps, distribution.getB()).computePDF(point) -
-    //               FisherSnedecor(distribution.getA(), distribution.getM() - eps, distribution.getB()).computePDF(point)) / (2.0 * eps);
-    // PDFgrFD[2] = (FisherSnedecor(distribution.getA(), distribution.getM(), distribution.getB() + eps).computePDF(point) -
-    //               FisherSnedecor(distribution.getA(), distribution.getM(), distribution.getB() - eps).computePDF(point)) / (2.0 * eps);
-    // fullprint << "pdf gradient (FD)=" << PDFgrFD << std::endl;
-    // NumericalPoint CDFgr = distribution.computeCDFGradient( point );
-    // fullprint << "cdf gradient     =" << CDFgr << std::endl;
-    // NumericalPoint CDFgrFD(3);
-    // CDFgrFD[0] = (FisherSnedecor(distribution.getA() + eps, distribution.getM(), distribution.getB()).computeCDF(point) -
-    //               FisherSnedecor(distribution.getA() - eps, distribution.getM(), distribution.getB()).computeCDF(point)) / (2.0 * eps);
-    // CDFgrFD[1] = (FisherSnedecor(distribution.getA(), distribution.getM() + eps, distribution.getB()).computeCDF(point) -
-    //               FisherSnedecor(distribution.getA(), distribution.getM() - eps, distribution.getB()).computeCDF(point)) / (2.0 * eps);
-    // CDFgrFD[2] = (FisherSnedecor(distribution.getA(), distribution.getM(), distribution.getB() + eps).computeCDF(point) -
-    //               FisherSnedecor(distribution.getA(), distribution.getM(), distribution.getB() - eps).computeCDF(point)) / (2.0 * eps);
-    // fullprint << "cdf gradient (FD)=" << CDFgrFD << std::endl;
+    NumericalPoint PDFgr = distribution.computePDFGradient( point );
+    fullprint << "pdf gradient     =" << PDFgr << std::endl;
+    NumericalPoint PDFgrFD(2);
+    PDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computePDF(point) -
+                  FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computePDF(point)) / (2.0 * eps);
+    PDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computePDF(point) -
+                  FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computePDF(point)) / (2.0 * eps);
+    fullprint << "pdf gradient (FD)=" << PDFgrFD << std::endl;
+    NumericalPoint logPDFgr = distribution.computeLogPDFGradient( point );
+    fullprint << "log-pdf gradient     =" << logPDFgr << std::endl;
+    NumericalPoint logPDFgrFD(2);
+    logPDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computeLogPDF(point) -
+                  FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computeLogPDF(point) -
+                  FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computeLogPDF(point)) / (2.0 * eps);
+    fullprint << "log-pdf gradient (FD)=" << logPDFgrFD << std::endl;
+    NumericalPoint CDFgr = distribution.computeCDFGradient( point );
+    fullprint << "cdf gradient     =" << CDFgr << std::endl;
+    NumericalPoint CDFgrFD(2);
+    CDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computeCDF(point) -
+                  FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computeCDF(point)) / (2.0 * eps);
+    CDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computeCDF(point) -
+                  FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computeCDF(point)) / (2.0 * eps);
+    fullprint << "cdf gradient (FD)=" << CDFgrFD << std::endl;
     NumericalPoint quantile = distribution.computeQuantile( 0.95 );
     fullprint << "quantile=" << quantile << std::endl;
     fullprint << "cdf(quantile)=" << distribution.computeCDF(quantile) << std::endl;

--- a/lib/test/t_FisherSnedecor_std.expout
+++ b/lib/test/t_FisherSnedecor_std.expout
@@ -30,6 +30,12 @@ Inverse survival=class=NumericalPoint name=Unnamed dimension=1 values=[0.230549]
 Survival(inverse survival)=0.95
 characteristic function=(0.385738,0.612601)
 log characteristic function=(-0.323062,1.00884)
+pdf gradient     =class=NumericalPoint name=Unnamed dimension=2 values=[0.0333323,0.00890862]
+pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=2 values=[0.0333323,0.00890862]
+log-pdf gradient     =class=NumericalPoint name=Unnamed dimension=2 values=[0.0644499,0.0172253]
+log-pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=2 values=[0.0644499,0.0172253]
+cdf gradient     =class=NumericalPoint name=Unnamed dimension=2 values=[-0.0101307,0.00377782]
+cdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=2 values=[-0.0101307,0.00377782]
 quantile=class=NumericalPoint name=Unnamed dimension=1 values=[3.2027]
 cdf(quantile)=0.95
 Minimum volume interval=class=Interval name=Unnamed dimension=1 lower bound=class=NumericalPoint name=Unnamed dimension=1 values=[0.0385599] upper bound=class=NumericalPoint name=Unnamed dimension=1 values=[3.21723] finite lower bound=[1] finite upper bound=[1]

--- a/lib/test/t_TrapezoidalFactory_std.cxx
+++ b/lib/test/t_TrapezoidalFactory_std.cxx
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
   setRandomGenerator();
 
   ResourceMap::SetAsBool("MaximumLikelihoodFactory-Parallel", false);
+  TBB::Disable();
   try
   {
     Trapezoidal distribution( 1.0, 2.3, 4.5, 5.0 );

--- a/lib/test/t_Trapezoidal_std.cxx
+++ b/lib/test/t_Trapezoidal_std.cxx
@@ -113,6 +113,18 @@ int main(int argc, char *argv[])
     PDFgrFD[3] = (Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() + eps).computePDF(point) -
                   Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() - eps).computePDF(point)) / (2.0 * eps);
     fullprint << "pdf gradient (FD)=" << PDFgrFD << std::endl;
+    NumericalPoint logPDFgr = distribution.computeLogPDFGradient( point );
+    fullprint << "log-pdf gradient     =" << logPDFgr << std::endl;
+    NumericalPoint logPDFgrFD(4);
+    logPDFgrFD[0] = (Trapezoidal(distribution.getA() + eps, distribution.getB(), distribution.getC(), distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA() - eps, distribution.getB(), distribution.getC(), distribution.getD()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[1] = (Trapezoidal(distribution.getA(), distribution.getB() + eps, distribution.getC(), distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB() - eps, distribution.getC(), distribution.getD()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[2] = (Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC() + eps, distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC() - eps, distribution.getD()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[3] = (Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() + eps).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() - eps).computeLogPDF(point)) / (2.0 * eps);
+    fullprint << "log-pdf gradient (FD)=" << logPDFgrFD << std::endl;
     NumericalPoint CDFgr = distribution.computeCDFGradient( point );
     fullprint << "cdf gradient     =" << CDFgr << std::endl;
     NumericalPoint CDFgrFD(4);

--- a/lib/test/t_Trapezoidal_std.expout
+++ b/lib/test/t_Trapezoidal_std.expout
@@ -34,6 +34,8 @@ characteristic function=(-0.115059,0.038602)
 log characteristic function=(-2.10898,2.8179)
 pdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[-0.333272,-0.333272,-0.00456538,-0.00456538]
 pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[-0.333272,-0.333272,-0.00456538,-0.00456538]
+log-pdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[-4.93243,-4.93243,-0.0675676,-0.0675676]
+log-pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[-4.93243,-4.93243,-0.0675676,-0.0675676]
 cdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[-0.0504474,-0.0166636,-0.000228269,-0.000228269]
 cdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[-0.0504474,-0.0166636,-0.000228269,-0.000228269]
 quantile=class=NumericalPoint name=Unnamed dimension=1 values=[11.1469]

--- a/lib/test/t_TruncatedNormal_std.cxx
+++ b/lib/test/t_TruncatedNormal_std.cxx
@@ -110,6 +110,19 @@ int main(int argc, char *argv[])
     PDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computePDF(point) -
                   TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computePDF(point)) / (2.0 * eps);
     fullprint << "pdf gradient (FD)=" << PDFgrFD << std::endl;
+    // log-pdf gradient
+    NumericalPoint logPDFgr = distribution.computeLogPDFGradient( point );
+    fullprint << "log-pdf gradient     =" << logPDFgr << std::endl;
+    NumericalPoint logPDFgrFD(4);
+    logPDFgrFD[0] = (TruncatedNormal(distribution.getMu() + eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu() - eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[1] = (TruncatedNormal(distribution.getMu(), distribution.getSigma() + eps, distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma() - eps, distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[2] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() + eps, distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() - eps, distribution.getB()).computeLogPDF(point)) / (2.0 * eps);
+    logPDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computeLogPDF(point)) / (2.0 * eps);
+    fullprint << "log-pdf gradient (FD)=" << logPDFgrFD << std::endl;
     NumericalPoint CDFgr = distribution.computeCDFGradient( point );
     fullprint << "cdf gradient     =" << CDFgr << std::endl;
     NumericalPoint CDFgrFD(4);

--- a/lib/test/t_TruncatedNormal_std.expout
+++ b/lib/test/t_TruncatedNormal_std.expout
@@ -32,6 +32,8 @@ characteristic function=(0.482702,0.0461049)
 log characteristic function=(-0.723814,0.0952254)
 pdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
 pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
+log-pdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
+log-pdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
 cdf gradient     =class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 cdf gradient (FD)=class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 quantile=class=NumericalPoint name=Unnamed dimension=1 values=[1.79498]

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -465,6 +465,25 @@ OT_Distribution_computeLogPDF_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_Distribution_computeLogPDFGradient_doc
+"Compute the gradient of the log probability density function.
+
+Parameters
+----------
+X : sequence of float
+    PDF input.
+
+Returns
+-------
+dfdtheta : :class:`~openturns.NumericalPoint`
+    Partial derivatives of the logPDF with respect to the distribution
+    parameters at input `X`."
+%enddef
+%feature("docstring") OT::DistributionImplementation::computeLogPDFGradient
+OT_Distribution_computeLogPDFGradient_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_Distribution_computePDF_doc
 "Compute the probability density function.
 

--- a/python/src/Distribution_doc.i.in
+++ b/python/src/Distribution_doc.i.in
@@ -50,6 +50,8 @@ OT_Distribution_computeUnilateralConfidenceInterval_doc
 OT_Distribution_computeUnilateralConfidenceIntervalWithMarginalProbability_doc
 %feature("docstring") OT::Distribution::computeLogPDF
 OT_Distribution_computeLogPDF_doc
+%feature("docstring") OT::Distribution::computeLogPDFGradient
+OT_Distribution_computeLogPDFGradient_doc
 %feature("docstring") OT::Distribution::computePDF
 OT_Distribution_computePDF_doc
 %feature("docstring") OT::Distribution::computePDFGradient

--- a/python/test/t_FisherSnedecor_std.expout
+++ b/python/test/t_FisherSnedecor_std.expout
@@ -15,6 +15,12 @@ pdf (FD)=0.517181
 cdf=0.531405
 ccdf=0.468595
 characteristic function=(0.385738+0.612601j)
+pdf gradient     = class=NumericalPoint name=Unnamed dimension=2 values=[0.0333323,0.00890862]
+pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=2 values=[0.0333323,0.00890862]
+cdf gradient     = class=NumericalPoint name=Unnamed dimension=2 values=[-0.0101307,0.00377782]
+cdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=2 values=[-0.0101307,0.00377782]
+log-pdf gradient     = class=NumericalPoint name=Unnamed dimension=2 values=[0.0644499,0.0172253]
+log-pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=2 values=[0.0644499,0.0172253]
 quantile= class=NumericalPoint name=Unnamed dimension=1 values=[3.2027]
 cdf(quantile)=0.950000
 InverseSurvival= class=NumericalPoint name=Unnamed dimension=1 values=[0.230549]

--- a/python/test/t_FisherSnedecor_std.py
+++ b/python/test/t_FisherSnedecor_std.py
@@ -73,21 +73,30 @@ try:
     print("ccdf=%.6f" % CCDF)
     CF = distribution.computeCharacteristicFunction(point[0])
     print("characteristic function=(%.6f+%.6fj)" % (CF.real, CF.imag))
-    ## PDFgr = distribution.computePDFGradient( point )
-    # print "pdf gradient     =" , repr(PDFgr)
+    PDFgr = distribution.computePDFGradient( point )
+    print( "pdf gradient     =" , repr(PDFgr))
     # by the finite difference technique
-    ## PDFgrFD = NumericalPoint(2)
-    ## PDFgrFD[0] = (FisherSnedecor(distribution.getLambda() + eps, distribution.getGamma()).computePDF(point) - FisherSnedecor(distribution.getLambda() - eps, distribution.getGamma()).computePDF(point)) / (2.0 * eps)
-    ## PDFgrFD[1] = (FisherSnedecor(distribution.getLambda(), distribution.getGamma() + eps).computePDF(point) - FisherSnedecor(distribution.getLambda(), distribution.getGamma() - eps).computePDF(point)) / (2.0 * eps)
-    # print "pdf gradient (FD)=" , repr(PDFgrFD)
+    PDFgrFD = NumericalPoint(2)
+    PDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computePDF(point) - FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computePDF(point)) / (2.0 * eps)
+    PDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computePDF(point) - FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computePDF(point)) / (2.0 * eps)
+    print( "pdf gradient (FD)=" , repr(PDFgrFD))
 
     # derivative of the PDF with regards the parameters of the distribution
-    ## CDFgr = distribution.computeCDFGradient( point )
-    # print "cdf gradient     =" , repr(CDFgr)
-    ## CDFgrFD = NumericalPoint(2)
-    ## CDFgrFD[0] = (FisherSnedecor(distribution.getLambda() + eps, distribution.getGamma()).computeCDF(point) - FisherSnedecor(distribution.getLambda() - eps, distribution.getGamma()).computeCDF(point)) / (2.0 * eps)
-    ## CDFgrFD[1] = (FisherSnedecor(distribution.getLambda(), distribution.getGamma() + eps).computeCDF(point) - FisherSnedecor(distribution.getLambda(), distribution.getGamma() - eps).computeCDF(point)) / (2.0 * eps)
-    # print "cdf gradient (FD)=",  repr(CDFgrFD)
+    CDFgr = distribution.computeCDFGradient( point )
+    print( "cdf gradient     =" , repr(CDFgr))
+    CDFgrFD = NumericalPoint(2)
+    CDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computeCDF(point) - FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computeCDF(point)) / (2.0 * eps)
+    CDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computeCDF(point) - FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computeCDF(point)) / (2.0 * eps)
+    print("cdf gradient (FD)=",  repr(CDFgrFD))
+
+    # derivative of the logPDF with regards the parameters of the distribution
+    logPDFgr = distribution.computeLogPDFGradient( point )
+    print( "log-pdf gradient     =" , repr(logPDFgr))
+    # by the finite difference technique
+    logPDFgrFD = NumericalPoint(2)
+    logPDFgrFD[0] = (FisherSnedecor(distribution.getD1() + eps, distribution.getD2()).computeLogPDF(point) - FisherSnedecor(distribution.getD1() - eps, distribution.getD2()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[1] = (FisherSnedecor(distribution.getD1(), distribution.getD2() + eps).computeLogPDF(point) - FisherSnedecor(distribution.getD1(), distribution.getD2() - eps).computeLogPDF(point)) / (2.0 * eps)
+    print("log-pdf gradient (FD)=" , repr(logPDFgrFD))
 
     # quantile
     quantile = distribution.computeQuantile(0.95)

--- a/python/test/t_TrapezoidalFactory_std.py
+++ b/python/test/t_TrapezoidalFactory_std.py
@@ -6,6 +6,7 @@ import openturns as ot
 ot.RandomGenerator.SetSeed(0)
 
 ot.ResourceMap.SetAsBool('MaximumLikelihoodFactory-Parallel', False)
+ot.TBB.Disable()
 
 distribution = ot.Trapezoidal(1.0, 2.3, 4.5, 5.0)
 size = 10000

--- a/python/test/t_Trapezoidal_std.expout
+++ b/python/test/t_Trapezoidal_std.expout
@@ -20,6 +20,8 @@ ccdf=0.996622
 characteristic function= (-0.115059431951+0.0386019620712j)
 pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[-0.333272,-0.333272,-0.00456538,-0.00456538]
 pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[-0.333272,-0.333272,-0.00456538,-0.00456538]
+log-pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[-4.93243,-4.93243,-0.0675676,-0.0675676]
+log-pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[-4.93243,-4.93243,-0.0675676,-0.0675676]
 cdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[-0.0504474,-0.0166636,-0.000228269,-0.000228269]
 cdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[-0.0504474,-0.0166636,-0.000228269,-0.000228269]
 quantile= class=NumericalPoint name=Unnamed dimension=1 values=[11.1469]

--- a/python/test/t_Trapezoidal_std.py
+++ b/python/test/t_Trapezoidal_std.py
@@ -86,6 +86,21 @@ try:
                   Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() - eps).computePDF(point)) / (2.0 * eps)
     print("pdf gradient (FD)=", repr(PDFgrFD))
 
+    # derivative of the logPDF with regards the parameters of the distribution
+    logPDFgr = distribution.computeLogPDFGradient(point)
+    print("log-pdf gradient     =", repr(logPDFgr))
+    # by the finite difference technique
+    logPDFgrFD = NumericalPoint(4)
+    logPDFgrFD[0] = (Trapezoidal(distribution.getA() + eps, distribution.getB(), distribution.getC(), distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA() - eps, distribution.getB(), distribution.getC(), distribution.getD()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[1] = (Trapezoidal(distribution.getA(), distribution.getB() + eps, distribution.getC(), distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB() - eps, distribution.getC(), distribution.getD()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[2] = (Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC() + eps, distribution.getD()).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC() - eps, distribution.getD()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[3] = (Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() + eps).computeLogPDF(point) -
+                  Trapezoidal(distribution.getA(), distribution.getB(), distribution.getC(), distribution.getD() - eps).computeLogPDF(point)) / (2.0 * eps)
+    print("log-pdf gradient (FD)=", repr(logPDFgrFD))
+
     # derivative of the PDF with regards the parameters of the distribution
     CDFgr = distribution.computeCDFGradient(point)
     print("cdf gradient     =", repr(CDFgr))

--- a/python/test/t_TruncatedNormal_std.expout
+++ b/python/test/t_TruncatedNormal_std.expout
@@ -17,6 +17,8 @@ cdf=0.743877
 ccdf=0.256123
 pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
 pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[0.0277138,-0.0118013,0.0515102,-0.0643285]
+log-pdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
+log-pdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[0.103363,-0.0440151,0.192116,-0.239924]
 cdf gradient     = class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 cdf gradient (FD)= class=NumericalPoint name=Unnamed dimension=4 values=[-0.0404404,0.00354582,-0.0492055,-0.178474]
 quantile= class=NumericalPoint name=Unnamed dimension=1 values=[1.79498]

--- a/python/test/t_TruncatedNormal_std.py
+++ b/python/test/t_TruncatedNormal_std.py
@@ -69,6 +69,7 @@ try:
     print("cdf=%.6f" % CDF)
     CCDF = distribution.computeComplementaryCDF(point)
     print("ccdf=%.6f" % CCDF)
+
     PDFgr = distribution.computePDFGradient(point)
     print("pdf gradient     =", repr(PDFgr))
     # by the finite difference technique
@@ -82,6 +83,21 @@ try:
     PDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computePDF(point) -
                   TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computePDF(point)) / (2.0 * eps)
     print("pdf gradient (FD)=", repr(PDFgrFD))
+
+    # derivative of the logPDF with regards the parameters of the distribution
+    logPDFgr = distribution.computeLogPDFGradient(point)
+    print("log-pdf gradient     =", repr(logPDFgr))
+    # by the finite difference technique
+    logPDFgrFD = NumericalPoint(4)
+    logPDFgrFD[0] = (TruncatedNormal(distribution.getMu() + eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu() - eps, distribution.getSigma(), distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[1] = (TruncatedNormal(distribution.getMu(), distribution.getSigma() + eps, distribution.getA(), distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma() - eps, distribution.getA(), distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[2] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() + eps, distribution.getB()).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA() - eps, distribution.getB()).computeLogPDF(point)) / (2.0 * eps)
+    logPDFgrFD[3] = (TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() + eps).computeLogPDF(point) -
+                  TruncatedNormal(distribution.getMu(), distribution.getSigma(), distribution.getA(), distribution.getB() - eps).computeLogPDF(point)) / (2.0 * eps)
+    print("log-pdf gradient (FD)=", repr(logPDFgrFD))
 
     # derivative of the PDF with regards the parameters of the distribution
     CDFgr = distribution.computeCDFGradient(point)


### PR DESCRIPTION
This PR implements a generic Distribution::computeLogPDFGradient (defined as PDFGradient/PDF), which purpose is to help for estimating distributions (see #349)

Indeed, when estimating distribution's parameters thanks to the MaximumLikelihoodFactory class, the function to maximize (the log-likelihood) was
previously defined as bind method function (+ difference finite gradient). We rework the internal structure "MaximumLikelihoodFactoryLogLikelihood" as follows:

 - It inherits now from NumericalMathEvaluationImplementation;
  - It implements the operator() (reuse the previous computeLogLikelihood method)
  - A gradient wrapper is added (maps Distribution::computeLogPDFGradient)
    Thus we get the function and is exact gradient for the evaluation.

Note that here the separation between NumericalMathEvaluationImplementation and NumericalMathGradientImplementation is mandatory as some optimization algorithms require explicitely the gradientImplementation and not only the gradient operator.

Finally to fix/speed up some tests, we implement specific computeLogPDFGradient to Fisher-Snedecor, TruncatedNormal and Trapezoidal distributions
