### PR TITLE
Rewrite some NSI methods to not use TBB

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -345,7 +345,6 @@
   <MaximumLikelihoodFactory-MaximumRelativeError    value="1.0e-10" />
   <MaximumLikelihoodFactory-MaximumObjectiveError   value="1.0e-10" />
   <MaximumLikelihoodFactory-MaximumConstraintError  value="1.0e-10" />
-  <MaximumLikelihoodFactory-Parallel                value="true" />
 
   <!-- OT::Student parameters -->
   <Student-MaximumNumberOfPoints          value="10000000" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -611,7 +611,6 @@ void ResourceMap::loadDefaultConfiguration()
   setAsNumericalScalar( "MaximumLikelihoodFactory-MaximumRelativeError", 1.0e-10 );
   setAsNumericalScalar( "MaximumLikelihoodFactory-MaximumObjectiveError", 1.0e-10 );
   setAsNumericalScalar( "MaximumLikelihoodFactory-MaximumConstraintError", 1.0e-10 );
-  setAsBool("MaximumLikelihoodFactory-Parallel", true);
 
   // Student parameters //
   setAsUnsignedInteger( "Student-MaximumNumberOfPoints", 10000000 );

--- a/lib/src/Base/Stat/openturns/NumericalSampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/NumericalSampleImplementation.hxx
@@ -467,6 +467,8 @@ public:
   /* Some typedefs for easy reading */
   typedef NSI_iterator               iterator;
   typedef NSI_const_iterator         const_iterator;
+  typedef       NumericalScalar *       data_iterator;
+  typedef const NumericalScalar * const_data_iterator;
 
   typedef Collection<UnsignedInteger>   UnsignedIntegerCollection;
 
@@ -532,6 +534,23 @@ public:
   inline const_iterator end() const
   {
     return const_iterator(*this, size_);
+  }
+
+  inline data_iterator data_begin()
+  {
+    return &data_[0];
+  }
+  inline data_iterator data_end()
+  {
+    return &data_[0] + size_ * dimension_;
+  }
+  inline const_data_iterator data_begin() const
+  {
+    return &data_[0];
+  }
+  inline const_data_iterator data_end() const
+  {
+    return &data_[0] + size_ * dimension_;
   }
 
   void erase(const UnsignedInteger first, const UnsignedInteger last);

--- a/lib/src/Uncertainty/Distribution/openturns/MaximumLikelihoodFactory.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MaximumLikelihoodFactory.hxx
@@ -65,7 +65,6 @@ public:
   void setOptimizationProblem(const OptimizationProblem & problem);
   OptimizationProblem getOptimizationProblem() const;
 
-  void setParallel(const Bool parallel);
 protected:
   /* The underlying distribution */
   Distribution distribution_;

--- a/lib/test/t_FisherSnedecorFactory_std.cxx
+++ b/lib/test/t_FisherSnedecorFactory_std.cxx
@@ -33,7 +33,6 @@ int main(int argc, char *argv[])
   try
   {
     PlatformInfo::SetNumericalPrecision(5);
-    ResourceMap::SetAsBool("MaximumLikelihoodFactory-Parallel", false);
     FisherSnedecor distribution(4.5, 8.4);
     UnsignedInteger size = 10000;
     NumericalSample sample(distribution.getSample(size));

--- a/lib/test/t_TrapezoidalFactory_std.cxx
+++ b/lib/test/t_TrapezoidalFactory_std.cxx
@@ -30,8 +30,6 @@ int main(int argc, char *argv[])
   OStream fullprint(std::cout);
   setRandomGenerator();
 
-  ResourceMap::SetAsBool("MaximumLikelihoodFactory-Parallel", false);
-  TBB::Disable();
   try
   {
     Trapezoidal distribution( 1.0, 2.3, 4.5, 5.0 );

--- a/python/src/MaximumLikelihoodFactory.i
+++ b/python/src/MaximumLikelihoodFactory.i
@@ -6,7 +6,6 @@
 
 %include MaximumLikelihoodFactory_doc.i
 
-%ignore OT::MaximumLikelihoodFactory::setParallel;
 %ignore OT::MaximumLikelihoodFactory::buildParameter;
 
 %include openturns/MaximumLikelihoodFactory.hxx

--- a/python/test/t_FisherSnedecorFactory_std.py
+++ b/python/test/t_FisherSnedecorFactory_std.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 import openturns as ot
 
-ot.ResourceMap.SetAsBool('MaximumLikelihoodFactory-Parallel', False)
 ot.PlatformInfo.SetNumericalPrecision(5)
 distribution = ot.FisherSnedecor(4.5, 8.4)
 size = 10000

--- a/python/test/t_TrapezoidalFactory_std.py
+++ b/python/test/t_TrapezoidalFactory_std.py
@@ -5,9 +5,6 @@ import openturns as ot
 
 ot.RandomGenerator.SetSeed(0)
 
-ot.ResourceMap.SetAsBool('MaximumLikelihoodFactory-Parallel', False)
-ot.TBB.Disable()
-
 distribution = ot.Trapezoidal(1.0, 2.3, 4.5, 5.0)
 size = 10000
 sample = distribution.getSample(size)


### PR DESCRIPTION
Rewrite computeMean, computeVariance and computeCovariance to not use TBB.  These methods are called by many internal code in OT, and the only solution to have fully reproducible results is to discard TBB.

With this commit, parallelism at a higher level is still possible, and will provide good performance with reproducible results.

There was also a subtle glitch in `LogLikelihoodEvaluation::operator()`, sequential code computes `logPdfSample(k, 0) / size` whereas parallel code computes `logPdfSample(k, 0) * (1.0 / size)`, and results do differ noticeably when an optimizer tries to find the best parameters.