### PR TITLE
Indices::check(n) <=> seq[j] < n

### DIFF
--- a/lib/src/Base/Func/AggregatedNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/AggregatedNumericalMathEvaluationImplementation.cxx
@@ -168,7 +168,7 @@ AggregatedNumericalMathEvaluationImplementation::Implementation AggregatedNumeri
 AggregatedNumericalMathEvaluationImplementation::Implementation AggregatedNumericalMathEvaluationImplementation::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getOutputDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal aggregated function must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal aggregated function must be in the range [0, dim-1] and must be different";
   NumericalMathFunctionCollection marginalFunctions;
   const UnsignedInteger indicesSize = indices.getSize();
   const UnsignedInteger size = functionsCollection_.getSize();

--- a/lib/src/Base/Func/AnalyticalNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathEvaluationImplementation.cxx
@@ -134,7 +134,7 @@ AnalyticalNumericalMathEvaluationImplementation::Implementation AnalyticalNumeri
 /* Get the function corresponding to indices components */
 AnalyticalNumericalMathEvaluationImplementation::Implementation AnalyticalNumericalMathEvaluationImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and must be different";
   const UnsignedInteger size = indices.getSize();
   Description marginalOutputVariablesNames(size);
   Description marginalFormulas(size);

--- a/lib/src/Base/Func/AnalyticalNumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathGradientImplementation.cxx
@@ -221,7 +221,7 @@ AnalyticalNumericalMathGradientImplementation::Implementation AnalyticalNumerica
 /* Get the function corresponding to indices components */
 AnalyticalNumericalMathGradientImplementation::Implementation AnalyticalNumericalMathGradientImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal gradient must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal gradient must be in the range [0, dim-1] and must be different";
   const UnsignedInteger marginalDimension = indices.getSize();
   Description marginalFormulas(marginalDimension);
   Description marginalOutputNames(marginalDimension);

--- a/lib/src/Base/Func/AnalyticalNumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/AnalyticalNumericalMathHessianImplementation.cxx
@@ -268,7 +268,7 @@ AnalyticalNumericalMathHessianImplementation::Implementation AnalyticalNumerical
 /* Get the function corresponding to indices components */
 AnalyticalNumericalMathHessianImplementation::Implementation AnalyticalNumericalMathHessianImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal hessian must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal hessian must be in the range [0, dim-1] and must be different";
   const UnsignedInteger marginalDimension = indices.getSize();
   Description marginalFormulas(marginalDimension);
   Description marginalOutputNames(marginalDimension);

--- a/lib/src/Base/Func/ComposedNumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ComposedNumericalMathEvaluationImplementation.cxx
@@ -57,7 +57,7 @@ ComposedNumericalMathEvaluationImplementation::Implementation ComposedNumericalM
 /* Get the function corresponding to indices components */
 ComposedNumericalMathEvaluationImplementation::Implementation ComposedNumericalMathEvaluationImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and must be different";
   return new ComposedNumericalMathEvaluationImplementation(p_leftFunction_->getMarginal(indices), p_rightFunction_);
 }
 

--- a/lib/src/Base/Func/DualLinearCombinationEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/DualLinearCombinationEvaluationImplementation.cxx
@@ -87,7 +87,7 @@ DualLinearCombinationEvaluationImplementation::Implementation DualLinearCombinat
 /* Get the function corresponding to indices components */
 DualLinearCombinationEvaluationImplementation::Implementation DualLinearCombinationEvaluationImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and must be different";
   // Special case for 1D marginal
   if (indices.getSize() == 1) return getMarginal(indices[0]);
   return new DualLinearCombinationEvaluationImplementation(functionsCollection_, coefficients_.getMarginal(indices));

--- a/lib/src/Base/Func/DynamicalFunctionImplementation.cxx
+++ b/lib/src/Base/Func/DynamicalFunctionImplementation.cxx
@@ -80,7 +80,7 @@ DynamicalFunctionImplementation::Implementation DynamicalFunctionImplementation:
 /* Get the function corresponding to indices components */
 DynamicalFunctionImplementation::Implementation DynamicalFunctionImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   throw NotYetImplementedException(HERE) << "In DynamicalFunctionImplementation::getMarginal(const Indices & indices) const";
 }
 

--- a/lib/src/Base/Func/LinearCombinationEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/LinearCombinationEvaluationImplementation.cxx
@@ -320,7 +320,7 @@ LinearCombinationEvaluationImplementation::Implementation LinearCombinationEvalu
 /* Get the function corresponding to indices components */
 LinearCombinationEvaluationImplementation::Implementation LinearCombinationEvaluationImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal function must be in the range [0, dim-1] and must be different";
   const UnsignedInteger size = functionsCollection_.getSize();
   NumericalMathFunctionCollection marginalFunctions(size);
   for (UnsignedInteger i = 0; i < size; ++i) marginalFunctions[i] = functionsCollection_[i].getMarginal(indices);

--- a/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathEvaluationImplementation.cxx
@@ -401,7 +401,7 @@ NumericalMathEvaluationImplementation::Implementation NumericalMathEvaluationImp
 /* Get the function corresponding to indices components */
 NumericalMathEvaluationImplementation::Implementation NumericalMathEvaluationImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   // We build an analytical function that extract the needed component
   // If X1,...,XN are the descriptions of the input of this function, it is a function from R^n to R^p
   // with formula Yk = Xindices[k] for k=1,...,p

--- a/lib/src/Base/Func/NumericalMathFunctionImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathFunctionImplementation.cxx
@@ -517,7 +517,7 @@ NumericalMathFunctionImplementation::Implementation NumericalMathFunctionImpleme
 /* Get the function corresponding to indices components */
 NumericalMathFunctionImplementation::Implementation NumericalMathFunctionImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   return new NumericalMathFunctionImplementation(p_evaluationImplementation_->getMarginal(indices), p_gradientImplementation_->getMarginal(indices), p_hessianImplementation_->getMarginal(indices));
 }
 

--- a/lib/src/Base/Func/NumericalMathGradientImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathGradientImplementation.cxx
@@ -133,7 +133,7 @@ NumericalMathGradientImplementation::Implementation NumericalMathGradientImpleme
 /* Get the function corresponding to indices components */
 NumericalMathGradientImplementation::Implementation NumericalMathGradientImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   // Here we use the linear algebra representation of the marginal extraction operation in order to extract the marginal gradient.
   // The chain rule gives:
   // D(Af) = AD(f) in our case, instead of D(gof) = Dg(f)Df, so we don't need f as in our case Dg(f) = A is a constant. As we don't

--- a/lib/src/Base/Func/NumericalMathHessianImplementation.cxx
+++ b/lib/src/Base/Func/NumericalMathHessianImplementation.cxx
@@ -133,7 +133,7 @@ NumericalMathHessianImplementation::Implementation NumericalMathHessianImplement
 /* Get the function corresponding to indices components */
 NumericalMathHessianImplementation::Implementation NumericalMathHessianImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   // Here we use the linear algebra representation of the marginal extraction operation in order to extract the marginal hessian.
   // The chain rule gives:
   // D2(Af) = AD2(f) in our case, instead of D2(gof) = D(Dg(f)Df) = (D2g(f)Df)Df + Dg(f)D2f, so we don't need f as in our case Dg(f) = A is a constant, and we don't need D(f) as D2g(f) = 0.

--- a/lib/src/Base/Func/ParametricEvaluationImplementation.cxx
+++ b/lib/src/Base/Func/ParametricEvaluationImplementation.cxx
@@ -54,7 +54,7 @@ ParametricEvaluationImplementation::ParametricEvaluationImplementation(const Num
   // Check if the given parameters positions are compatible with the input dimension of the function
   if (inputDimension < setDimension) throw InvalidArgumentException(HERE) << "Error: the size of the " << (parametersSet ? "parameters" : "input") << " positions=" << setDimension << " is greater than the input dimension=" << inputDimension << " of the function.";
   // Check if the given indices are valid
-  if (!set.check(inputDimension - 1)) throw InvalidArgumentException(HERE) << "Error: the given set of positions contain either duplicate positions or positions greater than the input dimension of the function.";
+  if (!set.check(inputDimension)) throw InvalidArgumentException(HERE) << "Error: the given set of positions contain either duplicate positions or positions greater than the input dimension of the function.";
   // Deduce the input position from the input dimension of the function and the parameters positions
   // Warning! the parameters positions can be in any order
   Indices fullIndices(inputDimension);

--- a/lib/src/Base/Func/SpatialFunction.cxx
+++ b/lib/src/Base/Func/SpatialFunction.cxx
@@ -115,7 +115,7 @@ SpatialFunction::Implementation SpatialFunction::getMarginal(const UnsignedInteg
 /* Get the function corresponding to indices components */
 SpatialFunction::Implementation SpatialFunction::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   return new SpatialFunction(p_evaluation_->getMarginal(indices));
 }
 

--- a/lib/src/Base/Func/TemporalFunction.cxx
+++ b/lib/src/Base/Func/TemporalFunction.cxx
@@ -127,7 +127,7 @@ TemporalFunction::Implementation TemporalFunction::getMarginal(const UnsignedInt
 /* Get the function corresponding to indices components */
 TemporalFunction::Implementation TemporalFunction::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getOutputDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and  must be different";
+  if (!indices.check(getOutputDimension())) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal function must be in the range [0, outputDimension-1] and must be different";
   return new TemporalFunction(p_evaluation_->getMarginal(indices));
 }
 

--- a/lib/src/Base/Geom/Mesh.cxx
+++ b/lib/src/Base/Geom/Mesh.cxx
@@ -141,7 +141,7 @@ void Mesh::checkValidity() const
     if (simplex.getSize() != getDimension() + 1)
       throw InvalidArgumentException(HERE) << "Error: mesh has dimension " << getDimension() << " but simplex #" << i << " has size" << simplex.getSize();
 
-    if (!simplex.check(getVerticesNumber() - 1))
+    if (!simplex.check(getVerticesNumber()))
       throw InvalidArgumentException(HERE) << "Error: mesh has " << getVerticesNumber() << " vertices but simplex #" << i << " refers to an unknown vertex";
   }
   // Check that no ball can be included into the intersection of two simplices

--- a/lib/src/Base/Stat/NumericalSampleImplementation.cxx
+++ b/lib/src/Base/Stat/NumericalSampleImplementation.cxx
@@ -2137,7 +2137,7 @@ NumericalSampleImplementation NumericalSampleImplementation::getMarginal(const U
 /* Get the marginal sample corresponding to indices dimensions */
 NumericalSampleImplementation NumericalSampleImplementation::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(dimension_ - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal sample must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension_)) throw InvalidArgumentException(HERE) << "The indices of a marginal sample must be in the range [0, dim-1] and must be different";
 
   // Special case for dimension 1
   if (dimension_ == 1) return *this;

--- a/lib/src/Base/Type/Indices.cxx
+++ b/lib/src/Base/Type/Indices.cxx
@@ -27,7 +27,7 @@ BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(Indices);
 static const Factory<Indices> Factory_Indices;
 
-/* Check that no value is repeated and no value exceed the given bound */
+/* Check that no value is repeated and no value exceeds the given bound */
 Bool Indices::check(const UnsignedInteger bound) const
 {
   if (getSize() == 0) return true;
@@ -37,7 +37,7 @@ Bool Indices::check(const UnsignedInteger bound) const
   iterator iter = std::unique(copy.begin(), copy.end());
   if (iter < copy.end()) return false;
   // Check if the values are in the given bound
-  if (*max_element(begin(), end()) > bound) return false;
+  if (*max_element(begin(), end()) >= bound) return false;
   return true;
 }
 

--- a/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
@@ -236,13 +236,13 @@ BayesDistribution::Implementation BayesDistribution::getMarginal(const UnsignedI
 BayesDistribution::Implementation BayesDistribution::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case
   // If the indices are in the conditioned part
   const UnsignedInteger conditionedDimension = conditionedDistribution_.getDimension();
-  if (indices.check(conditionedDimension - 1)) return ConditionalDistribution(conditionedDistribution_, conditioningDistribution_, linkFunction_).getMarginal(indices);
+  if (indices.check(conditionedDimension)) return ConditionalDistribution(conditionedDistribution_, conditioningDistribution_, linkFunction_).getMarginal(indices);
   // If the indices are in the conditioning part
   Indices conditioningIndices(0);
   const UnsignedInteger size = indices.getSize();

--- a/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
@@ -467,7 +467,7 @@ NumericalScalar ComposedCopula::computeConditionalQuantile(const NumericalScalar
 ComposedCopula::Implementation ComposedCopula::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   CopulaCollection marginalCopulas;
   const UnsignedInteger indicesSize = indices.getSize();
   const UnsignedInteger size = copulaCollection_.getSize();

--- a/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
@@ -567,7 +567,7 @@ ConditionalDistribution::Implementation ConditionalDistribution::getMarginal(con
 ConditionalDistribution::Implementation ConditionalDistribution::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   // Waiting for a better implementation
   return Mixture::getMarginal(indices);

--- a/lib/src/Uncertainty/Distribution/CumulativeDistributionNetwork.cxx
+++ b/lib/src/Uncertainty/Distribution/CumulativeDistributionNetwork.cxx
@@ -257,7 +257,7 @@ CumulativeDistributionNetwork::Implementation CumulativeDistributionNetwork::get
   LOGINFO(OSS() << "in getMarginal(" << indices << "), contributors=" << distributionCollection_ << ", graph=" << graph_);
   if (indices.getSize() == 1) return getMarginal(indices[0]);
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   return DistributionImplementation::getMarginal(indices);
   /*
   // General case

--- a/lib/src/Uncertainty/Distribution/Dirac.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirac.cxx
@@ -330,7 +330,7 @@ Dirac::Implementation Dirac::getMarginal(const UnsignedInteger i) const
 Dirac::Implementation Dirac::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   const UnsignedInteger outputDimension = indices.getSize();
   NumericalPoint pointMarginal(outputDimension);

--- a/lib/src/Uncertainty/Distribution/Dirichlet.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirichlet.cxx
@@ -447,7 +447,7 @@ Dirichlet::Implementation Dirichlet::getMarginal(const UnsignedInteger i) const
 Dirichlet::Implementation Dirichlet::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   const UnsignedInteger outputDimension = indices.getSize();
   NumericalPoint thetaMarginal(outputDimension + 1);

--- a/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
@@ -280,7 +280,7 @@ NumericalScalar FarlieGumbelMorgensternCopula::getTheta() const
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
 FarlieGumbelMorgensternCopula::Implementation FarlieGumbelMorgensternCopula::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(1)) throw InvalidArgumentException(HERE) << "The indices of an archimedean copula  must be in the range [0, 1] and  must be different";
+  if (!indices.check(2)) throw InvalidArgumentException(HERE) << "The indices of an archimedean copula must be in the range [0, 1] and must be different";
   // General case
   const UnsignedInteger outputDimension = indices.getSize();
   // Only one indice is needed, call the specialized method

--- a/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
@@ -227,7 +227,7 @@ LevelSet IndependentCopula::computeMinimumVolumeLevelSetWithThreshold(const Nume
 IndependentCopula::Implementation IndependentCopula::getMarginal(const Indices & indices) const
 {
   UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // General case
   return new IndependentCopula(indices.getSize());
 }

--- a/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
@@ -140,7 +140,7 @@ NumericalScalar KPermutationsDistribution::computeLogPDF(const NumericalPoint & 
     if (std::abs(k - ik) > supportEpsilon_) return SpecFunc::LogMinNumericalScalar;
     x[i] = ik;
   }
-  if (!x.check(n_ - 1)) return 0.0;
+  if (!x.check(n_)) return 0.0;
   return logPDFValue_;
 }
 
@@ -191,7 +191,7 @@ KPermutationsDistribution::Implementation KPermutationsDistribution::getMarginal
 KPermutationsDistribution::Implementation KPermutationsDistribution::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/KernelMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelMixture.cxx
@@ -503,7 +503,7 @@ KernelMixture::Implementation KernelMixture::getMarginal(const UnsignedInteger i
 KernelMixture::Implementation KernelMixture::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
@@ -130,7 +130,7 @@ Indices MarginalDistribution::getIndices() const
 void MarginalDistribution::setDistributionAndIndices(const Distribution & distribution,
     const Indices & indices)
 {
-  if (!indices.check(distribution.getDimension() - 1)) throw InvalidArgumentException(HERE) << "Error: the given indices=" << indices << " are not compatible with the given distribution dimension=" << distribution.getDimension();
+  if (!indices.check(distribution.getDimension())) throw InvalidArgumentException(HERE) << "Error: the given indices=" << indices << " are not compatible with the given distribution dimension=" << distribution.getDimension();
   distribution_ = distribution;
   indices_ = indices;
   // Set the dimension
@@ -298,7 +298,7 @@ MarginalDistribution::Implementation MarginalDistribution::getMarginal(const Uns
 MarginalDistribution::Implementation MarginalDistribution::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   // Build the indices associated to the marginal of the marginal
   const UnsignedInteger outputDimension = indices.getSize();

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
@@ -109,7 +109,7 @@ MaximumEntropyOrderStatisticsCopula::Implementation MaximumEntropyOrderStatistic
   const UnsignedInteger size = indices.getSize();
   if (size == 0) throw InvalidArgumentException(HERE) << "indices is empty";
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   if (size == 1)
   {

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
@@ -891,7 +891,7 @@ MaximumEntropyOrderStatisticsDistribution MaximumEntropyOrderStatisticsDistribut
   const UnsignedInteger size = indices.getSize();
   if (size < 2) throw InvalidArgumentException(HERE) << "indices must be of size at least 2";
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (!indices.isIncreasing()) throw InvalidArgumentException(HERE) << "Cannot take the marginal distribution of an order statistics distribution with nonincreasing indices.";
   // Here we know that if the size is equal to the dimension, the indices are [0,...,dimension-1]
   if (size == dimension) return *this;

--- a/lib/src/Uncertainty/Distribution/MethodOfMomentsFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MethodOfMomentsFactory.cxx
@@ -203,7 +203,7 @@ NumericalPoint MethodOfMomentsFactory::buildParameter(const NumericalSample & sa
 
   const UnsignedInteger effectiveParameterSize = distribution_.getParameterDimension();
 
-  if (!knownParameterIndices_.check(effectiveParameterSize - 1))
+  if (!knownParameterIndices_.check(effectiveParameterSize))
     throw InvalidArgumentException(HERE) << "Error: known indices cannot exceed parameter size";
   if (knownParameterValues_.getSize() != knownParameterIndices_.getSize())
     throw InvalidArgumentException(HERE) << "Error: known values size must match indices";

--- a/lib/src/Uncertainty/Distribution/MinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/MinCopula.cxx
@@ -150,7 +150,7 @@ CorrelationMatrix MinCopula::getKendallTau() const
 MinCopula::Implementation MinCopula::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -423,7 +423,7 @@ Mixture::Implementation Mixture::getMarginal(const UnsignedInteger i) const
 Mixture::Implementation Mixture::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   DistributionCollection collection;

--- a/lib/src/Uncertainty/Distribution/Multinomial.cxx
+++ b/lib/src/Uncertainty/Distribution/Multinomial.cxx
@@ -413,7 +413,7 @@ Multinomial::Implementation Multinomial::getMarginal(const UnsignedInteger i) co
 Multinomial::Implementation Multinomial::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -550,7 +550,7 @@ Normal::Implementation Normal::getMarginal(const UnsignedInteger i) const
 Normal::Implementation Normal::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/NormalCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/NormalCopula.cxx
@@ -438,7 +438,7 @@ NumericalScalar NormalCopula::computeConditionalQuantile(const NumericalScalar q
 NormalCopula::Implementation NormalCopula::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/OrdinalSumCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/OrdinalSumCopula.cxx
@@ -431,7 +431,7 @@ NumericalScalar OrdinalSumCopula::computeConditionalQuantile(const NumericalScal
 OrdinalSumCopula::Implementation OrdinalSumCopula::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   const UnsignedInteger size = copulaCollection_.getSize();
   CopulaCollection coll(size);
   for (UnsignedInteger i = 0; i < size; ++i) coll[i] = copulaCollection_[i].getMarginal(indices);

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -2605,7 +2605,7 @@ RandomMixture::Implementation RandomMixture::getMarginal(const UnsignedInteger i
 RandomMixture::Implementation RandomMixture::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   const UnsignedInteger outputDimension = indices.getSize();
   const UnsignedInteger size = distributionCollection_.getSize();

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -399,7 +399,7 @@ Student::Implementation Student::getMarginal(const UnsignedInteger i) const
 Student::Implementation Student::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Distribution/UserDefined.cxx
+++ b/lib/src/Uncertainty/Distribution/UserDefined.cxx
@@ -464,7 +464,7 @@ UserDefined::Implementation UserDefined::getMarginal(const UnsignedInteger i) co
 UserDefined::Implementation UserDefined::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "The indices of a marginal distribution must be in the range [0, dim-1] and must be different";
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case

--- a/lib/src/Uncertainty/Model/ArchimedeanCopula.cxx
+++ b/lib/src/Uncertainty/Model/ArchimedeanCopula.cxx
@@ -172,7 +172,7 @@ Bool ArchimedeanCopula::hasIndependentCopula() const
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
 ArchimedeanCopula::Implementation ArchimedeanCopula::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(1)) throw InvalidArgumentException(HERE) << "The indices of an archimedean copula  must be in the range [0, 1] and  must be different";
+  if (!indices.check(2)) throw InvalidArgumentException(HERE) << "The indices of an archimedean copula must be in the range [0, 1] and must be different";
   // General case
   const UnsignedInteger outputDimension = indices.getSize();
   // Only one indice is needed, call the specialized method

--- a/lib/src/Uncertainty/Model/CompositeRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/CompositeRandomVector.cxx
@@ -140,7 +140,7 @@ CompositeRandomVector::Implementation CompositeRandomVector::getMarginal(const U
 /* Get the marginal random vector corresponding to indices components */
 CompositeRandomVector::Implementation CompositeRandomVector::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and must be different";
   return new CompositeRandomVector(function_.getMarginal(indices), p_antecedent_);
 }
 

--- a/lib/src/Uncertainty/Model/ConstantRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/ConstantRandomVector.cxx
@@ -114,7 +114,7 @@ ConstantRandomVector::Implementation ConstantRandomVector::getMarginal(const Uns
 /* Get the marginal random vector corresponding to indices components */
 ConstantRandomVector::Implementation ConstantRandomVector::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and must be different";
   const UnsignedInteger marginalDimension = indices.getSize();
   NumericalPoint marginalPoint(marginalDimension);
   for (UnsignedInteger i = 0; i < marginalDimension; ++i) marginalPoint[i] = point_[indices[i]];

--- a/lib/src/Uncertainty/Model/FunctionalChaosRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/FunctionalChaosRandomVector.cxx
@@ -95,7 +95,7 @@ NumericalScalar FunctionalChaosRandomVector::getSobolIndex(const Indices & varia
     const UnsignedInteger marginalIndex) const
 {
   const UnsignedInteger inputDimension = getAntecedent()->getDimension();
-  if (!variableIndices.check(inputDimension - 1)) throw InvalidArgumentException(HERE) << "The variable indices of a Sobol indice must be in the range [0, dim-1] and  must be different.";
+  if (!variableIndices.check(inputDimension)) throw InvalidArgumentException(HERE) << "The variable indices of a Sobol indice must be in the range [0, dim-1] and must be different.";
   if (marginalIndex >= getDimension()) throw InvalidArgumentException(HERE) << "The marginal index must be in the range [0, dim-1].";
   // Check if the measure defining the basis has an independent copula else
   // the conditional covariance cannot be extracted from the decomposition
@@ -157,7 +157,7 @@ NumericalScalar FunctionalChaosRandomVector::getSobolTotalIndex(const Indices & 
     const UnsignedInteger marginalIndex) const
 {
   const UnsignedInteger inputDimension = getAntecedent()->getDimension();
-  if (!variableIndices.check(inputDimension - 1)) throw InvalidArgumentException(HERE) << "The variable indices of a Sobol indice must be in the range [0, dim-1] and  must be different.";
+  if (!variableIndices.check(inputDimension)) throw InvalidArgumentException(HERE) << "The variable indices of a Sobol indice must be in the range [0, dim-1] and must be different.";
   if (marginalIndex >= getDimension()) throw InvalidArgumentException(HERE) << "The marginal index must be in the range [0, dim-1].";
   // Check if the measure defining the basis has an independent copula else
   // the conditional covariance cannot be extracted from the decomposition

--- a/lib/src/Uncertainty/Model/ProcessImplementation.cxx
+++ b/lib/src/Uncertainty/Model/ProcessImplementation.cxx
@@ -208,7 +208,7 @@ ProcessImplementation::Implementation ProcessImplementation::getMarginal(const U
 ProcessImplementation::Implementation ProcessImplementation::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal process must be in the range [0, dim-1] and must be different";
   if (dimension == 1) return clone();
   throw NotYetImplementedException(HERE) << "In ProcessImplementation::getMarginal(const Indices & indices) const";
 }

--- a/lib/src/Uncertainty/Model/UsualRandomVector.cxx
+++ b/lib/src/Uncertainty/Model/UsualRandomVector.cxx
@@ -96,7 +96,7 @@ UsualRandomVector::Implementation UsualRandomVector::getMarginal(const UnsignedI
 /* Get the marginal random vector corresponding to indices components */
 UsualRandomVector::Implementation UsualRandomVector::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal random vector must be in the range [0, dim-1] and must be different";
   return new UsualRandomVector(distribution_.getMarginal(indices));
 }
 

--- a/lib/src/Uncertainty/Process/ARMA.cxx
+++ b/lib/src/Uncertainty/Process/ARMA.cxx
@@ -368,7 +368,7 @@ ARMA::Implementation ARMA::getMarginal(const UnsignedInteger i) const
 /* Get the marginal random vector corresponding to indices components */
 ARMA::Implementation ARMA::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(dimension_ - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension_)) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and must be different";
   throw NotYetImplementedException(HERE) << "In ARMA::getMarginal(const Indices & indices) const";
 }
 

--- a/lib/src/Uncertainty/Process/AggregatedProcess.cxx
+++ b/lib/src/Uncertainty/Process/AggregatedProcess.cxx
@@ -138,7 +138,7 @@ AggregatedProcess::Implementation AggregatedProcess::getMarginal(const UnsignedI
 AggregatedProcess::Implementation AggregatedProcess::getMarginal(const Indices & indices) const
 {
   const UnsignedInteger dimension = getDimension();
-  if (!indices.check(dimension - 1)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(dimension)) throw InvalidArgumentException(HERE) << "Error: the indices of a marginal process must be in the range [0, dim-1] and must be different";
   ProcessCollection marginalProcesses(0);
   const UnsignedInteger indicesSize = indices.getSize();
   const UnsignedInteger size = processCollection_.getSize();

--- a/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
+++ b/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
@@ -170,7 +170,7 @@ FunctionalBasisProcess::Implementation FunctionalBasisProcess::getMarginal(const
 /* Get the marginal random vector corresponding to indices components */
 FunctionalBasisProcess::Implementation FunctionalBasisProcess::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and must be different";
   // First the marginal distribution
   Distribution marginalDistribution(distribution_.getMarginal(indices));
   // Second the marginal basis

--- a/lib/src/Uncertainty/Process/RandomWalk.cxx
+++ b/lib/src/Uncertainty/Process/RandomWalk.cxx
@@ -149,7 +149,7 @@ RandomWalk::Implementation RandomWalk::getMarginal(const UnsignedInteger i) cons
 /* Get the marginal process corresponding to indices components */
 RandomWalk::Implementation RandomWalk::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and must be different";
   const UnsignedInteger size = indices.getSize();
   NumericalPoint marginalOrigin(size);
   for (UnsignedInteger i = 0; i < size; ++i) marginalOrigin[i] = origin_[indices[i]];

--- a/lib/src/Uncertainty/Process/WhiteNoise.cxx
+++ b/lib/src/Uncertainty/Process/WhiteNoise.cxx
@@ -143,7 +143,7 @@ WhiteNoise::Implementation WhiteNoise::getMarginal(const UnsignedInteger i) cons
 /* Get the marginal random vector corresponding to indices components */
 WhiteNoise::Implementation WhiteNoise::getMarginal(const Indices & indices) const
 {
-  if (!indices.check(getDimension() - 1)) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and  must be different";
+  if (!indices.check(getDimension())) throw InvalidArgumentException(HERE) << "The indices of a marginal process must be in the range [0, dim-1] and must be different";
   return new WhiteNoise(distribution_.getMarginal(indices), mesh_);
 }
 

--- a/python/src/Indices_doc.i.in
+++ b/python/src/Indices_doc.i.in
@@ -44,17 +44,17 @@ Use some functionalities:
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::Indices::check
-"Check that no value is repeated and no value exceed the given bound.
+"Check that no value is repeated and no value exceeds the given bound.
 
 Parameters
 ----------
 bound : positive int
-    A bound.
+    The bound value.
 
 Returns
 -------
 check : bool
-    *True* if no value is repeated and no value exceed the given bound."
+    *True* if no value is repeated and all values are < bound."
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
It's less error-prone to change the definition of Indices::check
to seq[j] < n for all j instead of seq[j] <= n for all j