### PR TITLE
Fix #875 in trac

### DIFF
--- a/lib/src/Base/Optim/OptimizationProblem.cxx
+++ b/lib/src/Base/Optim/OptimizationProblem.cxx
@@ -180,6 +180,11 @@ Bool OptimizationProblem::isMinimization() const
   return getImplementation()->isMinimization();
 }
 
+Bool OptimizationProblem::isValid() const
+{
+  return getImplementation()->isValid();
+}
+
 /* String converter */
 String OptimizationProblem::__repr__() const
 {

--- a/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
+++ b/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
@@ -232,6 +232,45 @@ Bool OptimizationProblemImplementation::isMinimization() const
   return minimization_;
 }
 
+Bool OptimizationProblemImplementation::isValid() const
+{
+  // isValid checks if the optimization problem is 'valid' (all functions have accurate dimension) :
+  // 1) Accurate bounds dimension if defined
+  // 2) Accuracy between equality constraint and objective function input dimensions
+  // 3) Accuracy between inequality constraint and objective function input dimensions
+  // 4) Accuracy between level function and objective function input dimensions
+  if (hasBounds() && (getDimension() != getBounds().getDimension()))
+  {
+    Log::Warn(OSS() << "Bounds have incompatible size with problem's objective input dimension."
+                    << " Objective input dimension = " << getDimension()
+                    << ", wheras bounds size = " << getBounds().getDimension());
+    return false;
+  }
+  // Accuracy between objective and equality constraints
+  if(hasEqualityConstraint() && (getEqualityConstraint().getInputDimension() != getDimension()))
+  {
+    Log::Warn(OSS() << "In OptimizationSolverImplementation::setProblem, problem's objective and equality constraints have differents input dimensions."
+              <<" Objective's input dimension = " << getDimension()
+              <<", equality constraint input dimension = " << getEqualityConstraint().getInputDimension());
+    return false;
+  }
+  if(hasInequalityConstraint() && (getInequalityConstraint().getInputDimension() != getDimension()))
+  {
+    Log::Warn( OSS() << "Objective and inequality constraints have differents input dimensions."
+                     << " Objective's input dimension = " << getDimension()
+                     << ", inequality constraint input dimension = " << getInequalityConstraint().getInputDimension());
+    return false;
+  }
+  if(hasLevelFunction() && (getLevelFunction().getInputDimension() != getDimension()))
+  {
+    Log::Warn( OSS() << "Objective and level function have differents input dimensions."
+                     << " Objective's input dimension = " << getDimension()
+                     << ", level function input dimension = " << getLevelFunction().getInputDimension());
+    return false;
+  }
+  return true;
+}
+
 /* String converter */
 String OptimizationProblemImplementation::__repr__() const
 {

--- a/lib/src/Base/Optim/openturns/OptimizationProblem.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationProblem.hxx
@@ -100,6 +100,9 @@ public:
   void setMinimization(Bool minimization);
   Bool isMinimization() const;
 
+  /** isValid method */
+  Bool isValid() const;
+
   /** String converter */
   virtual String __repr__() const;
 

--- a/lib/src/Base/Optim/openturns/OptimizationProblemImplementation.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationProblemImplementation.hxx
@@ -93,6 +93,9 @@ public:
   void setMinimization(Bool minimization);
   Bool isMinimization() const;
 
+  /** isValid method */
+  Bool isValid() const;
+
   /** String converter */
   virtual String __repr__() const;
 

--- a/lib/src/Uncertainty/Distribution/MethodOfMomentsFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MethodOfMomentsFactory.cxx
@@ -237,6 +237,35 @@ NumericalPoint MethodOfMomentsFactory::buildParameter(const NumericalSample & sa
     }
     solver.setStartingPoint(parameter);
   }
+  // Usually problem requires to set new bounds if dimension != effectiveDimension (for defined bounds)
+  if (problem.hasBounds() && (problem.getDimension() != problem.getBounds().getDimension()))
+  {
+    const Interval bounds(problem.getBounds());
+    const NumericalPoint lowerBound(bounds.getLowerBound());
+    const NumericalPoint upperBound(bounds.getUpperBound());
+    const Interval::BoolCollection finiteLowerBound(bounds.getFiniteLowerBound());
+    const Interval::BoolCollection finiteUpperBound(bounds.getFiniteUpperBound());
+    NumericalPoint effectiveLowerBound;
+    NumericalPoint effectiveUpperBound;
+    Interval::BoolCollection effectiveFiniteLowerBound;
+    Interval::BoolCollection effectiveFiniteUpperBound;
+    for (UnsignedInteger j = 0; j < effectiveParameterSize; ++ j)
+    {
+      if (!knownParameterIndices_.contains(j))
+      {
+        effectiveLowerBound.add(lowerBound[j]);
+        effectiveUpperBound.add(upperBound[j]);
+        effectiveFiniteLowerBound.add(finiteLowerBound[j]);
+        effectiveFiniteUpperBound.add(finiteUpperBound[j]);
+      }
+    }
+    Interval effectiveBounds(effectiveLowerBound, effectiveUpperBound, effectiveFiniteLowerBound, effectiveFiniteUpperBound);
+    problem.setBounds(effectiveBounds);
+  }
+  // Check that problem is valid
+  if(!problem.isValid())
+    throw InvalidArgumentException(HERE) << "In MaximumLikelihoodFactory::buildParameter, given problem is invalid."
+                                         << " Please check that bounds and various constraints have accurate dimensions";
   solver.setProblem(problem);
   solver.run();
   NumericalPoint effectiveParameter(effectiveParameterSize);

--- a/python/src/OptimizationProblemImplementation_doc.i.in
+++ b/python/src/OptimizationProblemImplementation_doc.i.in
@@ -363,3 +363,19 @@ objectiveFunction : :class:`~openturns.NumericalMathFunction`
 %feature("docstring") OT::OptimizationProblemImplementation::setObjective
 OT_OptimizationProblem_setObjective_doc
 
+// ---------------------------------------------------------------------
+
+%define OT_OptimizationProblem_isValid_doc
+"Test whether the problem is valid (accuracy in the problem definition).
+
+Returns
+-------
+value : bool
+    *True* if valid."
+
+%enddef
+
+%feature("docstring") OT::OptimizationProblemImplementation::isValid
+OT_OptimizationProblem_isValid_doc
+
+// ---------------------------------------------------------------------

--- a/python/src/OptimizationProblem_doc.i.in
+++ b/python/src/OptimizationProblem_doc.i.in
@@ -44,4 +44,6 @@ OT_OptimizationProblem_setLevelValue_doc
 OT_OptimizationProblem_setMinimization_doc
 %feature("docstring") OT::OptimizationProblem::setObjective
 OT_OptimizationProblem_setObjective_doc
+%feature("docstring") OT::OptimizationProblem::isValid
+OT_OptimizationProblem_isValid_doc
 


### PR DESCRIPTION
Fix http://trac.openturns.org/ticket/875

TruncatedNormalFactory randomly crashes on osx systems. This is due to
the new implementation in the MaximumLikelihoodFactory class (reduced
objective function but not accurate bounds). Thus to fix the problem:

 - We update OptimizationProblem's bounds :  they should be zero size or
 should have the same size as objective's function input dimension
 Thus we redefine new bounds in case
 - We update also Equality/Inequality constraints :  we raise an exception
 if their input dimension size is not compatible with objective function's
 input dimension

Same work has been done on the MethodOfMoment class as we should get the
same problems if we face reduced objective functions