### PR TITLE
Keep OptimizationProblem valid

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,10 +36,10 @@
 
 === Bug fixes ===
  * #729 (KDTree & save)
- * #774 (Exact limits of a normal distribution with unknown mean and
-	variance)
+ * #774 (Exact limits of a normal distribution with unknown mean and variance)
  * #871 (GeneralizedExponential P parameter : int or float ?)
  * #872 (Cannot draw a Text drawable using R)
+ * #875 (TruncatedNormalFactory randomly crashes)
 
 == 1.8 release (2016-11-18) == #release-1.8
 

--- a/lib/src/Base/Optim/OptimizationProblem.cxx
+++ b/lib/src/Base/Optim/OptimizationProblem.cxx
@@ -46,6 +46,13 @@ OptimizationProblem::OptimizationProblem(const Implementation & p_implementation
 }
 
 /* Constructor with constraints, bounds */
+OptimizationProblem::OptimizationProblem(const NumericalMathFunction & objective)
+: TypedInterfaceObject<OptimizationProblemImplementation>(new OptimizationProblemImplementation(objective))
+{
+  // Nothing to do
+}
+
+/* Constructor with constraints, bounds */
 OptimizationProblem::OptimizationProblem(const NumericalMathFunction & objective,
     const NumericalMathFunction & equalityConstraint,
     const NumericalMathFunction & inequalityConstraint,

--- a/lib/src/Base/Optim/OptimizationProblem.cxx
+++ b/lib/src/Base/Optim/OptimizationProblem.cxx
@@ -45,10 +45,7 @@ OptimizationProblem::OptimizationProblem(const Implementation & p_implementation
   // Nothing to do
 }
 
-/*
- * @brief  Standard constructor: the problem is defined by a scalar valued function  (in fact, a 1-D vector valued function)
- *         and a level value
- */
+/* Constructor with constraints, bounds */
 OptimizationProblem::OptimizationProblem(const NumericalMathFunction & objective,
     const NumericalMathFunction & equalityConstraint,
     const NumericalMathFunction & inequalityConstraint,

--- a/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
+++ b/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
@@ -47,6 +47,15 @@ OptimizationProblemImplementation::OptimizationProblemImplementation()
   // Nothing to do
 }
 
+OptimizationProblemImplementation::OptimizationProblemImplementation(const NumericalMathFunction & objective)
+  : PersistentObject()
+  , objective_(objective)
+  , minimization_(true)
+  , dimension_(objective.getInputDimension())
+{
+  // nothing to do
+}
+
 /*
  * @brief General multi-objective equality, inequality and bound constraints
  */

--- a/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
+++ b/lib/src/Base/Optim/OptimizationProblemImplementation.cxx
@@ -56,16 +56,12 @@ OptimizationProblemImplementation::OptimizationProblemImplementation(const Numer
     const Interval & bounds)
   : PersistentObject()
   , objective_(objective)
-  , equalityConstraint_(equalityConstraint)
-  , inequalityConstraint_(inequalityConstraint)
-  , bounds_(bounds)
   , minimization_(true)
   , dimension_(objective.getInputDimension())
 {
-  // Check if the input dimension of the objective, the constraints and the bounds are compatible
-  if (hasEqualityConstraint() && (equalityConstraint.getInputDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given equality constraints have an input dimension=" << equalityConstraint.getInputDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
-  if (hasInequalityConstraint() && (inequalityConstraint.getInputDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given inequality constraints have an input dimension=" << inequalityConstraint.getInputDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
-  if (hasBounds() && (bounds.getDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given bounds are of dimension=" << bounds.getDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
+  setEqualityConstraint(equalityConstraint);
+  setInequalityConstraint(inequalityConstraint);
+  setBounds(bounds);
 }
 
 /* Constructor for nearest point problem */
@@ -97,6 +93,14 @@ NumericalMathFunction OptimizationProblemImplementation::getObjective() const
 
 void OptimizationProblemImplementation::setObjective(const NumericalMathFunction & objective)
 {
+  if (objective.getInputDimension() != objective_.getInputDimension())
+  {
+    // clear constraints, bounds
+    LOGWARN(OSS() << "Clearing constraints and bounds");
+    equalityConstraint_ = NumericalMathFunction();
+    inequalityConstraint_ = NumericalMathFunction();
+    bounds_ = Interval(0);
+  }
   clearLevelFunction();
 
   objective_ = objective;
@@ -117,6 +121,8 @@ NumericalMathFunction OptimizationProblemImplementation::getEqualityConstraint()
 
 void OptimizationProblemImplementation::setEqualityConstraint(const NumericalMathFunction & equalityConstraint)
 {
+  if ((equalityConstraint.getInputDimension() > 0) && (equalityConstraint.getInputDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given equality constraints have an input dimension=" << equalityConstraint.getInputDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
+
   clearLevelFunction();
   equalityConstraint_ = equalityConstraint;
 }
@@ -134,6 +140,8 @@ NumericalMathFunction OptimizationProblemImplementation::getInequalityConstraint
 
 void OptimizationProblemImplementation::setInequalityConstraint(const NumericalMathFunction & inequalityConstraint)
 {
+  if ((inequalityConstraint.getInputDimension() > 0) && (inequalityConstraint.getInputDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given inequality constraints have an input dimension=" << inequalityConstraint.getInputDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
+
   clearLevelFunction();
   inequalityConstraint_ = inequalityConstraint;
 }
@@ -151,6 +159,8 @@ Interval OptimizationProblemImplementation::getBounds() const
 
 void OptimizationProblemImplementation::setBounds(const Interval & bounds)
 {
+  if ((bounds.getDimension() > 0) && (bounds.getDimension() != dimension_)) throw InvalidArgumentException(HERE) << "Error: the given bounds are of dimension=" << bounds.getDimension() << " different from the input dimension=" << dimension_ << " of the objective.";
+
   bounds_ = bounds;
 }
 
@@ -211,6 +221,7 @@ void OptimizationProblemImplementation::setNearestPointConstraints()
 
 void OptimizationProblemImplementation::clearLevelFunction()
 {
+  LOGWARN(OSS() << "Clearing level function");
   levelFunction_ = NumericalMathFunction();
   levelValue_ = 0.0;
 }

--- a/lib/src/Base/Optim/openturns/OptimizationProblem.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationProblem.hxx
@@ -55,6 +55,9 @@ public:
   OptimizationProblem(const Implementation & p_implementation);
 
   /** Constructor with parameters */
+  explicit OptimizationProblem(const NumericalMathFunction & objective);
+
+  /** Constructor with parameters */
   OptimizationProblem(const NumericalMathFunction & objective,
                       const NumericalMathFunction & equalityConstraint,
                       const NumericalMathFunction & inequalityConstraint,

--- a/lib/src/Base/Optim/openturns/OptimizationProblemImplementation.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationProblemImplementation.hxx
@@ -45,6 +45,9 @@ public:
   OptimizationProblemImplementation();
 
   /** Constructor with parameters */
+  explicit OptimizationProblemImplementation(const NumericalMathFunction & objective);
+
+  /** Constructor with parameters */
   OptimizationProblemImplementation(const NumericalMathFunction & objective,
                                     const NumericalMathFunction & equalityConstraint,
                                     const NumericalMathFunction & inequalityConstraint,

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralizedLinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralizedLinearModelAlgorithm.cxx
@@ -428,16 +428,12 @@ void GeneralizedLinearModelAlgorithm::initializeDefaultOptimizationSolver()
     solver_ = NLopt("LD_LBFGS");
   else
     throw InvalidArgumentException(HERE) << "Unknown optimization solver:" << solverName;
-  // Define Optimization Problem
-  // Default problem takes into account the bounds and thus determine the dimension
-  OptimizationProblem problem;
+
   // Bounds should be of size spatialDimension + dimension
-  const UnsignedInteger optimizationProblemSize = covarianceModel_.getParameter().getSize();
-  const NumericalPoint lowerBound(optimizationProblemSize, ResourceMap::GetAsNumericalScalar( "GeneralizedLinearModelAlgorithm-DefaultOptimizationLowerBound"));
-  const NumericalPoint upperBound(optimizationProblemSize, ResourceMap::GetAsNumericalScalar( "GeneralizedLinearModelAlgorithm-DefaultOptimizationUpperBound"));
-  const Interval bounds(lowerBound, upperBound);
-  problem.setBounds(bounds);
-  solver_.setProblem(problem);
+  const UnsignedInteger optimizationDimension = covarianceModel_.getParameter().getSize();
+  const NumericalPoint lowerBound(optimizationDimension, ResourceMap::GetAsNumericalScalar( "GeneralizedLinearModelAlgorithm-DefaultOptimizationLowerBound"));
+  const NumericalPoint upperBound(optimizationDimension, ResourceMap::GetAsNumericalScalar( "GeneralizedLinearModelAlgorithm-DefaultOptimizationUpperBound"));
+  optimizationBounds_ = Interval(lowerBound, upperBound);
 }
 
 /* Virtual constructor */
@@ -786,9 +782,10 @@ NumericalPoint GeneralizedLinearModelAlgorithm::optimizeLogLikelihood()
   if (!optimizeParameters_) return initialParameters;
 
   // Define Optimization problem
-  OptimizationProblem problem(solver_.getProblem());
+  OptimizationProblem problem;
   problem.setObjective(logLikelihoodFunction);
   problem.setMinimization(false);
+  problem.setBounds(optimizationBounds_);
   solver_.setStartingPoint(initialParameters);
   solver_.setProblem(problem);
   solver_.run();
@@ -810,19 +807,10 @@ OptimizationSolver GeneralizedLinearModelAlgorithm::getOptimizationSolver() cons
 {
   return solver_;
 }
+
 void GeneralizedLinearModelAlgorithm::setOptimizationSolver(const OptimizationSolver & solver)
 {
-  const Interval bounds(solver.getProblem().getBounds());
-  const UnsignedInteger optimizationProblemSize = covarianceModel_.getParameter().getSize();
-  OptimizationProblem problem;
-  if (bounds.getDimension() != optimizationProblemSize)
-  {
-    problem = solver_.getProblem();
-    solver_ = solver;
-    solver_.setProblem(problem);
-  }
-  else
-    solver_ = solver;
+  solver_ = solver;
   hasRun_ = false;
 }
 
@@ -865,6 +853,16 @@ void GeneralizedLinearModelAlgorithm::setOptimizeParameters(const Bool optimizeP
   }
 }
 
+/* Accessor to optimization bounds */
+void GeneralizedLinearModelAlgorithm::setOptimizationBounds(const Interval & optimizationBounds)
+{
+  optimizationBounds_ = optimizationBounds;
+}
+
+Interval GeneralizedLinearModelAlgorithm::getOptimizationBounds() const
+{
+  return optimizationBounds_;
+}
 
 /* Observation noise accessor */
 void GeneralizedLinearModelAlgorithm::setNoise(const NumericalPoint & noise)
@@ -959,6 +957,7 @@ void GeneralizedLinearModelAlgorithm::save(Advocate & adv) const
   adv.saveAttribute( "outputSample_", outputSample_ );
   adv.saveAttribute( "covarianceModel_", covarianceModel_ );
   adv.saveAttribute( "solver_", solver_ );
+  adv.saveAttribute( "optimizationBounds_", optimizationBounds_ );
   adv.saveAttribute( "basis_", basis_ );
   adv.saveAttribute( "result_", result_ );
   adv.saveAttribute( "method", method_ );
@@ -979,6 +978,7 @@ void GeneralizedLinearModelAlgorithm::load(Advocate & adv)
   adv.loadAttribute( "outputSample_", outputSample_ );
   adv.loadAttribute( "covarianceModel_", covarianceModel_ );
   adv.loadAttribute( "solver_", solver_ );
+  adv.loadAttribute( "optimizationBounds_", optimizationBounds_ );
   adv.loadAttribute( "basis_", basis_ );
   adv.loadAttribute( "result_", result_ );
   adv.loadAttribute( "method", method_ );

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
@@ -271,7 +271,18 @@ OptimizationSolver KrigingAlgorithm::getOptimizationSolver() const
 
 void KrigingAlgorithm::setOptimizationSolver(const OptimizationSolver & solver)
 {
-  return glmAlgo_.setOptimizationSolver(solver);
+  glmAlgo_.setOptimizationSolver(solver);
+}
+
+/* Accessor to optimization bounds */
+void KrigingAlgorithm::setOptimizationBounds(const Interval & optimizationBounds)
+{
+  glmAlgo_.setOptimizationBounds(optimizationBounds);
+}
+
+Interval KrigingAlgorithm::getOptimizationBounds() const
+{
+  return glmAlgo_.getOptimizationBounds();
 }
 
 /** Log-Likelihood function accessor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralizedLinearModelAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralizedLinearModelAlgorithm.hxx
@@ -118,7 +118,11 @@ public:
   /** Optimization flag accessor */
   Bool getOptimizeParameters() const;
   void setOptimizeParameters(const Bool optimizeParameters);
-  
+
+  /** Accessor to optimization bounds */
+  void setOptimizationBounds(const Interval & optimizationBounds);
+  Interval getOptimizationBounds() const;
+
   /** Observation noise accessor */
   void setNoise(const NumericalPoint & noise);
   NumericalPoint getNoise() const;
@@ -192,6 +196,9 @@ private:
 
   // The optimization algorithm used for the meta-parameters estimation
   mutable OptimizationSolver solver_;
+
+  // Bounds used for parameter optimization
+  Interval optimizationBounds_;
 
   // The coefficients of the current output conditional expectation part
   mutable NumericalPoint beta_;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingAlgorithm.hxx
@@ -102,6 +102,10 @@ public:
   OptimizationSolver getOptimizationSolver() const;
   void setOptimizationSolver(const OptimizationSolver & solver);
 
+  /** Accessor to optimization bounds */
+  void setOptimizationBounds(const Interval & optimizationBounds);
+  Interval getOptimizationBounds() const;
+
   /** Log-Likelihood function accessor */
   NumericalMathFunction getLogLikelihoodFunction();
 

--- a/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
@@ -77,12 +77,11 @@ FisherSnedecor FisherSnedecorFactory::buildAsFisherSnedecor(const NumericalSampl
   factory.setOptimizationSolver(solver);
 
   // override bounds
-  OptimizationProblem problem;
   NumericalPoint parametersLowerBound;
   parametersLowerBound.add(ResourceMap::GetAsNumericalScalar("FisherSnedecorFactory-D1LowerBound"));
   parametersLowerBound.add(ResourceMap::GetAsNumericalScalar("FisherSnedecorFactory-D2LowerBound"));
-  problem.setBounds(Interval(parametersLowerBound, NumericalPoint(dimension, SpecFunc::MaxNumericalScalar), Interval::BoolCollection(dimension, true), Interval::BoolCollection(dimension, false)));
-  factory.setOptimizationProblem(problem);
+  Interval bounds(parametersLowerBound, NumericalPoint(dimension, SpecFunc::MaxNumericalScalar), Interval::BoolCollection(dimension, true), Interval::BoolCollection(dimension, false));
+  factory.setOptimizationBounds(bounds);
 
   return buildAsFisherSnedecor(factory.buildParameter(sample));
 }

--- a/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumLikelihoodFactory.cxx
@@ -290,9 +290,10 @@ NumericalPoint MaximumLikelihoodFactory::buildParameter(const NumericalSample & 
   logLikelihood.setGradient(logLikelihoodGradientWrapper.clone());
 
   // Define optimization problem
-  OptimizationProblem problem(problem_);
+  OptimizationProblem problem;
   problem.setMinimization(false);
   problem.setObjective(logLikelihood);
+  problem.setBounds(optimizationBounds_);
   OptimizationSolver solver(solver_);
   if (solver.getStartingPoint().getDimension() != logLikelihood.getInputDimension())
   {
@@ -342,14 +343,20 @@ DistributionFactoryImplementation::Implementation MaximumLikelihoodFactory::buil
 }
 
 
-void MaximumLikelihoodFactory::setOptimizationProblem(const OptimizationProblem& problem)
+/* Accessor to optimization bounds */
+void MaximumLikelihoodFactory::setOptimizationBounds(const Interval & optimizationBounds)
 {
-  problem_ = problem;
+  optimizationBounds_ = optimizationBounds;
 }
 
-OptimizationProblem MaximumLikelihoodFactory::getOptimizationProblem() const
+Interval MaximumLikelihoodFactory::getOptimizationBounds() const
 {
-  return problem_;
+  return optimizationBounds_;
+}
+
+void MaximumLikelihoodFactory::setOptimizationInequalityConstraint(const NumericalMathFunction & optimizationInequalityConstraint)
+{
+  optimizationInequalityConstraint_ = optimizationInequalityConstraint;
 }
 
 void MaximumLikelihoodFactory::setOptimizationSolver(const OptimizationSolver& solver)
@@ -365,7 +372,7 @@ OptimizationSolver MaximumLikelihoodFactory::getOptimizationSolver() const
 void MaximumLikelihoodFactory::setKnownParameter(const NumericalPoint & values,
     const Indices & indices)
 {
-  if (knownParameterValues_.getSize() != knownParameterIndices_.getSize()) throw InvalidArgumentException(HERE);
+  if (knownParameterValues_.getSize() != knownParameterIndices_.getSize()) throw InvalidArgumentException(HERE) << "Known parameters values and indices must have the same size";
   knownParameterValues_ = values;
   knownParameterIndices_ = indices;
 }
@@ -387,6 +394,8 @@ void MaximumLikelihoodFactory::save(Advocate & adv) const
   DistributionFactoryImplementation::save(adv);
   adv.saveAttribute("knownParameterValues_", knownParameterValues_);
   adv.saveAttribute("knownParameterIndices_", knownParameterIndices_);
+  adv.saveAttribute("optimizationBounds_", optimizationBounds_);
+  adv.saveAttribute("optimizationInequalityConstraint_", optimizationInequalityConstraint_);
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -395,6 +404,8 @@ void MaximumLikelihoodFactory::load(Advocate & adv)
   DistributionFactoryImplementation::load(adv);
   adv.loadAttribute("knownParameterValues_", knownParameterValues_);
   adv.loadAttribute("knownParameterIndices_", knownParameterIndices_);
+  adv.loadAttribute("optimizationBounds_", optimizationBounds_);
+  adv.loadAttribute("optimizationInequalityConstraint_", optimizationInequalityConstraint_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
@@ -420,14 +420,14 @@ void MeixnerDistribution::update()
   MeixnerBoundB fB(clone());
   MeixnerBoundCD fCD(clone());
 
-  // Initilalyse Optimization problems
+  // Initialize Optimization problems
   OptimizationProblem problem;
-  problem.setBounds(getRange());
-  solver_.setStartingPoint(getMean());
 
   // Define Optimization problem1 : maximization fB
   problem.setMinimization(false);
   problem.setObjective(fB);
+  problem.setBounds(getRange());
+  solver_.setStartingPoint(getMean());
   solver_.setProblem(problem);
   solver_.run();
   b_ = std::sqrt(solver_.getResult().getOptimalValue()[0]);

--- a/lib/src/Uncertainty/Distribution/OrderStatisticsMarginalChecker.cxx
+++ b/lib/src/Uncertainty/Distribution/OrderStatisticsMarginalChecker.cxx
@@ -116,8 +116,8 @@ void OrderStatisticsMarginalChecker::check() const
       const NumericalScalar xMiddle = 0.5 * (xMin + xMax);
 
       // Define Optimization problem
-      problem.setBounds(Interval(xMin, xMax));
       problem.setObjective(f);
+      problem.setBounds(Interval(xMin, xMax));
       solver_.setStartingPoint(NumericalPoint(1, xMiddle));
       solver_.setProblem(problem);
       solver_.run();

--- a/lib/src/Uncertainty/Distribution/TrapezoidalFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/TrapezoidalFactory.cxx
@@ -131,9 +131,7 @@ Trapezoidal TrapezoidalFactory::buildAsTrapezoidal(const NumericalSample & sampl
   factory.setOptimizationSolver(solver);
 
   // override constraint
-  OptimizationProblem problem;
-  problem.setInequalityConstraint(getLogLikelihoodInequalityConstraint());
-  factory.setOptimizationProblem(problem);
+  factory.setOptimizationInequalityConstraint(getLogLikelihoodInequalityConstraint());
 
   Trapezoidal result(buildAsTrapezoidal(factory.buildParameter(sample)));
   result.setDescription(sample.getDescription());

--- a/lib/src/Uncertainty/Distribution/openturns/MaximumLikelihoodFactory.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MaximumLikelihoodFactory.hxx
@@ -62,8 +62,12 @@ public:
   void setOptimizationSolver(const OptimizationSolver & solver);
   OptimizationSolver getOptimizationSolver() const;
 
-  void setOptimizationProblem(const OptimizationProblem & problem);
-  OptimizationProblem getOptimizationProblem() const;
+  /** Accessor to optimization bounds */
+  void setOptimizationBounds(const Interval & optimizationBounds);
+  Interval getOptimizationBounds() const;
+
+  /** Accessor to inequality constraint */
+  void setOptimizationInequalityConstraint(const NumericalMathFunction & optimizationInequalityConstraint);
 
   /** Accessor to known parameter */
   void setKnownParameter(const NumericalPoint & values, const Indices & positions);
@@ -82,7 +86,12 @@ protected:
 
   /* Solver & optimization problem for log-likelihood maximization */
   OptimizationSolver solver_;
-  OptimizationProblem problem_;
+
+  // Bounds used for parameter optimization
+  Interval optimizationBounds_;
+
+  // Inequality constraint used for parameter optimization
+  NumericalMathFunction optimizationInequalityConstraint_;
 
   /* Known parameter */
   NumericalPoint knownParameterValues_;

--- a/lib/test/t_MultiStart_std.cxx
+++ b/lib/test/t_MultiStart_std.cxx
@@ -57,8 +57,7 @@ int main(int argc, char *argv[])
     Interval bounds(NumericalPoint(dim, -3.0), NumericalPoint(dim, 3.0));
 
     // problem
-    OptimizationProblem problem;
-    problem.setObjective(model);
+    OptimizationProblem problem(model);
     problem.setBounds(bounds);
 
     // solver

--- a/lib/test/t_Study_saveload.cxx
+++ b/lib/test/t_Study_saveload.cxx
@@ -383,8 +383,7 @@ int main(int argc, char *argv[])
       NumericalMathFunction model(input2, output2, formula2);
       model.setName("complex");
 
-      OptimizationProblem problem;
-      problem.setObjective(model);
+      OptimizationProblem problem(model);
       problem.setBounds(bounds);
       problem.setMinimization(true);
 

--- a/lib/test/t_Study_saveload.cxx
+++ b/lib/test/t_Study_saveload.cxx
@@ -384,8 +384,8 @@ int main(int argc, char *argv[])
       model.setName("complex");
 
       OptimizationProblem problem;
-      problem.setBounds(bounds);
       problem.setObjective(model);
+      problem.setBounds(bounds);
       problem.setMinimization(true);
 
       tnc.setProblem(problem);

--- a/lib/test/t_TNC_std.cxx
+++ b/lib/test/t_TNC_std.cxx
@@ -59,8 +59,7 @@ int main(int argc, char *argv[])
     solver.setStartingPoint(startingPoint);
 
     // Define Optimization Problem : minimization
-    OptimizationProblem problem;
-    problem.setObjective(levelFunction);
+    OptimizationProblem problem(levelFunction);
     problem.setBounds(bounds);
     problem.setMinimization(true);
     solver.setProblem(problem);
@@ -109,8 +108,7 @@ int main(int argc, char *argv[])
     // Define Optimization Solver :
     OptimizationSolver solver(new TNC());
 
-    OptimizationProblem problem;
-    problem.setObjective(levelFunction);
+    OptimizationProblem problem(levelFunction);
     problem.setBounds(bounds);
 
     {

--- a/lib/test/t_TNC_std.cxx
+++ b/lib/test/t_TNC_std.cxx
@@ -60,8 +60,8 @@ int main(int argc, char *argv[])
 
     // Define Optimization Problem : minimization
     OptimizationProblem problem;
-    problem.setBounds(bounds);
     problem.setObjective(levelFunction);
+    problem.setBounds(bounds);
     problem.setMinimization(true);
     solver.setProblem(problem);
     solver.run();
@@ -110,8 +110,8 @@ int main(int argc, char *argv[])
     OptimizationSolver solver(new TNC());
 
     OptimizationProblem problem;
-    problem.setBounds(bounds);
     problem.setObjective(levelFunction);
+    problem.setBounds(bounds);
 
     {
       // Define Optimization Problem : minimization

--- a/python/src/GeneralizedLinearModelAlgorithm_doc.i.in
+++ b/python/src/GeneralizedLinearModelAlgorithm_doc.i.in
@@ -331,6 +331,26 @@ optimizeParameters : bool
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::GeneralizedLinearModelAlgorithm::setOptimizationBounds
+"Optimization bounds accessor.
+
+Parameters
+----------
+bounds : :class:`~openturns.Interval`
+    Bounds for covariance model parameter optimization."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::GeneralizedLinearModelAlgorithm::getOptimizationBounds
+"Optimization bounds accessor.
+
+Returns
+-------
+bounds : :class:`~openturns.Interval`
+    Bounds for covariance model parameter optimization."
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::GeneralizedLinearModelAlgorithm::setNoise
 "Observation noise variance accessor.
 

--- a/python/src/KrigingAlgorithm_doc.i.in
+++ b/python/src/KrigingAlgorithm_doc.i.in
@@ -147,14 +147,30 @@ Create the Kriging algorithm with the optimizer option:
 >>> basis = ot.Basis([ot.AnalyticalFunction(['x'], ['0.0'])])
 >>> thetaInit = 1.0
 >>> covariance = ot.GeneralizedExponential([thetaInit], 2.0)
->>> optimizer = ot.TNC()
 >>> bounds = ot.Interval(1e-2,1e2)
->>> optimProblem = ot.OptimizationProblem()
->>> optimProblem.setBounds(bounds)
->>> optimizer.setProblem(optimProblem)
 >>> algo = ot.KrigingAlgorithm(input_data, output_data, basis, covariance)
->>> algo.setOptimizationSolver(optimizer)
+>>> algo.setOptimizationBounds(bounds)
 "
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::MaximumLikelihoodFactory::setOptimizationBounds
+"Accessor to the optimization bounds.
+
+Parameters
+----------
+problem : :class:`~openturns.Interval`
+    The bounds used for numerical optimization of the likelihood."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::MaximumLikelihoodFactory::getOptimizationBounds
+"Accessor to the optimization bounds.
+
+Returns
+-------
+problem : :class:`~openturns.Interval`
+    The bounds used for numerical optimization of the likelihood."
 
 // ---------------------------------------------------------------------
 

--- a/python/src/MaximumLikelihoodFactory_doc.i.in
+++ b/python/src/MaximumLikelihoodFactory_doc.i.in
@@ -46,23 +46,33 @@ solver : :class:`~openturns.OptimizationSolver`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::MaximumLikelihoodFactory::setOptimizationProblem
-"Accessor to the problem.
+%feature("docstring") OT::MaximumLikelihoodFactory::setOptimizationBounds
+"Accessor to the optimization bounds.
 
 Parameters
 ----------
-problem : :class:`~openturns.OptimizationProblem`
-    The problem used for numerical optimization of the likelihood."
+problem : :class:`~openturns.Interval`
+    The bounds used for numerical optimization of the likelihood."
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::MaximumLikelihoodFactory::getOptimizationProblem
-"Accessor to the problem.
+%feature("docstring") OT::MaximumLikelihoodFactory::getOptimizationBounds
+"Accessor to the optimization bounds.
 
 Returns
 -------
-problem : :class:`~openturns.OptimizationProblem`
-    The problem used for numerical optimization of the likelihood."
+problem : :class:`~openturns.Interval`
+    The bounds used for numerical optimization of the likelihood."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::MaximumLikelihoodFactory::setOptimizationInequalityConstraint
+"Accessor to the optimization inequality constraint.
+
+Parameters
+----------
+inequalityConstraint : :class:`~openturns.NumericalMathFunction`
+    The inequality constraint used for numerical optimization of the likelihood."
 
 // ---------------------------------------------------------------------
 

--- a/python/src/MultiStart_doc.i.in
+++ b/python/src/MultiStart_doc.i.in
@@ -23,8 +23,7 @@ Examples
 >>> dim = 2
 >>> model = ot.AnalyticalFunction(['x', 'y'], ['x^2+y^2*(1-x)^3'])
 >>> bounds = ot.Interval([-3.0] * dim, [3.0] * dim)
->>> problem = ot.OptimizationProblem()
->>> problem.setObjective(model)
+>>> problem = ot.OptimizationProblem(model)
 >>> problem.setBounds(bounds)
 >>> solver = ot.TNC(problem)
 >>> startingPoints = ot.Normal(dim).getSample(3)

--- a/python/src/OptimizationProblemImplementation_doc.i.in
+++ b/python/src/OptimizationProblemImplementation_doc.i.in
@@ -3,6 +3,8 @@
 
 Available constructors:
     OptimizationProblem()
+    
+    OptimizationProblem(*objective*)
 
     OptimizationProblem(*objective, equality, inequality, bounds*)
 
@@ -51,8 +53,7 @@ Define an optimization problem to find the minimum of the Rosenbrock function:
 
 >>> import openturns as ot
 >>> rosenbrock = ot.AnalyticalFunction(['x1', 'x2'], ['(1-x1)^2+100*(x2-x1^2)^2'])
->>> problem = ot.OptimizationProblem()
->>> problem.setObjective(rosenbrock)
+>>> problem = ot.OptimizationProblem(rosenbrock)
 
 Define an optimization problem to find the point with minimum norm which satisfies :math:`x1+2*x2-3*x3+4*x4=3`.
 

--- a/python/src/OptimizationProblemImplementation_doc.i.in
+++ b/python/src/OptimizationProblemImplementation_doc.i.in
@@ -11,7 +11,8 @@ Available constructors:
 Parameters
 ----------
 objective : :class:`~openturns.NumericalMathFunction`
-    Objective function.
+    Objective function. Additional constraints and bounds must always be
+    consistent with the objective input dimension.
 equality : :class:`~openturns.NumericalMathFunction`
     Equality constraints.
 inequality : :class:`~openturns.NumericalMathFunction`
@@ -356,8 +357,12 @@ OT_OptimizationProblem_setMinimization_doc
 Parameters
 ----------
 objectiveFunction : :class:`~openturns.NumericalMathFunction`
-    Objective function."
+    Objective function.
 
+Notes
+-----
+Constraints and bounds are cleared if the objective has a different input
+dimension in order to keep the problem valid at all time."
 %enddef
 
 %feature("docstring") OT::OptimizationProblemImplementation::setObjective

--- a/python/src/OptimizationSolverImplementation_doc.i.in
+++ b/python/src/OptimizationSolverImplementation_doc.i.in
@@ -25,8 +25,7 @@ Define an optimization problem to find the minimum of the Rosenbrock function:
 
 >>> import openturns as ot
 >>> rosenbrock = ot.AnalyticalFunction(['x1', 'x2'], ['(1-x1)^2+100*(x2-x1^2)^2'])
->>> problem = ot.OptimizationProblem()
->>> problem.setObjective(rosenbrock)
+>>> problem = ot.OptimizationProblem(rosenbrock)
 >>> solver = ot.OptimizationSolver(problem)
 >>> solver.setStartingPoint([0, 0])
 >>> solver.setMaximumResidualError(1.e-3)

--- a/python/test/t_MultiStart_std.py
+++ b/python/test/t_MultiStart_std.py
@@ -11,8 +11,7 @@ dim = 2
 model = ot.NumericalMathFunction(['x', 'y'], ['z'],
     ['3*(1-x)^2*exp(-x^2-(y+1)^2)-10*(x/5-x^3-y^5)*exp(-x^2-y^2)-exp(-(x+1)^2-y^2)/3'])
 bounds = ot.Interval([-3.0] * dim, [3.0] * dim)
-problem = ot.OptimizationProblem()
-problem.setObjective(model)
+problem = ot.OptimizationProblem(model)
 problem.setBounds(bounds)
 
 # solver

--- a/python/test/t_TNC_std.py
+++ b/python/test/t_TNC_std.py
@@ -30,8 +30,7 @@ bounds = ot.Interval(ot.NumericalPoint(4, -3.0), ot.NumericalPoint(4, 5.0))
 algo = ot.TNC()
 algo.setStartingPoint(startingPoint)
 
-problem = ot.OptimizationProblem()
-problem.setObjective(levelFunction)
+problem = ot.OptimizationProblem(levelFunction)
 problem.setBounds(bounds)
 problem.setMinimization(True)
 
@@ -69,8 +68,7 @@ startingPointNearMaximizationCorner[3] = 4.5
 bounds = ot.Interval(ot.NumericalPoint(4, -3.0), ot.NumericalPoint(4, 5.0))
 
 algo = ot.TNC()
-problem = ot.OptimizationProblem()
-problem.setObjective(levelFunction)
+problem = ot.OptimizationProblem(levelFunction)
 problem.setBounds(bounds)
 
 problem.setMinimization(True)

--- a/python/test/t_TNC_std.py
+++ b/python/test/t_TNC_std.py
@@ -31,8 +31,8 @@ algo = ot.TNC()
 algo.setStartingPoint(startingPoint)
 
 problem = ot.OptimizationProblem()
-problem.setBounds(bounds)
 problem.setObjective(levelFunction)
+problem.setBounds(bounds)
 problem.setMinimization(True)
 
 algo.setProblem(problem)
@@ -70,8 +70,8 @@ bounds = ot.Interval(ot.NumericalPoint(4, -3.0), ot.NumericalPoint(4, 5.0))
 
 algo = ot.TNC()
 problem = ot.OptimizationProblem()
-problem.setBounds(bounds)
 problem.setObjective(levelFunction)
+problem.setBounds(bounds)
 
 problem.setMinimization(True)
 algo.setProblem(problem)


### PR DESCRIPTION
Bounds and constraints have always the dimension of the objective.
They are cleared when the objective is set with a different input dimension.
So, we cannot use an OptimizationProblem to pass a partial problem to (eg GLM), so add accessors to set bounds etc.
Fixes http://trac.openturns.org/ticket/875