### PR TITLE
Viewer fixes

### DIFF
--- a/python/doc/sphinxext/execforresourcemap_directive.py
+++ b/python/doc/sphinxext/execforresourcemap_directive.py
@@ -3,11 +3,7 @@ from os.path import basename
 import openturns as ot
 
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
+from io import StringIO
 from sphinx.util.compat import Directive
 from docutils import nodes, statemachine
 

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -89,7 +89,7 @@ from .uncertainty import *
 from .coupling_tools import *
 
 
-def Show(graph, block=False):
+def Show(graph):
     """
     Display a graph pop-up.
 

--- a/python/src/viewer.py
+++ b/python/src/viewer.py
@@ -561,16 +561,13 @@ def ToSVGString(graph):
 
     Returns a SVG representation as string
     """
-    if sys.version_info[0] >= 3:
-        output = io.StringIO()
-    else:
-        output = io.BytesIO()
 
     # save interactive mode state
     ision = plt.isinteractive()
     plt.ioff()
 
     view = View(graph)
+    output = io.BytesIO()
     view.save(output, format='svg')
     view.close()
 
@@ -578,7 +575,8 @@ def ToSVGString(graph):
     if ision:
         plt.ion()
 
-    return output.getvalue()
+    svgBytes = output.getvalue()
+    return svgBytes.decode('utf-8')
 
 
 

--- a/python/src/viewer.py
+++ b/python/src/viewer.py
@@ -10,7 +10,7 @@ Examples
 >>> graph = ot.Normal().drawPDF()
 >>> view = View(graph, plot_kwargs={'color':'blue'})
 >>> view.save('curve.png', dpi=100)
->>> view.show(block=False)
+>>> view.show()
 """
 import openturns as ot
 import numpy as np
@@ -503,17 +503,15 @@ class View(object):
 
     def show(self, **kwargs):
         """
-        Display the graph on screen.
+        Display the graph.
 
-        Parameters
-        ----------
-        kwargs:
-            block: bool, optional
-                If true (default), block until the graph is closed.
-
-            These parameters are passed to matplotlib.pyplot.show()
+        See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure.show
         """
-        plt.show(**kwargs)
+        if hasattr(self._fig, 'show'):
+            self._fig.show(**kwargs)
+        else:
+            # mpl < 1.3.1, see https://github.com/ipython/ipython/pull/1615
+            plt.show(**kwargs)
 
     def save(self, fname, **kwargs):
         """

--- a/python/test/t_Viewer.py
+++ b/python/test/t_Viewer.py
@@ -8,6 +8,7 @@ try:
     # use non-interactive backend
     import matplotlib
     matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
 
     from openturns.viewer import View
     import openturns as ot
@@ -17,14 +18,14 @@ try:
     # graph.draw('curve1.png')
     view = View(graph, pixelsize=(800, 600), plot_kwargs={'color': 'blue'})
     # view.save('curve1.png')
-    view.show(block=False)
+    view.show()
 
     # Contour
     graph = ot.Normal([1, 2], [3, 5], ot.CorrelationMatrix(2)).drawPDF()
     # graph.draw('curve2.png')
     view = View(graph)
     # view.save('curve2.png')
-    view.show(block=False)
+    view.show()
 
     # Histogram tests
     normal = ot.Normal(1)
@@ -34,7 +35,7 @@ try:
     # graph.draw('curve3.png')
     view = View(graph)
     # view.save('curve3.png')
-    view.show(block=False)
+    view.show()
 
     # QQPlot tests
     size = 100
@@ -45,7 +46,7 @@ try:
     # graph.draw('curve4.png')
     view = View(graph)
     # view.save('curve4.png')
-    view.show()
+    plt.show(block=True)
 
     # Clouds tests
     dimension = (2)
@@ -65,7 +66,7 @@ try:
     # graph.draw('curve5.png')
     view = View(graph)
     # view.save('curve5.png')
-    view.show(block=False)
+    view.show()
 
     # Text
     graph = ot.Graph('Annotated cloud', 'x', 'y', True, '')
@@ -100,7 +101,7 @@ try:
 
     graph.add(text)
     view = View(graph)
-    view.show(block=False)
+    view.show()
 
     # CobWeb tests
     size = 100
@@ -119,7 +120,7 @@ try:
     # graph.draw('curve6.png')
     view = View(graph, legend_kwargs={'loc': 'lower center'})
     # view.save('curve6.png')
-    view.show(block=False)
+    view.show()
 
     # Staircase
     distribution = ot.Poisson(10.0)
@@ -127,7 +128,7 @@ try:
     # graph.draw('curve7.png')
     view = View(graph)
     # view.save('curve7.png')
-    view.show(block=False)
+    view.show()
 
     # Pie
     graph = ot.SobolIndicesAlgorithmImplementation.DrawImportanceFactors(
@@ -135,7 +136,7 @@ try:
     # graph.draw('curve8.png')
     view = View(graph)
     # view.save('curve8.png')
-    view.show()
+    plt.show(block=True)
 
     # Pairs
     dim = 5
@@ -155,7 +156,7 @@ try:
     # graph.draw('curve9.png')
     view = View(graph)
     # view.save('curve9.png')
-    view.show(block=False)
+    view.show()
 
     # Convergence graph curve
     aCollection = []
@@ -175,7 +176,7 @@ try:
     # graph.draw('curve10.png')
     view = View(graph)
     # view.save('curve10.png')
-    view.show(block=False)
+    view.show()
 
     # Polygon
     size = 50
@@ -201,7 +202,7 @@ try:
     # graph.draw('curve11.png')
     view = View(graph)
     # view.save('curve11.png')
-    view.show(block=False)
+    view.show()
 
     # PolygonArray
     generator = ot.Normal(2)
@@ -217,7 +218,7 @@ try:
     # graph.draw('curve12.png')
     view = View(graph)
     # view.save('curve12.png')
-    view.show()
+    plt.show(block=True)
 
 except:
     traceback.print_exc()


### PR DESCRIPTION
- A fix for svg file bytes conversion to unicode string for html when rendering a graph inside notebook
- View.show to show only current graph, not all queued plots (not available in matplotlib < 1.3.1)
side effect: the block keyword is removed -> use pyplot api for blocking show all in non-interactive mode
