### PR TITLE
More coherant KrigingAlgorithm constructors 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,8 @@
   * Deprecated NumericalMathFunction::GetValidConstants|GetValidFunctions|GetValidOperators
   * Renamed ComposedNumericalMathFunction to ComposedFunction
   * Renamed LinearNumericalMathFunction to LinearFunction
+  * Swap covModel and basis arguments in KrigingAlgorithm constructors
+  * Removed useless keepCholesky argument in KrigingAlgorithm constructors
 
 === Python module ===
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
@@ -47,7 +47,6 @@ KrigingAlgorithm::KrigingAlgorithm()
   , gamma_(0)
   , rho_(0)
   , result_()
-  , keepCholeskyFactor_(true)
   , covarianceCholeskyFactor_()
   , covarianceCholeskyFactorHMatrix_()
 {
@@ -58,10 +57,9 @@ KrigingAlgorithm::KrigingAlgorithm()
 /* Constructor */
 KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
                                    const NumericalSample & outputSample,
-                                   const Basis & basis,
                                    const CovarianceModel & covarianceModel,
-                                   const Bool normalize,
-                                   const Bool keepCholeskyFactor)
+                                   const Basis & basis,
+                                   const Bool normalize)
   : MetaModelAlgorithm()
   , inputSample_(inputSample)
   , outputSample_(outputSample)
@@ -71,7 +69,6 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
   , gamma_(0)
   , rho_(0)
   , result_()
-  , keepCholeskyFactor_(keepCholeskyFactor)
   , covarianceCholeskyFactor_()
   , covarianceCholeskyFactorHMatrix_()
 {
@@ -85,10 +82,9 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
 /* Constructor */
 KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
                                    const NumericalSample & outputSample,
-                                   const BasisCollection & basis,
                                    const CovarianceModel & covarianceModel,
-                                   const Bool normalize,
-                                   const Bool keepCholeskyFactor)
+                                   const BasisCollection & basisCollection,
+                                   const Bool normalize)
   : MetaModelAlgorithm()
   , inputSample_(inputSample)
   , outputSample_(outputSample)
@@ -98,13 +94,12 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
   , gamma_(0)
   , rho_(0)
   , result_()
-  , keepCholeskyFactor_(keepCholeskyFactor)
   , covarianceCholeskyFactor_()
   , covarianceCholeskyFactorHMatrix_()
 {
   // Here we must force the GLMAlgo to keep the Cholesky factor as it is mandatory
   // for the interpolation part
-  glmAlgo_ = GeneralizedLinearModelAlgorithm(inputSample, outputSample, covarianceModel, basis, normalize, true);
+  glmAlgo_ = GeneralizedLinearModelAlgorithm(inputSample, outputSample, covarianceModel, basisCollection, normalize, true);
   if (ResourceMap::Get("KrigingAlgorithm-LinearAlgebra") == "HMAT") glmAlgo_.setMethod(1);
 }
 
@@ -112,9 +107,8 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
 KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
                                    const NumericalMathFunction & inputTransformation,
                                    const NumericalSample & outputSample,
-                                   const Basis & basis,
                                    const CovarianceModel & covarianceModel,
-                                   const Bool keepCholeskyFactor)
+                                   const Basis & basis)
   : MetaModelAlgorithm()
   , inputSample_(inputSample)
   , outputSample_(outputSample)
@@ -123,7 +117,6 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
   , gamma_(0)
   , rho_(0)
   , result_()
-  , keepCholeskyFactor_(keepCholeskyFactor)
   , covarianceCholeskyFactor_()
   , covarianceCholeskyFactorHMatrix_()
 {
@@ -137,9 +130,8 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
 KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
                                    const NumericalMathFunction & inputTransformation,
                                    const NumericalSample & outputSample,
-                                   const BasisCollection & basis,
                                    const CovarianceModel & covarianceModel,
-                                   const Bool keepCholeskyFactor)
+                                   const BasisCollection & basisCollection)
   : MetaModelAlgorithm()
   , inputSample_(inputSample)
   , outputSample_(outputSample)
@@ -149,13 +141,12 @@ KrigingAlgorithm::KrigingAlgorithm(const NumericalSample & inputSample,
   , gamma_(0)
   , rho_(0)
   , result_()
-  , keepCholeskyFactor_(keepCholeskyFactor)
   , covarianceCholeskyFactor_()
   , covarianceCholeskyFactorHMatrix_()
 {
   // Here we must force the GLMAlgo to keep the Cholesky factor as it is mandatory
   // for the interpolation part
-  glmAlgo_ = GeneralizedLinearModelAlgorithm(inputSample, inputTransformation, outputSample, covarianceModel, basis, true);
+  glmAlgo_ = GeneralizedLinearModelAlgorithm(inputSample, inputTransformation, outputSample, covarianceModel, basisCollection, true);
   if (ResourceMap::Get("KrigingAlgorithm-LinearAlgebra") == "HMAT") glmAlgo_.setMethod(1);
 }
 
@@ -230,10 +221,7 @@ void KrigingAlgorithm::run()
     residuals[outputIndex] = sqrt(squaredResiduals[outputIndex] / size);
     relativeErrors[outputIndex] = squaredResiduals[outputIndex] / outputVariance[outputIndex];
   }
-  if (keepCholeskyFactor_)
-    result_ = KrigingResult(inputSample_, outputSample_, metaModel, residuals, relativeErrors, basis, trendCoefficients, conditionalCovarianceModel, covarianceCoefficients, covarianceCholeskyFactor_, covarianceCholeskyFactorHMatrix_);
-  else
-    result_ = KrigingResult(inputSample_, outputSample_, metaModel, residuals, relativeErrors, basis, trendCoefficients, conditionalCovarianceModel, covarianceCoefficients);
+  result_ = KrigingResult(inputSample_, outputSample_, metaModel, residuals, relativeErrors, basis, trendCoefficients, conditionalCovarianceModel, covarianceCoefficients, covarianceCholeskyFactor_, covarianceCholeskyFactorHMatrix_);
   // If normalize, set input transformation
   if (normalize_)
   {
@@ -326,7 +314,6 @@ void KrigingAlgorithm::save(Advocate & adv) const
   adv.saveAttribute( "outputSample_", outputSample_ );
   adv.saveAttribute( "covarianceModel_", covarianceModel_ );
   adv.saveAttribute( "result_", result_ );
-  adv.saveAttribute( "keepCholeskyFactor_", keepCholeskyFactor_ );
   adv.saveAttribute( "covarianceCholeskyFactor_", covarianceCholeskyFactor_ );
 }
 
@@ -340,7 +327,6 @@ void KrigingAlgorithm::load(Advocate & adv)
   adv.loadAttribute( "outputSample_", outputSample_ );
   adv.loadAttribute( "covarianceModel_", covarianceModel_ );
   adv.loadAttribute( "result_", result_ );
-  adv.loadAttribute( "keepCholeskyFactor_", keepCholeskyFactor_ );
   adv.loadAttribute( "covarianceCholeskyFactor_", covarianceCholeskyFactor_ );
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingAlgorithm.hxx
@@ -53,34 +53,30 @@ public:
   /** Constructor */
   KrigingAlgorithm (const NumericalSample & inputSample,
                     const NumericalSample & outputSample,
-                    const Basis & basis,
                     const CovarianceModel & covarianceModel,
-                    const Bool normalize = true,
-                    const Bool keepCholeskyFactor = true);
+                    const Basis & basis,
+                    const Bool normalize = true);
 
   /** Constructor */
   KrigingAlgorithm (const NumericalSample & inputSample,
                     const NumericalMathFunction & inputTransformation,
                     const NumericalSample & outputSample,
-                    const Basis & basis,
                     const CovarianceModel & covarianceModel,
-                    const Bool keepCholeskyFactor = true);
+                    const Basis & basis);
 
   /** Constructor */
   KrigingAlgorithm (const NumericalSample & inputSample,
                     const NumericalSample & outputSample,
-                    const BasisCollection & multivariateBasis,
                     const CovarianceModel & covarianceModel,
-                    const Bool normalize = true,
-                    const Bool keepCholeskyFactor = true);
+                    const BasisCollection & basisCollection,
+                    const Bool normalize = true);
 
   /** Constructor */
   KrigingAlgorithm (const NumericalSample & inputSample,
                     const NumericalMathFunction & inputTransformation,
                     const NumericalSample & outputSample,
-                    const BasisCollection & multivariateBasis,
                     const CovarianceModel & covarianceModel,
-                    const Bool keepCholeskyFactor = true);
+                    const BasisCollection & basisCollection);
 
   /** Virtual constructor */
   KrigingAlgorithm * clone() const;
@@ -112,7 +108,7 @@ public:
   /** Optimization flag accessor */
   Bool getOptimizeParameters() const;
   void setOptimizeParameters(const Bool optimizeParameters);
-  
+
   /** Observation noise accessor */
   void setNoise(const NumericalPoint & noise);
   NumericalPoint getNoise() const;
@@ -149,9 +145,6 @@ private:
 
   /** Result */
   KrigingResult result_;
-
-  /** Bool for keeping or not covariance factor */
-  Bool keepCholeskyFactor_;
 
   /** Cholesky factor ==>  TriangularMatrix */
   mutable TriangularMatrix covarianceCholeskyFactor_;

--- a/lib/src/Uncertainty/Distribution/RiceFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/RiceFactory.cxx
@@ -118,7 +118,7 @@ Rice RiceFactory::buildAsRice(const NumericalSample & sample) const
     if (fA * fB <= 0.0) break;
     b = 2.0 * b;
     fB = f(NumericalPoint(1, b))[0];
-    LOGINFO(OSS() << "a=" << a << ", fa=" << fA << ", b=" << b << ", fb=" << fB);
+    LOGDEBUG(OSS() << "a=" << a << ", fa=" << fA << ", b=" << b << ", fb=" << fB);
     ++iteration;
   }
   if ((std::abs(fA) > largeValue) || (std::abs(fB) > largeValue) || (std::abs(b) > largeValue) || (iteration == maximumIteration)) throw InvalidArgumentException(HERE) << "Error: cannot estimate parameters of a Rice distribution from the given sample";

--- a/lib/test/t_BasisFactory_std.cxx
+++ b/lib/test/t_BasisFactory_std.cxx
@@ -1,6 +1,6 @@
 //                                               -*- C++ -*-
 /**
- *  @brief The test file of KrigingAlgorithm class
+ *  @brief The test file of BasisFactory class
  *
  *  Copyright 2005-2017 Airbus-EDF-IMACS-Phimeca
  *

--- a/lib/test/t_ConditionedNormalProcess_std.cxx
+++ b/lib/test/t_ConditionedNormalProcess_std.cxx
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 
   // Kriring algorithm
   std::cerr << "before algo" << std::endl;
-  KrigingAlgorithm algo(inputSample, outputSample, basis, covarianceModel, true, true);
+  KrigingAlgorithm algo(inputSample, outputSample, covarianceModel, basis, true);
   std::cerr << "before run" << std::endl;
   algo.run();
   std::cerr << "run ok" << std::endl;

--- a/lib/test/t_KrigingAlgorithm_std.cxx
+++ b/lib/test/t_KrigingAlgorithm_std.cxx
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 
       Basis basis(ConstantBasisFactory(dimension).build());
       SquaredExponential covarianceModel(NumericalPoint(1, 1e-05), NumericalPoint(1, 4.11749));
-      KrigingAlgorithm algo(X, Y, basis, covarianceModel);
+      KrigingAlgorithm algo(X, Y, covarianceModel, basis);
 
       algo.run();
 
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
       NumericalPoint amplitude(1,  8.05);
       SquaredExponential covarianceModel(scale, amplitude);
 
-      KrigingAlgorithm algo(X, Y, basis, covarianceModel);
+      KrigingAlgorithm algo(X, Y, covarianceModel, basis);
       algo.run();
 
       // perform an evaluation

--- a/lib/test/t_KrigingAlgorithm_std_hmat.cxx
+++ b/lib/test/t_KrigingAlgorithm_std_hmat.cxx
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 
       Basis basis(ConstantBasisFactory(dimension).build());
       SquaredExponential covarianceModel(NumericalPoint(1, 1e-05), NumericalPoint(1, 4.11749));
-      KrigingAlgorithm algo(X, Y, basis, covarianceModel);
+      KrigingAlgorithm algo(X, Y, covarianceModel, basis);
 
       algo.run();
 
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
       NumericalPoint amplitude(1,  8.05);
       SquaredExponential covarianceModel(scale, amplitude);
 
-      KrigingAlgorithm algo(X, Y, basis, covarianceModel);
+      KrigingAlgorithm algo(X, Y, covarianceModel, basis);
       algo.run();
 
       // perform an evaluation

--- a/lib/test/t_KrigingRandomVector_std.cxx
+++ b/lib/test/t_KrigingRandomVector_std.cxx
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     Basis basis(ConstantBasisFactory(2).build());
 
     // Kriring algorithm
-    KrigingAlgorithm algo(inputSample, outputSample, basis, covarianceModel);
+    KrigingAlgorithm algo(inputSample, outputSample, covarianceModel, basis);
     algo.run();
 
     // Get result

--- a/lib/test/t_MetaModelValidation_std.cxx
+++ b/lib/test/t_MetaModelValidation_std.cxx
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     CovarianceModel covarianceModel = GeneralizedExponential(scale, amplitude, 2.0);
 
 
-    KrigingAlgorithm algo2(inputSample, outputSample, basis, covarianceModel, true, true);
+    KrigingAlgorithm algo2(inputSample, outputSample, covarianceModel, basis, true);
     algo2.setOptimizeParameters(false);
     algo2.run();
 

--- a/python/src/ConditionedNormalProcess_doc.i.in
+++ b/python/src/ConditionedNormalProcess_doc.i.in
@@ -53,7 +53,7 @@ Examples
 >>> # Basis definition
 >>> basis = ot.ConstantBasisFactory(spatialDimension).build()
 >>> # Kriring algorithm
->>> algo = ot.KrigingAlgorithm(inputSample, outputSample, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 >>> algo.run()
 >>> result = algo.getResult()
 >>> vertices = [[1.0, 0.0], [2.0, 0.0], [2.0, 1.0], [1.0, 1.0], [1.5, 0.5]]
@@ -90,7 +90,7 @@ Examples
 >>> # Basis definition
 >>> basis = ot.ConstantBasisFactory(spatialDimension).build()
 >>> # Kriring algorithm
->>> algo = ot.KrigingAlgorithm(inputSample, outputSample, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 >>> algo.run()
 >>> result = algo.getResult()
 >>> vertices = [[1.0, 0.0], [2.0, 0.0], [2.0, 1.0],[1.0, 1.0], [1.5, 0.5]]

--- a/python/src/KrigingAlgorithm_doc.i.in
+++ b/python/src/KrigingAlgorithm_doc.i.in
@@ -2,13 +2,13 @@
 "Kriging algorithm.
 
 Available constructors:
-    KrigingAlgorithm(*inputSample, outputSample, basis, covarianceModel, normalize=True, keepCovariance=True*)
+    KrigingAlgorithm(*inputSample, outputSample, covarianceModel, basis, normalize=True*)
 
-    KrigingAlgorithm(*inputSample, inputTransformation, outputSample, basis, covarianceModel, keepCovariance=True*)
+    KrigingAlgorithm(*inputSample, inputTransformation, outputSample, covarianceModel, basis*)
 
-    KrigingAlgorithm(*inputSample, outputSample, multivariateBasis, covarianceModel, normalize=True, keepCovariance=True*)
+    KrigingAlgorithm(*inputSample, outputSample, covarianceModel, basisCollection, normalize=True*)
 
-    KrigingAlgorithm(*inputSample, inputTransformation, outputSample, multivariateBasis, covarianceModel, keepCovariance=True*)
+    KrigingAlgorithm(*inputSample, inputTransformation, outputSample, covarianceModel, basisCollection*)
 
 Parameters
 ----------
@@ -22,19 +22,15 @@ basis : :class:`~openturns.Basis`
     Functional basis to estimate the trend (universal kriging): :math:`(\varphi_j)_{1 \leq j \leq n_1}: \Rset^d \rightarrow \Rset`.
 
     If :math:`p>1`, the same basis is used for each marginal output.
-multivariateBasis : sequence of :class:`~openturns.Basis`
-    Collection of :math:`p` functional basis: one basis for each marginal output: :math:`\left[(\varphi_j^1)_{1 \leq j \leq n_1}, \dots, (\varphi_j^p)_{1 \leq j \leq n_p}\right]`. If the sequence is empty, no trend coefficient is estimated (simple kriging).
 covarianceModel : :class:`~openturns.CovarianceModel`
     Covariance model used for the underlying Gaussian process assumption.
+basisCollection : sequence of :class:`~openturns.Basis`
+    Collection of :math:`p` functional basis: one basis for each marginal output: :math:`\left[(\varphi_j^1)_{1 \leq j \leq n_1}, \dots, (\varphi_j^p)_{1 \leq j \leq n_p}\right]`. If the sequence is empty, no trend coefficient is estimated (simple kriging).
 normalize : bool, optional
     Indicates whether the input sample has to be normalized.
 
     OpenTURNS uses the transformation fixed by the User in *inputTransformation* or the empirical mean and variance of the input sample.
     Default is set in resource map key `GeneralizedLinearModelAlgorithm-NormalizeData`
-keepCovariance : bool, optional
-    Indicates whether the covariance matrix has to be stored in the result structure *KrigingResult*.
-
-    Default is *True*.
 
 Notes
 -----
@@ -103,7 +99,7 @@ Create the algorithm:
 
 >>> basis = ot.ConstantBasisFactory().build()
 >>> covarianceModel = ot.SquaredExponential(1)
->>> algo = ot.KrigingAlgorithm(inputSample, outputSample, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 >>> algo.run()
 
 Get the resulting meta model:
@@ -146,7 +142,7 @@ Create the Kriging algorithm with the optimizer option:
 >>> thetaInit = 1.0
 >>> covariance = ot.GeneralizedExponential([thetaInit], 2.0)
 >>> bounds = ot.Interval(1e-2,1e2)
->>> algo = ot.KrigingAlgorithm(input_data, output_data, basis, covariance)
+>>> algo = ot.KrigingAlgorithm(input_data, output_data, covariance, basis)
 >>> algo.setOptimizationBounds(bounds)
 "
 
@@ -232,7 +228,7 @@ Create the algorithm:
 
 >>> basis = ot.ConstantBasisFactory().build()
 >>> covarianceModel = ot.SquaredExponential(1)
->>> algo = ot.KrigingAlgorithm(inputSample, outputSample, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 >>> algo.run()
 
 Get the reduced log-likelihood function:

--- a/python/src/KrigingRandomVector_doc.i.in
+++ b/python/src/KrigingRandomVector_doc.i.in
@@ -74,7 +74,7 @@ Examples
 >>> # create algorithm
 >>> basis = ot.ConstantBasisFactory(dimension).build()
 >>> covarianceModel = ot.SquaredExponential([2.23606797749979])
->>> algo = ot.KrigingAlgorithm(X, Y, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(X, Y, covarianceModel, basis)
 >>> algo.run()
 >>> # get the results
 >>> result = algo.getResult()
@@ -119,7 +119,7 @@ Examples
 >>> # create algorithm
 >>> basis = ot.ConstantBasisFactory(dimension).build()
 >>> covarianceModel = ot.SquaredExponential([2.23606797749979])
->>> algo = ot.KrigingAlgorithm(X, Y, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(X, Y, covarianceModel, basis)
 >>> algo.run()
 >>> # get the results
 >>> result = algo.getResult()
@@ -160,7 +160,7 @@ Examples
 >>> # create algorithm
 >>> basis = ot.ConstantBasisFactory(dimension).build()
 >>> covarianceModel = ot.SquaredExponential([2.23606797749979])
->>> algo = ot.KrigingAlgorithm(X, Y, basis, covarianceModel)
+>>> algo = ot.KrigingAlgorithm(X, Y, covarianceModel, basis)
 >>> algo.run()
 >>> # get the results
 >>> result = algo.getResult()

--- a/python/src/KrigingResult_doc.i.in
+++ b/python/src/KrigingResult_doc.i.in
@@ -85,7 +85,7 @@ Create the algorithm:
 
 >>> basis = ot.Basis([ot.SymbolicFunction(['x'], ['x']), ot.SymbolicFunction(['x'], ['x^2'])])
 >>> covarianceModel = ot.GeneralizedExponential([2.0], 2.0)
->>> algoKriging = ot.KrigingAlgorithm(sampleX, sampleY, basis, covarianceModel)
+>>> algoKriging = ot.KrigingAlgorithm(sampleX, sampleY, covarianceModel, basis)
 >>> algoKriging.run()
 
 Get the result:

--- a/python/test/t_ConditionedNormalProcess_std.py
+++ b/python/test/t_ConditionedNormalProcess_std.py
@@ -34,8 +34,8 @@ try:
         1, ot.ConstantBasisFactory(spatialDimension).build())
 
     # Kriring algorithm
-    algo = ot.KrigingAlgorithm(
-        inputSample, outputSample, basisCollection, covarianceModel)
+    algo = ot.KrigingAlgorithm(inputSample, outputSample,
+                               covarianceModel, basisCollection)
     algo.run()
     result = algo.getResult()
 

--- a/python/test/t_KrigingAlgorithm_std.py
+++ b/python/test/t_KrigingAlgorithm_std.py
@@ -29,7 +29,7 @@ Y2 = f(X2)
 basis = ConstantBasisFactory(dimension).build()
 covarianceModel = SquaredExponential([1e-05], [4.11749])
 
-algo = KrigingAlgorithm(X, Y, basis, covarianceModel)
+algo = KrigingAlgorithm(X, Y, covarianceModel, basis)
 algo.run()
 
 # perform an evaluation
@@ -83,7 +83,7 @@ basisCollection = BasisCollection(
 
 # Kriring algorithm
 algo = KrigingAlgorithm(inputSample, outputSample,
-                        basisCollection, covarianceModel)
+                        covarianceModel, basisCollection)
 algo.run()
 result = algo.getResult()
 # Get meta model

--- a/python/test/t_KrigingAlgorithm_std_hmat.py
+++ b/python/test/t_KrigingAlgorithm_std_hmat.py
@@ -32,7 +32,7 @@ Y2 = f(X2)
 basis = ConstantBasisFactory(dimension).build()
 covarianceModel = SquaredExponential([1e-05], [4.11749])
 
-algo = KrigingAlgorithm(X, Y, basis, covarianceModel)
+algo = KrigingAlgorithm(X, Y, covarianceModel, basis)
 
 algo.run()
 
@@ -86,8 +86,8 @@ basisCollection = BasisCollection(
     1, ConstantBasisFactory(spatialDimension).build())
 
 # Kriring algorithm
-algo = KrigingAlgorithm(
-    inputSample, outputSample, basisCollection, covarianceModel)
+algo = KrigingAlgorithm(inputSample, outputSample,
+                        covarianceModel, basisCollection)
 algo.run()
 result = algo.getResult()
 # Get meta model

--- a/python/test/t_KrigingRandomVector_std.py
+++ b/python/test/t_KrigingRandomVector_std.py
@@ -38,7 +38,7 @@ basisCollection = BasisCollection(
 
 # Kriring algorithm
 algo = KrigingAlgorithm(inputSample, outputSample,
-                        basisCollection, covarianceModel)
+                        covarianceModel, basisCollection)
 algo.run()
 result = algo.getResult()
 # Get meta model

--- a/python/test/t_MetaModelValidation_std.py
+++ b/python/test/t_MetaModelValidation_std.py
@@ -84,7 +84,7 @@ try:
     covarianceModel = ot.GeneralizedExponential(
         [1.933, 1.18, 1.644], [10.85], 2.0)
     algo2 = ot.KrigingAlgorithm(
-        inputSample, outputSample, basis, covarianceModel, True, True)
+        inputSample, outputSample, covarianceModel, basis, True)
     algo2.setOptimizeParameters(False);
     algo2.run()
     result2 = algo2.getResult()


### PR DESCRIPTION
Now KrigingAlgorithm constructors are coherant comparing to the GeneralizedLinearModel ones (data, covModel, basis). It is more coherant since the basis/basisCollection is an 'optionnal' argument

We remove also the useless keepCholesky argument in ctors
