### PR TITLE
Keep output sample out of LeastSquaresMethod

### DIFF
--- a/lib/src/Base/Algo/CholeskyMethod.cxx
+++ b/lib/src/Base/Algo/CholeskyMethod.cxx
@@ -44,10 +44,9 @@ CholeskyMethod::CholeskyMethod()
 
 /* Parameters constructor */
 CholeskyMethod::CholeskyMethod(const DesignProxy & proxy,
-                               const NumericalSample & outputSample,
                                const NumericalPoint & weight,
                                const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, weight, indices)
+  : LeastSquaresMethodImplementation(proxy, weight, indices)
   , l_(0)
 {
   // Nothing to do
@@ -56,9 +55,8 @@ CholeskyMethod::CholeskyMethod(const DesignProxy & proxy,
 
 /* Parameters constructor */
 CholeskyMethod::CholeskyMethod(const DesignProxy & proxy,
-                               const NumericalSample & outputSample,
                                const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, indices)
+  : LeastSquaresMethodImplementation(proxy, indices)
   , l_(0)
 {
   // Nothing to do

--- a/lib/src/Base/Algo/CorrectedLeaveOneOut.cxx
+++ b/lib/src/Base/Algo/CorrectedLeaveOneOut.cxx
@@ -68,10 +68,10 @@ NumericalScalar CorrectedLeaveOneOut::run(const NumericalSample & y,
   return FittingAlgorithmImplementation::run(y, weight, indices, proxy);
 }
 
-NumericalScalar CorrectedLeaveOneOut::run(LeastSquaresMethod & method) const
+NumericalScalar CorrectedLeaveOneOut::run(LeastSquaresMethod & method,
+                                          const NumericalSample & y) const
 {
   const NumericalSample x(method.getInputSample());
-  const NumericalSample y(method.getOutputSample());
 
   const UnsignedInteger sampleSize = y.getSize();
 

--- a/lib/src/Base/Algo/FittingAlgorithm.cxx
+++ b/lib/src/Base/Algo/FittingAlgorithm.cxx
@@ -85,8 +85,9 @@ NumericalScalar FittingAlgorithm::run(const NumericalSample & y,
   return getImplementation()->run(y, weight, indices, proxy);
 }
 
-NumericalScalar FittingAlgorithm::run(LeastSquaresMethod & method) const
+NumericalScalar FittingAlgorithm::run(LeastSquaresMethod & method,
+                                      const NumericalSample & y) const
 {
-  return getImplementation()->run(method);
+  return getImplementation()->run(method, y);
 }
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
@@ -67,19 +67,19 @@ NumericalScalar FittingAlgorithmImplementation::run(const NumericalSample & y,
     const Indices & indices,
     const DesignProxy & proxy) const
 {
-  LeastSquaresMethod method(proxy, y, weight, indices);
-  return run(method);
+  LeastSquaresMethod method(proxy, weight, indices);
+  return run(method, y);
 }
 
 NumericalScalar FittingAlgorithmImplementation::run(const NumericalSample & y,
     const Indices & indices,
     const DesignProxy & proxy) const
 {
-  LeastSquaresMethod method(proxy, y, indices);
-  return run(method);
+  LeastSquaresMethod method(proxy, indices);
+  return run(method, y);
 }
 
-NumericalScalar FittingAlgorithmImplementation::run(LeastSquaresMethod & method) const
+NumericalScalar FittingAlgorithmImplementation::run(LeastSquaresMethod & method, const NumericalSample & y) const
 {
   throw NotYetImplementedException(HERE);
 }

--- a/lib/src/Base/Algo/KFold.cxx
+++ b/lib/src/Base/Algo/KFold.cxx
@@ -71,10 +71,10 @@ NumericalScalar KFold::run(const NumericalSample & y,
   return FittingAlgorithmImplementation::run(y, weight, indices, proxy);
 }
 
-NumericalScalar KFold::run(LeastSquaresMethod & method) const
+NumericalScalar KFold::run(LeastSquaresMethod & method,
+                          const NumericalSample & y) const
 {
   const NumericalSample x(method.getInputSample());
-  const NumericalSample y(method.getOutputSample());
   const Basis basis(method.getBasis());
 
   const UnsignedInteger sampleSize = x.getSize();

--- a/lib/src/Base/Algo/LeastSquaresMethod.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMethod.cxx
@@ -38,19 +38,17 @@ LeastSquaresMethod::LeastSquaresMethod()
 
 /* Parameters constructor */
 LeastSquaresMethod::LeastSquaresMethod (const DesignProxy & proxy,
-                                        const NumericalSample & outputSample,
                                         const NumericalPoint & weight,
                                         const Indices & indices)
-  : TypedInterfaceObject<LeastSquaresMethodImplementation>(new SVDMethod(proxy, outputSample, weight, indices))
+  : TypedInterfaceObject<LeastSquaresMethodImplementation>(new SVDMethod(proxy, weight, indices))
 {
   // Nothing to do
 }
 
 /* Parameters constructor */
 LeastSquaresMethod::LeastSquaresMethod (const DesignProxy & proxy,
-                                        const NumericalSample & outputSample,
                                         const Indices & indices)
-  : TypedInterfaceObject<LeastSquaresMethodImplementation>(new SVDMethod(proxy, outputSample, indices))
+  : TypedInterfaceObject<LeastSquaresMethodImplementation>(new SVDMethod(proxy, indices))
 {
   // Nothing to do
 }
@@ -136,11 +134,6 @@ Indices LeastSquaresMethod::getInitialIndices() const
 NumericalSample LeastSquaresMethod::getInputSample() const
 {
   return getImplementation()->getInputSample();
-}
-
-NumericalSample LeastSquaresMethod::getOutputSample() const
-{
-  return getImplementation()->getOutputSample();
 }
 
 NumericalPoint LeastSquaresMethod::getWeight() const

--- a/lib/src/Base/Algo/LeastSquaresMethodImplementation.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMethodImplementation.cxx
@@ -37,19 +37,17 @@ LeastSquaresMethodImplementation::LeastSquaresMethodImplementation()
 
 /* Parameters constructor */
 LeastSquaresMethodImplementation::LeastSquaresMethodImplementation(const DesignProxy & proxy,
-    const NumericalSample & outputSample,
     const NumericalPoint & weight,
     const Indices & indices)
   : PersistentObject()
   , proxy_(proxy)
-  , outputSample_(outputSample)
   , weight_(0)
   , weightSqrt_(0)
   , hasUniformWeight_(false)
   , currentIndices_(indices)
   , initialIndices_(indices)
 {
-  const UnsignedInteger size = outputSample.getSize();
+  const UnsignedInteger size = proxy.getInputSample().getSize();
   if (size == 0) throw InvalidArgumentException(HERE) << "Error: expected a non-empty output sample";
   // Check the argument compatibility
   if (proxy.getInputSample().getSize() != size) throw InvalidArgumentException(HERE) << "Error: the size of the output sample=" << size << " is different from the size of the input sample=" << proxy.getInputSample().getSize();
@@ -60,21 +58,17 @@ LeastSquaresMethodImplementation::LeastSquaresMethodImplementation(const DesignP
 
 /* Parameters constructor */
 LeastSquaresMethodImplementation::LeastSquaresMethodImplementation(const DesignProxy & proxy,
-    const NumericalSample & outputSample,
     const Indices & indices)
   : PersistentObject()
   , proxy_(proxy)
-  , outputSample_(outputSample)
   , weight_(1, 1.0)
   , weightSqrt_(1, 1.0)
   , hasUniformWeight_(true)
   , currentIndices_(indices)
   , initialIndices_(indices)
 {
-  const UnsignedInteger size = outputSample.getSize();
+  const UnsignedInteger size = proxy.getInputSample().getSize();
   if (size == 0) throw InvalidArgumentException(HERE) << "Error: expected a non-empty output sample";
-  // Check the argument compatibility
-  if (proxy.getInputSample().getSize() != size) throw InvalidArgumentException(HERE) << "Error: the size of the output sample=" << size << " is different from the size of the input sample=" << proxy.getInputSample().getSize();
 }
 
 /* Weight accessor */
@@ -174,7 +168,6 @@ String LeastSquaresMethodImplementation::__repr__() const
 {
   return OSS() << "class=" << GetClassName()
          << ", proxy=" << proxy_
-         << ", outputSample=" << outputSample_
          << ", weight=" << weight_
          << ", weightSqrt=" << weightSqrt_
          << ", hasUniformWeight=" << hasUniformWeight_
@@ -201,12 +194,6 @@ NumericalSample LeastSquaresMethodImplementation::getInputSample() const
 {
   return proxy_.getInputSample();
 }
-
-NumericalSample LeastSquaresMethodImplementation::getOutputSample() const
-{
-  return outputSample_;
-}
-
 
 MatrixImplementation LeastSquaresMethodImplementation::computeWeightedDesign(const Bool whole) const
 {

--- a/lib/src/Base/Algo/QRMethod.cxx
+++ b/lib/src/Base/Algo/QRMethod.cxx
@@ -42,19 +42,17 @@ QRMethod::QRMethod()
 
 /* Parameters constructor */
 QRMethod::QRMethod(const DesignProxy & proxy,
-                   const NumericalSample & outputSample,
                    const NumericalPoint & weight,
                    const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, weight, indices)
+  : LeastSquaresMethodImplementation(proxy, weight, indices)
 {
   // Nothing to do
 }
 
 /* Parameters constructor */
 QRMethod::QRMethod(const DesignProxy & proxy,
-                   const NumericalSample & outputSample,
                    const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, indices)
+  : LeastSquaresMethodImplementation(proxy, indices)
 {
   // Nothing to do
 }

--- a/lib/src/Base/Algo/SVDMethod.cxx
+++ b/lib/src/Base/Algo/SVDMethod.cxx
@@ -43,10 +43,9 @@ SVDMethod::SVDMethod()
 
 /* Default constructor */
 SVDMethod::SVDMethod(const DesignProxy & proxy,
-                     const NumericalSample & outputSample,
                      const NumericalPoint & weight,
                      const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, weight, indices)
+  : LeastSquaresMethodImplementation(proxy, weight, indices)
 {
   // Nothing to do
 }
@@ -54,9 +53,8 @@ SVDMethod::SVDMethod(const DesignProxy & proxy,
 
 /* Default constructor */
 SVDMethod::SVDMethod(const DesignProxy & proxy,
-                     const NumericalSample & outputSample,
                      const Indices & indices)
-  : LeastSquaresMethodImplementation(proxy, outputSample, indices)
+  : LeastSquaresMethodImplementation(proxy, indices)
 {
   // Nothing to do
 }

--- a/lib/src/Base/Algo/openturns/CholeskyMethod.hxx
+++ b/lib/src/Base/Algo/openturns/CholeskyMethod.hxx
@@ -41,13 +41,11 @@ public:
 
   /** Parameters constructor */
   CholeskyMethod(const DesignProxy & proxy,
-                 const NumericalSample & outputSample,
                  const NumericalPoint & weight,
                  const Indices & indices);
 
   /** Parameters constructor */
   CholeskyMethod(const DesignProxy & proxy,
-                 const NumericalSample & outputSample,
                  const Indices & indices);
 
   /** Virtual constructor */

--- a/lib/src/Base/Algo/openturns/CorrectedLeaveOneOut.hxx
+++ b/lib/src/Base/Algo/openturns/CorrectedLeaveOneOut.hxx
@@ -60,7 +60,8 @@ public:
                               const Indices & indices,
                               const DesignProxy & proxy) const;
 
-  virtual NumericalScalar run(LeastSquaresMethod & method) const;
+  virtual NumericalScalar run(LeastSquaresMethod & method,
+                              const NumericalSample & y) const;
 #endif
 
   /** Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Algo/openturns/FittingAlgorithm.hxx
+++ b/lib/src/Base/Algo/openturns/FittingAlgorithm.hxx
@@ -71,7 +71,8 @@ public:
                       const Indices & indices,
                       const DesignProxy & proxy) const;
 
-  NumericalScalar run(LeastSquaresMethod & method) const;
+  NumericalScalar run(LeastSquaresMethod & method,
+                      const NumericalSample & y) const;
 #endif
 
 }; /* class FittingAlgorithm */

--- a/lib/src/Base/Algo/openturns/FittingAlgorithmImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/FittingAlgorithmImplementation.hxx
@@ -72,7 +72,8 @@ public:
                               const Indices & indices,
                               const DesignProxy & proxy) const;
 
-  virtual NumericalScalar run(LeastSquaresMethod & method) const;
+  virtual NumericalScalar run(LeastSquaresMethod & method,
+                              const NumericalSample & y) const;
 
 #endif
 

--- a/lib/src/Base/Algo/openturns/KFold.hxx
+++ b/lib/src/Base/Algo/openturns/KFold.hxx
@@ -62,7 +62,8 @@ public:
                               const Indices & indices,
                               const DesignProxy & proxy) const;
 
-  virtual NumericalScalar run(LeastSquaresMethod & method) const;
+  virtual NumericalScalar run(LeastSquaresMethod & method,
+                              const NumericalSample & y) const;
 #endif
 
   /** Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Algo/openturns/LeastSquaresMethod.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMethod.hxx
@@ -48,13 +48,11 @@ public:
 
   /** Parameters constructor */
   LeastSquaresMethod (const DesignProxy & proxy,
-                      const NumericalSample & outputSample,
                       const NumericalPoint & weight,
                       const Indices & indices);
 
   /** Parameters constructor */
   LeastSquaresMethod (const DesignProxy & proxy,
-                      const NumericalSample & outputSample,
                       const Indices & indices);
 
   /** Constructor from implementation */
@@ -69,9 +67,6 @@ public:
 
   /** Input sample accessor */
   NumericalSample getInputSample() const;
-
-  /** Output sample accessor */
-  NumericalSample getOutputSample() const;
 
   /** Weight accessor */
   NumericalPoint getWeight() const;

--- a/lib/src/Base/Algo/openturns/LeastSquaresMethodImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMethodImplementation.hxx
@@ -48,13 +48,11 @@ public:
 
   /** Parameters constructor */
   LeastSquaresMethodImplementation(const DesignProxy & proxy,
-                                   const NumericalSample & outputSample,
                                    const NumericalPoint & weight,
                                    const Indices & indices);
 
   /** Parameters constructor */
   LeastSquaresMethodImplementation(const DesignProxy & proxy,
-                                   const NumericalSample & outputSample,
                                    const Indices & indices);
 
   /** Virtual constructor */
@@ -65,9 +63,6 @@ public:
 
   /** Input sample accessor */
   virtual NumericalSample getInputSample() const;
-
-  /** Output sample accessor */
-  virtual NumericalSample getOutputSample() const;
 
   /** Weight accessor */
   virtual NumericalPoint getWeight() const;
@@ -130,9 +125,6 @@ protected:
 
   /** Proxy to the input sample and the basis */
   DesignProxy proxy_;
-
-  /** Target values */
-  NumericalSample outputSample_;
 
   /** Weights for the least-squares norm. The size is positive if and only if the weights are not uniform. */
   NumericalPoint weight_;

--- a/lib/src/Base/Algo/openturns/QRMethod.hxx
+++ b/lib/src/Base/Algo/openturns/QRMethod.hxx
@@ -41,13 +41,11 @@ public:
 
   /** Parameters constructor */
   QRMethod(const DesignProxy & proxy,
-           const NumericalSample & outputSample,
            const NumericalPoint & weight,
            const Indices & indices);
 
   /** Parameters constructor */
   QRMethod(const DesignProxy & proxy,
-           const NumericalSample & outputSample,
            const Indices & indices);
 
   /** Virtual constructor */

--- a/lib/src/Base/Algo/openturns/SVDMethod.hxx
+++ b/lib/src/Base/Algo/openturns/SVDMethod.hxx
@@ -41,13 +41,11 @@ public:
 
   /** Default constructor */
   SVDMethod(const DesignProxy & proxy,
-            const NumericalSample & outputSample,
             const NumericalPoint & weight,
             const Indices & indices);
 
   /** Default constructor */
   SVDMethod(const DesignProxy & proxy,
-            const NumericalSample & outputSample,
             const Indices & indices);
 
   /** Virtual constructor */

--- a/lib/src/Base/Func/BasisSequenceFactory.cxx
+++ b/lib/src/Base/Func/BasisSequenceFactory.cxx
@@ -81,9 +81,10 @@ BasisSequence BasisSequenceFactory::build(const NumericalSample & y,
   return getImplementation()->build(y, indices, proxy);
 }
 
-BasisSequence BasisSequenceFactory::build(LeastSquaresMethod & method)
+BasisSequence BasisSequenceFactory::build(LeastSquaresMethod & method,
+                                          const NumericalSample & y)
 {
-  return getImplementation()->build(method);
+  return getImplementation()->build(method, y);
 }
 
 void BasisSequenceFactory::initialize()
@@ -91,9 +92,10 @@ void BasisSequenceFactory::initialize()
   getImplementation()->initialize();
 }
 
-void BasisSequenceFactory::updateBasis(LeastSquaresMethod & method)
+void BasisSequenceFactory::updateBasis(LeastSquaresMethod & method,
+                                       const NumericalSample & y)
 {
-  getImplementation()->updateBasis(method);
+  getImplementation()->updateBasis(method, y);
 }
 
 

--- a/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
+++ b/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
@@ -85,21 +85,22 @@ BasisSequence BasisSequenceFactoryImplementation::build(const NumericalSample & 
     const Indices & indices,
     const DesignProxy & proxy)
 {
-  LeastSquaresMethod method(proxy, y, indices);
-  return build(method);
+  LeastSquaresMethod method(proxy, indices);
+  return build(method, y);
 }
 
-BasisSequence BasisSequenceFactoryImplementation::build(LeastSquaresMethod & method)
+BasisSequence BasisSequenceFactoryImplementation::build(LeastSquaresMethod & method,
+                                                        const NumericalSample & y)
 {
 //   BasisSequence basisSequence(method.buildCurrentBasis());
   BasisSequence basisSequence(method.getBasis());
   initialize();
 
-  updateBasis(method);
+  updateBasis(method, y);
   while ((addedPsi_k_ranks_.getSize() > 0) || (removedPsi_k_ranks_.getSize() > 0))
   {
     basisSequence.add(currentIndices_);
-    updateBasis(method);
+    updateBasis(method, y);
   }
   return basisSequence;
 }
@@ -113,7 +114,7 @@ void BasisSequenceFactoryImplementation::initialize()
 }
 
 
-void BasisSequenceFactoryImplementation::updateBasis(LeastSquaresMethod & method)
+void BasisSequenceFactoryImplementation::updateBasis(LeastSquaresMethod & method, const NumericalSample & y)
 {
   throw NotYetImplementedException(HERE) << " in BasisSequenceFactoryImplementation::updateBasis";
 }

--- a/lib/src/Base/Func/LARS.cxx
+++ b/lib/src/Base/Func/LARS.cxx
@@ -71,10 +71,10 @@ void LARS::initialize()
 }
 
 /* Method to create new BasisSequence objects */
-void LARS::updateBasis(LeastSquaresMethod & method)
+void LARS::updateBasis(LeastSquaresMethod & method,
+                       const NumericalSample & y)
 {
   NumericalSample x(method.getInputSample());
-  NumericalSample y(method.getOutputSample());
 
   const UnsignedInteger sampleSize = x.getSize();
 

--- a/lib/src/Base/Func/openturns/BasisSequenceFactory.hxx
+++ b/lib/src/Base/Func/openturns/BasisSequenceFactory.hxx
@@ -69,10 +69,12 @@ public:
                       const Indices & indices,
                       const DesignProxy & proxy);
 
-  BasisSequence build(LeastSquaresMethod & method);
+  BasisSequence build(LeastSquaresMethod & method,
+                      const NumericalSample & y);
 
   void initialize();
-  void updateBasis(LeastSquaresMethod & method);
+  void updateBasis(LeastSquaresMethod & method,
+                   const NumericalSample & y);
 
 #endif
 

--- a/lib/src/Base/Func/openturns/BasisSequenceFactoryImplementation.hxx
+++ b/lib/src/Base/Func/openturns/BasisSequenceFactoryImplementation.hxx
@@ -66,10 +66,12 @@ public:
                               const Indices & indices,
                               const DesignProxy & proxy);
 
-  virtual BasisSequence build(LeastSquaresMethod & method);
+  virtual BasisSequence build(LeastSquaresMethod & method,
+                              const NumericalSample & y);
 
   virtual void initialize();
-  virtual void updateBasis(LeastSquaresMethod & method);
+  virtual void updateBasis(LeastSquaresMethod & method,
+                           const NumericalSample & y);
 #endif
 
   /** Stopping criterion on the L1-norm of the coefficients accessor */

--- a/lib/src/Base/Func/openturns/LARS.hxx
+++ b/lib/src/Base/Func/openturns/LARS.hxx
@@ -56,7 +56,8 @@ public:
 //                               const DesignProxy & proxy);
 
   virtual void initialize();
-  virtual void updateBasis(LeastSquaresMethod & method);
+  virtual void updateBasis(LeastSquaresMethod & method,
+                            const NumericalSample & y);
 #endif
   /** String converter */
   virtual String __repr__() const;

--- a/lib/test/t_LeastSquaresMethod_std.cxx
+++ b/lib/test/t_LeastSquaresMethod_std.cxx
@@ -37,7 +37,6 @@ int main(int argc, char *argv[])
     const UnsignedInteger size = 20;
 
     NumericalSample x(Normal(dimension).getSample(size));
-    NumericalSample y(Normal(1).getSample(size));
     Collection<NumericalMathFunction> coll;
     const Description description(Description::BuildDefault(dimension, "x"));
     for(UnsignedInteger i = 0; i < dimension; ++i)
@@ -50,7 +49,7 @@ int main(int argc, char *argv[])
     DesignProxy proxy(x, psi);
 
     {
-      QRMethod qrMethod(proxy, y, indices);
+      QRMethod qrMethod(proxy, indices);
       qrMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "QR" << std::endl;
@@ -62,7 +61,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << qrMethod.getGramInverseDiag() << std::endl;
     }
     {
-      SVDMethod svdMethod(proxy, y, indices);
+      SVDMethod svdMethod(proxy, indices);
       svdMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "SVD" << std::endl;
@@ -74,7 +73,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << svdMethod.getGramInverseDiag() << std::endl;
     }
     {
-      CholeskyMethod choleskyMethod(proxy, y, indices);
+      CholeskyMethod choleskyMethod(proxy, indices);
       choleskyMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "Cholesky" << std::endl;

--- a/lib/test/t_LeastSquaresMethod_weighted.cxx
+++ b/lib/test/t_LeastSquaresMethod_weighted.cxx
@@ -37,7 +37,6 @@ int main(int argc, char *argv[])
     const UnsignedInteger size = 20;
 
     NumericalSample x(Normal(dimension).getSample(size));
-    NumericalSample y(Normal(1).getSample(size));
     Collection<NumericalMathFunction> coll;
     const Description description(Description::BuildDefault(dimension, "x"));
     for(UnsignedInteger i = 0; i < dimension; ++i)
@@ -51,7 +50,7 @@ int main(int argc, char *argv[])
     NumericalPoint weights(size, 10.0);
     fullprint << "Uniform weights" << std::endl << std::endl;
     {
-      QRMethod qrMethod(proxy, y, weights, indices);
+      QRMethod qrMethod(proxy, weights, indices);
       qrMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "QR" << std::endl;
@@ -63,7 +62,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << qrMethod.getGramInverseDiag() << std::endl;
     }
     {
-      SVDMethod svdMethod(proxy, y, weights, indices);
+      SVDMethod svdMethod(proxy, weights, indices);
       svdMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "SVD" << std::endl;
@@ -75,7 +74,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << svdMethod.getGramInverseDiag() << std::endl;
     }
     {
-      CholeskyMethod choleskyMethod(proxy, y, weights, indices);
+      CholeskyMethod choleskyMethod(proxy, weights, indices);
       choleskyMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "Cholesky" << std::endl;
@@ -90,7 +89,7 @@ int main(int argc, char *argv[])
     fullprint << std::endl << "Non-uniform weights" << std::endl << std::endl;
     weights[0] += 1.e-10;
     {
-      QRMethod qrMethod(proxy, y, weights, indices);
+      QRMethod qrMethod(proxy, weights, indices);
       qrMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "QR" << std::endl;
@@ -102,7 +101,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << qrMethod.getGramInverseDiag() << std::endl;
     }
     {
-      SVDMethod svdMethod(proxy, y, weights, indices);
+      SVDMethod svdMethod(proxy, weights, indices);
       svdMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "SVD" << std::endl;
@@ -114,7 +113,7 @@ int main(int argc, char *argv[])
       fullprint << "GramInverseDiag=" << svdMethod.getGramInverseDiag() << std::endl;
     }
     {
-      CholeskyMethod choleskyMethod(proxy, y, weights, indices);
+      CholeskyMethod choleskyMethod(proxy, weights, indices);
       choleskyMethod.update(Indices(0), indices, Indices(0));
 
       fullprint << "Cholesky" << std::endl;

--- a/python/src/BasisSequenceFactoryImplementation_doc.i.in
+++ b/python/src/BasisSequenceFactoryImplementation_doc.i.in
@@ -10,7 +10,7 @@ basisSeqFacImp : a BasisSequenceFactoryImplementation
 
 See also
 --------
-LAR
+LARS
 
 Notes
 -----

--- a/python/src/CholeskyMethod_doc.i.in
+++ b/python/src/CholeskyMethod_doc.i.in
@@ -2,16 +2,14 @@
 "Least squares solver using Cholesky decomposition.
 
 Available constructors:
-    CholeskyMethod(*proxy, y, weight, indices*)
+    CholeskyMethod(*proxy, weight, indices*)
 
-    CholeskyMethod(*proxy, y, indices*)
+    CholeskyMethod(*proxy, indices*)
 
 Parameters
 ----------
 proxy : :class:`~openturns.DesignProxy`
     Input sample
-y : :class:`~openturns.NumericalSample`
-    Output sample
 weight : sequence of float
     Output weights
 indices : sequence of int

--- a/python/src/LeastSquaresMethodImplementation_doc.i.in
+++ b/python/src/LeastSquaresMethodImplementation_doc.i.in
@@ -2,16 +2,14 @@
 "Base class for least square solvers.
 
 Available constructors:
-    LeastSquaresMethod(*proxy, y, weight, indices*)
+    LeastSquaresMethod(*proxy, weight, indices*)
 
-    LeastSquaresMethod(*proxy, y, indices*)
+    LeastSquaresMethod(*proxy, indices*)
 
 Parameters
 ----------
 proxy : :class:`~openturns.DesignProxy`
     Input sample
-y : :class:`~openturns.NumericalSample`
-    Output sample
 weight : sequence of float
     Output weights
 indices : sequence of int
@@ -45,19 +43,6 @@ inputSample : :class:`~openturns.NumericalSample`
 %enddef
 %feature("docstring") OT::LeastSquaresMethodImplementation::getInputSample
 OT_LeastSquaresMethod_getInputSample_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_LeastSquaresMethod_getOutputSample_doc
-"Output sample accessor.
-
-Returns
--------
-inputSample : :class:`~openturns.NumericalSample`
-    Output sample."
-%enddef
-%feature("docstring") OT::LeastSquaresMethodImplementation::getOutputSample
-OT_LeastSquaresMethod_getOutputSample_doc
 
 // ---------------------------------------------------------------------
 

--- a/python/src/LeastSquaresMethod_doc.i.in
+++ b/python/src/LeastSquaresMethod_doc.i.in
@@ -6,8 +6,6 @@ OT_LeastSquaresMethod_buildCurrentBasis_doc
 OT_LeastSquaresMethod_computeWeightedDesign_doc
 %feature("docstring") OT::LeastSquaresMethod::getInputSample
 OT_LeastSquaresMethod_getInputSample_doc
-%feature("docstring") OT::LeastSquaresMethod::getOutputSample
-OT_LeastSquaresMethod_getOutputSample_doc
 %feature("docstring") OT::LeastSquaresMethod::getWeight
 OT_LeastSquaresMethod_getWeight_doc
 %feature("docstring") OT::LeastSquaresMethod::getBasis

--- a/python/src/QRMethod_doc.i.in
+++ b/python/src/QRMethod_doc.i.in
@@ -2,16 +2,14 @@
 "Least squares solver using the QR decomposition.
 
 Available constructors:
-    QRMethod(*proxy, y, weight, indices*)
+    QRMethod(*proxy, weight, indices*)
 
-    QRMethod(*proxy, y, indices*)
+    QRMethod(*proxy, indices*)
 
 Parameters
 ----------
 proxy : :class:`~openturns.DesignProxy`
     Input sample
-y : :class:`~openturns.NumericalSample`
-    Output sample
 weight : sequence of float
     Output weights
 indices : sequence of int

--- a/python/src/SVDMethod_doc.i.in
+++ b/python/src/SVDMethod_doc.i.in
@@ -2,16 +2,14 @@
 "Least squares solver using SVD decomposition.
 
 Available constructors:
-    SVDMethod(*proxy, y, weight, indices*)
+    SVDMethod(*proxy, weight, indices*)
 
-    SVDMethod(*proxy, y, indices*)
+    SVDMethod(*proxy, indices*)
 
 Parameters
 ----------
 proxy : :class:`~openturns.DesignProxy`
     Input sample
-y : :class:`~openturns.NumericalSample`
-    Output sample
 weight : sequence of float
     Output weights
 indices : sequence of int

--- a/python/test/t_LeastSquaresMethod_std.py
+++ b/python/test/t_LeastSquaresMethod_std.py
@@ -10,8 +10,6 @@ X = ot.NumericalSample(sampleSize, 1)
 for i in range(sampleSize):
     X[i, 0] = i + 1.0
 
-Y = ot.NumericalSample(sampleSize, 1)
-
 phis = []
 for j in range(basisSize):
     phis.append(ot.NumericalMathFunction(['x'],['y'], ['x^' + str(j + 1)]))
@@ -23,9 +21,9 @@ proxy = ot.DesignProxy(X, basis)
 full = range(basisSize)
 
 design = proxy.computeDesign(full)
-methods = [ot.SVDMethod(proxy, Y, full),
-           ot.CholeskyMethod(proxy, Y, full),
-           ot.QRMethod(proxy, Y, full)]
+methods = [ot.SVDMethod(proxy, full),
+           ot.CholeskyMethod(proxy, full),
+           ot.QRMethod(proxy, full)]
 for method in methods:
     print(method.__class__.__name__)
     y = [1.0] * 3


### PR DESCRIPTION
Output sample is contained in LeastSquaresMethod for convenience.
This has an impact over the BasisSequenceFactory & FittingAlgorithm APIs.
The result is we are able to use these prior to instanciating the output sample.