### PR TITLE
Add optimization callbacks

### DIFF
--- a/lib/src/Base/Optim/AbdoRackwitz.cxx
+++ b/lib/src/Base/Optim/AbdoRackwitz.cxx
@@ -197,6 +197,20 @@ void AbdoRackwitz::run()
     result_.setLagrangeMultipliers(NumericalPoint(1, currentLambda_));
 
     LOGINFO(getResult().__repr__());
+
+    // callbacks
+    if (progressCallback_.first)
+    {
+      progressCallback_.first((100.0 * iterationNumber) / getMaximumIterationNumber(), progressCallback_.second);
+    }
+    if (stopCallback_.first)
+    {
+      Bool stop = stopCallback_.first(stopCallback_.second);
+      if (stop) {
+        convergence = true;
+        LOGWARN(OSS() << "AbdoRackwitz was stopped by user");
+      }
+    }
   }
 
   /* Check if we converged */

--- a/lib/src/Base/Optim/OptimizationAlgorithm.cxx
+++ b/lib/src/Base/Optim/OptimizationAlgorithm.cxx
@@ -191,5 +191,16 @@ void OptimizationAlgorithm::run()
   getImplementation()->run();
 }
 
+void OptimizationAlgorithm::setProgressCallback(ProgressCallback callBack, void * data)
+{
+  getImplementation()->setProgressCallback(callBack, data);
+}
+
+
+void OptimizationAlgorithm::setStopCallback(StopCallback callBack, void * data)
+{
+  getImplementation()->setStopCallback(callBack, data);
+}
+
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Optim/OptimizationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Optim/OptimizationAlgorithmImplementation.cxx
@@ -28,6 +28,8 @@ CLASSNAMEINIT(OptimizationAlgorithmImplementation);
 /* Default constructor */
 OptimizationAlgorithmImplementation::OptimizationAlgorithmImplementation()
   : PersistentObject()
+  , progressCallback_(std::make_pair<ProgressCallback, void *>(0, 0))
+  , stopCallback_(std::make_pair<StopCallback, void *>(0, 0))
   , startingPoint_(NumericalPoint(0))
   , maximumIterationNumber_(ResourceMap::GetAsUnsignedInteger("OptimizationAlgorithm-DefaultMaximumIteration"))
   , maximumEvaluationNumber_(ResourceMap::GetAsUnsignedInteger("OptimizationAlgorithm-DefaultMaximumEvaluationNumber"))
@@ -45,6 +47,8 @@ OptimizationAlgorithmImplementation::OptimizationAlgorithmImplementation()
  */
 OptimizationAlgorithmImplementation::OptimizationAlgorithmImplementation(const OptimizationProblem & problem)
   : PersistentObject()
+  , progressCallback_(std::make_pair<ProgressCallback, void *>(0, 0))
+  , stopCallback_(std::make_pair<StopCallback, void *>(0, 0))
   , problem_(problem)
   , maximumIterationNumber_(ResourceMap::GetAsUnsignedInteger("OptimizationAlgorithm-DefaultMaximumIteration"))
   , maximumEvaluationNumber_(ResourceMap::GetAsUnsignedInteger("OptimizationAlgorithm-DefaultMaximumEvaluationNumber"))
@@ -308,5 +312,18 @@ void OptimizationAlgorithmImplementation::load(Advocate & adv)
   adv.loadAttribute( "maximumConstraintError_", maximumConstraintError_);
   adv.loadAttribute( "verbose_", verbose_);
 }
+
+
+void OptimizationAlgorithmImplementation::setProgressCallback(ProgressCallback callBack, void * data)
+{
+  progressCallback_ = std::pair<ProgressCallback, void *>(callBack, data);
+}
+
+
+void OptimizationAlgorithmImplementation::setStopCallback(StopCallback callBack, void * data)
+{
+  stopCallback_ = std::pair<StopCallback, void *>(callBack, data);
+}
+
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Optim/SQP.cxx
+++ b/lib/src/Base/Optim/SQP.cxx
@@ -247,6 +247,20 @@ void SQP::run()
     result_.setLagrangeMultipliers(NumericalPoint(1, currentLambda_));
 
     LOGINFO(getResult().__repr__());
+
+    // callbacks
+    if (progressCallback_.first)
+    {
+      progressCallback_.first((100.0 * iterationNumber) / getMaximumIterationNumber(), progressCallback_.second);
+    }
+    if (stopCallback_.first)
+    {
+      Bool stop = stopCallback_.first(stopCallback_.second);
+      if (stop) {
+        convergence = true;
+        LOGWARN(OSS() << "SQP was stopped by user");
+      }
+    }
   }
 
   /* Check if we converged */

--- a/lib/src/Base/Optim/openturns/NLopt.hxx
+++ b/lib/src/Base/Optim/openturns/NLopt.hxx
@@ -114,6 +114,8 @@ private:
   NumericalSample evaluationInputHistory_;
   NumericalSample evaluationOutputHistory_;
 
+  // internal solver
+  void * p_opt_;
 };
 
 

--- a/lib/src/Base/Optim/openturns/OptimizationAlgorithm.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationAlgorithm.hxx
@@ -94,6 +94,14 @@ public:
   Bool getVerbose() const;
   void setVerbose(const Bool verbose);
 
+  /** Progress callback */
+  typedef void (*ProgressCallback)(NumericalScalar, void * data);
+  void setProgressCallback(ProgressCallback callBack, void * data = 0);
+
+  /** Stop callback */
+  typedef Bool (*StopCallback)(void * data);
+  void setStopCallback(StopCallback callBack, void * data = 0);
+
   /** String converter */
   virtual String __repr__() const;
 

--- a/lib/src/Base/Optim/openturns/OptimizationAlgorithmImplementation.hxx
+++ b/lib/src/Base/Optim/openturns/OptimizationAlgorithmImplementation.hxx
@@ -116,12 +116,24 @@ public:
   Bool getVerbose() const;
   void setVerbose(const Bool verbose);
 
+  /** Progress callback */
+  typedef void (*ProgressCallback)(NumericalScalar, void * data);
+  virtual void setProgressCallback(ProgressCallback callBack, void * data = 0);
+
+  /** Stop callback */
+  typedef Bool (*StopCallback)(void * data);
+  virtual void setStopCallback(StopCallback callBack, void * data = 0);
+
 protected:
   /** Check whether this problem can be solved by this solver.  Must be overloaded by the actual optimisation algorithm */
   virtual void checkProblem(const OptimizationProblem & problem) const;
 
   /** The result of the algorithm */
   OptimizationResult result_;
+
+  // callbacks
+  std::pair< ProgressCallback, void *> progressCallback_;
+  std::pair< StopCallback, void *> stopCallback_;
 
 private:
   NumericalPoint startingPoint_;

--- a/lib/src/Base/Optim/openturns/TNC.hxx
+++ b/lib/src/Base/Optim/openturns/TNC.hxx
@@ -127,6 +127,8 @@ private:
   NumericalSample evaluationInputHistory_;
   NumericalSample evaluationOutputHistory_;
 
+  void * p_nfeval_;
+
 }; /* class TNC */
 
 

--- a/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
@@ -251,7 +251,7 @@ void Simulation::run()
     // callbacks
     if (progressCallback_.first)
     {
-      progressCallback_.first((100. * outerSampling) / getMaximumOuterSampling(), progressCallback_.second);
+      progressCallback_.first((100.0 * outerSampling) / getMaximumOuterSampling(), progressCallback_.second);
     }
     if (stopCallback_.first)
     {

--- a/python/src/Cobyla_doc.i.in
+++ b/python/src/Cobyla_doc.i.in
@@ -18,6 +18,7 @@ Notes
 It constructs successive linear approximations of the objective function and
 constraints via a simplex of :math:`d+1` points, and optimizes these
 approximations in a trust region at each step.
+This solver does not implement any callbacks.
 
 See also
 --------

--- a/python/src/NLopt_doc.i.in
+++ b/python/src/NLopt_doc.i.in
@@ -13,6 +13,10 @@ algoName : str
     The NLopt identifier of the algorithm.
     Use :func:`GetAlgorithmNames()` to list available names.
 
+Notes
+-----
+This solver does not implement the progress callback.
+
 See also
 --------
 AbdoRackwitz, Cobyla, SQP, TNC

--- a/python/src/OptimizationAlgorithm.i
+++ b/python/src/OptimizationAlgorithm.i
@@ -2,11 +2,50 @@
 
 %{
 #include "openturns/OptimizationAlgorithm.hxx"
+#include "openturns/PythonWrappingFunctions.hxx"
+
+static void OptimizationAlgorithm_ProgressCallback(OT::NumericalScalar percent, void * data) {
+  PyObject * pyObj = reinterpret_cast<PyObject *>(data);
+  OT::ScopedPyObjectPointer point(OT::convert< OT::NumericalScalar, OT::_PyFloat_ >(percent));
+  OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs( pyObj, point.get(), NULL ));
+}
+
+static OT::Bool OptimizationAlgorithm_StopCallback(void * data) {
+  PyObject * pyObj = reinterpret_cast<PyObject *>(data);
+  OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs( pyObj, NULL ));
+  return OT::convert< OT::_PyInt_, OT::UnsignedInteger >(result.get());
+}
 %}
 
 %include OptimizationAlgorithm_doc.i
 
+%ignore OT::OptimizationAlgorithm::setProgressCallback(ProgressCallback callBack, void * data);
+%ignore OT::OptimizationAlgorithm::setStopCallback(StopCallback callBack, void * data);
+
 OTTypedInterfaceObjectHelper(OptimizationAlgorithm)
 
 %include openturns/OptimizationAlgorithm.hxx
-namespace OT{ %extend OptimizationAlgorithm { OptimizationAlgorithm(const OptimizationAlgorithm & other) { return new OT::OptimizationAlgorithm(other); } } }
+namespace OT{ %extend OptimizationAlgorithm {
+
+OptimizationAlgorithm(const OptimizationAlgorithm & other) { return new OT::OptimizationAlgorithm(other); }
+
+
+void setProgressCallback(PyObject * callBack) {
+  if (PyCallable_Check(callBack)) {
+    self->setProgressCallback(&OptimizationAlgorithm_ProgressCallback, callBack);
+  }
+  else {
+    throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
+  }
+}
+
+void setStopCallback(PyObject * callBack) {
+  if (PyCallable_Check(callBack)) {
+    self->setStopCallback(&OptimizationAlgorithm_StopCallback, callBack);
+  }
+  else {
+    throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
+  }
+}
+
+} }

--- a/python/src/OptimizationAlgorithmImplementation.i
+++ b/python/src/OptimizationAlgorithmImplementation.i
@@ -2,9 +2,50 @@
 
 %{
 #include "openturns/OptimizationAlgorithmImplementation.hxx"
+#include "openturns/PythonWrappingFunctions.hxx"
+
+static void OptimizationAlgorithmImplementation_ProgressCallback(OT::NumericalScalar percent, void * data) {
+  PyObject * pyObj = reinterpret_cast<PyObject *>(data);
+  OT::ScopedPyObjectPointer point(OT::convert< OT::NumericalScalar, OT::_PyFloat_ >(percent));
+  OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs( pyObj, point.get(), NULL ));
+}
+
+static OT::Bool OptimizationAlgorithmImplementation_StopCallback(void * data) {
+  PyObject * pyObj = reinterpret_cast<PyObject *>(data);
+  OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs( pyObj, NULL ));
+  return OT::convert< OT::_PyInt_, OT::UnsignedInteger >(result.get());
+}
 %}
 
 %include OptimizationAlgorithmImplementation_doc.i
 
+%ignore OT::OptimizationAlgorithmImplementation::setProgressCallback(ProgressCallback callBack, void * data);
+%ignore OT::OptimizationAlgorithmImplementation::setStopCallback(StopCallback callBack, void * data);
+
 %include openturns/OptimizationAlgorithmImplementation.hxx
-namespace OT{ %extend OptimizationAlgorithmImplementation { OptimizationAlgorithmImplementation(const OptimizationAlgorithmImplementation & other) { return new OT::OptimizationAlgorithmImplementation(other); } } }
+namespace OT{ %extend OptimizationAlgorithmImplementation {
+
+
+OptimizationAlgorithmImplementation(const OptimizationAlgorithmImplementation & other) {
+  return new OT::OptimizationAlgorithmImplementation(other);
+}
+
+void setProgressCallback(PyObject * callBack) {
+  if (PyCallable_Check(callBack)) {
+    self->setProgressCallback(&OptimizationAlgorithmImplementation_ProgressCallback, callBack);
+  }
+  else {
+    throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
+  }
+}
+
+void setStopCallback(PyObject * callBack) {
+  if (PyCallable_Check(callBack)) {
+    self->setStopCallback(&OptimizationAlgorithmImplementation_StopCallback, callBack);
+  }
+  else {
+    throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
+  }
+}
+
+} }

--- a/python/src/OptimizationAlgorithmImplementation_doc.i.in
+++ b/python/src/OptimizationAlgorithmImplementation_doc.i.in
@@ -395,3 +395,40 @@ verbose : bool
 
 %feature("docstring") OT::OptimizationAlgorithmImplementation::getVerbose
 OT_OptimizationAlgorithm_getVerbose_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_OptimizationAlgorithm_setProgressCallback_doc
+"Set up a progress callback.
+
+Parameters
+----------
+callback : callable
+    Takes a float as argument as percentage of progress.
+
+Notes
+-----
+May not be implemented by all solvers, refer to the solver documentation.
+"
+%enddef
+
+%feature("docstring") OT::OptimizationAlgorithmImplementation::setProgressCallback
+OT_OptimizationAlgorithm_setProgressCallback_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_OptimizationAlgorithm_setStopCallback_doc
+"Set up a stop callback.
+
+Parameters
+----------
+callback : callable
+    Returns an int deciding whether to stop or continue.
+
+Notes
+-----
+May not be implemented by all solvers, refer to the solver documentation."
+%enddef
+
+%feature("docstring") OT::OptimizationAlgorithmImplementation::setStopCallback
+OT_OptimizationAlgorithm_setStopCallback_doc

--- a/python/src/OptimizationAlgorithm_doc.i.in
+++ b/python/src/OptimizationAlgorithm_doc.i.in
@@ -46,3 +46,7 @@ OT_OptimizationAlgorithm_setStartingPoint_doc
 OT_OptimizationAlgorithm_setVerbose_doc
 %feature("docstring") OT::OptimizationAlgorithm::getVerbose
 OT_OptimizationAlgorithm_getVerbose_doc
+%feature("docstring") OT::OptimizationAlgorithm::setProgressCallback
+OT_OptimizationAlgorithm_setProgressCallback_doc
+%feature("docstring") OT::OptimizationAlgorithm::setStopCallback
+OT_OptimizationAlgorithm_setStopCallback_doc

--- a/python/src/OptimizationProblemImplementation_doc.i.in
+++ b/python/src/OptimizationProblemImplementation_doc.i.in
@@ -368,4 +368,3 @@ dimension in order to keep the problem valid at all time."
 
 %feature("docstring") OT::OptimizationProblemImplementation::setObjective
 OT_OptimizationProblem_setObjective_doc
-

--- a/python/src/TNC_doc.i.in
+++ b/python/src/TNC_doc.i.in
@@ -32,6 +32,7 @@ rescale : float
 Notes
 -----
 Non-linear optimizer supporting bound constraints.
+This solver does not implement the progress callback.
 
 See also
 --------


### PR DESCRIPTION
A possible use-case is to control FORM optimization by the number of calls (http://trac.openturns.org/ticket/351)

This is not implemented by all solvers, the behavior of each solver is documented if it doesnt implement one of the callbacks.