### PR TITLE
Fix osx failure on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - if test "$TRAVIS_OS_NAME" = "osx"; then
         brew update &&
         brew tap homebrew/science &&
-        brew install swig tbb muparser R openblas &&
+        brew install swig muparser R openblas &&
         export HOMEBREW_PREFIX=`brew --prefix`;
     fi
 
@@ -90,10 +90,23 @@ install:
 # use latest nlopt
   - git clone https://github.com/stevengj/nlopt.git
   - pushd nlopt
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_PYTHON=OFF -DBUILD_OCTAVE=OFF -DBUILD_GUILE=OFF .
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_PYTHON=OFF -DBUILD_OCTAVE=OFF -DBUILD_GUILE=OFF -DCMAKE_MACOSX_RPATH=ON .
   - make -j2
   - make install
   - popd
+
+# use tbb from sources for osx (not brew)
+  - if test "$TRAVIS_OS_NAME" = "osx"; then
+       git clone https://github.com/01org/tbb.git &&
+       pushd tbb &&
+       git checkout 2017_U5 &&
+       make -j4 cfg=release stdlib=libc++ &&
+       install -d $HOME/.local/lib &&
+       install -d $HOME/.local/include &&
+       cp `find . -name "*lib*" | grep tbb | grep release` $HOME/.local/lib &&
+       cp -r ./include/tbb $HOME/.local/include &&
+       popd;
+   fi
 
 before_script:
   - R CMD INSTALL --library=$PWD utils/rot_1.4.6.tar.gz


### PR DESCRIPTION
The PR fixes the recent `OS X` failures on the travis-ci platform

Problem is due to the used `tbb` imported thanks to Homebrew. For now, `tbb` sources are compiled