### PR TITLE
Add WhittleFactory::buildWithCriteria

### DIFF
--- a/lib/src/Uncertainty/Process/ARMAFactoryImplementation.cxx
+++ b/lib/src/Uncertainty/Process/ARMAFactoryImplementation.cxx
@@ -155,22 +155,10 @@ ARMA ARMAFactoryImplementation::build(const TimeSeries & timeSeries) const
   throw NotYetImplementedException(HERE) << "In ARMAFactoryImplementation::build(const TimeSeries & timeSeries) const";
 }
 
-ARMA ARMAFactoryImplementation::build(const TimeSeries & timeSeries,
-                                      Point & informationCriteria) const
-{
-  throw NotYetImplementedException(HERE) << "In ARMAFactoryImplementation::build(const TimeSeries & timeSeries, Point & informationCriteria) const";
-}
-
 /* Build method */
 ARMA ARMAFactoryImplementation::build(const ProcessSample & sample) const
 {
   throw NotYetImplementedException(HERE) << "In ARMAFactoryImplementation::build(const ProcessSample & sample) const";
-}
-
-ARMA ARMAFactoryImplementation::build(const ProcessSample & sample,
-                                      Point & informationCriteria) const
-{
-  throw NotYetImplementedException(HERE) << "In ARMAFactoryImplementation::build(const ProcessSample & sample, Point & informationCriteria) const";
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Uncertainty/Process/WhittleFactory.cxx
+++ b/lib/src/Uncertainty/Process/WhittleFactory.cxx
@@ -354,8 +354,8 @@ void WhittleFactory::setSpectralModelFactory(const WelchFactory & factory)
  *                       =\left|\frac{\beta(\exp(-i\lambda))}{\alpha(\exp(-i\lambda))}\right|^2
  * It can be noticed that dropping the term -\sum_{j=1}^m\log f(\lambda_j|\theta, \sigma^2) in the Whittle likelihood or the term
  */
-ARMA WhittleFactory::build(const TimeSeries & timeSeries,
-                           Point & informationCriteria) const
+ARMA WhittleFactory::buildWithCriteria(const TimeSeries & timeSeries,
+                                       Point & informationCriteria) const
 {
   if (timeSeries.getDimension() != 1)
     throw NotYetImplementedException(HERE) << "In WhittleFactory::build(const TimeSeries & timeSeries, Point & informationCriteria) const: currently implemented for 1 d case only";
@@ -369,12 +369,12 @@ ARMA WhittleFactory::build(const TimeSeries & timeSeries,
 ARMA WhittleFactory::build(const TimeSeries & timeSeries) const
 {
   Point informationCriteria;
-  return build(timeSeries, informationCriteria);
+  return buildWithCriteria(timeSeries, informationCriteria);
 }
 
 /* Build method */
-ARMA WhittleFactory::build(const ProcessSample & sample,
-                           Point & informationCriteria) const
+ARMA WhittleFactory::buildWithCriteria(const ProcessSample & sample,
+                                       Point & informationCriteria) const
 {
   if (sample.getDimension() != 1)
     throw NotYetImplementedException(HERE) << "In WhittleFactory::build(const ProcessSample & sample, Point & informationCriteria) const: currently implemented for 1 d case only";
@@ -387,7 +387,7 @@ ARMA WhittleFactory::build(const ProcessSample & sample,
 ARMA WhittleFactory::build(const ProcessSample & sample) const
 {
   Point informationCriteria;
-  return build(sample, informationCriteria);
+  return buildWithCriteria(sample, informationCriteria);
 }
 
 /* Do the likelihood maximization */

--- a/lib/src/Uncertainty/Process/openturns/ARMAFactoryImplementation.hxx
+++ b/lib/src/Uncertainty/Process/openturns/ARMAFactoryImplementation.hxx
@@ -79,13 +79,9 @@ public:
 
   /** Build method */
   virtual ARMA build(const TimeSeries & timeSeries) const;
-  virtual ARMA build(const TimeSeries & timeSeries,
-                     Point & informationCriteria) const;
 
   /** Build method */
   virtual ARMA build(const ProcessSample & sample) const;
-  virtual ARMA build(const ProcessSample & sample,
-                     Point & informationCriteria) const;
 
   /** Method save() stores the object through the StorageManager */
   virtual void save(Advocate & adv) const;

--- a/lib/src/Uncertainty/Process/openturns/WhittleFactory.hxx
+++ b/lib/src/Uncertainty/Process/openturns/WhittleFactory.hxx
@@ -65,12 +65,12 @@ public:
   void setSpectralModelFactory(const WelchFactory & factory);
 
   /** Build method ==> estimating the coefficients */
-  ARMA build(const TimeSeries & timeSeries,
-             Point & informationCriteria) const;
-  ARMA build(const TimeSeries & timeSeries) const;
-  ARMA build(const ProcessSample & sample,
-             Point & informationCriteria) const;
-  ARMA build(const ProcessSample & sample) const;
+  virtual ARMA build(const TimeSeries & timeSeries) const;
+  ARMA buildWithCriteria(const TimeSeries & timeSeries,
+                         Point & informationCriteria) const;
+  virtual ARMA build(const ProcessSample & sample) const;
+  ARMA buildWithCriteria(const ProcessSample & sample,
+                         Point & informationCriteria) const;
 
   /** Verbosity accessor */
   Bool getVerbose() const;

--- a/lib/test/t_WhittleFactory_std.cxx
+++ b/lib/test/t_WhittleFactory_std.cxx
@@ -60,11 +60,11 @@ int main(int argc, char *argv[])
       // factory.setVerbose(true);
       fullprint << "factory=" << factory << std::endl;
       Point informationCriteria;
-      Process result(factory.build(timeSeries, informationCriteria));
+      Process result(factory.buildWithCriteria(timeSeries, informationCriteria));
       // Commented due to a bug in the cobyla algorithm
       //fullprint << "Estimated ARMA=" << result.__str__() << std::endl;
       //fullprint << "Information criteria=" << informationCriteria.__str__() << std::endl;
-      Process result2(factory.build(sample, informationCriteria));
+      Process result2(factory.buildWithCriteria(sample, informationCriteria));
       // Commented due to a bug in the cobyla algorithm
       //fullprint << "Estimated ARMA=" << result2.__str__() << std::endl;
       //fullprint << "Information criteria=" << informationCriteria.__str__() << std::endl;
@@ -79,12 +79,12 @@ int main(int argc, char *argv[])
     // factory.setVerbose(true);
     fullprint << "factory=" << factory << std::endl;
     Point informationCriteria;
-    Process result(factory.build(timeSeries, informationCriteria));
+    Process result(factory.buildWithCriteria(timeSeries, informationCriteria));
     // Commented due to a bug in the cobyla algorithm
     //fullprint << "Estimated ARMA=" << result.__str__() << std::endl;
     //fullprint << "Information criteria=" << informationCriteria.__str__() << std::endl;
     //fullprint << "History=" << factory.getHistory().__str__()  << std::endl;
-    Process result2(factory.build(sample, informationCriteria));
+    Process result2(factory.buildWithCriteria(sample, informationCriteria));
     // Commented due to a bug in the cobyla algorithm
     //fullprint << "Estimated ARMA=" << result2.__str__() << std::endl;
     //fullprint << "Information criteria=" << informationCriteria.__str__() << std::endl;

--- a/python/doc/examples/statistical_estimation/estimate_arma.ipynb
+++ b/python/doc/examples/statistical_estimation/estimate_arma.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -74,8 +74,7 @@
    ],
    "source": [
     "# Estimate the ARMA process\n",
-    "myCriterion = ot.Point()\n",
-    "myARMA_42 = myFactory_42.build(ot.TimeSeries(myTimeSeries), myCriterion)\n",
+    "myARMA_42, myCriterion = myFactory_42.buildWithCriteria(ot.TimeSeries(myTimeSeries))\n",
     "AICc, AIC, BIC = myCriterion[0:3]\n",
     "print(AICc, AIC, BIC)"
    ]

--- a/python/src/ARMAFactoryImplementation_doc.i.in
+++ b/python/src/ARMAFactoryImplementation_doc.i.in
@@ -11,7 +11,7 @@ OT_ARMAFactory_doc
 %define OT_ARMAFactory_build_doc
 "Estimate the ARMA model from data.
 
-Available constructors:
+Available usages:
     build(*myTimeSeries*)
 
     build(*myProcessSample*)
@@ -27,7 +27,7 @@ Returns
 -------
 myARMA : :class:`~openturns.ARMA`
     The estimated spectral model.
- "
+"
 %enddef
 %feature("docstring") OT::ARMAFactoryImplementation::build
 OT_ARMAFactory_build_doc

--- a/python/src/ARMAFactory_doc.i.in
+++ b/python/src/ARMAFactory_doc.i.in
@@ -4,3 +4,4 @@
 OT_ARMAFactory_doc
 %feature("docstring") OT::ARMAFactory::build
 OT_ARMAFactory_build_doc
+

--- a/python/src/WhittleFactory.i
+++ b/python/src/WhittleFactory.i
@@ -1,5 +1,13 @@
 // SWIG file WhittleFactory.i
 
+// do not pass argument by reference, return it as tuple item
+%typemap(in, numinputs=0) OT::Point & informationCriteria ($*ltype temp) %{ temp = OT::Point(); $1 = &temp; %}
+%typemap(argout) OT::Point & informationCriteria %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::Point(*$1), SWIG_TypeQuery("OT::Point *"), SWIG_POINTER_OWN |  0 )); %}
+OT::ARMA OT::WhittleFactory::buildWithCriteria(const OT::TimeSeries & timeSeries,
+                                               OT::Point & informationCriteria) const;
+OT::ARMA OT::WhittleFactory::buildWithCriteria(const OT::ProcessSample & sample,
+                                               OT::Point & informationCriteria) const;
+
 %{
 #include "openturns/WhittleFactory.hxx"
 %}

--- a/python/src/WhittleFactory_doc.i.in
+++ b/python/src/WhittleFactory_doc.i.in
@@ -131,8 +131,7 @@ p = [1, 2, 4] and q = [4,5,6]:
 
 To get the quantified AICc, AIC and BIC criteria:
 
->>> myCriterion = ot.Point()
->>> myARMA_42 = myFactory_42.build(ot.TimeSeries(myTimeSeries), myCriterion)
+>>> myARMA_42, myCriterion = myFactory_42.buildWithCriteria(ot.TimeSeries(myTimeSeries))
 >>> AICc, AIC, BIC = myCriterion[0:3]"
 
 // ---------------------------------------------------------------------
@@ -141,16 +140,14 @@ To get the quantified AICc, AIC and BIC criteria:
 "Estimate the ARMA process.
 
 Available usages:
-    build(*myTimeSeries, criterion*)
+    build(*myTimeSeries*)
 
-    build(*myProcessSample, criterion*)
+    build(*myProcessSample*)
 
 Parameters
 ----------
 myTimeSeries : :class:`~openturns.TimeSeries`
     One realization of the  process.
-criterion : :class:`~openturns.Point` with the default implementation, optional
-    To get the evaluation of the AICc, AIC and BIC criteria
 myProcessSample : :class:`~openturns.ProcessSample`
     Several realizations of the  process.
 
@@ -165,6 +162,36 @@ The model selection is made using the spectral density built using the given dat
 
 The best ARMA process is selected according to the corrected AIC criterion.
 "
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::WhittleFactory::buildWithCriteria
+"Estimate the ARMA process.
+
+Available usages:
+    buildWithCriteria(*myTimeSeries*)
+
+    buildWithCriteria(*myProcessSample*)
+
+Parameters
+----------
+myTimeSeries : :class:`~openturns.TimeSeries`
+    One realization of the  process.
+myProcessSample : :class:`~openturns.ProcessSample`
+    Several realizations of the  process.
+
+Returns
+-------
+myARMA : :class:`~openturns.ARMA`
+    The  process estimated with the Whittle estimator.
+criterion : :class:`~openturns.Point`
+    Result of the evaluation of the AICc, AIC and BIC criteria
+
+Notes
+-----
+The model selection is made using the spectral density built using the given data and theoretical spectral density of the ARMA process.
+
+The best ARMA process is selected according to the corrected AIC criterion."
 
 // ---------------------------------------------------------------------
 

--- a/python/test/t_WhittleFactory_std.py
+++ b/python/test/t_WhittleFactory_std.py
@@ -6,65 +6,60 @@ from openturns import *
 TESTPREAMBLE()
 RandomGenerator.SetSeed(0)
 
-try:
 
-    # Reduce the precision output as the estimation is based on a lazy
-    # optimizer
-    PlatformInfo.SetNumericalPrecision(4)
+# Reduce the precision output as the estimation is based on a lazy
+# optimizer
+PlatformInfo.SetNumericalPrecision(4)
 
-    # ARMA(p, q)
-    p = 1
-    q = 1
+# ARMA(p, q)
+p = 1
+q = 1
 
-    # ARMACoefficients intializing
-    arCoefficients = Point(p, 0.80)
-    maCoefficients = Point(q, 0.50)
+# ARMACoefficients intializing
+arCoefficients = Point(p, 0.80)
+maCoefficients = Point(q, 0.50)
 
-    # ARMA creation
-    myARMA = ARMA(ARMACoefficients(arCoefficients),
-                  ARMACoefficients(maCoefficients), WhiteNoise(Normal(0.0, 0.05)))
-    myARMA.setTimeGrid(RegularGrid(0.0, 0.1, 256))
-    print("myARMA process=", myARMA)
+# ARMA creation
+myARMA = ARMA(ARMACoefficients(arCoefficients),
+              ARMACoefficients(maCoefficients), WhiteNoise(Normal(0.0, 0.05)))
+myARMA.setTimeGrid(RegularGrid(0.0, 0.1, 256))
+print("myARMA process=", myARMA)
 
-    # Create a realization
-    timeSeries = myARMA.getRealization()
+# Create a realization
+timeSeries = myARMA.getRealization()
 
-    # Create a sample
-    sample = myARMA.getSample(100)
+# Create a sample
+sample = myARMA.getSample(100)
 
-    # First, build an ARMA based on a given order using the WhittleFactory
-    factory = WhittleFactory(p, q)
-    # factory.setVerbose(False)
-    print("factory=", factory)
-    print("factory as an ARMA factory=", ARMAFactory(factory))
-    informationCriteria = Point()
-    result = factory.build(TimeSeries(timeSeries), informationCriteria)
-    # print "Estimated ARMA=", result
-    # print "Information criteria=", informationCriteria
-    result2 = factory.build(sample, informationCriteria)
-    # print "Estimated ARMA=", result2
-    # print "Information criteria=", informationCriteria
+# First, build an ARMA based on a given order using the WhittleFactory
+factory = WhittleFactory(p, q)
+# factory.setVerbose(False)
+print("factory=", factory)
+print("factory as an ARMA factory=", ARMAFactory(factory))
+informationCriteria = Point()
+result, informationCriteria = factory.buildWithCriteria(TimeSeries(timeSeries))
+# print "Estimated ARMA=", result
+# print "Information criteria=", informationCriteria
+result2, informationCriteria = factory.buildWithCriteria(sample)
+# print "Estimated ARMA=", result2
+# print "Information criteria=", informationCriteria
 
-    # Second, build the best ARMA based on a given range of order using the
-    # WhittleFactory
-    pIndices = Indices(p + 1)
-    pIndices.fill()
-    qIndices = Indices(q + 1)
-    qIndices.fill()
-    factory = WhittleFactory(pIndices, qIndices)
-    print("factory=", factory)
-    informationCriteria = Point()
-    result = factory.build(TimeSeries(timeSeries), informationCriteria)
-    # print "Estimated ARMA=", result
-    # print "Information criteria=", informationCriteria
-    # print "History=", factory.getHistory()
-    result2 = factory.build(sample, informationCriteria)
-    # print "Estimated ARMA=", result2
-    # print "Information criteria=", informationCriteria
-    history = WhittleFactoryStateCollection(factory.getHistory())
-    firstTestes = WhittleFactoryState(history[0])
-    # print "History=", factory.getHistory()
-
-except:
-    import sys
-    print("t_WhittleFactory_std.py", sys.exc_info()[0], sys.exc_info()[1])
+# Second, build the best ARMA based on a given range of order using the
+# WhittleFactory
+pIndices = Indices(p + 1)
+pIndices.fill()
+qIndices = Indices(q + 1)
+qIndices.fill()
+factory = WhittleFactory(pIndices, qIndices)
+print("factory=", factory)
+informationCriteria = Point()
+result, informationCriteria = factory.buildWithCriteria(TimeSeries(timeSeries))
+# print "Estimated ARMA=", result
+# print "Information criteria=", informationCriteria
+# print "History=", factory.getHistory()
+result2, informationCriteria = factory.buildWithCriteria(sample)
+# print "Estimated ARMA=", result2
+# print "Information criteria=", informationCriteria
+history = WhittleFactoryStateCollection(factory.getHistory())
+firstTestes = WhittleFactoryState(history[0])
+# print "History=", factory.getHistory()


### PR DESCRIPTION
- Allows to disambiguate whether to return information criteria
- Return it in a tuple instead of by reference
- Removed useless ARMAFactoryImplementation::build with reference