### PR TITLE
Allow notebook testing without nbsphinx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ if (BUILD_PYTHON)
   find_python_module (numpy)
   find_python_module (scipy)
   find_python_module (matplotlib 1.1)
+  find_python_module (nbconvert)
 
   if (USE_SPHINX)
     find_program (SPHINX_EXECUTABLE NAMES sphinx-build DOC "Sphinx Documentation Builder (sphinx-doc.org)")

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -615,7 +615,7 @@ ot_pyinstallcheck_test (Waarts_system_series)
 ot_pyinstallcheck_test (Waarts_saddle)
 
 ## Misc
-if (NBSPHINX_FOUND) # depends on nbconvert, nbformat
+if (NBCONVERT_FOUND AND MATPLOTLIB_FOUND AND R_rot_FOUND)
   ot_pyinstallcheck_test (notebook IGNOREOUT)
 endif ()
 if (MATPLOTLIB_FOUND)


### PR DESCRIPTION
nbsphinx is not necessary to enable notebook tests, only nbconvert, mpl...