### PR TITLE
Fix (Linear|Quadratic)NumericalMathFunction aliases

### DIFF
--- a/python/src/LinearFunction.i
+++ b/python/src/LinearFunction.i
@@ -11,8 +11,8 @@ namespace OT { %extend LinearFunction { LinearFunction(const LinearFunction & ot
 
 %pythoncode %{
 # deprecated
-class LinearFunction(LinearFunction):
+class LinearNumericalMathFunction(LinearFunction):
     def __init__(self, *args):
-        super(LinearFunction, self).__init__(*args)
-        openturns.common.Log.Warn('class LinearFunction is deprecated in favor of LinearFunction')
+        super(LinearNumericalMathFunction, self).__init__(*args)
+        openturns.common.Log.Warn('class LinearNumericalMathFunction is deprecated in favor of LinearFunction')
 %}

--- a/python/src/QuadraticFunction.i
+++ b/python/src/QuadraticFunction.i
@@ -11,8 +11,8 @@ namespace OT { %extend QuadraticFunction { QuadraticFunction(const QuadraticFunc
 
 %pythoncode %{
 # deprecated
-class QuadraticFunction(QuadraticFunction):
+class QuadraticNumericalMathFunction(QuadraticFunction):
     def __init__(self, *args):
-        super(QuadraticFunction, self).__init__(*args)
-        openturns.common.Log.Warn('class QuadraticFunction is deprecated in favor of QuadraticFunction')
+        super(QuadraticNumericalMathFunction, self).__init__(*args)
+        openturns.common.Log.Warn('class QuadraticNumericalMathFunction is deprecated in favor of QuadraticFunction')
 %}


### PR DESCRIPTION
These are deprecated, and that also fixes the documentation as it shadows the dostrings of LinearFunction, QuadraticFunction