### PR TITLE
Disable hmat-oss progress bar during factorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if (MUPARSER_FOUND)
 endif ()
 
 if (USE_HMAT)
-  find_package (HMAT 1.1 NO_MODULE)
+  find_package (HMAT 1.2 NO_MODULE)
 endif ()
 if (HMAT_FOUND)
   set (OPENTURNS_HAVE_HMAT TRUE)

--- a/lib/src/Base/Stat/HMatrixImplementation.cxx
+++ b/lib/src/Base/Stat/HMatrixImplementation.cxx
@@ -310,7 +310,11 @@ void HMatrixImplementation::factorize(const String& method)
 
   try
   {
-    static_cast<hmat_interface_t*>(hmatInterface_)->factorize(static_cast<hmat_matrix_t*>(hmat_), fact_method);
+    hmat_factorization_context_t context;
+    hmat_factorization_context_init(&context);
+    context.factorization = fact_method;
+    context.progress = NULL;
+    static_cast<hmat_interface_t*>(hmatInterface_)->factorize_generic(static_cast<hmat_matrix_t*>(hmat_), &context);
   }
   catch (std::exception& ex)
   {

--- a/python/doc/developer_guide/architecture.rst
+++ b/python/doc/developer_guide/architecture.rst
@@ -195,7 +195,7 @@ The tools chosen for the development of the platform are:
 +---------------------------------------+-----------------------------------------------------------+-------------------+
 | Linear algebra                        | `LAPACK <http://www.netlib.org/lapack/>`_                 | 3.0               |
 +---------------------------------------+-----------------------------------------------------------+-------------------+
-| Linear algebra (optional)             | `HMat <https://github.com/jeromerobert/hmat-oss>`_        | 1.1               |
+| Linear algebra (optional)             | `HMat <https://github.com/jeromerobert/hmat-oss>`_        | 1.2               |
 +---------------------------------------+-----------------------------------------------------------+-------------------+
 | Analytical parser (optional)          | `muParser <http://muparser.beltoforion.de/>`_             | 1.32              |
 +---------------------------------------+-----------------------------------------------------------+-------------------+


### PR DESCRIPTION
This progress bar had been added in latest hmat-oss (> 1.5.0).
We can replace calls to factorize by factorize_generic (added in hmat-oss 1.2.0)
to disable this progress bar.