### PR TITLE
Fix RandomMixture::computePDF with 2 atoms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -115,6 +115,7 @@
  * #879 (Incomplete arguments in FunctionalChaosRandomVector docstrings)
  * #882 (RandomMixture segfaults with Dirac)
  * #883 (VisualTest.DrawHistogram should rely on Histogram.drawPDF)
+ * #887 (Bogus PDF evaluation in RandomMixture with mix of continuous/discrete variables)
 
 == 1.8 release (2016-11-18) == #release-1.8
 

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -2683,7 +2683,7 @@ Bool RandomMixture::isIntegral() const
     if (!distributionCollection_[i].isDiscrete()) return false;
     // Check if all the weights are integer
     for (UnsignedInteger j = 0; j < dimension; ++j)
-      if (weights_(i, j) != round(weights_(i, j))) return false;
+      if (weights_(j, i) != round(weights_(j, i))) return false;
   }
   return true;
 }

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -744,8 +744,8 @@ Scalar RandomMixture::computePDF(const Point & point) const
   const Point upperBound(range.getUpperBound());
   for (UnsignedInteger j = 0; j < dimension_; ++j)
     if ((point[j] <= lowerBound[j]) || (point[j] >= upperBound[j])) return 0.0;
-  // Special case for 1D distributions with exactly 2 atoms
-  if ((dimension_ == 1) && (distributionCollection_.getSize() == 2))
+  // Special case for 1D distributions with exactly 2 continuous atoms
+  if ((dimension_ == 1) && (distributionCollection_.getSize() == 2) && distributionCollection_[0].isContinuous() && distributionCollection_[1].isContinuous())
   {
     // Get the parameters of the random mixture
     const Scalar z0 = point[0] - constant_[0];
@@ -1727,8 +1727,8 @@ Scalar RandomMixture::computeCDF(const Point & point) const
   const Scalar upperBound = range.getUpperBound()[0];
   if (x <= lowerBound) return 0.0;
   if (x >= upperBound) return 1.0;
-  // Special case for 1D distributions with exactly 2 atoms
-  if ((dimension_ == 1) && (distributionCollection_.getSize() == 2))
+  // Special case for 1D distributions with exactly 2 continuous atoms
+  if ((dimension_ == 1) && (distributionCollection_.getSize() == 2) && distributionCollection_[0].isContinuous() && distributionCollection_[1].isContinuous())
   {
     // Get the parameters of the random mixture
     const Scalar z0 = x - constant_[0];


### PR DESCRIPTION
This fix http://trac.openturns.org/ticket/887 : the kernel convolution should be performed only if all atoms are continuous.

Fix also a small bug in RandomMixture::isIntegral

