### PR TITLE
Fix Mixture::isContinuous

### DIFF
--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -544,8 +544,8 @@ Bool Mixture::isElliptical() const
 Bool Mixture::isContinuous() const
 {
   const UnsignedInteger size = distributionCollection_.getSize();
-  for (UnsignedInteger i = 0; i < size; ++i) if (!distributionCollection_[i].isContinuous()) return false;
-  return true;
+  for (UnsignedInteger i = 0; i < size; ++i) if (distributionCollection_[i].isContinuous()) return true;
+  return false;
 }
 
 /* Check if the distribution is discrete */


### PR DESCRIPTION
 Distribution is continuous as soon as one of the atoms is continuous