### PR TITLE
Fixed TensorApproximationResult

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationResult.cxx
@@ -23,7 +23,6 @@
 #include "openturns/OSS.hxx"
 #include "openturns/Sample.hxx"
 #include "openturns/PersistentObjectFactory.hxx"
-#include "openturns/CenteredFiniteDifferenceGradient.hxx"
 #include "openturns/CenteredFiniteDifferenceHessian.hxx"
 #include "openturns/CanonicalTensorGradient.hxx"
 
@@ -72,6 +71,7 @@ TensorApproximationResult::TensorApproximationResult(
     Function tensorFunction;
     tensorFunction.setEvaluation(tensorCollection_[outputIndex].clone());
     tensorFunction.setGradient(CanonicalTensorGradient(tensorCollection_[outputIndex]));
+    tensorFunction.setHessian(new CenteredFiniteDifferenceHessian(ResourceMap::GetAsScalar( "CenteredFiniteDifferenceHessian-DefaultEpsilon" ), tensorFunction.getEvaluation()));
     marginals.add(tensorFunction);
   }
   composedMetaModel_ = Function(marginals);


### PR DESCRIPTION
The getMarginal() method failed when called on a TensorApproximationResult meta-model due to a missing implementation of the Hessian