### PR TITLE
Install sphinx stable on precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,7 @@ install:
    fi
 # sphinx >=1.2 is looking better
   - if test "$TRAVIS_OS_NAME" = "linux"; then
-      pip install six docutils numpydoc --user &&
-      pip install git+https://github.com/sphinx-doc/sphinx.git --user;
+      pip install numpydoc sphinx --user;
     fi
 # keep an eye on swig
   - git clone https://github.com/swig/swig.git


### PR DESCRIPTION
as git version requires to use newer setuptools on the contrary to the wheels package