### PR TITLE
New method SampleImplementation::operator()(i,j)

### DIFF
--- a/lib/src/Base/Stat/Sample.cxx
+++ b/lib/src/Base/Stat/Sample.cxx
@@ -165,7 +165,7 @@ Scalar & Sample::operator () (const UnsignedInteger i,
   return this->at(i, j);
 #else
   copyOnWrite();
-  return (*getImplementation())[i][j];
+  return (*getImplementation())(i, j);
 #endif /* DEBUG_BOUNDCHECKING */
 }
 
@@ -175,7 +175,7 @@ const Scalar & Sample::operator () (const UnsignedInteger i,
 #ifdef DEBUG_BOUNDCHECKING
   return this->at(i, j);
 #else
-  return (*getImplementation())[i][j];
+  return (*getImplementation())(i, j);
 #endif /* DEBUG_BOUNDCHECKING */
 }
 

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -570,6 +570,17 @@ public:
     return NSI_const_point(this, index);
   }
 
+  inline Scalar & operator () (const UnsignedInteger i,
+                               const UnsignedInteger j)
+  {
+    return data_[j + i * dimension_];
+  }
+  inline const Scalar & operator () (const UnsignedInteger i,
+                                     const UnsignedInteger j) const
+  {
+    return data_[j + i * dimension_];
+  }
+
   void swap_points(const UnsignedInteger a, const UnsignedInteger b);
   void swap_range_points(const UnsignedInteger fa, const UnsignedInteger ta, const UnsignedInteger fb);
 #endif


### PR DESCRIPTION
Call it from Sample::operator()(i,j) to avoid creation of
NSI_point or NSI_const_point objects.