### PR TITLE
Fix loading configuration file on OSX when installing with conda

### DIFF
--- a/lib/src/Base/Common/Path.cxx
+++ b/lib/src/Base/Common/Path.cxx
@@ -111,7 +111,11 @@ FileName Path::GetInstallationDirectory()
   }
   if (!dirExists)
   {
-    directory = String(INSTALL_PATH);
+    // NOTE: When installing with conda, INSTALL_PATH is substituted during
+    // package installation.  On OSX, String(INSTALL_PATH) creates a
+    // string with new content but original size; thus we use a C string
+    // to update string length
+    directory = String(INSTALL_PATH).c_str();
   }
   return directory;
 }
@@ -218,7 +222,8 @@ Path::DirectoryList Path::GetConfigDirectoryList()
   }
   if (!dirExists)
   {
-    directory = String(SYSCONFIG_PATH) + PrefixConfigSubdirectory_;
+    // See in NOTE above why we use c_str() here
+    directory = String() + String(SYSCONFIG_PATH).c_str() + PrefixConfigSubdirectory_;
   }
   directoryList.push_back(directory);
 


### PR DESCRIPTION
Conda performs prefix substitution within libraries so that packages
are relocatable.  On OSX, line
  directory = String(SYSCONFIG_PATH) + PrefixConfigSubdirectory_;
causes trouble.  When compiling, conda makes SYSCONFIG_PATH a very long
string, and it is replaced during installation.
On Linux, it works as expected, string contains the new path, and /openturns
is appended to it afterwards.
On OSX, string also contains the new path, but it keeps its original length,
and thus /openturns is appended after lots of \0.

With
  directory = String() + String(SYSCONFIG_PATH).c_str() + PrefixConfigSubdirectory_;
SYSCONFIG_PATH is adjusted to have the new length.