### PR TITLE
Improve Sample I/O

### DIFF
--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -493,10 +493,12 @@ String SampleImplementation::streamToRFormat() const
   oss.setPrecision(16);
   oss << "matrix(c(";
   String separator("");
+  UnsignedInteger index = 0;
   for (UnsignedInteger j = 0; j < dimension_; ++j)
     for (UnsignedInteger i = 0; i < size_; ++i, separator = ",")
     {
-      const Scalar value = operator[](i)[j];
+      const Scalar value = data_[index];
+      ++index;
       const Bool isNaN = value != value;
       oss << separator << (isNaN ? "\"" : "") << value << (isNaN ? "\"" : "");
     }

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -2139,6 +2139,7 @@ void SampleImplementation::exportToCSVFile(const FileName & filename,
     throw FileOpenException(HERE) << "Could not open file " << filename;
   csvFile.imbue(std::locale("C"));
   csvFile.precision(16);
+  csvFile << std::scientific;
   // Export the description
   if (!p_description_.isNull())
   {
@@ -2152,24 +2153,24 @@ void SampleImplementation::exportToCSVFile(const FileName & filename,
       if (isBlank) csvFile << separator << "\"NoDescription\"";
       else csvFile << separator << "\"" << description[i] << "\"";
     }
-    csvFile << std::endl;
+    csvFile << "\n";
   }
-
   // Write the data
+  UnsignedInteger index = 0;
   for(UnsignedInteger i = 0; i < size_; ++i)
-  {
-    String separator;
-    for(UnsignedInteger j = 0; j < dimension_; ++j, separator = csvSeparator)
     {
-      csvFile << separator << std::scientific << operator[](i)[j];
-    }
-    csvFile << std::endl;
-  }
-
+      csvFile << data_[index];
+      ++index;
+      for(UnsignedInteger j = 1; j < dimension_; ++j)
+	{
+	  csvFile << csvSeparator << data_[index];
+	  ++index;
+	} // j
+      csvFile << "\n";
+    } // i
   // Close the file
   csvFile.close();
 }
-
 
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -462,17 +462,25 @@ String SampleImplementation::storeToTemporaryFile() const
 {
   const String dataFileName(Path::BuildTemporaryFileName("RData.txt.XXXXXX"));
   std::ofstream dataFile(dataFileName.c_str());
+  dataFile << std::setprecision(16);
   // Fill-in the data file
+  UnsignedInteger index = 0;
   for (UnsignedInteger i = 0; i < size_; ++i)
   {
-    String separator = "";
-    for (UnsignedInteger j = 0; j < dimension_; ++j, separator = " ")
+    Scalar value = data_[index];
+    ++index;
+    Bool isNaN = value != value;
+    if (isNaN) dataFile << '\"' << value << '\"';
+    else dataFile << value;
+    for (UnsignedInteger j = 1; j < dimension_; ++j)
     {
-      const Scalar value = operator[](i)[j];
-      const Bool isNaN = value != value;
-      dataFile << separator << std::setprecision(16) << (isNaN ? "\"" : "") << value << (isNaN ? "\"" : "");
+      value = data_[index];
+      ++index;
+      isNaN = value != value;
+      if (isNaN) dataFile << ' ' << '\"' << value << '\"';
+      else dataFile << ' ' << value;
     }
-    dataFile << std::endl;
+    dataFile << "\n";
   }
   dataFile.close();
   return dataFileName;

--- a/lib/src/Base/Stat/csv_lexer.ll
+++ b/lib/src/Base/Stat/csv_lexer.ll
@@ -49,7 +49,7 @@ space     [ \t]
 
 %%
 
-{real}      { std::istringstream iss(yytext); iss.imbue(std::locale("C")); iss >> yylval_param->real; return(REAL); }
+{real} { yylval_param->real = atof(yytext); return(REAL); }
 
 {string}    { yylval_param->st = yytext; return(STRING); }
 


### PR DESCRIPTION
With this PR:
- the import of CSV files using the flex/yacc parser is much more efficient thanks to the use of atof (and thanks to @dbarbier )
- the export to CSV files is more efficient 
- the streaming to R format and the export to temporary file are also slightly improved

On a 6x10000000 (ie 800Mo) file, with OT 1.9 I get:

> Text import
t= 56.2426171303 s, speed= 1.06680668613 Mvalues/s
CSV import via Text
t= 77.4492180347 s, speed= 0.774701172232 Mvalues/s
CSV import
t= 72.4423568249 s, speed= 0.828244726287 Mvalues/s
CSV export
t= 45.195127964 s, speed= 1.3275767257 Mvalues/s
Stream to R format
t= 44.9941790104 s, speed= 1.33350582941 Mvalues/s
Store to temporary file
t= 41.1363098621 s, speed= 1.45856544258 Mvalues/s
Pandas import CSV
t= 10.5111160278 s, speed= 5.70824257302 Mvalues/s

and with this PR:

> Text import
t= 53.5143899918 s, speed= 1.12119375759 Mvalues/s
CSV import via Text
t= 77.2043898106 s, speed= 0.777157881142 Mvalues/s
CSV import
t= 15.3106789589 s, speed= 3.91883339472 Mvalues/s
CSV export
t= 22.0157170296 s, speed= 2.72532572614 Mvalues/s
Stream to R format                                                                                                                                                                                                                           
t= 40.2659649849 s, speed= 1.49009219132 Mvalues/s                                                                                                                                                                                           
Store to temporary file                                                                                                                                                                                                                      
t= 36.420114994 s, speed= 1.64744125629 Mvalues/s                                                                                                                                                                                            
Pandas import CSV                                                                                                                                                                                                                            
t= 10.755480051 s, speed= 5.57855155839 Mvalues/s                                                                                                                                                                                            

The other methods will be improved in a separate PR