### PR TITLE
Remove Sample Scalar translation operators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
  * Removed deprecated GramSchmidtAlgorithm, ChebychevAlgorithm classes
  * Removed [gs]etOptimizationSolver methods
  * Removed CovarianceModel::compute{AsScalar,StandardRepresentative} overloads
+ * Removed Sample Scalar translation operators
 
 === Python module ===
 

--- a/lib/src/Base/Stat/Sample.cxx
+++ b/lib/src/Base/Stat/Sample.cxx
@@ -552,13 +552,6 @@ UnsignedInteger Sample::find(const Point & point) const
 /*
  * Translate realizations in-place
  */
-Sample & Sample::operator += (const Scalar translation)
-{
-  copyOnWrite();
-  if (translation != 0.0) getImplementation()->operator +=(Point(getDimension(), translation));
-  return *this;
-}
-
 Sample & Sample::operator += (const Point & translation)
 {
   copyOnWrite();
@@ -570,13 +563,6 @@ Sample & Sample::operator += (const Sample & translation)
 {
   copyOnWrite();
   getImplementation()->operator +=(*translation.getImplementation());
-  return *this;
-}
-
-Sample & Sample::operator -= (const Scalar translation)
-{
-  copyOnWrite();
-  if (translation != 0.0) getImplementation()->operator -=(Point(getDimension(), translation));
   return *this;
 }
 
@@ -594,12 +580,6 @@ Sample & Sample::operator -= (const Sample & translation)
   return *this;
 }
 
-Sample Sample::operator + (const Scalar translation) const
-{
-  const Sample sample(getImplementation()->operator + (translation));
-  return sample;
-}
-
 Sample Sample::operator + (const Point & translation) const
 {
   const Sample sample(getImplementation()->operator + (translation));
@@ -609,12 +589,6 @@ Sample Sample::operator + (const Point & translation) const
 Sample Sample::operator + (const Sample & translation) const
 {
   const Sample sample(getImplementation()->operator + (*translation.getImplementation()));
-  return sample;
-}
-
-Sample Sample::operator - (const Scalar translation) const
-{
-  const Sample sample(getImplementation()->operator - (translation));
   return sample;
 }
 

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -1830,12 +1830,6 @@ void SampleImplementation::translate(const Point & translation)
   TBB::ParallelFor( 0, size_, functor );
 }
 
-SampleImplementation & SampleImplementation::operator += (const Scalar translation)
-{
-  translate(Point(dimension_, translation));
-  return *this;
-}
-
 SampleImplementation & SampleImplementation::operator += (const Point & translation)
 {
   translate(translation);
@@ -1883,11 +1877,6 @@ SampleImplementation & SampleImplementation::operator += (const SampleImplementa
   return *this;
 }
 
-SampleImplementation & SampleImplementation::operator -= (const Scalar translation)
-{
-  return operator +=(-translation);
-}
-
 SampleImplementation & SampleImplementation::operator -= (const Point & translation)
 {
   return operator +=(translation * (-1.0));
@@ -1900,11 +1889,6 @@ SampleImplementation & SampleImplementation::operator -= (const SampleImplementa
   const NegativeTranslationSamplePolicy policy( translation, *this );
   TBB::ParallelFor( 0, size_, policy );
   return *this;
-}
-
-SampleImplementation SampleImplementation::operator + (const Scalar translation) const
-{
-  return operator+(Point(dimension_, translation));
 }
 
 SampleImplementation SampleImplementation::operator + (const Point & translation) const
@@ -1921,11 +1905,6 @@ SampleImplementation SampleImplementation::operator + (const SampleImplementatio
   sample += translation;
   sample.setName("");
   return sample;
-}
-
-SampleImplementation SampleImplementation::operator - (const Scalar translation) const
-{
-  return operator-(Point(dimension_, translation));
 }
 
 SampleImplementation SampleImplementation::operator - (const Point & translation) const

--- a/lib/src/Base/Stat/openturns/Sample.hxx
+++ b/lib/src/Base/Stat/openturns/Sample.hxx
@@ -278,18 +278,14 @@ public:
   /**
    * Translate realizations in-place
    */
-  Sample & operator += (const Scalar translation);
   Sample & operator += (const Point & translation);
   Sample & operator += (const Sample & translation);
-  Sample & operator -= (const Scalar translation);
   Sample & operator -= (const Point & translation);
   Sample & operator -= (const Sample & translation);
 
   /** Translate/scale realizations */
-  Sample operator + (const Scalar translation) const;
   Sample operator + (const Point & translation) const;
   Sample operator + (const Sample & translation) const;
-  Sample operator - (const Scalar translation) const;
   Sample operator - (const Point & translation) const;
   Sample operator - (const Sample & translation) const;
   Sample operator * (const Scalar scaling) const;

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -761,18 +761,14 @@ public:
   /**
    * Translate realizations in-place
    */
-  SampleImplementation & operator += (const Scalar translation);
   SampleImplementation & operator += (const Point & translation);
   SampleImplementation & operator += (const SampleImplementation & translation);
-  SampleImplementation & operator -= (const Scalar translation);
   SampleImplementation & operator -= (const Point & translation);
   SampleImplementation & operator -= (const SampleImplementation & translation);
 
   /** Translate realizations */
-  SampleImplementation operator + (const Scalar translation) const;
   SampleImplementation operator + (const Point & translation) const;
   SampleImplementation operator + (const SampleImplementation & translation) const;
-  SampleImplementation operator - (const Scalar translation) const;
   SampleImplementation operator - (const Point & translation) const;
   SampleImplementation operator - (const SampleImplementation & translation) const;
 

--- a/python/src/Axial_doc.i.in
+++ b/python/src/Axial_doc.i.in
@@ -42,6 +42,6 @@ Examples
 >>> myCenteredReductedGrid = ot.Axial(2, levels)
 >>> mySample = myCenteredReductedGrid.generate()
 >>> # Translate the grid
->>> mySample+=4
+>>> mySample += [4.0]*2
 >>> # Scale each direction
->>> mySample*=2"
+>>> mySample *= 2.0"

--- a/python/src/Composite_doc.i.in
+++ b/python/src/Composite_doc.i.in
@@ -39,6 +39,6 @@ Examples
 >>> myCenteredReductedGrid = ot.Composite(2, levels)
 >>> mySample = myCenteredReductedGrid.generate()
 >>> # Translate the grid
->>> mySample+=4
+>>> mySample += [4.0]*2
 >>> # Scale each direction
->>> mySample*=2"
+>>> mySample *= 2.0"

--- a/python/src/Factorial_doc.i.in
+++ b/python/src/Factorial_doc.i.in
@@ -42,6 +42,6 @@ Examples
 >>> myCenteredReductedGrid = ot.Factorial(2, levels)
 >>> mySample = myCenteredReductedGrid.generate()
 >>> # Translate the grid
->>> mySample+=4
+>>> mySample += [4.0]*2
 >>> # Scale each direction
->>> mySample*=2"
+>>> mySample *= 2.0"

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -79,10 +79,6 @@ experiments
 0 : [ 0 0 ]
 1 : [ 2 2 ]
 2 : [ 4 4 ]
->>> print(sample - sample[0, 0])
-0 : [ 0 1 ]
-1 : [ 2 3 ]
-2 : [ 4 5 ]
 
 **Scaling:** right multiplication or division of a (compatible) square matrix
 with the points in the sample (this can be used e.g. for rotating all the


### PR DESCRIPTION
Removes Sample::operator+/-[=](Scalar) for consistency with other objects.