### PR TITLE
Make MatrixImplementation::isPositiveDefinite const

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@
  * Removed CovarianceModel::compute{AsScalar,StandardRepresentative} overloads
  * Deprecated PosteriorRandomVector
  * Deprecated MonteCarlo, ImportanceSampling, QuasiMonteCarlo, RandomizedQuasiMonteCarlo, RandomizedLHS classes
+ * Made MatrixImplementation::isPositiveDefinite const and removed its argument
 
 === Python module ===
 

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -100,9 +100,7 @@ PenalizedLeastSquaresAlgorithm::PenalizedLeastSquaresAlgorithm(const Sample & x,
   const UnsignedInteger basisSize = indices.getSize();
   // Check if the penalization matrix has the proper dimension
   if (penalizationMatrix_.getDimension() != basisSize) throw InvalidArgumentException(HERE) << "Error: the given penalization matrix has an improper dimension.";
-  // Must const_cast here because the isPositiveDefinite() method is not const in
-  // the general case, but no modification will occur here.
-  if (!const_cast<CovarianceMatrix*>(&penalizationMatrix)->isPositiveDefinite()) throw NotSymmetricDefinitePositiveException(HERE) << "Error: the given penalization matrix is not strictly definite positive.";
+  if (!penalizationMatrix_.isPositiveDefinite()) throw NotSymmetricDefinitePositiveException(HERE) << "Error: the given penalization matrix is not strictly definite positive.";
 }
 
 void PenalizedLeastSquaresAlgorithm::run()

--- a/lib/src/Base/Stat/CovarianceMatrix.cxx
+++ b/lib/src/Base/Stat/CovarianceMatrix.cxx
@@ -92,9 +92,9 @@ CovarianceMatrix CovarianceMatrix::operator * (const IdentityMatrix & m) const
 }
 
 /* Check if the matrix is SPD */
-Bool CovarianceMatrix::isPositiveDefinite(const Bool keepIntact)
+Bool CovarianceMatrix::isPositiveDefinite() const
 {
-  return getImplementation()->isPositiveDefinite(keepIntact);
+  return getImplementation()->isPositiveDefinite();
 }
 
 /* Build the Cholesky factorization of the matrix */

--- a/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
@@ -71,7 +71,7 @@ public:
   CovarianceMatrix operator * (const IdentityMatrix & m) const;
 
   /** Check if the matrix is SPD */
-  virtual Bool isPositiveDefinite(const Bool keepIntact = true);
+  virtual Bool isPositiveDefinite() const;
 
   /** Build the Cholesky factorization of the matrix */
   virtual TriangularMatrix computeCholesky(const Bool keepIntact = true);

--- a/lib/src/Base/Type/IdentityMatrix.cxx
+++ b/lib/src/Base/Type/IdentityMatrix.cxx
@@ -160,7 +160,7 @@ Point IdentityMatrix::computeSVD(Matrix & u,
 }
 
 /* Check if the matrix is SPD */
-Bool IdentityMatrix::isPositiveDefinite(const Bool keepIntact)
+Bool IdentityMatrix::isPositiveDefinite() const
 {
   return true;
 }

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -1240,19 +1240,15 @@ Point MatrixImplementation::computeSVD(MatrixImplementation & u,
 
 
 /* Check if the matrix is SPD */
-Bool MatrixImplementation::isPositiveDefinite(const Bool keepIntact)
+Bool MatrixImplementation::isPositiveDefinite() const
 {
   int info;
   int n(nbRows_);
   if (n == 0) throw InvalidDimensionException(HERE) << "Cannot check the definite positiveness of an empty matrix";
   char uplo('L');
   int luplo(1);
-  if (keepIntact)
-  {
-    MatrixImplementation A(*this);
-    dpotrf_(&uplo, &n, &A[0], &n, &info, &luplo);
-  }
-  else dpotrf_(&uplo, &n, &(*this)[0], &n, &info, &luplo);
+  MatrixImplementation A(*this);
+  dpotrf_(&uplo, &n, &A[0], &n, &info, &luplo);
   return (info == 0) ;
 }
 

--- a/lib/src/Base/Type/openturns/IdentityMatrix.hxx
+++ b/lib/src/Base/Type/openturns/IdentityMatrix.hxx
@@ -92,7 +92,7 @@ public:
                   const Bool keepIntact = true);
 
   /** Check if the matrix is SPD */
-  virtual Bool isPositiveDefinite(const Bool keepIntact = true);
+  virtual Bool isPositiveDefinite() const;
 
   /** Build the Cholesky factorization of the matrix */
   TriangularMatrix computeCholesky(const Bool keepIntact = true);

--- a/lib/src/Base/Type/openturns/MatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/MatrixImplementation.hxx
@@ -239,7 +239,7 @@ public:
   virtual Bool isSymmetric() const;
 
   /** Check if the matrix is SPD */
-  virtual Bool isPositiveDefinite(const Bool keepIntact = true);
+  virtual Bool isPositiveDefinite() const;
 
   /** Check if the matrix values belong to (-1;1) */
   virtual Bool hasUnitRange() const;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -454,7 +454,7 @@ Normal KrigingResult::operator()(const Sample & xi) const
   // Check the covariance matrix. Indeed, if point is very similar to one of the learning points, covariance is null
   // Even if this check is done in Normal::Normal, we perform debugging
   LOGINFO("In KrigingResult::operator() : evaluationg the Normal distribution");
-  if (!const_cast<CovarianceMatrix*>(&covarianceMatrix)->isPositiveDefinite()) throw InvalidArgumentException(HERE) << "In KrigingResult::operator(), the covariance matrix is not positive definite. The given points could be very close to the learning set. Could not build the Normal distribution";
+  if (!covarianceMatrix.isPositiveDefinite()) throw InvalidArgumentException(HERE) << "In KrigingResult::operator(), the covariance matrix is not positive definite. The given points could be very close to the learning set. Could not build the Normal distribution";
   // Finally return the distribution
   return Normal(mean, covarianceMatrix);
 }

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -101,7 +101,7 @@ Normal::Normal(const Point & mean,
   setName("Normal");
   UnsignedInteger dimension = mean.getDimension();
   if (C.getDimension() != dimension) throw InvalidArgumentException(HERE) << "Error: the mean vector and the covariance matrix have incompatible dimensions";
-  if (!const_cast<CovarianceMatrix*>(&C)->isPositiveDefinite()) throw InvalidArgumentException(HERE) << "Error: the covariance matrix is not positive definite";
+  if (!C.isPositiveDefinite()) throw InvalidArgumentException(HERE) << "Error: the covariance matrix is not positive definite";
   Point sigma(dimension);
   CorrelationMatrix R(dimension);
   for (UnsignedInteger i = 0; i < dimension; ++i)

--- a/lib/src/Uncertainty/Model/EllipticalDistribution.cxx
+++ b/lib/src/Uncertainty/Model/EllipticalDistribution.cxx
@@ -481,7 +481,7 @@ void EllipticalDistribution::setCorrelation(const CorrelationMatrix & R)
         << "). Unable to construct elliptical distribution object.";
 
   // We check that the given correlation matrix is definite positive
-  if ( !const_cast<CorrelationMatrix*>(&R)->isPositiveDefinite()) throw InvalidArgumentException(HERE) << "The correlation matrix must be definite positive R=" << R;
+  if ( !R.isPositiveDefinite()) throw InvalidArgumentException(HERE) << "The correlation matrix must be definite positive R=" << R;
   R_ = R;
   update();
   isAlreadyComputedCovariance_ = false;

--- a/python/src/CovarianceMatrix_doc.i.in
+++ b/python/src/CovarianceMatrix_doc.i.in
@@ -82,12 +82,6 @@ cholesky_factor : :class:`~openturns.SquareMatrix`
 A matrix :math:`\mat{M}` is positive definite if :math:`\Tr{\vect{z}} \mat{M} \vect{z}`
 is positive for every compatible non-zero column vector :math:`\vect{z}`.
 
-Parameters
-----------
-keep_intact : bool, optional
-    A flag telling whether the present matrix can be overwritten or not.
-    Default is *True* and leaves the present matrix unchanged.
-
 Notes
 -----
 This uses LAPACK's `DPOTRF <http://www.netlib.org/lapack/lapack-3.1.1/html/dpotrf.f.html>`_.


### PR DESCRIPTION
Drop its argument.

No code actually calls this method with keepIntact=false, and this is
normal since it does not make sense to overwrite the matrix.