### PR TITLE
Let ProcessSample::getField() method throw OutOfBoundException

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@
 === Bug fixes ===
  * #890 (Cannot build triangular distribution)
  * #891 (Viewer issue with Pairs drawables)
+ * #896 (Python iteration in ProcessSample leads to capacity overflow)
  * #897 (Bug in Graph::draw with small data)
 
 == 1.9 release (2017-04-18) == #release-1.9

--- a/lib/src/Base/Stat/ProcessSample.cxx
+++ b/lib/src/Base/Stat/ProcessSample.cxx
@@ -116,27 +116,27 @@ void ProcessSample::add(const Sample & values)
 /* Operators accessors */
 Field ProcessSample::getField(const UnsignedInteger index) const
 {
-  if (index >= data_.getSize()) throw InvalidArgumentException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
+  if (index >= data_.getSize()) throw OutOfBoundException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
   return Field(mesh_, data_[index]);
 }
 
 void ProcessSample::setField(const Field & field,
                              const UnsignedInteger index)
 {
-  if (index >= data_.getSize()) throw InvalidArgumentException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
+  if (index >= data_.getSize()) throw OutOfBoundException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
   if (field.getDimension() != data_[0].getDimension()) throw InvalidArgumentException(HERE) << "Error: expected a field of dimension=" << data_[0].getDimension() << ", got a field of dimension=" << field.getDimension();
   data_[index] = field.getValues();
 }
 
 Sample & ProcessSample::operator[] (const UnsignedInteger index)
 {
-  if (index >= data_.getSize()) throw InvalidArgumentException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
+  if (index >= data_.getSize()) throw OutOfBoundException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
   return data_[index];
 }
 
 const Sample & ProcessSample::operator[] (const UnsignedInteger index) const
 {
-  if (index >= data_.getSize()) throw InvalidArgumentException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
+  if (index >= data_.getSize()) throw OutOfBoundException(HERE)  << " Error - index should be between 0 and " << data_.getSize() - 1;
   return data_[index];
 }
 

--- a/python/src/Field.i
+++ b/python/src/Field.i
@@ -23,17 +23,16 @@ Point __getitem__ (SignedInteger index) const
   if (index < 0) {
     index += self->getSize();
   }
-  return self->getValueAtIndex(index);
+  return self->at(index);
 }
 
 void __setitem__ (SignedInteger index,
                   const Point & val)
 {
-  self->copyOnWrite();
   if (index < 0) {
     index += self->getSize();
   }
-  self->setValueAtIndex(index, val);
+  self->at(index) = val;
 }
 
 UnsignedInteger __len__() const


### PR DESCRIPTION
This method is called from `ProcessSample::__getitem__`.
OTexception.i transforms OutOfBoundException into IndexError,
which is needed by Python to end its for loops.
Fix http://trac.openturns.org/ticket/896

For consistency reason, the same change is applied to setField and operator[].

In `Field::__getitem__`, call `at()` method instead of `getValueAtIndex()`;
the former checks its argument and will thus generate an IndexError.
Copy `FieldImplementation::__setitem__` into Field class, there is no reason
to have different implementations.