### PR TITLE
Handle comments in BuildFromTextFile

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -220,6 +220,7 @@
   <Sample-SmallKendallTau value="23" />
   <Sample-PrintEllipsisThreshold value="1000" />
   <Sample-PrintEllipsisSize value="3" />
+  <Sample-CommentMarkers value="#" />
 
   <!-- OT::DomainImplementation parameters -->
   <Domain-SmallVolume   value="1.0e-12" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -494,6 +494,7 @@ void ResourceMap::loadDefaultConfiguration()
   setAsUnsignedInteger( "Sample-SmallKendallTau", 23 );
   setAsUnsignedInteger("Sample-PrintEllipsisThreshold", 1000);
   setAsUnsignedInteger("Sample-PrintEllipsisSize", 3);
+  set("Sample-CommentMarkers", "#");
 
   // DomainImplementation parameters
   setAsScalar( "Domain-SmallVolume",   1.0e-12 );

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -808,13 +808,16 @@ public:
 private:
   // Parse a string into a vector of scalars and tell if there was an error
   static Bool ParseStringAsValues(const String & line,
-				  const char theSeparator,
-				  Point & data);
-  
+                                  const char theSeparator,
+                                  Point & data);
+
   // Parse a string into a vector of strings and tell if there was an error
-  static Bool ParseStringAsDescription(const String & line,
-				       const char theSeparator,
-				       Description & data);
+  static Bool ParseStringAsDescription (const String & line,
+                                        const char theSeparator,
+                                        Description & data);
+
+  // Parse a comment line
+  static Bool ParseComment(const String & line, const String & markers);
 
   void translate(const Point & translation);
   void scale(const Point & scaling);

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -158,6 +158,8 @@ Notes
 The file may or may not contain a header line (columns spanned with strings
 delimited with quotes). If it does contain such a header line, it will be
 used for setting the sample description using :py:meth:`setDescription`.
+It can also contain some comments, if a line starts with one of the
+characters contained in `Sample-CommentsMarker` from the :class:`~openturns.ResourceMap`.
 
 See Also
 --------

--- a/python/test/t_Sample_csv.expout
+++ b/python/test/t_Sample_csv.expout
@@ -16,3 +16,4 @@ aSample with missing entries (see log)= class=Sample name=a sample with missing 
 aSample with special chars (see log)= class=Sample name=a sample with special chars implementation=class=SampleImplementation name=a sample with special chars size=2 dimension=3 description=[X1,X2!()#{}%&<=>^$+-*./:\|`?,X3[unit]] data=[[5.6,-6.7,7.8],[-0.1,3.2,7.5]]
 aSample with special chars (see log)= class=Sample name=a sample with special chars implementation=class=SampleImplementation name=a sample with special chars size=2 dimension=3 description=[X1,X2!()#{}%&<=>^$+-*./:\|`?,X3[unit]] data=[[5.6,-6.7,7.8],[-0.1,3.2,7.5]]
 Stream to R format =  matrix(c(5.6,-0.1,-6.7,3.2,7.8,7.5), nrow=2, ncol=3)
+aSample with comments= class=Sample name=sample.csv implementation=class=SampleImplementation name=sample.csv size=3 dimension=4 description=[h1,h2,h3,h4] data=[[-1.2,2.3,3.4,-4.5],[5.6,-6.7,7.8,8.9],[-0.1,3.2,5.1,7.5]]

--- a/python/test/t_Sample_csv.py
+++ b/python/test/t_Sample_csv.py
@@ -94,8 +94,6 @@ try:
     aSample.setName("a sample with special chars")
     print("aSample with special chars (see log)=", repr(aSample))
 
-    os.remove('sample.csv')
-
     # Print stream to R format
     print ("Stream to R format = ",  aSample.getImplementation().streamToRFormat())
 
@@ -106,6 +104,14 @@ try:
     assert_almost_equal(tmpSample, aSample, 1e-15, 1e-15);
     os.remove(tmpFilename)
 
+    # text file with comments
+    f = open('sample.csv', 'w')
+    f.write("# hello\n\nh1 h2 h3 h4 \n-1.2 2.3 3.4 -4.5 \n#spock\n5.6 -6.7 7.8 8.9 \n-0.1 3.2 5.1 7.5 \n")
+    f.close()
+    aSample = Sample.ImportFromTextFile("sample.csv")
+    print("aSample with comments=", repr(aSample))
+
+    os.remove('sample.csv')
 except:
     import sys
     print("t_Sample_csv.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
PR #508 broke otpmml which relied on ImportFromTextFile to ignore comments.

Now lines starting with one of the chars contained in Sample-CommentMarkers setting are ignored.
This means the initial check for dimension has to look for the first data or description line.

This makes ImportFromTextFile closer to the behavior of numpy.loadtxt.

Also there was a small bug in ParseStringAsValues not eating blank spaces when the separator is ' '.