### PR TITLE
Minor swig improvement

### DIFF
--- a/python/src/Field.i
+++ b/python/src/Field.i
@@ -20,8 +20,12 @@ Field(const Field & other)
 
 Point __getitem__ (SignedInteger index) const
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   return self->at(index);
 }
@@ -29,8 +33,12 @@ Point __getitem__ (SignedInteger index) const
 void __setitem__ (SignedInteger index,
                   const Point & val)
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   self->at(index) = val;
 }

--- a/python/src/Field.i
+++ b/python/src/Field.i
@@ -40,6 +40,8 @@ void __setitem__ (SignedInteger index,
   if (index < 0) {
     throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
+  // CopyOnWrite only if index is ok
+  self->copyOnWrite();
   self->at(index) = val;
 }
 

--- a/python/src/FieldImplementation.i
+++ b/python/src/FieldImplementation.i
@@ -23,8 +23,12 @@ namespace OT{
 
 const Point __getitem__ (SignedInteger index) const
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   return self->at(index);
 }
@@ -32,8 +36,12 @@ const Point __getitem__ (SignedInteger index) const
 void __setitem__ (SignedInteger index,
                   const Point & val)
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   self->at(index) = val;
 }

--- a/python/src/ProcessSample.i
+++ b/python/src/ProcessSample.i
@@ -19,8 +19,12 @@ ProcessSample(const ProcessSample & other)
 
 Field __getitem__ (SignedInteger index) const
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   return self->getField(index);
 }
@@ -28,8 +32,12 @@ Field __getitem__ (SignedInteger index) const
 void __setitem__(SignedInteger index,
                  const Field & field)
 {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   self->setField(field, index);
 }

--- a/python/src/Sample.i
+++ b/python/src/Sample.i
@@ -107,18 +107,27 @@ namespace OT {
 %extend Sample {
 
 Point __getitem__(SignedInteger index) const {
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
+  }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
   }
   return self->at(index);
 }
 
 void __setitem__ (SignedInteger index,
                   const Point & val) {
-  self->copyOnWrite();
+  OT::UnsignedInteger size = self->getSize();
   if (index < 0) {
     index += self->getSize();
   }
+  if (index < 0) {
+    throw OT::OutOfBoundException(HERE) << "index should be in [-" << size << ", " << size - 1 << "]." ;
+  }
+  // CopyOnWrite only if index is ok
+  self->copyOnWrite();
   self->at(index) = val;
 }
 


### PR DESCRIPTION
This PR performs some {set,get}item methods : index in python should be in [-size, size-1].

The current implementation throws an OutOfBoundException in case index not in the previous interval. However there is a confusion between SignedInteger/UnsignedInteger and thus leads to a *strange* message error, which is fixed here.