### PR TITLE
Avoid using *this= in ::load

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -533,7 +533,7 @@
 
   <!-- OT::MarginalTransformationEvaluation parameters -->
   <MarginalTransformationEvaluation-DefaultTailThreshold value="0.99"  />
-  <MarginalTransformationEvaluation-Simplify             value="1"     />
+  <MarginalTransformationEvaluation-Simplify             value="true"  />
   <MarginalTransformationEvaluation-ParametersEpsilon    value="1.0e-14" />
 
   <!-- OT::DistributionImplementation parameters -->

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -806,7 +806,7 @@ void ResourceMap::loadDefaultConfiguration()
 
   // MarginalTransformationEvaluation parameters //
   setAsScalar( "MarginalTransformationEvaluation-DefaultTailThreshold", 0.99 );
-  setAsUnsignedInteger( "MarginalTransformationEvaluation-Simplify", 1 );
+  setAsBool( "MarginalTransformationEvaluation-Simplify", true );
   setAsScalar( "MarginalTransformationEvaluation-ParametersEpsilon", 1.0e-14 );
 
   // DistributionImplementation parameters //

--- a/lib/src/Base/Func/GradientImplementation.cxx
+++ b/lib/src/Base/Func/GradientImplementation.cxx
@@ -171,6 +171,7 @@ void GradientImplementation::save(Advocate & adv) const
 {
   PersistentObject::save(adv);
   adv.saveAttribute( "callsNumber_", callsNumber_ );
+  adv.saveAttribute( "parameter_", parameter_ );
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -178,6 +179,7 @@ void GradientImplementation::load(Advocate & adv)
 {
   PersistentObject::load(adv);
   adv.loadAttribute( "callsNumber_", callsNumber_ );
+  adv.loadAttribute( "parameter_", parameter_ );
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/HaarWavelet.cxx
+++ b/lib/src/Base/Func/HaarWavelet.cxx
@@ -43,14 +43,19 @@ HaarWavelet::HaarWavelet(const UnsignedInteger j,
   , b_(1.0)
   , value_(1.0)
 {
-  // Nothing to do
-  if (!isScaling)
+  initialize();
+}
+
+
+void HaarWavelet::initialize()
+{
+  if (!isScaling_)
   {
-    const Scalar denominator = 1 << j;
+    const Scalar denominator = 1 << j_;
     value_ = std::sqrt(denominator);
-    a_ = k / denominator;
-    m_ = (k + 0.5) / denominator;
-    b_ = (k + 1.0) / denominator;
+    a_ = k_ / denominator;
+    m_ = (k_ + 0.5) / denominator;
+    b_ = (k_ + 1.0) / denominator;
   }
 }
 
@@ -124,7 +129,7 @@ void HaarWavelet::load(Advocate & adv)
   adv.loadAttribute("j_", j_);
   adv.loadAttribute("k_", k_);
   adv.loadAttribute("isScaling_", isScaling_);
-  *this = HaarWavelet(j_, k_, isScaling_);
+  initialize();
 }
 
 

--- a/lib/src/Base/Func/HessianImplementation.cxx
+++ b/lib/src/Base/Func/HessianImplementation.cxx
@@ -168,6 +168,7 @@ void HessianImplementation::save(Advocate & adv) const
 {
   PersistentObject::save(adv);
   adv.saveAttribute( "callsNumber_", callsNumber_ );
+  adv.saveAttribute( "parameter_", parameter_ );
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -175,6 +176,7 @@ void HessianImplementation::load(Advocate & adv)
 {
   PersistentObject::load(adv);
   adv.loadAttribute( "callsNumber_", callsNumber_ );
+  adv.loadAttribute( "parameter_", parameter_ );
 }
 
 

--- a/lib/src/Base/Func/SymbolicEvaluation.cxx
+++ b/lib/src/Base/Func/SymbolicEvaluation.cxx
@@ -48,11 +48,16 @@ SymbolicEvaluation::SymbolicEvaluation(const Description & inputVariablesNames,
     throw InvalidDimensionException(HERE) << "The number of outputVariablesNames (" << outputVariablesNames.getSize()
                                           << ") does not match the number of formulas (" << formulas.getSize() << ")";
 
-  parser_.setVariablesFormulas(inputVariablesNames, formulas);
-  setInputDescription(inputVariablesNames_);
-  setOutputDescription(outputVariablesNames_);
+  initialize();
 } // SymbolicEvaluation
 
+
+void SymbolicEvaluation::initialize()
+{
+  parser_.setVariablesFormulas(inputVariablesNames_, formulas_);
+  setInputDescription(inputVariablesNames_);
+  setOutputDescription(outputVariablesNames_);
+}
 
 /* Virtual constructor */
 SymbolicEvaluation * SymbolicEvaluation::clone() const
@@ -181,7 +186,7 @@ void SymbolicEvaluation::load(Advocate & adv)
   adv.loadAttribute( "inputVariablesNames_", inputVariablesNames_ );
   adv.loadAttribute( "outputVariablesNames_", outputVariablesNames_ );
   adv.loadAttribute( "formulas_", formulas_ );
-  *this = SymbolicEvaluation(inputVariablesNames_, outputVariablesNames_, formulas_);
+  initialize();
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/SymbolicGradient.cxx
+++ b/lib/src/Base/Func/SymbolicGradient.cxx
@@ -247,7 +247,6 @@ void SymbolicGradient::load(Advocate & adv)
 {
   GradientImplementation::load(adv);
   adv.loadAttribute( "evaluation_", evaluation_ );
-  *this = SymbolicGradient(evaluation_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/SymbolicHessian.cxx
+++ b/lib/src/Base/Func/SymbolicHessian.cxx
@@ -294,7 +294,6 @@ void SymbolicHessian::load(Advocate & adv)
 {
   HessianImplementation::load(adv);
   adv.loadAttribute( "evaluation_", evaluation_ );
-  *this = SymbolicHessian(evaluation_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/openturns/HaarWavelet.hxx
+++ b/lib/src/Base/Func/openturns/HaarWavelet.hxx
@@ -67,6 +67,8 @@ public:
   void load(Advocate & adv);
 
 protected:
+  void initialize();
+
   /* Wavelet order */
   UnsignedInteger j_;
 

--- a/lib/src/Base/Func/openturns/SymbolicEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/SymbolicEvaluation.hxx
@@ -85,6 +85,9 @@ public:
 protected:
 
 private:
+  // initialize parser
+  void initialize();
+
   friend class SymbolicGradient;
   friend class SymbolicHessian;
 

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
@@ -50,11 +50,19 @@ MarginalTransformationEvaluation::MarginalTransformationEvaluation(const Distrib
   EvaluationImplementation(),
   inputDistributionCollection_(inputDistributionCollection),
   outputDistributionCollection_(outputDistributionCollection),
-  direction_(FROMTO),
-  simplifications_(inputDistributionCollection.getSize(), 0),
-  expressions_(inputDistributionCollection.getSize())
+  direction_(FROMTO)
 {
-  const UnsignedInteger size = inputDistributionCollection.getSize();
+  initialize(simplify);
+}
+
+
+void MarginalTransformationEvaluation::initialize(const Bool simplify)
+{
+  const UnsignedInteger size = inputDistributionCollection_.getSize();
+
+  simplifications_ = Indices(size, 0);
+  expressions_.resize(size);
+
   // Check that the collections of input and output distributions have the same size
   if (outputDistributionCollection_.getSize() != size) throw InvalidArgumentException(HERE) << "Error: a MarginalTransformationEvaluation cannot be built using collections of input and output distributions of different size";
   // First, check that the distributions are all 1D
@@ -72,8 +80,8 @@ MarginalTransformationEvaluation::MarginalTransformationEvaluation(const Distrib
     // Third, look for possible simplifications
     for (UnsignedInteger i = 0; i < size; ++i)
     {
-      const Distribution inputDistribution(inputDistributionCollection[i]);
-      const Distribution outputDistribution(outputDistributionCollection[i]);
+      const Distribution inputDistribution(inputDistributionCollection_[i]);
+      const Distribution outputDistribution(outputDistributionCollection_[i]);
       const String xName(getInputDescription()[i]);
       const String yName(getOutputDescription()[i]);
       const String inputClass(inputDistribution.getImplementation()->getClassName());
@@ -540,8 +548,9 @@ void MarginalTransformationEvaluation::load(Advocate & adv)
   adv.loadAttribute( "outputDistributionCollection_", outputDistributionCollection_ );
   UnsignedInteger direction = FROMTO;
   adv.loadAttribute( "direction_", direction );
-  *this = MarginalTransformationEvaluation(inputDistributionCollection_, outputDistributionCollection_);
   setDirection(static_cast<TranformationDirection>(direction));
+  const Bool simplify = ResourceMap::GetAsBool("MarginalTransformationEvaluation-Simplify");
+  initialize(simplify);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/openturns/MarginalTransformationEvaluation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/openturns/MarginalTransformationEvaluation.hxx
@@ -60,7 +60,7 @@ public:
   /** Parameter constructor */
   MarginalTransformationEvaluation(const DistributionCollection & inputDistributionCollection,
                                    const DistributionCollection & outputDistributionCollection,
-                                   const Bool simplify = (0 != ResourceMap::GetAsUnsignedInteger("MarginalTransformationEvaluation-Simplify")));
+                                   const Bool simplify = ResourceMap::GetAsBool("MarginalTransformationEvaluation-Simplify"));
 
   /** Virtual constructor */
   virtual MarginalTransformationEvaluation * clone() const;
@@ -110,6 +110,8 @@ protected:
 
 
 private:
+  void initialize(const Bool simplify);
+
   // Make the gradient and the hessian friend classes of the evaluation in order to share the input and output distribution collections
   friend class MarginalTransformationGradient;
   friend class MarginalTransformationHessian;
@@ -124,10 +126,10 @@ private:
   UnsignedInteger direction_;
 
   // Flag to tell if simpler expressions are available
-  Collection<UnsignedInteger> simplifications_;
+  mutable Indices simplifications_;
 
   // Collection of simpler expressions
-  Collection<Function> expressions_;
+  mutable Collection<Function> expressions_;
 }; /* MarginalTransformationEvaluation */
 
 


### PR DESCRIPTION
We should not use '*this = ...' in ::load to loose attributes from parent class