### PR TITLE
ProbabilitySimulation to handle general events

### DIFF
--- a/lib/src/Uncertainty/Algorithm/Simulation/ProbabilitySimulationAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/ProbabilitySimulationAlgorithm.cxx
@@ -36,6 +36,23 @@ CLASSNAMEINIT(ProbabilitySimulationAlgorithm);
 
 static const Factory<ProbabilitySimulationAlgorithm> Factory_ProbabilitySimulationAlgorithm;
 
+ProbabilitySimulationAlgorithm::ProbabilitySimulationAlgorithm(const Bool verbose,
+                                             const HistoryStrategy & convergenceStrategy)
+  : Simulation(verbose, convergenceStrategy)
+  , isExperimentProvided_(false)
+{
+  // Nothing to do
+}
+
+/* Constructor with parameters */
+ProbabilitySimulationAlgorithm::ProbabilitySimulationAlgorithm(const Event & event,
+                                             const Bool verbose,
+                                             const HistoryStrategy & convergenceStrategy)
+  : Simulation(event, verbose, convergenceStrategy)
+  , isExperimentProvided_(false)
+{
+  // Nothing to do
+}
 
 /* Constructor with parameters */
 ProbabilitySimulationAlgorithm::ProbabilitySimulationAlgorithm(const Event & event,
@@ -43,16 +60,10 @@ ProbabilitySimulationAlgorithm::ProbabilitySimulationAlgorithm(const Event & eve
                                              const Bool verbose,
                                              const HistoryStrategy & convergenceStrategy)
   : Simulation(event, verbose, convergenceStrategy)
+  , isExperimentProvided_(true)
 {
   if (!getEvent().isComposite()) throw InvalidArgumentException(HERE) << "ProbabilitySimulationAlgorithm requires a composite event";
   setExperiment(experiment);
-}
-
-ProbabilitySimulationAlgorithm::ProbabilitySimulationAlgorithm(const Bool verbose,
-                                             const HistoryStrategy & convergenceStrategy)
-  : Simulation(verbose, convergenceStrategy)
-{
-  // Nothing to do
 }
 
 /* Virtual constructor */
@@ -89,6 +100,13 @@ String ProbabilitySimulationAlgorithm::__repr__() const
 /* Compute the block sample and the points that realized the event */
 Sample ProbabilitySimulationAlgorithm::computeBlockSample()
 {
+  if (isExperimentProvided_)
+    return computeBlockSampleComposite();
+  return event_.getSample(blockSize_);
+}
+
+Sample ProbabilitySimulationAlgorithm::computeBlockSampleComposite()
+{
   Point weights;
   const Sample inputSample(experiment_.generateWithWeights(weights));
   Sample blockSample(getEvent().getImplementation()->getFunction()(inputSample));
@@ -100,12 +118,12 @@ Sample ProbabilitySimulationAlgorithm::computeBlockSample()
   return blockSample;
 }
 
-
 /* Method save() stores the object through the StorageManager */
 void ProbabilitySimulationAlgorithm::save(Advocate & adv) const
 {
   Simulation::save(adv);
   adv.saveAttribute("experiment_", experiment_);
+  adv.saveAttribute("isExperimentProvided_", isExperimentProvided_);
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -113,6 +131,7 @@ void ProbabilitySimulationAlgorithm::load(Advocate & adv)
 {
   Simulation::load(adv);
   adv.loadAttribute("experiment_", experiment_);
+  adv.loadAttribute("isExperimentProvided_", isExperimentProvided_);
 }
 
 void ProbabilitySimulationAlgorithm::setBlockSize(const UnsignedInteger blockSize)

--- a/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/Simulation.cxx
@@ -263,7 +263,7 @@ void Simulation::run()
 /* Compute the block sample and the points that realized the event */
 Sample Simulation::computeBlockSample()
 {
-  return event_.getSample(blockSize_);
+  throw NotYetImplementedException(HERE) << "In Simulation::computeBlockSample()";
 }
 
 /* Convergence strategy accessor */

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/ProbabilitySimulationAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/ProbabilitySimulationAlgorithm.hxx
@@ -42,6 +42,11 @@ public:
 
   /** Constructor with parameters */
   ProbabilitySimulationAlgorithm(const Event & event,
+                        const Bool verbose = true,
+                        const HistoryStrategy & convergenceStrategy = Compact());
+
+  /** Constructor with parameters */
+  ProbabilitySimulationAlgorithm(const Event & event,
                         const WeightedExperiment & experiment,
                         const Bool verbose = true,
                         const HistoryStrategy & convergenceStrategy = Compact());
@@ -69,11 +74,11 @@ protected:
 
   /** Compute the block sample and the points that realized the event */
   virtual Sample computeBlockSample();
+  Sample computeBlockSampleComposite();
 
   // The experiment type
   WeightedExperiment experiment_;
-
-
+  Bool isExperimentProvided_;
 private:
 
 } ; /* class ProbabilitySimulationAlgorithm */

--- a/python/src/ProbabilitySimulationAlgorithm_doc.i.in
+++ b/python/src/ProbabilitySimulationAlgorithm_doc.i.in
@@ -1,8 +1,10 @@
 %feature("docstring") OT::ProbabilitySimulationAlgorithm
-"Sequential sampling methods.
+"Iterative sampling methods.
 
 Available constructor:
     ProbabilitySimulationAlgorithm(*event, experiment, verbose=True, convergenceStrategy=ot.Compact()*)
+
+    ProbabilitySimulationAlgorithm(*event, verbose=True, convergenceStrategy=ot.Compact()*)
 
 Parameters
 ----------

--- a/python/test/t_ProbabilitySimulationAlgorithm_std.py
+++ b/python/test/t_ProbabilitySimulationAlgorithm_std.py
@@ -124,7 +124,7 @@ for i, event in enumerate(all_events):
         experiment = ot.MonteCarloExperiment()
         myAlgo = ot.ProbabilitySimulationAlgorithm(event, experiment)
     else:
-        myAlgo = ot.Simulation(event)
+        myAlgo = ot.ProbabilitySimulationAlgorithm(event)
     myAlgo.setMaximumOuterSampling(250)
     myAlgo.setBlockSize(4)
     myAlgo.setMaximumCoefficientOfVariation(0.1)


### PR DESCRIPTION
ProbabilitySimulation was able to handle only composite events (Y=f(X)) now added a ctor without experiment that handles general events. Also reverts the Simulation change to make it abstract.