### PR TITLE
Fix MarginalTransformationEvaluation

### DIFF
--- a/lib/src/Base/Func/ComposedEvaluation.cxx
+++ b/lib/src/Base/Func/ComposedEvaluation.cxx
@@ -126,18 +126,11 @@ void ComposedEvaluation::setParameter(const Point & parameter)
   const UnsignedInteger rightDimension = rightParameter.getDimension();
   Point leftParameter(p_leftFunction_->getParameter());
   const UnsignedInteger leftDimension = leftParameter.getDimension();
-  UnsignedInteger index = 0;
-  for (UnsignedInteger i = 0; i < rightDimension; ++ i)
-  {
-    rightParameter[i] = parameter[index];
-    ++ index;
-  }
+  if (parameter.getDimension() != rightDimension + leftDimension)
+    throw InvalidArgumentException(HERE) << "Required parameter of dimension " << rightDimension + leftDimension << " provided " << parameter.getDimension();
+  std::copy(parameter.begin(), parameter.begin() + rightDimension, rightParameter.begin());
   p_rightFunction_->setParameter(rightParameter);
-  for (UnsignedInteger i = 0; i < leftDimension; ++ i)
-  {
-    leftParameter[i] = parameter[index];
-    ++ index;
-  }
+  std::copy(parameter.begin() + rightDimension, parameter.begin() + rightDimension + leftDimension, leftParameter.begin());
   p_leftFunction_->setParameter(leftParameter);
 }
 
@@ -155,18 +148,11 @@ void ComposedEvaluation::setParameterDescription(const Description & description
   const UnsignedInteger rightDimension = rightDescription.getSize();
   Description leftDescription(p_leftFunction_->getParameterDescription());
   const UnsignedInteger leftDimension = leftDescription.getSize();
-  UnsignedInteger index = 0;
-  for (UnsignedInteger i = 0; i < rightDimension; ++ i)
-  {
-    rightDescription[i] = description[index];
-    ++ index;
-  }
+  if (description.getSize() != rightDimension + leftDimension)
+    throw InvalidArgumentException(HERE) << "Required parameter description of dimension " << rightDimension + leftDimension << " provided " << description.getSize();
+  std::copy(description.begin(), description.begin() + rightDimension, rightDescription.begin());
   p_rightFunction_->setParameterDescription(rightDescription);
-  for (UnsignedInteger i = 0; i < leftDimension; ++ i)
-  {
-    leftDescription[i] = description[index];
-    ++ index;
-  }
+  std::copy(description.begin() + rightDimension, description.begin() + rightDimension + leftDimension, leftDescription.begin());
   p_leftFunction_->setParameterDescription(leftDescription);
 }
 

--- a/lib/src/Base/Func/ComposedFunction.cxx
+++ b/lib/src/Base/Func/ComposedFunction.cxx
@@ -150,6 +150,7 @@ String ComposedFunction::__repr__() const
 Matrix ComposedFunction::parameterGradient(const Point & inP) const
 {
   const UnsignedInteger inputDimension = getInputDimension();
+  const UnsignedInteger outputDimension = getOutputDimension();
   if (inP.getDimension() != inputDimension) throw InvalidArgumentException(HERE) << "Error: the given point has an invalid dimension. Expect a dimension " << inputDimension << ", got " << inP.getDimension();
   // y = G(x, pg)
   const Point y(p_rightFunction_->operator()(inP));
@@ -164,19 +165,19 @@ Matrix ComposedFunction::parameterGradient(const Point & inP) const
   // Build the full gradient
   const UnsignedInteger rightParametersDimension = upper.getNbRows();
   const UnsignedInteger leftParametersDimension = leftGradientP.getNbRows();
-  Matrix grad(rightParametersDimension + leftParametersDimension, inputDimension);
+  Matrix grad(rightParametersDimension + leftParametersDimension, outputDimension);
   UnsignedInteger rowIndex = 0;
   // Gradient according to left parameters
   for (UnsignedInteger i = 0; i < rightParametersDimension; ++i)
   {
-    for (UnsignedInteger j = 0; j < inputDimension; ++j)
+    for (UnsignedInteger j = 0; j < outputDimension; ++j)
       grad(rowIndex, j) = upper(i, j);
     ++ rowIndex;
   }
   // Gradient according to right parameters
   for (UnsignedInteger i = 0; i < leftParametersDimension; ++i)
   {
-    for (UnsignedInteger j = 0; j < inputDimension; ++j)
+    for (UnsignedInteger j = 0; j < outputDimension; ++j)
       grad(rowIndex, j) = leftGradientP(i, j);
     ++ rowIndex;
   }

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/MarginalTransformationEvaluation.cxx
@@ -384,19 +384,12 @@ Matrix MarginalTransformationEvaluation::parameterGradient(const Point & inP) co
           const Scalar denominator = outputMarginal.computePDF(outputMarginal.computeQuantile(inputMarginal.computeCDF(x)));
           if (denominator > 0.0)
           {
-            try
+            const Point normalizedCDFGradient(inputMarginal.computeCDFGradient(x) * (1.0 / denominator));
+            const UnsignedInteger marginalParametersDimension = normalizedCDFGradient.getDimension();
+            for (UnsignedInteger i = 0; i < marginalParametersDimension; ++i)
             {
-              const Point normalizedCDFGradient(inputMarginal.computeCDFGradient(x) * (1.0 / denominator));
-              const UnsignedInteger marginalParametersDimension = normalizedCDFGradient.getDimension();
-              for (UnsignedInteger i = 0; i < marginalParametersDimension; ++i)
-              {
-                result(rowIndex, j) = normalizedCDFGradient[i];
-                ++rowIndex;
-              }
-            }
-            catch (NotYetImplementedException &)
-            {
-              LOGWARN(OSS() << "Cannot compute the gradient according to the parameters of the " << j << "th marginal distribution");
+              result(rowIndex, j) = normalizedCDFGradient[i];
+              ++ rowIndex;
             }
           }
         } // FROM
@@ -415,19 +408,12 @@ Matrix MarginalTransformationEvaluation::parameterGradient(const Point & inP) co
           const Scalar denominator = outputMarginal.computePDF(q);
           if (denominator > 0.0)
           {
-            try
+            const Point normalizedCDFGradient(outputMarginal.computeCDFGradient(q) * (-1.0 / denominator));
+            const UnsignedInteger marginalParametersDimension = normalizedCDFGradient.getDimension();
+            for (UnsignedInteger i = 0; i < marginalParametersDimension; ++i)
             {
-              const Point normalizedCDFGradient(outputMarginal.computeCDFGradient(q) * (-1.0 / denominator));
-              const UnsignedInteger marginalParametersDimension = normalizedCDFGradient.getDimension();
-              for (UnsignedInteger i = 0; i < marginalParametersDimension; ++i)
-              {
-                result(rowIndex, j) = normalizedCDFGradient[i];
-                ++rowIndex;
-              }
-            }
-            catch (NotYetImplementedException &)
-            {
-              LOGWARN(OSS() << "Cannot compute the gradient according to the parameters of the " << j << "th marginal distribution");
+              result(rowIndex, j) = normalizedCDFGradient[i];
+              ++ rowIndex;
             }
           }
         } // TO

--- a/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/openturns/MarginalTransformationEvaluation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/MarginalTransformation/openturns/MarginalTransformationEvaluation.hxx
@@ -31,6 +31,7 @@
 #include "openturns/Distribution.hxx"
 #include "openturns/StorageManager.hxx"
 #include "openturns/ResourceMap.hxx"
+#include "openturns/Uniform.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -48,14 +49,15 @@ public:
   typedef Collection<Distribution>              DistributionCollection;
   typedef PersistentCollection<Distribution>    DistributionPersistentCollection;
 
-  enum TranformationDirection { FROM, TO, FROMTO };
+  enum TranformationDirection { FROM, TO };
 
   /** Default constructor */
   MarginalTransformationEvaluation();
 
   /** Parameter constructor */
   explicit MarginalTransformationEvaluation(const DistributionCollection & distributionCollection,
-      const UnsignedInteger direction = FROM);
+                                            const UnsignedInteger direction = FROM,
+                                            const Distribution & standardMarginal = Uniform(0.0, 1.0));
 
   /** Parameter constructor */
   MarginalTransformationEvaluation(const DistributionCollection & inputDistributionCollection,
@@ -72,15 +74,19 @@ public:
   /** Gradient according to the marginal parameters */
   Matrix parameterGradient(const Point & inP) const;
 
+  /** Parameters value accessor */
+  virtual void setParameter(const Point & parameter);
+  virtual Point getParameter() const;
+
+  /** Parameters description accessor */
+  virtual Description getParameterDescription() const;
+  virtual void setParameterDescription(const Description & description);
+
   /** Accessor for input point dimension */
   UnsignedInteger getInputDimension() const;
 
   /** Accessor for output point dimension */
   UnsignedInteger getOutputDimension() const;
-
-  /** Direction accessor */
-  void setDirection(const TranformationDirection direction);
-  UnsignedInteger getDirection() const;
 
   /** Input distribution collection accessor */
   void setInputDistributionCollection(const DistributionCollection & inputDistributionCollection);
@@ -108,7 +114,6 @@ public:
 
 protected:
 
-
 private:
   void initialize(const Bool simplify);
 
@@ -122,8 +127,10 @@ private:
   // Marginal distributions of the output
   DistributionPersistentCollection outputDistributionCollection_;
 
-  // Direction of the transformation
-  UnsignedInteger direction_;
+  // Parameter location flag
+  enum ParameterSide { NONE, LEFT, RIGHT, BOTH };
+
+  UnsignedInteger parameterSide_;
 
   // Flag to tell if simpler expressions are available
   mutable Indices simplifications_;

--- a/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
@@ -783,9 +783,7 @@ ComposedDistribution::IsoProbabilisticTransformation ComposedDistribution::getIs
   if (hasIndependentCopula())
   {
     // Get the evaluation implementations
-    MarginalTransformationEvaluation evaluation(distributionCollection_, DistributionCollection(dimension, Normal()));
-    // We have to correct the direction because the output collection corresponds to the standard space, so there is no parameter to take into account for these distributions
-    evaluation.setDirection(MarginalTransformationEvaluation::FROM);
+    MarginalTransformationEvaluation evaluation(distributionCollection_, MarginalTransformationEvaluation::FROM, Normal());
     IsoProbabilisticTransformation marginalTransformation(evaluation.clone(), new MarginalTransformationGradient(evaluation), new MarginalTransformationHessian(evaluation));
     marginalTransformation.setParameter(parameters);
     marginalTransformation.setParameterDescription(description);
@@ -811,9 +809,7 @@ ComposedDistribution::IsoProbabilisticTransformation ComposedDistribution::getIs
     const Distribution standardDistribution(getStandardDistribution());
     // Get the evaluation implementations
     const Distribution standardMarginal(standardDistribution.getMarginal(0));
-    MarginalTransformationEvaluation evaluation(distributionCollection_, DistributionCollection(dimension, standardMarginal));
-    // We have to correct the direction because the output collection corresponds to the standard space, so there is no parameter to take into account for these distributions
-    evaluation.setDirection(MarginalTransformationEvaluation::FROM);
+    MarginalTransformationEvaluation evaluation(distributionCollection_, MarginalTransformationEvaluation::FROM, standardMarginal);
     IsoProbabilisticTransformation marginalTransformation(evaluation.clone(), MarginalTransformationGradient(evaluation).clone(), MarginalTransformationHessian(evaluation).clone());
     marginalTransformation.setParameter(parameters);
     marginalTransformation.setParameterDescription(description);
@@ -826,7 +822,7 @@ ComposedDistribution::IsoProbabilisticTransformation ComposedDistribution::getIs
   // Get the IsoProbabilisticTransformation from the copula
   const IsoProbabilisticTransformation copulaIsoprobabilisticTransformation(copula_.getIsoProbabilisticTransformation());
   // Get the right function implementations
-  const MarginalTransformationEvaluation evaluation(distributionCollection_, MarginalTransformationEvaluation::FROM);
+  const MarginalTransformationEvaluation evaluation(distributionCollection_);
   IsoProbabilisticTransformation marginalTransformation(evaluation.clone(), new MarginalTransformationGradient(evaluation), new MarginalTransformationHessian(evaluation));
   marginalTransformation.setParameter(parameters);
   marginalTransformation.setParameterDescription(description);
@@ -859,9 +855,7 @@ ComposedDistribution::InverseIsoProbabilisticTransformation ComposedDistribution
   if (hasIndependentCopula())
   {
     // Get the evaluation implementations
-    MarginalTransformationEvaluation evaluation(DistributionCollection(dimension, Normal()), distributionCollection_);
-    // We have to correct the direction because the input collection corresponds to the standard space, so there is no parameter to take into account for these distributions
-    evaluation.setDirection(MarginalTransformationEvaluation::TO);
+    MarginalTransformationEvaluation evaluation(distributionCollection_, MarginalTransformationEvaluation::TO, Normal());
     IsoProbabilisticTransformation marginalTransformation(evaluation.clone(), new MarginalTransformationGradient(evaluation), new MarginalTransformationHessian(evaluation));
     marginalTransformation.setParameter(parameters);
     marginalTransformation.setParameterDescription(description);
@@ -887,9 +881,7 @@ ComposedDistribution::InverseIsoProbabilisticTransformation ComposedDistribution
     const Distribution standardDistribution(getStandardDistribution());
     // Get the evaluation implementations
     const Distribution standardMarginal(standardDistribution.getMarginal(0));
-    MarginalTransformationEvaluation evaluation(DistributionCollection(dimension, standardMarginal), distributionCollection_);
-    // We have to correct the direction because the output collection corresponds to the standard space, so there is no parameter to take into account for these distributions
-    evaluation.setDirection(MarginalTransformationEvaluation::TO);
+    MarginalTransformationEvaluation evaluation(distributionCollection_, MarginalTransformationEvaluation::TO, standardMarginal);
     InverseIsoProbabilisticTransformation marginalTransformation(evaluation.clone(), new MarginalTransformationGradient(evaluation), new MarginalTransformationHessian(evaluation));
     marginalTransformation.setParameter(parameters);
     marginalTransformation.setParameterDescription(description);

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -3076,12 +3076,9 @@ DistributionImplementation::IsoProbabilisticTransformation DistributionImplement
   // Special case for dimension 1
   if (dimension_ == 1)
   {
-    DistributionCollection collection(1);
-    collection[0] = *this;
+    DistributionCollection collection(1, *this);
     // Get the marginal transformation evaluation implementation
-    MarginalTransformationEvaluation evaluation(collection, DistributionCollection(1, Normal()));
-    // We have to correct the direction because the output collection corresponds to the standard space, so there is no parameter to take into account.
-    evaluation.setDirection(MarginalTransformationEvaluation::FROM);
+    MarginalTransformationEvaluation evaluation(collection, MarginalTransformationEvaluation::FROM, Normal());
     const EvaluationPointer p_evaluation(evaluation.clone());
     // Get the marginal transformation gradient implementation
     const GradientPointer p_gradient = new MarginalTransformationGradient(evaluation);
@@ -3107,12 +3104,9 @@ DistributionImplementation::InverseIsoProbabilisticTransformation DistributionIm
   // Special case for dimension 1
   if (dimension_ == 1)
   {
-    DistributionCollection collection(1);
-    collection[0] = *this;
+    DistributionCollection collection(1, *this);
     // Get the marginal transformation evaluation implementation
-    MarginalTransformationEvaluation evaluation(DistributionCollection(1, Normal()), collection);
-    // We have to correct the direction because the input collection corresponds to the standard space, so there is no parameter to take into account.
-    evaluation.setDirection(MarginalTransformationEvaluation::TO);
+    MarginalTransformationEvaluation evaluation(collection, MarginalTransformationEvaluation::TO, Normal());
     const EvaluationPointer p_evaluation(evaluation.clone());
     // Get the marginal transformation gradient implementation
     const GradientPointer p_gradient = new MarginalTransformationGradient(evaluation);

--- a/python/src/MarginalTransformationEvaluation_doc.i.in
+++ b/python/src/MarginalTransformationEvaluation_doc.i.in
@@ -4,7 +4,7 @@
 Available constructors:
     MarginalTransformationEvaluation(*distCol*)
 
-    MarginalTransformationEvaluation(*distCol, direction*)
+    MarginalTransformationEvaluation(*distCol, direction, standardMarginal*)
 
     MarginalTransformationEvaluation(*distCol, outputDistCol*)
 
@@ -18,6 +18,9 @@ direction : integer
     *MarginalTransformationEvaluation.FROM* (associated to the integer 0) or 
     *MarginalTransformationEvaluation.TO* (associated to the integer 1).
     Default is 0.
+standardMarginal : :class:`~openturns.Distribution`
+    Target distribution marginal
+    Default is Uniform(0, 1)
 outputDistCol : :class:`~openturns.DistributionCollection`
     A collection of distributions.
 
@@ -70,16 +73,6 @@ Examples
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::MarginalTransformationEvaluation::getDirection
-"Accessor to the direction.
-
-Returns
--------
-direction : integer
-    The direction of the transformation."
-
-// ---------------------------------------------------------------------
-
 %feature("docstring") OT::MarginalTransformationEvaluation::getExpressions
 "Accessor to the numerical math function.
 
@@ -116,13 +109,23 @@ outputDistCol : :class:`~openturns.DistributionCollection`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::MarginalTransformationEvaluation::setDirection
-"Accessor to the direction.
+%feature("docstring") OT::MarginalTransformationEvaluation::setParameterSide
+"Accessor to the parameter side flag.
 
 Parameters
 ----------
-direction : integer
-    The direction of the transformation."
+param_side : int
+    The location of the parameters."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::MarginalTransformationEvaluation::getParameterSide
+"Accessor to the parameter side flag.
+
+Returns
+-------
+param_side : int
+    The location of the parameters."
 
 // ---------------------------------------------------------------------
 

--- a/python/test/t_FunctionalChaos_ishigami.py
+++ b/python/test/t_FunctionalChaos_ishigami.py
@@ -92,6 +92,7 @@ try:
 
             # Examine the results
             result = FunctionalChaosResult(algo.getResult())
+            pGrad = result.getMetaModel().parameterGradient(distribution.getMean())
             print("###################################")
             print(algo.getAdaptiveStrategy())
             print(algo.getProjectionStrategy())


### PR DESCRIPTION
- In DistributionTransformation we use the MarginalTransformationEvaluation(DistributionCollection, DistributionCollection) ctor
in this case the direction flag is not initialized to something valid (FROMTO), so I added it to that ctor.

- In MarginalTransformationEvaluation::parameterGradient when there are no parameters the matrix is empty; exit sooner so as to avoid range exception in matrix.

This fixes computing FORM sensitivities on a FCE metamodel.

cc @aurelieladier 
