### PR TITLE
Covariance model: only activate scale & amplitude parameters by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,7 @@
 === Miscellaneous ===
 
 === Bug fixes ===
+ * #926 (Covariance model active parameter set behavior)
  * #928 (Covariance model/ Field/Process properties naming)
 
 == 1.10rc1 release (2017-10-11) == #release-1.10rc1

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -72,7 +72,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , definesComputeStandardRepresentative_(false)
   , isDiagonal_(true)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + (outputDimension_ * (outputDimension_ + 1)) / 2)
+  , activeParameter_(inputDimension_ + outputDimension_)
 {
   setAmplitude(amplitude);
   setScale(scale);
@@ -95,7 +95,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , definesComputeStandardRepresentative_(false)
   , isDiagonal_(true)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + (outputDimension_ * (outputDimension_ + 1)) / 2)
+  , activeParameter_(inputDimension_ + outputDimension_)
 {
   setAmplitude(amplitude);
   setScale(scale);
@@ -117,7 +117,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , definesComputeStandardRepresentative_(false)
   , isDiagonal_(true)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + (outputDimension_ * (outputDimension_ + 1)) / 2)
+  , activeParameter_(inputDimension_ + outputDimension_)
 {
   Point amplitude(outputDimension_);
   for (UnsignedInteger i = 0; i < outputDimension_; ++i) amplitude[i] = sqrt(spatialCovariance(i, i));

--- a/python/test/t_ExponentialModel_std.py
+++ b/python/test/t_ExponentialModel_std.py
@@ -74,6 +74,7 @@ try:
 
     # parameter bug
     model = ExponentialModel([1.0]*3, [2.0] * 2)
+    model.setActiveParameter(range(6))
     p = model.getParameter()
     print(p)
     p[-1] = 0.5


### PR DESCRIPTION
Consistently only enable scale & amplitude whatever ctor is used
see http://trac.openturns.org/ticket/926