### PR TITLE
Fix chaos memory usage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -111,6 +111,7 @@
  * #919 (Wrong simplification mechanism in MarginalTransformationEvaluation for Exponential distribution)
  * #921 (Cannot print a FixedExperiment when built from sample and weight)
  * #923 (Fix ExponentialModel::getParameter for diagonal correlation)
+ * #927 (Functional chaos is memory hungry)
  * #930 (The getMean method has a weird behavior on parametrized distribution)
 
 == 1.9 release (2017-04-18) == #release-1.9

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
@@ -78,9 +78,21 @@ WeightedExperiment ProjectionStrategy::getExperiment() const
 }
 
 /* Sample accessors */
+void ProjectionStrategy::setInputSample(const Sample & inputSample)
+{
+  copyOnWrite();
+  getImplementation()->setInputSample(inputSample);
+}
+
 Sample ProjectionStrategy::getInputSample() const
 {
   return getImplementation()->getInputSample();
+}
+
+void ProjectionStrategy::setOutputSample(const Sample & outputSample)
+{
+  copyOnWrite();
+  getImplementation()->setOutputSample(outputSample);
 }
 
 Sample ProjectionStrategy::getOutputSample() const
@@ -89,6 +101,12 @@ Sample ProjectionStrategy::getOutputSample() const
 }
 
 /* Weights accessor */
+void ProjectionStrategy::setWeights(const Point & weights)
+{
+  copyOnWrite();
+  getImplementation()->setWeights(weights);
+}
+
 Point ProjectionStrategy::getWeights() const
 {
   return getImplementation()->getWeights();

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -155,12 +155,13 @@ Distribution ProjectionStrategyImplementation::getMeasure() const
 /* Experiment accessors */
 void ProjectionStrategyImplementation::setExperiment(const WeightedExperiment & weightedExperiment)
 {
-  if (!(weightedExperiment == weightedExperiment_))
-  {
+  // TODO: implement experiments comparison
+//   if (!(weightedExperiment == weightedExperiment_))
+//   {
     weightedExperiment_ = weightedExperiment;
     weightedExperiment_.setDistribution(getMeasure());
     inputSample_ = Sample(0, 0);
-  }
+//   }
 }
 
 WeightedExperiment ProjectionStrategyImplementation::getExperiment() const
@@ -169,9 +170,19 @@ WeightedExperiment ProjectionStrategyImplementation::getExperiment() const
 }
 
 /* Sample accessors */
+void ProjectionStrategyImplementation::setInputSample(const Sample & inputSample)
+{
+  inputSample_ = inputSample;
+}
+
 Sample ProjectionStrategyImplementation::getInputSample() const
 {
   return inputSample_;
+}
+
+void ProjectionStrategyImplementation::setOutputSample(const Sample & outputSample)
+{
+  outputSample_ = outputSample;
 }
 
 Sample ProjectionStrategyImplementation::getOutputSample() const
@@ -180,6 +191,11 @@ Sample ProjectionStrategyImplementation::getOutputSample() const
 }
 
 /* Weights accessor */
+void ProjectionStrategyImplementation::setWeights(const Point & weights)
+{
+  weights_ = weights;
+}
+
 Point ProjectionStrategyImplementation::getWeights() const
 {
   return weights_;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
@@ -56,10 +56,14 @@ public:
   Distribution getMeasure() const;
 
   /** Sample accessors */
+  virtual void setInputSample(const Sample & inputSample);
   virtual Sample getInputSample() const;
+
+  virtual void setOutputSample(const Sample & outputSample);
   virtual Sample getOutputSample() const;
 
   /** Weights accessor */
+  virtual void setWeights(const Point & weights);
   virtual Point getWeights() const;
 
   /** Residual accessor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
@@ -85,10 +85,14 @@ public:
   Distribution getMeasure() const;
 
   /** Sample accessors */
+  virtual void setInputSample(const Sample & inputSample);
   virtual Sample getInputSample() const;
+
+  virtual void setOutputSample(const Sample & outputSample);
   virtual Sample getOutputSample() const;
 
   /** Weights accessor */
+  virtual void setWeights(const Point & weights);
   virtual Point getWeights() const;
 
   /** Residual accessor */
@@ -98,6 +102,7 @@ public:
   virtual Scalar getRelativeError() const;
 
   /** Relative error accessor */
+//   virtual void setCoefficients(const Point & alpha_k);
   virtual Point getCoefficients() const;
 
   /** Experiment accessors */
@@ -119,9 +124,7 @@ public:
   /** Method load() reloads the object from the StorageManager */
   virtual void load(Advocate & adv);
 
-
 protected:
-
   /** The collection of Alpha_k coefficients */
   Point alpha_k_p_;
 

--- a/lib/test/t_FunctionalChaos_ishigami_database.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami_database.cxx
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
         FunctionalChaosResult result(algo.getResult());
         fullprint << "//////////////////////////////////////////////////////////////////////" << std::endl;
         fullprint << adaptiveStrategy << std::endl;
-        fullprint << projectionStrategy << std::endl;
+        fullprint << algo.getProjectionStrategy() << std::endl;
         Point residuals(result.getResiduals());
         fullprint << "residuals=" << std::fixed << std::setprecision(5) << residuals << std::endl;
         Point relativeErrors(result.getRelativeErrors());

--- a/python/src/ProjectionStrategyImplementation_doc.i.in
+++ b/python/src/ProjectionStrategyImplementation_doc.i.in
@@ -109,6 +109,19 @@ OT_ProjectionStrategy_getExperiment_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_ProjectionStrategy_setInputSample_doc
+"Accessor to the input sample.
+
+Parameters
+----------
+X : :class:`~openturns.Sample`
+    Input Sample."
+%enddef
+%feature("docstring") OT::ProjectionStrategyImplementation::setInputSample
+OT_ProjectionStrategy_setInputSample_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_ProjectionStrategy_getInputSample_doc
 "Accessor to the input sample.
 
@@ -132,6 +145,19 @@ mu : Distribution
 %enddef
 %feature("docstring") OT::ProjectionStrategyImplementation::getMeasure
 OT_ProjectionStrategy_getMeasure_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_ProjectionStrategy_setOutputSample_doc
+"Accessor to the output sample.
+
+Parameters
+----------
+Y : :class:`~openturns.Sample`
+    Output Sample."
+%enddef
+%feature("docstring") OT::ProjectionStrategyImplementation::setOutputSample
+OT_ProjectionStrategy_setOutputSample_doc
 
 // ---------------------------------------------------------------------
 
@@ -171,6 +197,19 @@ er : float
 %enddef
 %feature("docstring") OT::ProjectionStrategyImplementation::getResidual
 OT_ProjectionStrategy_getResidual_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_ProjectionStrategy_setWeights_doc
+"Accessor to the weights.
+
+Parameters
+----------
+w : :class:`~openturns.Point`
+    Weights of the design of experiments."
+%enddef
+%feature("docstring") OT::ProjectionStrategyImplementation::setWeights
+OT_ProjectionStrategy_setWeights_doc
 
 // ---------------------------------------------------------------------
 

--- a/python/src/ProjectionStrategy_doc.i.in
+++ b/python/src/ProjectionStrategy_doc.i.in
@@ -6,16 +6,22 @@ OT_ProjectionStrategy_doc
 OT_ProjectionStrategy_getCoefficients_doc
 %feature("docstring") OT::ProjectionStrategy::getExperiment
 OT_ProjectionStrategy_getExperiment_doc
+%feature("docstring") OT::ProjectionStrategy::setInputSample
+OT_ProjectionStrategy_setInputSample_doc
 %feature("docstring") OT::ProjectionStrategy::getInputSample
 OT_ProjectionStrategy_getInputSample_doc
 %feature("docstring") OT::ProjectionStrategy::getMeasure
 OT_ProjectionStrategy_getMeasure_doc
+%feature("docstring") OT::ProjectionStrategy::setOutputSample
+OT_ProjectionStrategy_setOutputSample_doc
 %feature("docstring") OT::ProjectionStrategy::getOutputSample
 OT_ProjectionStrategy_getOutputSample_doc
 %feature("docstring") OT::ProjectionStrategy::getRelativeError
 OT_ProjectionStrategy_getRelativeError_doc
 %feature("docstring") OT::ProjectionStrategy::getResidual
 OT_ProjectionStrategy_getResidual_doc
+%feature("docstring") OT::ProjectionStrategy::setWeights
+OT_ProjectionStrategy_setWeights_doc
 %feature("docstring") OT::ProjectionStrategy::getWeights
 OT_ProjectionStrategy_getWeights_doc
 %feature("docstring") OT::ProjectionStrategy::setExperiment


### PR DESCRIPTION
Add accessors to the ProjectionStrategy interface to fix the reference counting in FunctionalChaosAlgorithm.
Fixes http://trac.openturns.org/ticket/927 (Functional chaos is memory hungry)

Note that now the projection strategy passed as argument of FCA is not modified in-place hence the modification to t_FunctionalChaos_ishigami_database.expout
I kept the friendship of ProjectionStrategyImplementation to FCA only for the updateBasis method and not to copy the Proxy at that moment. But this remains a bad design.

I also think that we shouldnt build metamodel algorithms without passing the actual input/output data: in FCA we do lots of complicated stuff to override the data.