### PR TITLE
Compute the exact log-likelihood in computeReducedLogLikelihood

### DIFF
--- a/lib/src/Base/Type/openturns/Cache.hxx
+++ b/lib/src/Base/Type/openturns/Cache.hxx
@@ -277,7 +277,7 @@ public:
       {
         ++(*it).second.second; // increment age
         ++hits_;
-        LOGINFO(OSS() << "Cache hit !");
+        LOGDEBUG(OSS() << "Cache hit !");
         return V_( (*it).second.first );
 
       }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelAlgorithm.cxx
@@ -738,6 +738,7 @@ Point GeneralLinearModelAlgorithm::computeReducedLogLikelihood(const Point & par
                                          << " covariance model requires an argument of size " << reducedCovarianceModel_.getParameter().getSize()
                                          << " but here we got " << parameters.getSize();
   LOGDEBUG(OSS(false) << "Compute reduced log-likelihood for parameters=" << parameters);
+  const Scalar constant = - SpecFunc::LOGSQRT2PI * static_cast<Scalar>(inputSample_.getSize()) * static_cast<Scalar>(outputSample_.getDimension());
   Scalar logDeterminant = 0.0;
   // If the amplitude is deduced from the other parameters, work with
   // the correlation function
@@ -772,7 +773,7 @@ Point GeneralLinearModelAlgorithm::computeReducedLogLikelihood(const Point & par
   LOGDEBUG(OSS(false) << "epsilon=||rho||^2=" << epsilon);
   if (epsilon <= 0) lastReducedLogLikelihood_ = SpecFunc::LogMinScalar;
   // For the general multidimensional case, we have to compute the general log-likelihood (ie including marginal variances)
-  else lastReducedLogLikelihood_ = -0.5 * (logDeterminant + epsilon);
+  else lastReducedLogLikelihood_ = constant - 0.5 * (logDeterminant + epsilon);
   LOGINFO(OSS(false) << "Reduced log-likelihood=" << lastReducedLogLikelihood_);
   return Point(1, lastReducedLogLikelihood_);
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralLinearModelAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralLinearModelAlgorithm.hxx
@@ -180,7 +180,12 @@ private:
     // It is a simple call to the computeReducedLogLikelihood() of the algo
     Point operator() (const Point & point) const
     {
+      if (p_cache_->hasKey(point))
+      {
+        return p_cache_->find(point);
+      }
       const Point value(algorithm_.computeReducedLogLikelihood(point));
+      p_cache_->add( point, value );
       return value;
     }
 


### PR DESCRIPTION
We are only interested to find its maximum value, and thus we did not care to add the constant part, but user may be interested by the exact value.

Let loglikelihood function really uses its cache, it was enabled but not used.
