### PR TITLE
Speed-up computeStandardRepresentative() when called on a Sample

### DIFF
--- a/lib/src/Base/Stat/AbsoluteExponential.cxx
+++ b/lib/src/Base/Stat/AbsoluteExponential.cxx
@@ -70,6 +70,19 @@ Scalar AbsoluteExponential::computeStandardRepresentative(const Point & tau) con
   return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-tauOverThetaNorm);
 }
 
+Scalar AbsoluteExponential::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar tauOverThetaNorm = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    tauOverThetaNorm += std::abs(*s_it - *t_it) / scale_[i];
+  }
+  return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-tauOverThetaNorm);
+}
+
 /* Gradient */
 Matrix AbsoluteExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/AbsoluteExponential.cxx
+++ b/lib/src/Base/Stat/AbsoluteExponential.cxx
@@ -33,14 +33,14 @@ static const Factory<AbsoluteExponential> Factory_AbsoluteExponential;
 AbsoluteExponential::AbsoluteExponential(const UnsignedInteger spatialDimension)
   : StationaryCovarianceModel(Point(spatialDimension, ResourceMap::GetAsScalar("AbsoluteExponential-DefaultTheta")), Point(1, 1.0))
 {
-  // Nothing to do
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
 AbsoluteExponential::AbsoluteExponential(const Point & scale)
   : StationaryCovarianceModel(scale, Point(1, 1.0))
 {
-  // Nothing to do
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
@@ -51,6 +51,7 @@ AbsoluteExponential::AbsoluteExponential(const Point & scale,
   if (getOutputDimension() != 1)
     throw InvalidArgumentException(HERE) << "In AbsoluteExponential::AbsoluteExponential, only unidimensional models should be defined."
                                          << " Here, (got dimension=" << getOutputDimension() << ")";
+  definesComputeStandardRepresentative_ = true;
 }
 
 /* Virtual constructor */

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -307,7 +307,10 @@ struct CovarianceModelDiscretizePolicy
 struct CovarianceModelDiscretizeKroneckerPolicy
 {
   const SampleImplementation & input_;
-  CovarianceMatrix & output_;
+  // output_ is a CovarianceMatrix, but since we fill only its half part,
+  // we can directly store results in the underlying MatrixImplementation.
+  // This avoids comparing row and column numbers.
+  MatrixImplementation & output_;
   const CovarianceModelImplementation & model_;
   const UnsignedInteger inputDimension_;
 
@@ -315,7 +318,7 @@ struct CovarianceModelDiscretizeKroneckerPolicy
       CovarianceMatrix & output,
       const CovarianceModelImplementation & model)
     : input_(*input.getImplementation())
-    , output_(output)
+    , output_(*output.getImplementation())
     , model_(model)
     , inputDimension_(input_.getDimension())
   {}
@@ -326,7 +329,8 @@ struct CovarianceModelDiscretizeKroneckerPolicy
     {
       const UnsignedInteger jLocal = static_cast< UnsignedInteger >(sqrt(2.0 * i + 0.25) - 0.5);
       const UnsignedInteger iLocal = i - (jLocal * (jLocal + 1)) / 2;
-      output_(iLocal, jLocal) = model_.computeStandardRepresentative(input_.data_begin() + iLocal * inputDimension_, input_.data_begin() + jLocal * inputDimension_);
+      // By construction, iLocal <= jLocal
+      output_(jLocal, iLocal) = model_.computeStandardRepresentative(input_.data_begin() + iLocal * inputDimension_, input_.data_begin() + jLocal * inputDimension_);
     }
   }
   static void genericKroneckerProduct(const SquareMatrix & leftMatrix, const SquareMatrix & rightMatrix, SquareMatrix & productMatrix)

--- a/lib/src/Base/Stat/ExponentialModel.cxx
+++ b/lib/src/Base/Stat/ExponentialModel.cxx
@@ -77,13 +77,28 @@ ExponentialModel * ExponentialModel::clone() const
  */
 Scalar ExponentialModel::computeStandardRepresentative(const Point & tau) const
 {
-  if (tau.getDimension() != getInputDimension())
+  if (tau.getDimension() != inputDimension_)
     throw InvalidArgumentException(HERE) << "In ExponentialModel::computeStandardRepresentative: expected a shift of dimension=" << getInputDimension() << ", got dimension=" << tau.getDimension();
   // Absolute value of tau / scale
   Point tauOverTheta(getInputDimension());
   for (UnsignedInteger i = 0; i < getInputDimension(); ++i) tauOverTheta[i] = tau[i] / scale_[i];
   const Scalar tauOverThetaNorm = tauOverTheta.norm();
   // Return value
+  return (tauOverThetaNorm == 0.0 ? 1.0 + nuggetFactor_ : exp(- tauOverThetaNorm ));
+}
+
+Scalar ExponentialModel::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar tauOverThetaNorm = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) / scale_[i];
+    tauOverThetaNorm += dx * dx;
+  }
+  tauOverThetaNorm = sqrt(tauOverThetaNorm);
   return (tauOverThetaNorm == 0.0 ? 1.0 + nuggetFactor_ : exp(- tauOverThetaNorm ));
 }
 

--- a/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
+++ b/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
@@ -87,6 +87,22 @@ Scalar ExponentiallyDampedCosineModel::computeStandardRepresentative(const Point
   return exp(-absTau) * cos(2.0 * M_PI * absTau);
 }
 
+Scalar ExponentiallyDampedCosineModel::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar absTau = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) / scale_[i];
+    absTau += dx * dx;
+  }
+  absTau = sqrt(absTau);
+  if (absTau <= SpecFunc::ScalarEpsilon) return 1.0 + nuggetFactor_;
+  return exp(-absTau) * cos(2.0 * M_PI * absTau);
+}
+
 /* Discretize the covariance function on a given TimeGrid */
 CovarianceMatrix ExponentiallyDampedCosineModel::discretize(const RegularGrid & timeGrid) const
 {

--- a/lib/src/Base/Stat/GeneralizedExponential.cxx
+++ b/lib/src/Base/Stat/GeneralizedExponential.cxx
@@ -34,7 +34,7 @@ GeneralizedExponential::GeneralizedExponential(const UnsignedInteger spatialDime
   : StationaryCovarianceModel(Point(spatialDimension, ResourceMap::GetAsScalar("GeneralizedExponential-DefaultTheta")), Point(1, 1.0))
   , p_(1.0)
 {
-  // Nothing to do
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
@@ -44,6 +44,7 @@ GeneralizedExponential::GeneralizedExponential(const Point & scale,
   , p_(0.0) // To pass the test !(p_ == p)
 {
   setP(p);
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
@@ -57,6 +58,7 @@ GeneralizedExponential::GeneralizedExponential(const Point & scale,
     throw InvalidArgumentException(HERE) << "In GeneralizedExponential::GeneralizedExponential, only unidimensional models should be defined."
                                          << " Here, (got dimension=" << getOutputDimension() << ")";
   setP(p);
+  definesComputeStandardRepresentative_ = true;
 }
 
 /* Virtual constructor */

--- a/lib/src/Base/Stat/GeneralizedExponential.cxx
+++ b/lib/src/Base/Stat/GeneralizedExponential.cxx
@@ -77,6 +77,21 @@ Scalar GeneralizedExponential::computeStandardRepresentative(const Point & tau) 
   return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-pow(tauOverThetaNorm, p_));
 }
 
+Scalar GeneralizedExponential::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar tauOverThetaNorm = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) / scale_[i];
+    tauOverThetaNorm += dx * dx;
+  }
+  tauOverThetaNorm = sqrt(tauOverThetaNorm);
+  return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-pow(tauOverThetaNorm, p_));
+}
+
 /* Gradient wrt s */
 Matrix GeneralizedExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/MaternModel.cxx
+++ b/lib/src/Base/Stat/MaternModel.cxx
@@ -99,6 +99,24 @@ Scalar MaternModel::computeStandardRepresentative(const Point & tau) const
     return exp(logNormalizationFactor_ + nu_ * std::log(scaledPoint) + SpecFunc::LogBesselK(nu_, scaledPoint));
 }
 
+Scalar MaternModel::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar scaledPoint = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) * sqrt2nuOverTheta_[i];
+    scaledPoint += dx * dx;
+  }
+  scaledPoint = sqrt(scaledPoint);
+  if (scaledPoint <= SpecFunc::ScalarEpsilon)
+    return 1.0 + nuggetFactor_;
+  else
+    return exp(logNormalizationFactor_ + nu_ * std::log(scaledPoint) + SpecFunc::LogBesselK(nu_, scaledPoint));
+}
+
 /* Gradient */
 Matrix MaternModel::partialGradient(const Point & s,
                                     const Point & t) const

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -112,18 +112,19 @@ Scalar ProductCovarianceModel::computeStandardRepresentative(const Point & s,
   if (s.getDimension() != inputDimension_) throw InvalidArgumentException(HERE) << "Error: the point s has dimension=" << s.getDimension() << ", expected dimension=" << inputDimension_;
   if (t.getDimension() != inputDimension_) throw InvalidArgumentException(HERE) << "Error: the point t has dimension=" << t.getDimension() << ", expected dimension=" << inputDimension_;
 
+  return computeStandardRepresentative(s.begin(), t.begin());
+}
+
+Scalar ProductCovarianceModel::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
   Scalar rho = 1.0;
   UnsignedInteger start = 0;
   for (UnsignedInteger i = 0; i < collection_.getSize(); ++i)
   {
     const UnsignedInteger localSpatialDimension = collection_[i].getInputDimension();
-    const UnsignedInteger stop = start + localSpatialDimension;
-    Point localS(localSpatialDimension);
-    std::copy(s.begin() + start, s.begin() + stop, localS.begin());
-    Point localT(localSpatialDimension);
-    std::copy(t.begin() + start, t.begin() + stop, localT.begin());
-    rho *= collection_[i].computeStandardRepresentative(localS, localT);
-    start = stop;
+    rho *= collection_[i].getImplementation()->computeStandardRepresentative(s_begin + start, t_begin + start);
+    start += localSpatialDimension;
   }
   return rho;
 }

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -1132,8 +1132,8 @@ Point SampleImplementation::computeMean() const
   if (size_ == 0) throw InternalException(HERE) << "Error: cannot compute the mean of an empty sample.";
   Point accumulated(dimension_);
 
-  const_data_iterator it(data_begin());
-  const const_data_iterator guard(data_end());
+  data_const_iterator it(data_begin());
+  const data_const_iterator guard(data_end());
   while (it != guard)
   {
     for (UnsignedInteger i = 0; i < dimension_; ++i, ++it)
@@ -1162,8 +1162,8 @@ CovarianceMatrix SampleImplementation::computeCovariance() const
   const UnsignedInteger squaredDim(dimension_ * dimension_);
   Point accumulated(squaredDim);
 
-  const_data_iterator it(data_begin());
-  const const_data_iterator guard(data_end());
+  data_const_iterator it(data_begin());
+  const data_const_iterator guard(data_end());
   while (it != guard)
   {
     UnsignedInteger baseIndex = 0;
@@ -1211,8 +1211,8 @@ Point SampleImplementation::computeVariance() const
   const Point mean( computeMean() );
   Point accumulated(dimension_);
 
-  const_data_iterator it(data_begin());
-  const const_data_iterator guard(data_end());
+  data_const_iterator it(data_begin());
+  const data_const_iterator guard(data_end());
   while (it != guard)
   {
     for (UnsignedInteger i = 0; i < dimension_; ++i, ++it)

--- a/lib/src/Base/Stat/SphericalModel.cxx
+++ b/lib/src/Base/Stat/SphericalModel.cxx
@@ -87,6 +87,23 @@ Scalar SphericalModel::computeStandardRepresentative(const Point & tau) const
   return 1.0 - 0.5 * normTauOverScaleA * (3.0 - normTauOverScaleA * normTauOverScaleA);
 }
 
+Scalar SphericalModel::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar normTauOverScaleA = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) / scale_[i];
+    normTauOverScaleA += dx * dx;
+  }
+  normTauOverScaleA = sqrt(normTauOverScaleA) / radius_;
+  if (normTauOverScaleA <= SpecFunc::ScalarEpsilon) return 1.0 + nuggetFactor_;
+  if (normTauOverScaleA >= 1.0) return 0.0;
+  return 1.0 - 0.5 * normTauOverScaleA * (3.0 - normTauOverScaleA * normTauOverScaleA);
+}
+
 /* Discretize the covariance function on a given TimeGrid */
 CovarianceMatrix SphericalModel::discretize(const RegularGrid & timeGrid) const
 {

--- a/lib/src/Base/Stat/SquaredExponential.cxx
+++ b/lib/src/Base/Stat/SquaredExponential.cxx
@@ -33,14 +33,14 @@ static const Factory<SquaredExponential> Factory_SquaredExponential;
 SquaredExponential::SquaredExponential(const UnsignedInteger spatialDimension)
   : StationaryCovarianceModel(Point(spatialDimension, ResourceMap::GetAsScalar("SquaredExponential-DefaultTheta")), Point(1, 1.0))
 {
-  // Nothing to do
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
 SquaredExponential::SquaredExponential(const Point & scale)
   : StationaryCovarianceModel(scale, Point(1, 1.0))
 {
-  // Nothing to do
+  definesComputeStandardRepresentative_ = true;
 }
 
 /** Parameters constructor */
@@ -51,6 +51,7 @@ SquaredExponential::SquaredExponential(const Point & scale,
   if (getOutputDimension() != 1)
     throw InvalidArgumentException(HERE) << "In SquaredExponential::SquaredExponential, only unidimensional models should be defined."
                                          << " Here, (got dimension=" << getOutputDimension() << ")";
+  definesComputeStandardRepresentative_ = true;
 }
 
 /* Virtual constructor */

--- a/lib/src/Base/Stat/SquaredExponential.cxx
+++ b/lib/src/Base/Stat/SquaredExponential.cxx
@@ -70,6 +70,20 @@ Scalar SquaredExponential::computeStandardRepresentative(const Point & tau) cons
   return tauOverTheta2 <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-0.5 * tauOverTheta2);
 }
 
+Scalar SquaredExponential::computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  Scalar tauOverTheta2 = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it) / scale_[i];
+    tauOverTheta2 += dx * dx;
+  }
+  return tauOverTheta2 <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-0.5 * tauOverTheta2);
+}
+
 /* Gradient */
 Matrix SquaredExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/openturns/AbsoluteExponential.hxx
+++ b/lib/src/Base/Stat/openturns/AbsoluteExponential.hxx
@@ -52,6 +52,10 @@ public:
   /** Computation of the covariance function */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
   /** Gradient */
   virtual Matrix partialGradient(const Point & s,
                                  const Point & t) const;

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -84,6 +84,11 @@ public:
   virtual Scalar computeStandardRepresentative(const Point & s,
       const Point & t) const;
 
+#ifndef SWIG
+  virtual Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
+
   // Special case for 1D model
   virtual Scalar computeAsScalar (const Point & s,
                                   const Point & t) const;

--- a/lib/src/Base/Stat/openturns/ExponentialModel.hxx
+++ b/lib/src/Base/Stat/openturns/ExponentialModel.hxx
@@ -68,6 +68,10 @@ public:
   /** Computation of the covariance function, stationary interface */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   /** Gradient */
   using StationaryCovarianceModel::partialGradient;

--- a/lib/src/Base/Stat/openturns/ExponentiallyDampedCosineModel.hxx
+++ b/lib/src/Base/Stat/openturns/ExponentiallyDampedCosineModel.hxx
@@ -59,6 +59,11 @@ public:
   /** Computation of the covariance function, stationary interface */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
+
   using StationaryCovarianceModel::operator();
   CovarianceMatrix operator() (const Point & tau) const;
   Scalar computeAsScalar(const Point & tau) const;

--- a/lib/src/Base/Stat/openturns/GeneralizedExponential.hxx
+++ b/lib/src/Base/Stat/openturns/GeneralizedExponential.hxx
@@ -53,6 +53,10 @@ public:
   /** Computation of the covariance function */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   /** Gradient */
   virtual Matrix partialGradient(const Point & s,

--- a/lib/src/Base/Stat/openturns/MaternModel.hxx
+++ b/lib/src/Base/Stat/openturns/MaternModel.hxx
@@ -53,6 +53,10 @@ public:
   /** Computation of the covariance function */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   /** Gradient */
   virtual Matrix partialGradient(const Point & s,

--- a/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
@@ -54,6 +54,10 @@ public:
   using CovarianceModelImplementation::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & s,
                                        const Point & t) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   /** Gradient */
   virtual Matrix partialGradient(const Point & s,

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -467,8 +467,8 @@ public:
   /* Some typedefs for easy reading */
   typedef NSI_iterator               iterator;
   typedef NSI_const_iterator         const_iterator;
-  typedef       Scalar *       data_iterator;
-  typedef const Scalar * const_data_iterator;
+  typedef Collection<Scalar>::iterator       data_iterator;
+  typedef Collection<Scalar>::const_iterator data_const_iterator;
 
   typedef Collection<UnsignedInteger>   UnsignedIntegerCollection;
 
@@ -539,19 +539,19 @@ public:
 
   inline data_iterator data_begin()
   {
-    return &data_[0];
+    return data_.begin();
   }
   inline data_iterator data_end()
   {
-    return &data_[0] + size_ * dimension_;
+    return data_.end();
   }
-  inline const_data_iterator data_begin() const
+  inline data_const_iterator data_begin() const
   {
-    return &data_[0];
+    return data_.begin();
   }
-  inline const_data_iterator data_end() const
+  inline data_const_iterator data_end() const
   {
-    return &data_[0] + size_ * dimension_;
+    return data_.end();
   }
 
   void erase(const UnsignedInteger first, const UnsignedInteger last);

--- a/lib/src/Base/Stat/openturns/SphericalModel.hxx
+++ b/lib/src/Base/Stat/openturns/SphericalModel.hxx
@@ -59,6 +59,11 @@ public:
   /** Computation of the covariance function, stationary interface */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
+
   using StationaryCovarianceModel::operator();
   CovarianceMatrix operator() (const Point & tau) const;
   Scalar computeAsScalar(const Point & tau) const;

--- a/lib/src/Base/Stat/openturns/SquaredExponential.hxx
+++ b/lib/src/Base/Stat/openturns/SquaredExponential.hxx
@@ -52,6 +52,10 @@ public:
   /** Computation of the covariance function */
   using StationaryCovarianceModel::computeStandardRepresentative;
   Scalar computeStandardRepresentative(const Point & tau) const;
+#ifndef SWIG
+  Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   /** Gradient */
   virtual Matrix partialGradient(const Point & s,


### PR DESCRIPTION
Overload CovarianceModelImplementation::computeStandardRepresentative() method with arguments being iterators on Collection<Scalar>, instead of Point. This avoids the creation of temporary Point instances.