### PR TITLE
Alternate implementation of Cache

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralLinearModelAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/GeneralLinearModelAlgorithm.hxx
@@ -180,12 +180,7 @@ private:
     // It is a simple call to the computeReducedLogLikelihood() of the algo
     Point operator() (const Point & point) const
     {
-      if (p_cache_->hasKey(point))
-      {
-        return p_cache_->find(point);
-      }
       const Point value(algorithm_.computeReducedLogLikelihood(point));
-      p_cache_->add( point, value );
       return value;
     }
 

--- a/lib/test/t_Cache_std.expout
+++ b/lib/test/t_Cache_std.expout
@@ -1,10 +1,10 @@
 myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=0 hits=0 points={}
-myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=1 hits=0 points={[1,2,3]->[10,20]/0}
+myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=1 hits=0 points={([1,2,3],[10,20])}
 Is ko in myCache ? false
 Cache value for ko = []
 Is ok in myCache ? true
 Cache value for ok = [10,20]
-myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=1 hits=1 points={[1,2,3]->[10,20]/1}
-myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=2 hits=1 points={[1,2,3]->[10,20]/1, [2,4,6]->[20,40]/0}
-myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=3 hits=1 points={[1,2,3]->[10,20]/1, [2,4,6]->[20,40]/0, [3,6,9]->[30,60]/0}
-myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=3 hits=1 points={[1,2,3]->[10,20]/1, [3,6,9]->[30,60]/0, [4,8,12]->[40,80]/0}
+myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=1 hits=1 points={([1,2,3],[10,20])}
+myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=2 hits=1 points={([2,4,6],[20,40]), ([1,2,3],[10,20])}
+myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=3 hits=1 points={([3,6,9],[30,60]), ([2,4,6],[20,40]), ([1,2,3],[10,20])}
+myCache = class=Cache<PersistentCollection<Scalar>, PersistentCollection<Scalar>> enabled=true name=aCache maxSize=3 size=3 hits=1 points={([4,8,12],[40,80]), ([3,6,9],[30,60]), ([2,4,6],[20,40])}


### PR DESCRIPTION
With the previous implementation, when the Cache is full, the least recently used element is searched by traversing all elements whenever a new element is inserted.

This new implementation is more standard, it stores keys in a doubly-linked list, and uses a map to store the position of each key in this iterator. Key is moved at the beginning at the list when it is accessed, so tail list always contains the last recently used key.

Since the cache size is fixed, it would be better to use a hash map, but OT does not use hash map anywhere.