### PR TITLE
Worked around bug #864 (parallel BernsteinCopulaFactory segfault)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -96,6 +96,7 @@
 
 === Miscellaneous ===
  * Changed bounds evaluation in UniformFactory, BetaFactory
+ * Worked around bug #864 (parallel segfault in BernsteinCopulaFactory)
 
 === Bug fixes ===
  * #890 (Cannot build triangular distribution)

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -249,7 +249,7 @@
   <Matrix-SymmetryThreshold value="1.0e-12"    />
 
   <!-- OT::BernsteinCopulaFactory parameters -->
-  <BernsteinCopulaFactory-Parallel value="true" />
+  <BernsteinCopulaFactory-Parallel value="false" />
 
   <!-- OT::BurrFactory parameters -->
   <BurrFactory-AbsolutePrecision value="1e-12" />

--- a/lib/src/Uncertainty/Distribution/openturns/BernsteinCopulaFactory.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/BernsteinCopulaFactory.hxx
@@ -47,18 +47,18 @@ public:
 
   /** Build a Bernstein copula based on the given sample. The bin number is computed according to the inverse power rule */
   using DistributionFactoryImplementation::build;
-  virtual Distribution build(const Sample & sample);
+  virtual Implementation build(const Sample & sample);
 
   /** Build a Bernstein copula based on the given sample and bin number */
-  virtual Distribution build(const Sample & sample,
-                             const UnsignedInteger binNumber);
+  virtual Implementation build(const Sample & sample,
+                               const UnsignedInteger binNumber);
 
 private:
-  virtual Distribution buildParallel(const Sample & sample,
-                                     const UnsignedInteger binNumber);
-
-  virtual Distribution buildSequential(const Sample & sample,
+  virtual Implementation buildParallel(const Sample & sample,
                                        const UnsignedInteger binNumber);
+
+  virtual Implementation buildSequential(const Sample & sample,
+                                         const UnsignedInteger binNumber);
 public:
 
   /** Compute the number of bins according to the inverse power rule */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -1191,6 +1191,7 @@ Sample DistributionImplementation::computeDDF(const Sample & inSample) const
 /* Get the PDF of the distribution */
 Sample DistributionImplementation::computePDFSequential(const Sample & inSample) const
 {
+  LOGINFO("In DistributionImplementation::computePDFSequential(const Sample & inSample)");
   const UnsignedInteger size = inSample.getSize();
   Sample outSample(size, 1);
   for (UnsignedInteger i = 0; i < size; ++i) outSample[i][0] = computePDF(inSample[i]);
@@ -1214,13 +1215,14 @@ struct ComputePDFPolicy
 
   inline void operator()( const TBB::BlockedRange<UnsignedInteger> & r ) const
   {
-    for (UnsignedInteger i = r.begin(); i != r.end(); ++i) output_[i][0] = distribution_.computePDF(input_[i]);
+    for (UnsignedInteger i = r.begin(); i != r.end(); ++i) output_(i, 0) = distribution_.computePDF(input_[i]);
   }
 
 }; /* end struct ComputePDFPolicy */
 
 Sample DistributionImplementation::computePDFParallel(const Sample & inSample) const
 {
+  LOGINFO("In DistributionImplementation::computePDFParallel(const Sample & inSample)");
   if (inSample.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: the given sample has an invalid dimension. Expect a dimension " << dimension_ << ", got " << inSample.getDimension();
   const UnsignedInteger size = inSample.getSize();
   Sample result(size, 1);


### PR DESCRIPTION
The default value of BernsteinCopulaFactory-Parallel is *false* and the resulting Mixture has its parallel_ flag set to *false*
The return type of BernsteinCopulaFactory::build() is now a Pointer to a DistributionImplementation instead of an actual distribution in order to conform to the other distribution factories.