### PR TITLE
Speed-up Piecewise{Hermite,Linear}Evaluation on a Sample

### DIFF
--- a/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
@@ -170,7 +170,7 @@ Point PiecewiseHermiteEvaluation::operator () (const Point & inP) const
 
 Sample PiecewiseHermiteEvaluation::operator () (const Sample & inSample) const
 {
-  if (inSample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: expected an input point of dimension 1, got dimension=" << inSample.getDimension();
+  if (inSample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: expected an input sample of dimension 1, got dimension=" << inSample.getDimension();
   const UnsignedInteger size = inSample.getSize();
   const UnsignedInteger dimension = getOutputDimension();
   Sample output(size, dimension);

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -53,7 +53,7 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
   // Convert the values into a sample
   const UnsignedInteger size = values.getSize();
   Sample sampleValues(size, 1);
-  for (UnsignedInteger i = 0; i < size; ++i) sampleValues[i][0] = values[i];
+  for (UnsignedInteger i = 0; i < size; ++i) sampleValues(i, 0) = values[i];
   // Check the input
   setLocationsAndValues(locations, sampleValues);
 }
@@ -89,6 +89,46 @@ String PiecewiseLinearEvaluation::__str__(const String & offset) const
   return OSS(false) << offset << __repr__();
 }
 
+namespace {
+Bool computeRegular(const Point & locations)
+{
+  const UnsignedInteger size = locations.getSize();
+  const Scalar step = locations[1] - locations[0];
+  const Scalar relativeEpsilon = ResourceMap::GetAsScalar("PiecewiseLinearEvaluation-EpsilonRegular") * std::abs(step);
+  for (UnsignedInteger i = 2; i < size; ++i)
+  {
+    if (!(std::abs(locations[i] - locations[0] - i * step) < relativeEpsilon))
+      return false;
+  }
+  return true;
+}
+
+// Find the segment containing value by bisection
+UnsignedInteger findSegmentIndex(const Point & locations, const Scalar value, const UnsignedInteger start)
+{
+  UnsignedInteger iRight = locations.getSize() - 1;
+  UnsignedInteger iLeft  = start;
+  if (value >= locations[start])
+  {
+    // Shortcuts for the most common cases when looping over a Sample
+    if (start == iRight || value < locations[start+1])
+      return start;
+    else if (start + 1 == iRight || value < locations[start+2])
+      return start + 1 ;
+  }
+  else
+    iLeft = 0;
+
+  while (iRight > iLeft + 1)
+  {
+    const UnsignedInteger im = (iRight + iLeft) / 2;
+    if (value < locations[im]) iRight = im;
+    else iLeft = im;
+  }
+  return  iLeft;
+}
+
+}
 
 /* Evaluation operator */
 Point PiecewiseLinearEvaluation::operator () (const Point & inP) const
@@ -102,30 +142,56 @@ Point PiecewiseLinearEvaluation::operator () (const Point & inP) const
   if (x >= locations_[iRight])
     return values_[iRight];
   if (isRegular_)
-  {
     iLeft = static_cast<UnsignedInteger>(floor((x - locations_[0]) / (locations_[1] - locations_[0])));
-    iRight = iLeft + 1;
-  }
   else
-    // Find the segment containing x by bisection
-    while (iRight - iLeft > 1)
-    {
-      const UnsignedInteger im = (iRight + iLeft) / 2;
-      if (x < locations_[im]) iRight = im;
-      else iLeft = im;
-    }
+    iLeft = findSegmentIndex(locations_, x, 0);
 
   const Scalar xLeft = locations_[iLeft];
-  const Scalar xRight = locations_[iRight];
+  const Scalar xRight = locations_[iLeft + 1];
   const Scalar dx = xLeft - xRight;
-  const Point vLeft(values_[iLeft]);
-  const Point vRight(values_[iRight]);
   const UnsignedInteger dimension = getOutputDimension();
   Point value(dimension);
   const Scalar alpha = (x - xRight) / dx;
   const Scalar beta = (xLeft - x) / dx;
-  for (UnsignedInteger i = 0; i < dimension; ++i) value[i] = alpha * vLeft[i] + beta * vRight[i];
+  for (UnsignedInteger i = 0; i < dimension; ++i) value[i] = alpha * values_(iLeft, i) + beta * values_(iLeft + 1, i);
   return value;
+}
+
+Sample PiecewiseLinearEvaluation::operator () (const Sample & inSample) const
+{
+  if (inSample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: expected an input point of dimension 1, got dimension=" << inSample.getDimension();
+  const UnsignedInteger size = inSample.getSize();
+  const UnsignedInteger dimension = getOutputDimension();
+  Sample output(size, dimension);
+  const UnsignedInteger maxIndex = locations_.getSize() - 1;
+  UnsignedInteger iLeft = 0;
+  for (UnsignedInteger i = 0; i < size; ++i)
+  {
+    const Scalar x = inSample(i, 0);
+    if (x <= locations_[0])
+    {
+      for (UnsignedInteger j = 0; j < dimension; ++j) output(i, j) = values_(0, j);
+      continue;
+    }
+    UnsignedInteger iRight = maxIndex;
+    if (x >= locations_[iRight])
+    {
+      for (UnsignedInteger j = 0; j < dimension; ++j) output(i, j) = values_(iRight, j);
+      continue;
+    }
+    if (isRegular_)
+      iLeft = static_cast<UnsignedInteger>(floor((x - locations_[0]) / (locations_[1] - locations_[0])));
+    else
+      iLeft = findSegmentIndex(locations_, x, iLeft);
+
+    const Scalar xLeft = locations_[iLeft];
+    const Scalar xRight = locations_[iLeft + 1];
+    const Scalar dx = xLeft - xRight;
+    const Scalar alpha = (x - xRight) / dx;
+    const Scalar beta = (xLeft - x) / dx;
+    for (UnsignedInteger j = 0; j < dimension; ++j) output(i, j) = alpha * values_(iLeft, j) + beta * values_(iLeft + 1, j);
+  }
+  return output;
 }
 
 /* Locations accessor */
@@ -149,10 +215,7 @@ void PiecewiseLinearEvaluation::setLocations(const Point & locations)
     locations_[i] = locationsAndValues[i].first;
     values_[i] = locationsAndValues[i].second;
   }
-  const Scalar step = locations_[1] - locations_[0];
-  const Scalar epsilon = ResourceMap::GetAsScalar("PiecewiseLinearEvaluation-EpsilonRegular") * std::abs(step);
-  isRegular_ = true;
-  for (UnsignedInteger i = 0; i < size; ++i) isRegular_ = isRegular_ && (std::abs(locations_[i] - locations_[0] - i * step) < epsilon);
+  isRegular_ = computeRegular(locations_);
 }
 
 /* Values accessor */
@@ -166,7 +229,7 @@ void PiecewiseLinearEvaluation::setValues(const Point & values)
   const UnsignedInteger size = values.getSize();
   if (size != locations_.getSize()) throw InvalidArgumentException(HERE) << "Error: the number of values=" << size << " must match the number of previously set locations=" << locations_.getSize();
   Sample sampleValues(size, 1);
-  for (UnsignedInteger i = 0; i < size; ++i) sampleValues[i][0] = values[i];
+  for (UnsignedInteger i = 0; i < size; ++i) sampleValues(i, 0) = values[i];
   values_ = sampleValues;
 }
 
@@ -188,23 +251,20 @@ void PiecewiseLinearEvaluation::setLocationsAndValues(const Point & locations,
   Sample data(size, 1 + dimension);
   for (UnsignedInteger i = 0; i < size; ++i)
   {
-    data[i][0] = locations[i];
+    data(i, 0) = locations[i];
     for (UnsignedInteger j = 0; j < dimension; ++j)
-      data[i][j + 1] = values[i][j];
+      data(i, j + 1) = values(i, j);
   }
   data = data.sortAccordingToAComponent(0);
   locations_ = Point(size);
   values_ = Sample(size, dimension);
-  const Scalar step = data[1][0] - data[0][0];
-  const Scalar epsilon = ResourceMap::GetAsScalar("PiecewiseLinearEvaluation-EpsilonRegular") * std::abs(step);
-  isRegular_ = true;
   for (UnsignedInteger i = 0; i < size; ++i)
   {
-    locations_[i] = data[i][0];
-    isRegular_ = isRegular_ && (std::abs(locations_[i] - locations_[0] - i * step) < epsilon);
+    locations_[i] = data(i, 0);
     for (UnsignedInteger j = 0; j < dimension; ++j)
-      values_[i][j] = data[i][j + 1];
+      values_(i, j) = data(i, j + 1);
   }
+  isRegular_ = computeRegular(locations_);
 }
 
 /* Input dimension accessor */
@@ -235,6 +295,7 @@ void PiecewiseLinearEvaluation::load(Advocate & adv)
   EvaluationImplementation::load(adv);
   adv.loadAttribute( "locations_", locations_ );
   adv.loadAttribute( "values_", values_ );
+  isRegular_ = computeRegular(locations_);
 }
 
 

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -159,7 +159,7 @@ Point PiecewiseLinearEvaluation::operator () (const Point & inP) const
 
 Sample PiecewiseLinearEvaluation::operator () (const Sample & inSample) const
 {
-  if (inSample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: expected an input point of dimension 1, got dimension=" << inSample.getDimension();
+  if (inSample.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: expected an input sample of dimension 1, got dimension=" << inSample.getDimension();
   const UnsignedInteger size = inSample.getSize();
   const UnsignedInteger dimension = getOutputDimension();
   Sample output(size, dimension);

--- a/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
@@ -63,6 +63,7 @@ public:
   /** Evaluation operator */
   using EvaluationImplementation::operator ();
   Point operator () (const Point & inP) const;
+  Sample operator () (const Sample & inSample) const;
 
   /** Compute the derivative */
   Point derivate(const Point & inP) const;

--- a/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
@@ -61,6 +61,7 @@ public:
   /** Evaluation operator */
   using EvaluationImplementation::operator ();
   Point operator () (const Point & inP) const;
+  Sample operator () (const Sample & inSample) const;
 
   /** Locations accessor */
   Point getLocations() const;


### PR DESCRIPTION
When interpolating on a Sample, it is likely than points are looked at in ascending order, bisection search can then be greatly fastened.

Use Sample::operator() instead of operator[].