### PR TITLE
[RFC] Smaller allocation of DesignProxy

### DIFF
--- a/lib/src/Base/Algo/DesignProxy.cxx
+++ b/lib/src/Base/Algo/DesignProxy.cxx
@@ -43,7 +43,8 @@ DesignProxy::DesignProxy ()
 
 /* Parameters constructor */
 DesignProxy::DesignProxy(const Sample & x,
-                         const Basis & basis)
+                         const Basis & basis,
+                         const UnsignedInteger maximumDimension)
   : Object()
   , x_(x)
   , basis_(basis)
@@ -53,11 +54,11 @@ DesignProxy::DesignProxy(const Sample & x,
   , weight_(0)
 {
   // keep initialization in the ctor for designCache_ to be shared among DesignProxy copies
-  initialize();
+  initialize(maximumDimension);
 }
 
 
-void DesignProxy::initialize() const
+void DesignProxy::initialize(const UnsignedInteger maximumDimension) const
 {
   // allocate cache
   UnsignedInteger cacheSize = ResourceMap::GetAsUnsignedInteger("DesignProxy-DefaultCacheSize");
@@ -67,6 +68,7 @@ void DesignProxy::initialize() const
   UnsignedInteger nbCols = cacheSize / nbRows;
   // The cache stores at least the first function values
   if (nbCols <= 0) nbCols = 1;
+  if (maximumDimension > 0 && nbCols > maximumDimension) nbCols = maximumDimension;
   designCache_ = Matrix(nbRows, nbCols);
   alreadyComputed_ = Indices(nbCols, 0);
 }

--- a/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/FittingAlgorithmImplementation.cxx
@@ -21,6 +21,7 @@
 
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/FittingAlgorithmImplementation.hxx"
+#include <algorithm>
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -48,7 +49,8 @@ Scalar FittingAlgorithmImplementation::run(const Sample & x,
     const Basis & basis,
     const Indices & indices) const
 {
-  const DesignProxy proxy(x, basis);
+  const UnsignedInteger maximumDimension = *std::max_element(indices.begin(), indices.end());
+  const DesignProxy proxy(x, basis, maximumDimension);
   return run(y, weight, indices, proxy);
 }
 
@@ -57,7 +59,8 @@ Scalar FittingAlgorithmImplementation::run(const Sample & x,
     const Basis & basis,
     const Indices & indices) const
 {
-  const DesignProxy proxy(x, basis);
+  const UnsignedInteger maximumDimension = *std::max_element(indices.begin(), indices.end());
+  const DesignProxy proxy(x, basis, maximumDimension);
   return run(y, indices, proxy);
 }
 

--- a/lib/src/Base/Algo/openturns/DesignProxy.hxx
+++ b/lib/src/Base/Algo/openturns/DesignProxy.hxx
@@ -45,7 +45,8 @@ public:
 
   /** Parameters constructor */
   DesignProxy(const Sample & x,
-              const Basis & basis);
+              const Basis & basis,
+              const UnsignedInteger maximumDimension = 0);
 
   /** Virtual constructor */
   virtual DesignProxy * clone() const;
@@ -78,7 +79,7 @@ public:
   Bool hasWeight() const;
 
 protected:
-  void initialize() const;
+  void initialize(const UnsignedInteger maximumDimension) const;
 
   /** Input sample */
   Sample x_;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -272,6 +272,7 @@ AdaptiveStrategy FunctionalChaosAlgorithm::getAdaptiveStrategy() const
 void FunctionalChaosAlgorithm::run()
 {
   const UnsignedInteger outputDimension = model_.getOutputDimension();
+  const UnsignedInteger maximumDimension = adaptiveStrategy_.getMaximumDimension();
 
   // Get the measure upon which the orthogonal basis is built
   const OrthogonalBasis basis(adaptiveStrategy_.getImplementation()->basis_);
@@ -319,7 +320,7 @@ void FunctionalChaosAlgorithm::run()
     Scalar marginalResidual = -1.0;
     Scalar marginalRelativeError = -1.0;
     // Compute the indices, the coefficients, the residual and the relative error of the current marginal output
-    runMarginal(outputIndex, marginalIndices, marginalAlpha_k, marginalResidual, marginalRelativeError);
+    runMarginal(outputIndex, maximumDimension, marginalIndices, marginalAlpha_k, marginalResidual, marginalRelativeError);
     residuals[outputIndex] = marginalResidual;
     relativeErrors[outputIndex] = marginalRelativeError;
     for (UnsignedInteger j = 0; j < marginalIndices.getSize(); ++j)
@@ -361,6 +362,7 @@ void FunctionalChaosAlgorithm::run()
 
 /* Marginal computation */
 void FunctionalChaosAlgorithm::runMarginal(const UnsignedInteger marginalIndex,
+    const UnsignedInteger maximumDimension,
     Indices & indices,
     Point & coefficients,
     Scalar & residual,
@@ -372,7 +374,7 @@ void FunctionalChaosAlgorithm::runMarginal(const UnsignedInteger marginalIndex,
   do
   {
     LOGINFO("Compute the coefficients");
-    projectionStrategy_.computeCoefficients(composedModel_, *adaptiveStrategy_.getImplementation()->basis_.getImplementation(), adaptiveStrategy_.getImplementation()->I_p_, adaptiveStrategy_.getImplementation()->addedPsi_k_ranks_, adaptiveStrategy_.getImplementation()->conservedPsi_k_ranks_, adaptiveStrategy_.getImplementation()->removedPsi_k_ranks_, marginalIndex);
+    projectionStrategy_.computeCoefficients(composedModel_, *adaptiveStrategy_.getImplementation()->basis_.getImplementation(), adaptiveStrategy_.getImplementation()->I_p_, adaptiveStrategy_.getImplementation()->addedPsi_k_ranks_, adaptiveStrategy_.getImplementation()->conservedPsi_k_ranks_, adaptiveStrategy_.getImplementation()->removedPsi_k_ranks_, maximumDimension, marginalIndex);
     // The basis is adapted under the following conditions:
     // + the current residual is small enough
     // + the adaptive strategy has no more vector to propose

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
@@ -139,6 +139,7 @@ void IntegrationStrategy::computeCoefficients(const Function & function,
     const Indices & addedRanks,
     const Indices & conservedRanks,
     const Indices & removedRanks,
+    const UnsignedInteger maximumDimension,
     const UnsignedInteger marginalIndex)
 {
   // Check if the marginal index is not compatible with the function output dimension
@@ -156,7 +157,7 @@ void IntegrationStrategy::computeCoefficients(const Function & function,
   if (proxy_.getInputSample().getSize() == 0 || !(proxy_.getBasis() == basis))
   {
     LOGINFO(OSS() << "Initialize the proxy, reason=" << (proxy_.getInputSample().getSize() == 0 ? "empty input sample" : "new basis"));
-    proxy_ = DesignProxy(inputSample_, basis);
+    proxy_ = DesignProxy(inputSample_, basis, maximumDimension);
   }
   // First, copy the coefficients that are common with the previous partial basis
   Point alpha(0);

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
@@ -114,6 +114,7 @@ void LeastSquaresStrategy::computeCoefficients(const Function & function,
     const Indices & addedRanks,
     const Indices & conservedRanks,
     const Indices & removedRanks,
+    const UnsignedInteger maximumDimension,
     const UnsignedInteger marginalIndex)
 {
   // Check if the marginal index is not compatible with the function output dimension
@@ -133,7 +134,7 @@ void LeastSquaresStrategy::computeCoefficients(const Function & function,
   if (proxy_.getInputSample().getSize() == 0 || !(proxy_.getBasis() == basis))
   {
     LOGINFO(OSS() << "Initialize the proxy, reason=" << (proxy_.getInputSample().getSize() == 0 ? "empty input sample" : "new basis"));
-    proxy_ = DesignProxy(inputSample_, basis);
+    proxy_ = DesignProxy(inputSample_, basis, maximumDimension);
   }
 
   // Run the Approximation Algorithm

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
@@ -138,9 +138,10 @@ void ProjectionStrategy::computeCoefficients(const Function & function,
     const Indices & addedRanks,
     const Indices & conservedRanks,
     const Indices & removedRanks,
+    const UnsignedInteger maximumDimension,
     const UnsignedInteger marginalIndex)
 {
-  getImplementation()->computeCoefficients(function, basis, indices, addedRanks, conservedRanks, removedRanks, marginalIndex);
+  getImplementation()->computeCoefficients(function, basis, indices, addedRanks, conservedRanks, removedRanks, maximumDimension, marginalIndex);
 }
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -226,9 +226,10 @@ void ProjectionStrategyImplementation::computeCoefficients(const Function & func
     const Indices & addedRanks,
     const Indices & conservedRanks,
     const Indices & removedRanks,
+    const UnsignedInteger maximumDimension,
     const UnsignedInteger marginalIndex)
 {
-  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::computeCoefficients(const Function & function, const Basis & basis, const Indices & indices, const Indices & addedRanks, const Indices & conservedRanks, const Indices & removedRanks, const UnsignedInteger marginalIndex)";
+  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::computeCoefficients(const Function & function, const Basis & basis, const Indices & indices, const Indices & addedRanks, const Indices & conservedRanks, const Indices & removedRanks, const UnsignedInteger maximumDimension, const UnsignedInteger marginalIndex)";
 }
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosAlgorithm.hxx
@@ -130,6 +130,7 @@ private:
 
   /** Marginal computation */
   void runMarginal(const UnsignedInteger marginalIndex,
+                   const UnsignedInteger maximumDimension,
                    Indices & indices,
                    Point & coefficients,
                    Scalar & residual,

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
@@ -75,6 +75,7 @@ public:
                            const Indices & addedRanks,
                            const Indices & conservedRanks,
                            const Indices & removedRanks,
+                           const UnsignedInteger maximumDimension,
                            const UnsignedInteger marginalIndex = 0);
 
   /** Method save() stores the object through the StorageManager */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
@@ -82,6 +82,7 @@ public:
                            const Indices & addedRanks,
                            const Indices & conservedRanks,
                            const Indices & removedRanks,
+                           const UnsignedInteger maximumDimension,
                            const UnsignedInteger marginalIndex = 0);
 
   /** Method save() stores the object through the StorageManager */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
@@ -86,6 +86,7 @@ public:
                            const Indices & addedRanks,
                            const Indices & conservedRanks,
                            const Indices & removedRanks,
+                           const UnsignedInteger maximumDimension,
                            const UnsignedInteger marginalIndex = 0);
 
   /** String converter */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
@@ -116,6 +116,7 @@ public:
                                    const Indices & addedRanks,
                                    const Indices & conservedRanks,
                                    const Indices & removedRanks,
+                                   const UnsignedInteger maximumDimension,
                                    const UnsignedInteger marginalIndex = 0);
 
   /** Method save() stores the object through the StorageManager */

--- a/python/src/DesignProxy_doc.i.in
+++ b/python/src/DesignProxy_doc.i.in
@@ -10,7 +10,9 @@ Parameters
 x : :class:`~openturns.Sample`
     Input sample
 psi : :class:`~openturns.Basis`
-    Functional basis"
+    Functional basis
+ncol : int, optional
+    Maximum number of columns"
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
If the maximum number of columns is known, it can be used.
Default cache size is 128MB, which is *huge* and can stress
kernel allocator if many instances are created and destroyed.