### PR TITLE
Do not clone newly built objects

### DIFF
--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
@@ -58,8 +58,7 @@ PenalizedLeastSquaresAlgorithm * PenalizedLeastSquaresAlgorithmFactory::build(co
     const Basis & psi,
     const Indices & indices) const
 {
-  const PenalizedLeastSquaresAlgorithm algo( x, y, weight, psi, indices, false, useNormal_ );
-  return algo.clone();
+  return new PenalizedLeastSquaresAlgorithm( x, y, weight, psi, indices, false, useNormal_ );
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Func/EvaluationImplementation.cxx
+++ b/lib/src/Base/Func/EvaluationImplementation.cxx
@@ -432,12 +432,12 @@ EvaluationImplementation::Implementation EvaluationImplementation::getMarginal(c
   Point constant(outputDimension);
   const LinearEvaluation left(center, constant, linear);
 #endif
-  ComposedEvaluation marginal(left.clone(), clone());
+  EvaluationImplementation::Implementation marginal(new ComposedEvaluation(left.clone(), clone()));
   if (isHistoryEnabled())
   {
-    marginal.enableHistory();
+    marginal->enableHistory();
   }
-  return marginal.clone();
+  return marginal;
 }
 
 /* Get the number of calls to operator() */

--- a/lib/src/Uncertainty/Distribution/Arcsine.cxx
+++ b/lib/src/Uncertainty/Distribution/Arcsine.cxx
@@ -262,7 +262,7 @@ Point Arcsine::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Arcsine::Implementation Arcsine::getStandardRepresentative() const
 {
-  return Arcsine(-1.0, 1.0).clone();
+  return new Arcsine(-1.0, 1.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/BernsteinCopulaFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/BernsteinCopulaFactory.cxx
@@ -102,10 +102,10 @@ BernsteinCopulaFactory::Implementation BernsteinCopulaFactory::buildParallel(con
   Mixture::DistributionCollection atomsMixture(size);
   BernsteinCopulaFactoryPolicy policy(empiricalCopulaSample, binNumber, atomsMixture);
   TBB::ParallelFor( 0, size, policy );
-  Mixture result(atomsMixture);
+  Mixture* result(new Mixture(atomsMixture));
   // Here we know that the mixture is a copula even if none of its atoms is.
-  result.isCopula_ = true;
-  return result.clone();
+  result->isCopula_ = true;
+  return result;
 }
 
 BernsteinCopulaFactory::Implementation BernsteinCopulaFactory::buildSequential(const Sample & empiricalCopulaSample,
@@ -122,10 +122,10 @@ BernsteinCopulaFactory::Implementation BernsteinCopulaFactory::buildSequential(c
       atomsKernel[j] = Beta(std::floor(nu[j] * binNumber) + 1.0, binNumber + 1.0, 0.0, 1.0);
     atomsMixture[i] = ComposedDistribution(atomsKernel);
   }
-  Mixture result(atomsMixture);
+  Mixture* result(new Mixture(atomsMixture));
   // Here we know that the mixture is a copula even if none of its atoms is.
-  result.isCopula_ = true;
-  return result.clone();
+  result->isCopula_ = true;
+  return result;
 }
 
 BernsteinCopulaFactory::Implementation BernsteinCopulaFactory::build(const Sample & sample,

--- a/lib/src/Uncertainty/Distribution/Beta.cxx
+++ b/lib/src/Uncertainty/Distribution/Beta.cxx
@@ -286,7 +286,7 @@ Point Beta::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Beta::Implementation Beta::getStandardRepresentative() const
 {
-  return Beta(r_, t_, -1.0, 1.0).clone();
+  return new Beta(r_, t_, -1.0, 1.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
@@ -734,9 +734,9 @@ Point ComposedDistribution::getKurtosis() const
 ComposedDistribution::Implementation ComposedDistribution::getMarginal(const UnsignedInteger i) const
 {
   if (i >= getDimension()) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
-  Distribution marginal(distributionCollection_[i]);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.getImplementation()->clone();
+  ComposedDistribution::Implementation marginal(distributionCollection_[i].getImplementation()->clone());
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */

--- a/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
@@ -754,9 +754,9 @@ ComposedDistribution::Implementation ComposedDistribution::getMarginal(const Ind
     marginalDistributions.add(distributionCollection_[j]);
     marginalDescription[i] = description[j];
   }
-  ComposedDistribution marginal(marginalDistributions, marginalCopula);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  ComposedDistribution::Implementation marginal(new ComposedDistribution(marginalDistributions, marginalCopula));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 }
 
 /* Get the isoprobabilistic transformation */

--- a/lib/src/Uncertainty/Distribution/CumulativeDistributionNetwork.cxx
+++ b/lib/src/Uncertainty/Distribution/CumulativeDistributionNetwork.cxx
@@ -248,7 +248,7 @@ CumulativeDistributionNetwork::Implementation CumulativeDistributionNetwork::get
     }
   } // Loop over the CDFs
   if (contributors.getSize() == 1) return contributors[0].getImplementation()->clone();
-  return CumulativeDistributionNetwork(contributors, marginalGraph).clone();
+  return new CumulativeDistributionNetwork(contributors, marginalGraph);
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -292,7 +292,7 @@ CumulativeDistributionNetwork::Implementation CumulativeDistributionNetwork::get
     } // Loop over the CDFs
   if (contributors.getSize() == 1) return contributors[0].getImplementation()->clone();
   LOGINFO(OSS() << "in getMarginal(" << indices << "), marginal contributors=" << contributors << ", marginalGraph=" << marginalGraph);
-  return CumulativeDistributionNetwork(contributors, marginalGraph).clone();
+  return new CumulativeDistributionNetwork(contributors, marginalGraph);
   */
 }
 

--- a/lib/src/Uncertainty/Distribution/Dirac.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirac.cxx
@@ -323,9 +323,9 @@ Dirac::Implementation Dirac::getMarginal(const UnsignedInteger i) const
   const UnsignedInteger dimension = getDimension();
   if (i >= dimension) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
   if (dimension == 1) return clone();
-  Dirac marginal(point_[i]);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Dirac::Implementation marginal(new Dirac(point_[i]));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -344,9 +344,9 @@ Dirac::Implementation Dirac::getMarginal(const Indices & indices) const
     pointMarginal[i] = point_[index_i];
     marginalDescription[i] = description[index_i];
   }
-  Dirac marginal(pointMarginal);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  Dirac::Implementation marginal(new Dirac(pointMarginal));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Check if the distribution is elliptical */

--- a/lib/src/Uncertainty/Distribution/Dirichlet.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirichlet.cxx
@@ -440,9 +440,9 @@ Dirichlet::Implementation Dirichlet::getMarginal(const UnsignedInteger i) const
   Point thetaMarginal(2);
   thetaMarginal[0] = theta_[i];
   thetaMarginal[1] = sumTheta_ - theta_[i];
-  Dirichlet marginal(thetaMarginal);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Dirichlet::Implementation marginal(new Dirichlet(thetaMarginal));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -465,7 +465,7 @@ Dirichlet::Implementation Dirichlet::getMarginal(const Indices & indices) const
     marginalDescription[i] = description[index_i];
   }
   thetaMarginal[outputDimension] = sumTheta_ - sumMarginal;
-  Dirichlet marginal(thetaMarginal);
+  Dirichlet* marginal(new Dirichlet(thetaMarginal));
   // Initialize the CDF computation if the data are available
   if (isInitializedCDF_)
   {
@@ -476,12 +476,12 @@ Dirichlet::Implementation Dirichlet::getMarginal(const Indices & indices) const
       marginalIntegrationNodes_.add(integrationNodes_[indices[i]]);
       marginalIntegrationWeights_.add(integrationWeights_[indices[i]]);
     }
-    marginal.integrationNodes_ = marginalIntegrationNodes_;
-    marginal.integrationWeights_ = marginalIntegrationWeights_;
-    marginal.isInitializedCDF_ = true;
+    marginal->integrationNodes_ = marginalIntegrationNodes_;
+    marginal->integrationWeights_ = marginalIntegrationWeights_;
+    marginal->isInitializedCDF_ = true;
   }
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Tell if the distribution has independent marginals */

--- a/lib/src/Uncertainty/Distribution/Exponential.cxx
+++ b/lib/src/Uncertainty/Distribution/Exponential.cxx
@@ -238,7 +238,7 @@ Point Exponential::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Exponential::Implementation Exponential::getStandardRepresentative() const
 {
-  return Exponential(1.0).clone();
+  return new Exponential(1.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/Frechet.cxx
+++ b/lib/src/Uncertainty/Distribution/Frechet.cxx
@@ -284,7 +284,7 @@ Point Frechet::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Frechet::Implementation Frechet::getStandardRepresentative() const
 {
-  return Frechet(alpha_, 1.0, 0.0).clone();
+  return new Frechet(alpha_, 1.0, 0.0);
 }
 
 /* Alpha accessor */

--- a/lib/src/Uncertainty/Distribution/Gamma.cxx
+++ b/lib/src/Uncertainty/Distribution/Gamma.cxx
@@ -343,7 +343,7 @@ Point Gamma::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Gamma::Implementation Gamma::getStandardRepresentative() const
 {
-  return Gamma(k_, 1.0, 0.0).clone();
+  return new Gamma(k_, 1.0, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
+++ b/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
@@ -285,7 +285,7 @@ Point GeneralizedPareto::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 GeneralizedPareto::Implementation GeneralizedPareto::getStandardRepresentative() const
 {
-  return GeneralizedPareto(1.0, xi_).clone();
+  return new GeneralizedPareto(1.0, xi_);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Gumbel.cxx
+++ b/lib/src/Uncertainty/Distribution/Gumbel.cxx
@@ -235,7 +235,7 @@ Point Gumbel::getKurtosis() const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Gumbel::Implementation Gumbel::getStandardRepresentative() const
 {
-  return Gumbel(1.0, 0.0).clone();
+  return new Gumbel(1.0, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Histogram.cxx
+++ b/lib/src/Uncertainty/Distribution/Histogram.cxx
@@ -332,7 +332,7 @@ Histogram::Implementation Histogram::getStandardRepresentative() const
   if (first_ == -1.0 && std::abs(cumulatedWidth_[size - 1] - 2.0) <= ResourceMap::GetAsScalar("Distribution-DefaultQuantileEpsilon")) return clone();
   const Scalar first = -1.0;
   const Scalar factor = 2.0 / cumulatedWidth_[size - 1];
-  return Histogram(first, factor * width_, height_ / factor).clone();
+  return new Histogram(first, factor * width_, height_ / factor);
 }
 
 /* Parameters value and description accessor */

--- a/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
@@ -290,7 +290,7 @@ Point InverseChiSquare::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 InverseChiSquare::Implementation InverseChiSquare::getStandardRepresentative() const
 {
-  return InverseChiSquare(nu_).clone();
+  return new InverseChiSquare(nu_);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/InverseGamma.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseGamma.cxx
@@ -325,7 +325,7 @@ Point InverseGamma::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 InverseGamma::Implementation InverseGamma::getStandardRepresentative() const
 {
-  return InverseGamma(k_, 1.0).clone();
+  return new InverseGamma(k_, 1.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
@@ -184,9 +184,9 @@ KPermutationsDistribution::Implementation KPermutationsDistribution::getMarginal
 {
   const UnsignedInteger dimension = getDimension();
   if (i >= dimension) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
-  KPermutationsDistribution marginal(1, n_);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  KPermutationsDistribution::Implementation marginal(new KPermutationsDistribution(1, n_));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -205,9 +205,9 @@ KPermutationsDistribution::Implementation KPermutationsDistribution::getMarginal
     const UnsignedInteger index_i = indices[i];
     marginalDescription[i] = description[index_i];
   }
-  KPermutationsDistribution marginal(outputDimension, n_);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  KPermutationsDistribution::Implementation marginal(new KPermutationsDistribution(outputDimension, n_));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Get the support of a discrete distribution that intersect a given interval */

--- a/lib/src/Uncertainty/Distribution/KernelMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelMixture.cxx
@@ -495,9 +495,9 @@ KernelMixture::Implementation KernelMixture::getMarginal(const UnsignedInteger i
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case
-  KernelMixture marginal(kernel_, Point(1, bandwidth_[i]), sample_.getMarginal(i));
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  KernelMixture::Implementation marginal(new KernelMixture(kernel_, Point(1, bandwidth_[i]), sample_.getMarginal(i)));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -518,9 +518,9 @@ KernelMixture::Implementation KernelMixture::getMarginal(const Indices & indices
     marginalBandwidth[i] = bandwidth_[index_i];
     marginalDescription[i] = description[index_i];
   }
-  KernelMixture marginal(kernel_, marginalBandwidth, sample_.getMarginal(indices));
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  KernelMixture::Implementation marginal(new KernelMixture(kernel_, marginalBandwidth, sample_.getMarginal(indices)));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 }
 
 /* Compute the mean of the KernelMixture

--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -247,17 +247,17 @@ KernelSmoothing::Implementation KernelSmoothing::build(const Sample & sample,
   if (bined_ != mustBin) LOGINFO("Will not bin the data because the bin number is greater than the sample size");
   if ((dimension > 2) || ((!mustBin) && (!boundaryCorrection_)))
   {
-    KernelMixture result(kernel_, bandwidth, sample);
-    result.setDescription(sample.getDescription());
-    return result.clone();
+    KernelSmoothing::Implementation result(new KernelMixture(kernel_, bandwidth, sample));
+    result->setDescription(sample.getDescription());
+    return result;
   }
   const Point xmin(sample.getMin());
   const Point xmax(sample.getMax());
   if (xmin == xmax)
   {
-    Dirac result(xmin);
-    result.setDescription(sample.getDescription());
-    return result.clone();
+    KernelSmoothing::Implementation result(new Dirac(xmin));
+    result->setDescription(sample.getDescription());
+    return result;
   }
   // 2D binning?
   if ((dimension == 2) && mustBin)
@@ -298,9 +298,9 @@ KernelSmoothing::Implementation KernelSmoothing::build(const Sample & sample,
         atoms[i + j * binNumber_] = atom;
       }
     }
-    Mixture result(atoms, reducedData);
-    result.setDescription(sample.getDescription());
-    return result.clone();
+    KernelSmoothing::Implementation result(new Mixture(atoms, reducedData));
+    result->setDescription(sample.getDescription());
+    return result;
   } // 2D binning
 
   // Here we are in the 1D case, with at least binning or boundary boundary correction
@@ -322,9 +322,9 @@ KernelSmoothing::Implementation KernelSmoothing::build(const Sample & sample,
   // Now, work on the extended sample
   if (!mustBin)
   {
-    TruncatedDistribution result(KernelMixture(kernel_, bandwidth, newSample), xmin[0], xmax[0]);
-    result.setDescription(sample.getDescription());
-    return result.clone();
+    KernelSmoothing::Implementation result(new TruncatedDistribution(KernelMixture(kernel_, bandwidth, newSample), xmin[0], xmax[0]));
+    result->setDescription(sample.getDescription());
+    return result;
   }
   if (boundaryCorrection_)
   {
@@ -354,13 +354,13 @@ KernelSmoothing::Implementation KernelSmoothing::build(const Sample & sample,
   }
   if (boundaryCorrection_)
   {
-    TruncatedDistribution result(Mixture(atoms, reducedData), xmin[0], xmax[0]);
-    result.setDescription(sample.getDescription());
-    return result.clone();
+    KernelSmoothing::Implementation result(new TruncatedDistribution(Mixture(atoms, reducedData), xmin[0], xmax[0]));
+    result->setDescription(sample.getDescription());
+    return result;
   }
-  Mixture result(atoms, reducedData);
-  result.setDescription(sample.getDescription());
-  return result.clone();
+  KernelSmoothing::Implementation result(new Mixture(atoms, reducedData));
+  result->setDescription(sample.getDescription());
+  return result;
 }
 
 /* Bandwidth accessor */

--- a/lib/src/Uncertainty/Distribution/Laplace.cxx
+++ b/lib/src/Uncertainty/Distribution/Laplace.cxx
@@ -232,7 +232,7 @@ Point Laplace::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Laplace::Implementation Laplace::getStandardRepresentative() const
 {
-  return Laplace(1.0, 0.0).clone();
+  return new Laplace(1.0, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/LogNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/LogNormal.cxx
@@ -336,7 +336,7 @@ Point LogNormal::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 LogNormal::Implementation LogNormal::getStandardRepresentative() const
 {
-  return LogNormal(muLog_, sigmaLog_, 0.0).clone();
+  return new LogNormal(muLog_, sigmaLog_, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Logistic.cxx
+++ b/lib/src/Uncertainty/Distribution/Logistic.cxx
@@ -298,7 +298,7 @@ Point Logistic::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Logistic::Implementation Logistic::getStandardRepresentative() const
 {
-  return Logistic(0.0, 1.0).clone();
+  return new Logistic(0.0, 1.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
@@ -306,7 +306,7 @@ MarginalDistribution::Implementation MarginalDistribution::getMarginal(const Ind
   Indices marginalIndices(outputDimension);
   for (UnsignedInteger i = 0; i < outputDimension; ++i)
     marginalIndices[i] = indices_[indices[i]];
-  return MarginalDistribution(distribution_, marginalIndices).clone();
+  return new MarginalDistribution(distribution_, marginalIndices);
 }
 
 /* Get the isoprobabilistic transformation */

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsCopula.cxx
@@ -119,14 +119,14 @@ MaximumEntropyOrderStatisticsCopula::Implementation MaximumEntropyOrderStatistic
   }
   Description marginalDescription(0);
   const Description description(getDescription());
-  MaximumEntropyOrderStatisticsCopula marginal(distribution_.getMarginalAsMaximumEntropyOrderStatisticsDistribution(indices));
+  MaximumEntropyOrderStatisticsCopula::Implementation marginal(new MaximumEntropyOrderStatisticsCopula(distribution_.getMarginalAsMaximumEntropyOrderStatisticsDistribution(indices)));
   for (UnsignedInteger i = 0; i < size; ++i)
   {
     const UnsignedInteger j = indices[i];
     marginalDescription.add(description[j]);
   }
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  marginal->setDescription(marginalDescription);
+  return marginal;
 }
 
 

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
@@ -872,9 +872,9 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalQuantile(con
 MaximumEntropyOrderStatisticsDistribution::Implementation MaximumEntropyOrderStatisticsDistribution::getMarginal(const UnsignedInteger i) const
 {
   if (i >= getDimension()) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
-  Distribution marginal(distributionCollection_[i]);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.getImplementation()->clone();
+  MaximumEntropyOrderStatisticsDistribution::Implementation marginal(distributionCollection_[i].getImplementation()->clone());
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 

--- a/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MeixnerDistribution.cxx
@@ -561,7 +561,7 @@ Point MeixnerDistribution::getKurtosis() const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 MeixnerDistribution::Implementation MeixnerDistribution::getStandardRepresentative() const
 {
-  return MeixnerDistribution(1.0, beta_, delta_, 0.0).clone();
+  return new MeixnerDistribution(1.0, beta_, delta_, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -416,10 +416,10 @@ Mixture::Implementation Mixture::getMarginal(const UnsignedInteger i) const
     collection.add(distributionCollection_[index].getMarginal(i));
     collection[index].setWeight(distributionCollection_[index].getWeight());
   }
-  Mixture marginal(collection);
-  marginal.isCopula_ = isCopula_;
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Mixture* marginal(new Mixture(collection));
+  marginal->isCopula_ = isCopula_;
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -444,10 +444,10 @@ Mixture::Implementation Mixture::getMarginal(const Indices & indices) const
     const UnsignedInteger index_i = indices[i];
     marginalDescription[i] = description[index_i];
   }
-  Mixture marginal(collection);
-  marginal.isCopula_ = isCopula_;
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  Mixture* marginal(new Mixture(collection));
+  marginal->isCopula_ = isCopula_;
+  marginal->setDescription(marginalDescription);
+  return marginal;
 }
 
 /* Compute the mean of the Mixture */

--- a/lib/src/Uncertainty/Distribution/Multinomial.cxx
+++ b/lib/src/Uncertainty/Distribution/Multinomial.cxx
@@ -406,9 +406,9 @@ Multinomial::Implementation Multinomial::getMarginal(const UnsignedInteger i) co
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case
-  Binomial marginal(n_, p_[i]);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Multinomial::Implementation marginal(new Binomial(n_, p_[i]));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -430,9 +430,9 @@ Multinomial::Implementation Multinomial::getMarginal(const Indices & indices) co
     marginalP[i] = p_[index_i];
     marginalDescription[i] = description[index_i];
   }
-  Multinomial marginal(n_, marginalP);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  Multinomial::Implementation marginal(new Multinomial(n_, marginalP));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Get the support of a discrete distribution that intersect a given interval */

--- a/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
+++ b/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
@@ -179,7 +179,7 @@ Point NonCentralStudent::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 NonCentralStudent::Implementation NonCentralStudent::getStandardRepresentative() const
 {
-  return NonCentralStudent(nu_, delta_, 0.0).clone();
+  return new NonCentralStudent(nu_, delta_, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -549,9 +549,9 @@ Normal::Implementation Normal::getMarginal(const UnsignedInteger i) const
   CorrelationMatrix R(1);
   Point sigma(1, sigma_[i]);
   Point mean(1, mean_[i]);
-  Normal marginal(mean, sigma, R);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Normal::Implementation marginal(new Normal(mean, sigma, R));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -580,9 +580,9 @@ Normal::Implementation Normal::getMarginal(const Indices & indices) const
     }
     marginalDescription[i] = description[index_i];
   }
-  Normal marginal(mean, sigma, R);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  Normal::Implementation marginal(new Normal(mean, sigma, R));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Get the skewness of the distribution */
@@ -604,7 +604,7 @@ Point Normal::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Normal::Implementation Normal::getStandardRepresentative() const
 {
-  return Normal(0.0, 1.0).clone();
+  return new Normal(0.0, 1.0);
 }
 
 /* Get the roughness, i.e. the L2-norm of the PDF */

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -3033,9 +3033,9 @@ RandomMixture::Implementation RandomMixture::getMarginal(const UnsignedInteger i
   const UnsignedInteger dimension = getDimension();
   if (i >= dimension) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
   if (dimension == 1) return clone();
-  RandomMixture marginal(distributionCollection_, weights_.getRow(i), Point(1, constant_[i]));
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  RandomMixture::Implementation marginal(new RandomMixture(distributionCollection_, weights_.getRow(i), Point(1, constant_[i])));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -3058,9 +3058,9 @@ RandomMixture::Implementation RandomMixture::getMarginal(const Indices & indices
     for (UnsignedInteger j = 0; j < outputDimension; ++j) marginalWeights(i, j) = row(0, j);
     marginalDescription[i] = description[index_i];
   }
-  RandomMixture marginal(distributionCollection_, marginalWeights, marginalConstant);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  RandomMixture::Implementation marginal(new RandomMixture(distributionCollection_, marginalWeights, marginalConstant));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Tell if the distribution has independent copula */

--- a/lib/src/Uncertainty/Distribution/Rayleigh.cxx
+++ b/lib/src/Uncertainty/Distribution/Rayleigh.cxx
@@ -247,7 +247,7 @@ Point Rayleigh::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Rayleigh::Implementation Rayleigh::getStandardRepresentative() const
 {
-  return Rayleigh(1.0, 0.0).clone();
+  return new Rayleigh(1.0, 0.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -391,9 +391,9 @@ Student::Implementation Student::getMarginal(const UnsignedInteger i) const
   const CorrelationMatrix R(1);
   const Point sigma(1, sigma_[i]);
   const Point mean(1, mean_[i]);
-  Student marginal(nu_, mean, sigma, R);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  Student::Implementation marginal(new Student(nu_, mean, sigma, R));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -419,9 +419,9 @@ Student::Implementation Student::getMarginal(const Indices & indices) const
     for (UnsignedInteger j = 0; j <= i; ++j) R(i, j) = R_(index_i, indices[j]);
     marginalDescription[i] = description[index_i];
   }
-  Student marginal(nu_, mean, sigma, R);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  Student::Implementation marginal(new Student(nu_, mean, sigma, R));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Compute the radial distribution CDF */
@@ -495,7 +495,7 @@ Point Student::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Student::Implementation Student::getStandardRepresentative() const
 {
-  return Student(nu_).clone();
+  return new Student(nu_);
 }
 
 /* Parameters value and description accessor */

--- a/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
+++ b/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
@@ -396,7 +396,7 @@ Point Trapezoidal::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Trapezoidal::Implementation Trapezoidal::getStandardRepresentative() const
 {
-  return Trapezoidal(-1.0, 1.0 - 2.0 * (d_ - b_) / (d_ - a_), 1.0 - 2.0 * (d_ - c_) / (d_ - a_), 1.0).clone();
+  return new Trapezoidal(-1.0, 1.0 - 2.0 * (d_ - b_) / (d_ - a_), 1.0 - 2.0 * (d_ - c_) / (d_ - a_), 1.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Triangular.cxx
+++ b/lib/src/Uncertainty/Distribution/Triangular.cxx
@@ -314,7 +314,7 @@ Point Triangular::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Triangular::Implementation Triangular::getStandardRepresentative() const
 {
-  return Triangular(-1.0, ((m_ - a_) + (m_ - b_)) / (b_ - a_), 1.0).clone();
+  return new Triangular(-1.0, ((m_ - a_) + (m_ - b_)) / (b_ - a_), 1.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -437,7 +437,7 @@ TruncatedDistribution::Implementation TruncatedDistribution::getMarginal(const U
 TruncatedDistribution::Implementation TruncatedDistribution::getMarginal(const Indices & indices) const
 {
   Interval marginalBounds(bounds_.getMarginal(indices));
-  return TruncatedDistribution(distribution_.getMarginal(indices), marginalBounds).clone();
+  return new TruncatedDistribution(distribution_.getMarginal(indices), marginalBounds);
 }
 
 /* Realization threshold accessor */

--- a/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
@@ -423,7 +423,7 @@ Point TruncatedNormal::getKurtosis() const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 TruncatedNormal::Implementation TruncatedNormal::getStandardRepresentative() const
 {
-  return TruncatedNormal((2.0 * mu_ - (b_ + a_)) / (b_ - a_), 2.0 * sigma_ / (b_ - a_), -1.0, 1.0).clone();
+  return new TruncatedNormal((2.0 * mu_ - (b_ + a_)) / (b_ - a_), 2.0 * sigma_ / (b_ - a_), -1.0, 1.0);
 }
 
 /* Compute the covariance of the distribution */

--- a/lib/src/Uncertainty/Distribution/Uniform.cxx
+++ b/lib/src/Uncertainty/Distribution/Uniform.cxx
@@ -286,7 +286,7 @@ Point Uniform::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Uniform::Implementation Uniform::getStandardRepresentative() const
 {
-  return Uniform(-1.0, 1.0).clone();
+  return new Uniform(-1.0, 1.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/UserDefined.cxx
+++ b/lib/src/Uncertainty/Distribution/UserDefined.cxx
@@ -456,9 +456,9 @@ UserDefined::Implementation UserDefined::getMarginal(const UnsignedInteger i) co
   // Special case for dimension 1
   if (dimension == 1) return clone();
   // General case
-  UserDefined marginal(points_.getMarginal(i), probabilities_);
-  marginal.setDescription(Description(1, getDescription()[i]));
-  return marginal.clone();
+  UserDefined::Implementation marginal(new UserDefined(points_.getMarginal(i), probabilities_));
+  marginal->setDescription(Description(1, getDescription()[i]));
+  return marginal;
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -477,9 +477,9 @@ UserDefined::Implementation UserDefined::getMarginal(const Indices & indices) co
     const UnsignedInteger index_i = indices[i];
     marginalDescription[i] = description[index_i];
   }
-  UserDefined marginal(points_.getMarginal(indices), probabilities_);
-  marginal.setDescription(marginalDescription);
-  return marginal.clone();
+  UserDefined::Implementation marginal(new UserDefined(points_.getMarginal(indices), probabilities_));
+  marginal->setDescription(marginalDescription);
+  return marginal;
 } // getMarginal(Indices)
 
 /* Interface specific to UserDefined */

--- a/lib/src/Uncertainty/Distribution/Weibull.cxx
+++ b/lib/src/Uncertainty/Distribution/Weibull.cxx
@@ -300,7 +300,7 @@ Point Weibull::getStandardMoment(const UnsignedInteger n) const
 /* Get the standard representative in the parametric family, associated with the standard moments */
 Weibull::Implementation Weibull::getStandardRepresentative() const
 {
-  return Weibull(1.0, beta_, 0.0).clone();
+  return new Weibull(1.0, beta_, 0.0);
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -155,7 +155,7 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
   Collection< Distribution > coll(2);
   coll[0] = *this;
   coll[1] = *other;
-  return RandomMixture(coll).clone();
+  return new RandomMixture(coll);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::operator + (const Scalar value) const
@@ -165,7 +165,7 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
   Collection< Distribution > coll(2);
   coll[0] = *this;
   coll[1] = Dirac(Point(1, value));
-  return RandomMixture(coll).clone();
+  return new RandomMixture(coll);
 }
 
 /* Substraction operator */
@@ -183,7 +183,7 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
   Point weights(2);
   weights[0] = 1.0;
   weights[1] = -1.0;
-  return RandomMixture(coll, weights).clone();
+  return new RandomMixture(coll, weights);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::operator - (const Scalar value) const
@@ -193,7 +193,7 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
   Collection< Distribution > coll(2);
   coll[0] = *this;
   coll[1] = Dirac(Point(1, -value));
-  return RandomMixture(coll).clone();
+  return new RandomMixture(coll);
 }
 
 /* Multiplication operator */
@@ -209,7 +209,7 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
   {
     const Point parameters(getParameter());
     const Point otherParameters(other->getParameter());
-    return LogNormal(parameters[0] + otherParameters[0], std::sqrt(parameters[1] * parameters[1] + otherParameters[1] * otherParameters[1])).clone();
+    return new LogNormal(parameters[0] + otherParameters[0], std::sqrt(parameters[1] * parameters[1] + otherParameters[1] * otherParameters[1]));
   }
   if ((getClassName() == "LogUniform") && (other->getClassName() == "LogUniform"))
   {
@@ -229,17 +229,17 @@ DistributionImplementation::Implementation DistributionImplementation::operator 
     const Point otherParameters(other->getParameter());
     return (Normal(parameters[0], parameters[1]) + Uniform(otherParameters[0], otherParameters[1]))->exp();
   }
-  return ProductDistribution(*this, *other).clone();
+  return new ProductDistribution(*this, *other);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::operator * (const Scalar value) const
 {
   if (dimension_ != 1) throw NotYetImplementedException(HERE) << "In DistributionImplementation::operator * (const Scalar value) const: can multiply by a constant 1D distributions only.";
-  if (value == 0.0) return Dirac(Point(1, 0.0)).clone();
+  if (value == 0.0) return new Dirac(Point(1, 0.0));
   if (value == 1.0) return clone();
   const Collection< Distribution > coll(1, *this);
   const Point weight(1, value);
-  return RandomMixture(coll, weight).clone();
+  return new RandomMixture(coll, weight);
 }
 
 /* Division operator */
@@ -331,7 +331,7 @@ DistributionImplementation::Implementation maximum(const DistributionImplementat
   MaximumDistribution::DistributionCollection coll(2);
   coll[0] = p_left;
   coll[1] = p_right;
-  return MaximumDistribution(coll).clone();
+  return new MaximumDistribution(coll);
 }
 
 DistributionImplementation::Implementation maximum(const DistributionImplementation & left,
@@ -340,7 +340,7 @@ DistributionImplementation::Implementation maximum(const DistributionImplementat
   MaximumDistribution::DistributionCollection coll(2);
   coll[0] = left;
   coll[1] = p_right;
-  return MaximumDistribution(coll).clone();
+  return new MaximumDistribution(coll);
 }
 
 DistributionImplementation::Implementation maximum(const DistributionImplementation::Implementation & p_left,
@@ -349,7 +349,7 @@ DistributionImplementation::Implementation maximum(const DistributionImplementat
   MaximumDistribution::DistributionCollection coll(2);
   coll[0] = p_left;
   coll[1] = right;
-  return MaximumDistribution(coll).clone();
+  return new MaximumDistribution(coll);
 }
 
 DistributionImplementation::Implementation maximum(const DistributionImplementation & left,
@@ -358,7 +358,7 @@ DistributionImplementation::Implementation maximum(const DistributionImplementat
   MaximumDistribution::DistributionCollection coll(2);
   coll[0] = left;
   coll[1] = right;
-  return MaximumDistribution(coll).clone();
+  return new MaximumDistribution(coll);
 }
 
 
@@ -3049,7 +3049,7 @@ DistributionImplementation::Implementation DistributionImplementation::getMargin
   if (!(i < dimension_)) throw InvalidArgumentException(HERE) << "Marginal index cannot exceed dimension";
   if (dimension_ == 1) return clone();
   if (isCopula()) return new Uniform(0.0, 1.0);
-  return MarginalDistribution(*this, i).clone();
+  return new MarginalDistribution(*this, i);
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
@@ -3060,7 +3060,7 @@ DistributionImplementation::Implementation DistributionImplementation::getMargin
   full.fill();
   if (indices == full) return clone();
   if (isCopula() && (indices.getSize() == 1)) return new Uniform(0.0, 1.0);
-  return MarginalDistribution(*this, indices).clone();
+  return new MarginalDistribution(*this, indices);
 }
 
 /* Get the copula of a distribution */
@@ -4019,7 +4019,7 @@ DistributionImplementation::Implementation DistributionImplementation::cos() con
   }
   bounds.add(b);
   values.add(std::cos(b));
-  return CompositeDistribution(SymbolicFunction("x", "cos(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "cos(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::sin() const
@@ -4038,7 +4038,7 @@ DistributionImplementation::Implementation DistributionImplementation::sin() con
   }
   bounds.add(b);
   values.add(std::sin(b));
-  return CompositeDistribution(SymbolicFunction("x", "sin(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "sin(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::tan() const
@@ -4063,7 +4063,7 @@ DistributionImplementation::Implementation DistributionImplementation::tan() con
   }
   bounds.add(b);
   values.add(std::tan(b));
-  return CompositeDistribution(SymbolicFunction("x", "tan(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "tan(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::acos() const
@@ -4077,7 +4077,7 @@ DistributionImplementation::Implementation DistributionImplementation::acos() co
   Point values(1, std::acos(a));
   bounds.add(b);
   values.add(std::acos(b));
-  return CompositeDistribution(SymbolicFunction("x", "acos(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "acos(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::asin() const
@@ -4091,7 +4091,7 @@ DistributionImplementation::Implementation DistributionImplementation::asin() co
   Point values(1, std::asin(a));
   bounds.add(b);
   values.add(std::asin(b));
-  return CompositeDistribution(SymbolicFunction("x", "asin(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "asin(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::atan() const
@@ -4103,7 +4103,7 @@ DistributionImplementation::Implementation DistributionImplementation::atan() co
   const Scalar b = getRange().getUpperBound()[0];
   bounds.add(b);
   values.add(std::atan(b));
-  return CompositeDistribution(SymbolicFunction("x", "atan(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "atan(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::cosh() const
@@ -4120,7 +4120,7 @@ DistributionImplementation::Implementation DistributionImplementation::cosh() co
   }
   bounds.add(b);
   values.add(std::cosh(b));
-  return CompositeDistribution(SymbolicFunction("x", "cosh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "cosh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::sinh() const
@@ -4132,7 +4132,7 @@ DistributionImplementation::Implementation DistributionImplementation::sinh() co
   Point values(1, std::sinh(a));
   bounds.add(b);
   values.add(std::sinh(b));
-  return CompositeDistribution(SymbolicFunction("x", "sinh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "sinh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::tanh() const
@@ -4144,7 +4144,7 @@ DistributionImplementation::Implementation DistributionImplementation::tanh() co
   Point values(1, std::tanh(a));
   bounds.add(b);
   values.add(std::tanh(b));
-  return CompositeDistribution(SymbolicFunction("x", "tanh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "tanh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::acosh() const
@@ -4157,7 +4157,7 @@ DistributionImplementation::Implementation DistributionImplementation::acosh() c
   Point values(1, SpecFunc::Acosh(a));
   bounds.add(b);
   values.add(SpecFunc::Acosh(b));
-  return CompositeDistribution(SymbolicFunction("x", "acosh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "acosh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::asinh() const
@@ -4169,7 +4169,7 @@ DistributionImplementation::Implementation DistributionImplementation::asinh() c
   Point values(1, SpecFunc::Asinh(a));
   bounds.add(b);
   values.add(SpecFunc::Asinh(b));
-  return CompositeDistribution(SymbolicFunction("x", "asinh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "asinh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::atanh() const
@@ -4186,7 +4186,7 @@ DistributionImplementation::Implementation DistributionImplementation::atanh() c
   Point values(1, a == -1.0 ? SpecFunc::Atanh(computeQuantile(quantileEpsilon_)[0]) : SpecFunc::Atanh(a));
   bounds.add(b);
   values.add(b == 1.0 ? SpecFunc::Atanh(computeQuantile(quantileEpsilon_, true)[0]) : SpecFunc::Atanh(b));
-  return CompositeDistribution(SymbolicFunction("x", "atanh(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "atanh(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::exp() const
@@ -4196,12 +4196,12 @@ DistributionImplementation::Implementation DistributionImplementation::exp() con
   if (getClassName() == "Normal")
   {
     Point parameters(getParameter());
-    return LogNormal(parameters[0], parameters[1]).clone();
+    return new LogNormal(parameters[0], parameters[1]);
   }
   if (getClassName() == "Uniform")
   {
     Point parameters(getParameter());
-    return LogUniform(parameters[0], parameters[1]).clone();
+    return new LogUniform(parameters[0], parameters[1]);
   }
   const Scalar a = getRange().getLowerBound()[0];
   const Scalar b = getRange().getUpperBound()[0];
@@ -4209,7 +4209,7 @@ DistributionImplementation::Implementation DistributionImplementation::exp() con
   Point values(1, std::exp(a));
   bounds.add(b);
   values.add(std::exp(b));
-  return CompositeDistribution(SymbolicFunction("x", "exp(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "exp(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::log() const
@@ -4219,12 +4219,12 @@ DistributionImplementation::Implementation DistributionImplementation::log() con
   if (getClassName() == "LogNormal")
   {
     Point parameters(getParameter());
-    if (parameters[2] == 0.0) return Normal(parameters[0], parameters[1]).clone();
+    if (parameters[2] == 0.0) return new Normal(parameters[0], parameters[1]);
   }
   if (getClassName() == "LogUniform")
   {
     Point parameters(getParameter());
-    return Uniform(parameters[0], parameters[1]).clone();
+    return new Uniform(parameters[0], parameters[1]);
   }
   const Scalar a = getRange().getLowerBound()[0];
   if (!(a >= 0.0)) throw NotDefinedException(HERE) << "Error: cannot take the logarithm of a random variable that takes negative values with positive probability.";
@@ -4233,7 +4233,7 @@ DistributionImplementation::Implementation DistributionImplementation::log() con
   Point values(1, (a == 0.0 ? std::log(computeQuantile(quantileEpsilon_)[0]) : std::log(a)));
   bounds.add(b);
   values.add(std::log(b));
-  return CompositeDistribution(SymbolicFunction("x", "log(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "log(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::ln() const
@@ -4255,13 +4255,13 @@ DistributionImplementation::Implementation DistributionImplementation::pow(const
   const Scalar b = getRange().getUpperBound()[0];
   bounds.add(b);
   values.add(std::pow(b, exponent));
-  return CompositeDistribution(toPower, clone(), bounds, values).clone();
+  return new CompositeDistribution(toPower, clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::pow(const SignedInteger exponent) const
 {
   if (getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the distribution must be univariate.";
-  if (exponent == 0.0) return Dirac(Point(1, 1.0)).clone();
+  if (exponent == 0.0) return new Dirac(Point(1, 1.0));
   const Scalar a = getRange().getLowerBound()[0];
   SymbolicFunction toPower("x", String(OSS() << (exponent < 0.0 ? "x^(" : "x^") << exponent << (exponent < 0.0 ? ")" : "")));
   // Easy case: a >= 0
@@ -4272,7 +4272,7 @@ DistributionImplementation::Implementation DistributionImplementation::pow(const
     const Scalar b = getRange().getUpperBound()[0];
     bounds.add(b);
     values.add(std::pow(b, 1.0 * exponent));
-    return CompositeDistribution(toPower, clone(), bounds, values).clone();
+    return new CompositeDistribution(toPower, clone(), bounds, values);
   }
   // Easy case: b <= 0
   Point bounds(1, a);
@@ -4282,7 +4282,7 @@ DistributionImplementation::Implementation DistributionImplementation::pow(const
   {
     bounds.add(b);
     values.add(b == 0.0 ? (exponent < 0.0 ? std::pow(computeQuantile(quantileEpsilon_, true)[0], 1.0 * exponent) : 0.0) : std::pow(b, 1.0 * exponent));
-    return CompositeDistribution(toPower, clone(), bounds, values).clone();
+    return new CompositeDistribution(toPower, clone(), bounds, values);
   }
   // Difficult case: a < 0 < b
   // For odd exponents, the function is bijective
@@ -4293,7 +4293,7 @@ DistributionImplementation::Implementation DistributionImplementation::pow(const
     {
       bounds.add(b);
       values.add(std::pow(b, 1.0 * exponent));
-      return CompositeDistribution(toPower, clone(), bounds, values).clone();
+      return new CompositeDistribution(toPower, clone(), bounds, values);
     }
     // A singularity at 0 for negative exponent
     bounds.add(0.0);
@@ -4302,14 +4302,14 @@ DistributionImplementation::Implementation DistributionImplementation::pow(const
     values.add(SpecFunc::MaxScalar);
     bounds.add(b);
     values.add(std::pow(b, 1.0 * exponent));
-    return CompositeDistribution(SymbolicFunction("x", String(OSS() << "x^(" << exponent << ")")), clone(), bounds, values).clone();
+    return new CompositeDistribution(SymbolicFunction("x", String(OSS() << "x^(" << exponent << ")")), clone(), bounds, values);
   }
   // For even exponent, the behaviour changes at 0
   bounds.add(0.0);
   values.add(exponent > 0 ? 0.0 : SpecFunc::MaxScalar);
   bounds.add(b);
   values.add(std::pow(b, 1.0 * exponent));
-  return CompositeDistribution(toPower, clone(), bounds, values).clone();
+  return new CompositeDistribution(toPower, clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::sqr() const
@@ -4318,7 +4318,7 @@ DistributionImplementation::Implementation DistributionImplementation::sqr() con
   if (getClassName() == "Chi")
   {
     Point parameters(getParameter());
-    return ChiSquare(parameters[0]).clone();
+    return new ChiSquare(parameters[0]);
   }
   return pow(static_cast< SignedInteger >(2));
 }
@@ -4338,7 +4338,7 @@ DistributionImplementation::Implementation DistributionImplementation::inverse()
       values.add(1.0 / b);
     else
       values.add(0.0);
-    return CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values).clone();
+    return new CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values);
   }
   // Here, a < 0
   Point values(1);
@@ -4352,7 +4352,7 @@ DistributionImplementation::Implementation DistributionImplementation::inverse()
   {
     bounds.add(b);
     values.add(b == 0.0 ? 1.0 / computeQuantile(quantileEpsilon_, true)[0] : 1.0 / b);
-    return CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values).clone();
+    return new CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values);
   }
   // Difficult case: a < 0 < b
   // A singularity at 0
@@ -4370,7 +4370,7 @@ DistributionImplementation::Implementation DistributionImplementation::inverse()
     values.add(1.0 / b);
   else
     values.add(0.0);
-  return CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "1.0 / x"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::sqrt() const
@@ -4380,7 +4380,7 @@ DistributionImplementation::Implementation DistributionImplementation::sqrt() co
   if (getClassName() == "ChiSquare")
   {
     Point parameters(getParameter());
-    return Chi(parameters[0]).clone();
+    return new Chi(parameters[0]);
   }
   const Scalar a = getRange().getLowerBound()[0];
   if (!(a >= 0.0)) throw NotDefinedException(HERE) << "Error: cannot take the square root of a random variable that takes negative values with positive probability.";
@@ -4389,7 +4389,7 @@ DistributionImplementation::Implementation DistributionImplementation::sqrt() co
   const Scalar b = getRange().getUpperBound()[0];
   bounds.add(b);
   values.add(std::sqrt(b));
-  return CompositeDistribution(SymbolicFunction("x", "sqrt(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "sqrt(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::cbrt() const
@@ -4401,7 +4401,7 @@ DistributionImplementation::Implementation DistributionImplementation::cbrt() co
   const Scalar b = getRange().getUpperBound()[0];
   bounds.add(b);
   values.add(SpecFunc::Cbrt(b));
-  return CompositeDistribution(SymbolicFunction("x", "cbrt(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "cbrt(x)"), clone(), bounds, values);
 }
 
 DistributionImplementation::Implementation DistributionImplementation::abs() const
@@ -4418,7 +4418,7 @@ DistributionImplementation::Implementation DistributionImplementation::abs() con
   }
   bounds.add(b);
   values.add(std::abs(b));
-  return CompositeDistribution(SymbolicFunction("x", "abs(x)"), clone(), bounds, values).clone();
+  return new CompositeDistribution(SymbolicFunction("x", "abs(x)"), clone(), bounds, values);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
+++ b/lib/src/Uncertainty/Process/FunctionalBasisProcess.cxx
@@ -199,7 +199,7 @@ FunctionalBasisProcess::Implementation FunctionalBasisProcess::getMarginal(const
   Basis marginalBasis(basisSize);
   for (UnsignedInteger i = 0; i < basisSize; ++i) marginalBasis[i] = basis_[i].getMarginal(indices);
   // Return the associated FunctionalBasisProcess
-  return FunctionalBasisProcess(marginalDistribution, marginalBasis, mesh_).clone();
+  return new FunctionalBasisProcess(marginalDistribution, marginalBasis, mesh_);
 }
 
 /* Distribution accessor */

--- a/lib/src/Uncertainty/Process/WhiteNoise.cxx
+++ b/lib/src/Uncertainty/Process/WhiteNoise.cxx
@@ -138,7 +138,7 @@ TimeSeries WhiteNoise::getFuture(const UnsignedInteger stepNumber) const
 WhiteNoise::Implementation WhiteNoise::getMarginal(const UnsignedInteger i) const
 {
   if (i >= getOutputDimension()) throw InvalidArgumentException(HERE) << "The index of a marginal process must be in the range [0, dim-1]";
-  return WhiteNoise(distribution_.getMarginal(i), mesh_).clone();
+  return new WhiteNoise(distribution_.getMarginal(i), mesh_);
 }
 
 /* Get the marginal random vector corresponding to indices components */


### PR DESCRIPTION
When cloning newly built objects, constructor is called twice, this is useless.