### PR TITLE
Use nbsphinx stable

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install -y cmake gfortran bison flex libmuparser-dev liblapack-dev libxml2-dev libboost-math-dev libtbb-dev libnlopt-dev r-base-core
     - sudo apt-get install -y python-dev python-scipy python-matplotlib texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra pandoc
-    - pip install matplotlib git+https://github.com/sphinx-doc/sphinx.git numpydoc git+https://github.com/spatialaudio/nbsphinx.git jupyter_client ipython==5.* --user --upgrade
+    - pip install matplotlib git+https://github.com/sphinx-doc/sphinx.git numpydoc nbsphinx jupyter_client ipython==5.* --user --upgrade
     - sudo rm -r /opt/circleci/.pyenv
     # keep an eye on swig
     - git clone https://github.com/swig/swig.git


### PR DESCRIPTION
In the git version links to sphinx must be absolute and will need to be changed:
https://github.com/spatialaudio/nbsphinx/pull/136

failling build:
https://circleci.com/gh/openturns/openturns/1152?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

