### PR TITLE
Check pointer value in sequence helper

### DIFF
--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -518,7 +518,7 @@ isAPythonSequenceOf(PyObject * pyObj)
     for( UnsignedInteger i = 0; ok && (i < size); ++i )
     {
       ScopedPyObjectPointer elt(PySequence_ITEM( pyObj, i ));
-      int elt_ok = isAPython<PYTHON_Type>(elt.get());
+      int elt_ok = elt.get() && isAPython<PYTHON_Type>(elt.get());
       ok *= elt_ok;
     }
   }


### PR DESCRIPTION
Trying to convert a DataFrame to a sample crashes instead of raising an exception.
(a DataFrame mixes labels and values so it cannot yet be converted into a Sample directly, maybe TODO)

```
import pandas as pd
import openturns as ot
d = {'col1': [1.0, 2.0, 3.0], 'col2': [4.0, 5.0, 6.0]}
df = pd.DataFrame(data=d)
s = ot.Sample(df) # should throw
s = ot.Sample(df.values) # ok
```