### PR TITLE
Multiply a matrix by a sample

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,3 +6,5 @@ Remove deprecated SecondOrderModel::getDimension, getSpatialDimension in 1.12
 Remove deprecated SpectralModel::getDimension, getSpatialDimension, getSpatialCorrelation in 1.12
 Remove deprecated TruncatedDistribution single bound accessors in favor of setBound/getRange in 1.12
 Remove deprecated Function ctors in 1.12
+Remove deprecated Sample,SampleImplementation::operator*(SquareMatrix) and operator/(SquareMatrix) (and in-place operators) in 1.12
+Remove deprecated SampleImplementation::scale(SquareMatrix) in 1.12

--- a/lib/src/Base/Func/LinearEvaluation.cxx
+++ b/lib/src/Base/Func/LinearEvaluation.cxx
@@ -131,16 +131,8 @@ Sample LinearEvaluation::operator() (const Sample & inS) const
   if (inS.getDimension() != center_.getDimension()) throw InvalidArgumentException(HERE) << "Invalid input dimension";
   const UnsignedInteger size = inS.getSize();
   if (size == 0) return Sample(0, getOutputDimension());
-  SampleImplementation temporary(inS.getSize(), getOutputDimension());
-  // Some OT black magic
-  // + We use the parallelized translation of the input sample inS - center_
-  // + We cast the resulting sample into a matrix
-  // + We perform a matrix/matrix multiplication, using potentially
-  //   high-performance BLAS
-  // + Then the resulting matrix is converted into a sample and the final
-  //   translation is parallelized
-  temporary.setData(*(linear_ * Matrix(getInputDimension(), inS.getSize(), (inS - center_).getImplementation()->getData())).getImplementation());
-  const Sample result(temporary + constant_);
+  const Sample centered(inS - center_);
+  const Sample result(linear_.getImplementation()->genSampleProd(centered, true, false, 'R') + constant_);
   callsNumber_ += size;
   if (isHistoryEnabled_)
   {

--- a/lib/src/Base/Geom/Mesh.cxx
+++ b/lib/src/Base/Geom/Mesh.cxx
@@ -645,8 +645,8 @@ Graph Mesh::draw3D(const Bool drawEdge,
   if (verticesSize == 0) throw InvalidArgumentException(HERE) << "Error: cannot draw a mesh with no vertex or no simplex.";
   // We use a basic Painter algorithm for the visualization
   // Second, transform the vertices if needed
-  Sample visuVertices(vertices_);
-  if (!rotation.isDiagonal()) visuVertices *= rotation;
+  const Sample visuVertices(rotation.isDiagonal() ? vertices_ : rotation.getImplementation()->genSampleProd(vertices_, true, false, 'R'));
+
   // Third, split all the simplices into triangles and compute their mean depth
   Sample trianglesAndDepth(0, 4);
   Point triWithDepth(4);

--- a/lib/src/Base/Stat/openturns/Sample.hxx
+++ b/lib/src/Base/Stat/openturns/Sample.hxx
@@ -299,9 +299,11 @@ public:
   Sample operator - (const Sample & translation) const;
   Sample operator * (const Scalar scaling) const;
   Sample operator * (const Point & scaling) const;
+  /** @deprecated */
   Sample operator * (const SquareMatrix & scaling) const;
   Sample operator / (const Scalar scaling) const;
   Sample operator / (const Point & scaling) const;
+  /** @deprecated */
   Sample operator / (const SquareMatrix & scaling) const;
 
   /**
@@ -309,9 +311,11 @@ public:
    */
   Sample & operator *= (const Scalar scaling);
   Sample & operator *= (const Point & scaling);
+  /** @deprecated */
   Sample & operator *= (const SquareMatrix & scaling);
   Sample & operator /= (const Scalar scaling);
   Sample & operator /= (const Point & scaling);
+  /** @deprecated */
   Sample & operator /= (const SquareMatrix & scaling);
 
   /** Ranked sample */

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -782,9 +782,11 @@ public:
 
   SampleImplementation operator * (const Scalar scaling) const;
   SampleImplementation operator * (const Point & scaling) const;
+  /** @deprecated */
   SampleImplementation operator * (const SquareMatrix & scaling) const;
   SampleImplementation operator / (const Scalar scaling) const;
   SampleImplementation operator / (const Point & scaling) const;
+  /** @deprecated */
   SampleImplementation operator / (const SquareMatrix & scaling) const;
 
   /**
@@ -793,9 +795,11 @@ public:
 
   SampleImplementation & operator *= (const Scalar scaling);
   SampleImplementation & operator *= (const Point & scaling);
+  /** @deprecated */
   SampleImplementation & operator *= (const SquareMatrix & scaling);
   SampleImplementation & operator /= (const Scalar scaling);
   SampleImplementation & operator /= (const Point & scaling);
+  /** @deprecated */
   SampleImplementation & operator /= (const SquareMatrix & scaling);
 
   /** Save to CSV file */
@@ -825,6 +829,7 @@ private:
 
   void translate(const Point & translation);
   void scale(const Point & scaling);
+  /** @deprecated */
   void scale(const SquareMatrix & scaling);
 
   /** The size of the sample */

--- a/lib/src/Base/Type/Matrix.cxx
+++ b/lib/src/Base/Type/Matrix.cxx
@@ -23,6 +23,7 @@
 #include "openturns/SymmetricMatrix.hxx"
 #include "openturns/IdentityMatrix.hxx"
 #include "openturns/ResourceMap.hxx"
+#include "openturns/Sample.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -185,6 +186,12 @@ Matrix Matrix::operator* (const SymmetricMatrix & m) const
 Matrix Matrix::operator* (const IdentityMatrix & m) const
 {
   return *this;
+}
+
+/* Multiplication with a Sample (must have consistent dimensions) */
+Sample Matrix::operator* (const Sample & sample) const
+{
+  return getImplementation()->genSampleProd(sample, false, false, 'L');
 }
 
 /* Multiplication with a Point (must have consistent dimensions) */

--- a/lib/src/Base/Type/openturns/Matrix.hxx
+++ b/lib/src/Base/Type/openturns/Matrix.hxx
@@ -31,6 +31,7 @@ class CovarianceMatrix;
 class IdentityMatrix;
 class SquareMatrix;
 class SymmetricMatrix;
+class Sample;
 
 /**
  * @class Matrix
@@ -131,6 +132,9 @@ public:
   Matrix operator * (const Matrix & m) const;
   Matrix operator * (const SymmetricMatrix & m) const;
   Matrix operator * (const IdentityMatrix & m) const;
+
+  /** Multiplication with a Sample (must have consistent dimensions) */
+  Sample operator * (const Sample & sample) const;
 
   /** Multiplication with a Point (must have consistent dimensions) */
   Point operator * (const Point & pt) const;

--- a/lib/src/Base/Type/openturns/MatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/MatrixImplementation.hxx
@@ -36,6 +36,7 @@ BEGIN_NAMESPACE_OPENTURNS
 
 // Forward declaration of ComplexMatrixImplementation
 class ComplexMatrixImplementation;
+class Sample;
 
 class OT_API MatrixImplementation
   : public PersistentCollection<Scalar>
@@ -137,6 +138,12 @@ public:
   /** MatrixImplementation integer power */
   MatrixImplementation genPower(const UnsignedInteger n) const;
   MatrixImplementation symPower(const UnsignedInteger n) const;
+
+  /** Multiplications with a SampleImplementation (must have consistent dimensions) */
+  Sample genSampleProd (const Sample & sample,
+                        const Bool transposeMatrix,
+                        const Bool transposeSample,
+                        const char side) const;
 
   /** Multiplications with a Point (must have consistent dimensions) */
   Point genVectProd (const Point & pt,

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -949,38 +949,28 @@ Point RandomMixture::getRealization() const
   return weights_ * realization + constant_;
 }
 
-/* Get a of the RandomMixture */
+/* Get a Sample of the RandomMixture */
 Sample RandomMixture::getSample(const UnsignedInteger size) const
 {
   const UnsignedInteger atomSize = distributionCollection_.getSize();
-  MatrixImplementation sample(size, atomSize);
-  UnsignedInteger index = 0;
+  Sample sample(atomSize, size);
   for (UnsignedInteger i = 0; i < atomSize; ++i)
   {
-    const Point atomSample(distributionCollection_[i].getSample(size).getImplementation()->getData());
-    std::copy(atomSample.begin(), atomSample.end(), sample.begin() + index);
-    index += size;
+    sample[i] = distributionCollection_[i].getSample(size).asPoint();
   }
-  SampleImplementation result(size, getDimension());
-  result.setData(sample.genProd(*weights_.getImplementation(), false, true));
-  return result + constant_;
+  return weights_.getImplementation()->genSampleProd(sample, true, true, 'R') + constant_;
 }
 
 Sample RandomMixture::getSampleByQMC(const UnsignedInteger size) const
 {
   const UnsignedInteger atomSize = distributionCollection_.getSize();
-  MatrixImplementation sample(size, atomSize);
-  UnsignedInteger index = 0;
+  Sample sample(atomSize, size);
   const Point u(SobolSequence(1).generate(size).getImplementation()->getData());
   for (UnsignedInteger i = 0; i < atomSize; ++i)
   {
-    const Point atomSample(distributionCollection_[i].computeQuantile(u).getImplementation()->getData());
-    std::copy(atomSample.begin(), atomSample.end(), sample.begin() + index);
-    index += size;
+    sample[i] = distributionCollection_[i].computeQuantile(u).asPoint();
   }
-  SampleImplementation result(size, getDimension());
-  result.setData(sample.genProd(*weights_.getImplementation(), false, true));
-  return result + constant_;
+  return weights_.getImplementation()->genSampleProd(sample, true, true, 'R') + constant_;
 }
 
 /* Get the DDF of the RandomMixture */

--- a/lib/test/t_Matrix_std.cxx
+++ b/lib/test/t_Matrix_std.cxx
@@ -147,10 +147,10 @@ int main(int argc, char *argv[])
   fullprint << "prod = " << prod << std::endl;
 
 
-  /** TEST NUMBER TEN : MULTIPLICATION WITH A NUMERICAL POINT METHOD */
-  fullprint << "test number ten : multiplication with a numerical point method" << std::endl;
+  /** TEST NUMBER TEN : MULTIPLICATION WITH A POINT METHOD */
+  fullprint << "test number ten : multiplication with a point method" << std::endl;
 
-  /* Create the numerical point */
+  /* Create the point */
   Point pt ;
   pt.add(1.) ;
   pt.add(2.) ;
@@ -160,8 +160,8 @@ int main(int argc, char *argv[])
   Point ptResult = matrix1.operator * ( pt ) ;
   fullprint << "ptResult = " << ptResult << std::endl;
 
-  /** TEST NUMBER ELEVEN : MULTIPLICATION AND DIVISION BY A NUMERICAL SCALAR METHODS */
-  fullprint << "test number eleven : multiplication and division by a numerical scalar methods" << std::endl;
+  /** TEST NUMBER ELEVEN : MULTIPLICATION AND DIVISION BY A SCALAR METHODS */
+  fullprint << "test number eleven : multiplication and division by a scalar methods" << std::endl;
 
   /* Check the multiplication method */
   double s = 3.;
@@ -195,10 +195,10 @@ int main(int argc, char *argv[])
             << "matrix6 is empty = " << matrix6.isEmpty() << std::endl
             << "matrix0 is empty = " << matrix0.isEmpty() << std::endl;
 
-  /** TEST NUMBER FOURTEEN : MULTIPLICATION WITH A NUMERICAL POINT METHOD */
-  fullprint << "test number fourteen : multiplication with a numerical point method" << std::endl;
+  /** TEST NUMBER FOURTEEN : MULTIPLICATION WITH A POINT METHOD */
+  fullprint << "test number fourteen : multiplication with a point method" << std::endl;
 
-  /* Create the numerical point */
+  /* Create the point */
   Point pt_test ;
   pt_test.add(1.) ;
   pt_test.add(2.) ;
@@ -219,6 +219,58 @@ int main(int argc, char *argv[])
   fullprint << "id = " << id << std::endl;
   fullprint << "ptResult2 = " << ptResult2 << std::endl;
 
+
+  /** TEST NUMBER FIFTEEN : MULTIPLICATION WITH A SAMPLE METHOD */
+  fullprint << "test number fifteen : multiplication with a sample method" << std::endl;
+  Sample S(2,4);
+  S(0,0) = 1.0;
+  S(0,1) = 3.0;
+  S(0,2) = -1.0;
+  S(0,3) = -3.0;
+  S(1,0) = -2.0;
+  S(1,1) = -5.0;
+  S(1,2) = 3.0;
+  S(1,3) = 1.0;
+  Matrix matrix32 = Matrix(3, 2, elementsValues);
+  Matrix matrix23 = Matrix(2, 3, elementsValues);
+  Collection<double> elementsValues12(elementsValues);
+  for(UnsignedInteger i = 7; i < 13; ++i)
+    elementsValues12.add(i);
+  Matrix matrix34 = Matrix(3, 4, elementsValues12);
+  Matrix matrix43 = Matrix(4, 3, elementsValues12);
+  fullprint << "matrix32 = " << matrix32 << std::endl;
+  fullprint << "matrix23 = " << matrix23 << std::endl;
+  fullprint << "matrix34 = " << matrix34 << std::endl;
+  fullprint << "matrix43 = " << matrix43 << std::endl;
+  fullprint << "S = " << S << std::endl;
+  Sample resultS = matrix32.operator * (S);
+  fullprint << "matrix32*S = " << resultS << std::endl;
+  Sample resultS1(matrix32.getImplementation()->genSampleProd(S, false, false, 'L'));
+  fullprint << "matrix32*S = " << resultS1 << std::endl;
+  Sample resultS2(matrix23.getImplementation()->genSampleProd(S, true, false, 'L'));
+  fullprint << "matrix23^T*S = " << resultS2 << std::endl;
+  Sample resultS3(matrix43.getImplementation()->genSampleProd(S, false, false, 'R'));
+  fullprint << "S*matrix43 = " << resultS3 << std::endl;
+  Sample resultS4(matrix34.getImplementation()->genSampleProd(S, true, false, 'R'));
+  fullprint << "S*matrix34^T = " << resultS4 << std::endl;
+  Sample S2(4,2);
+  S2(0,0) = S(0,0);
+  S2(1,0) = S(0,1);
+  S2(2,0) = S(0,2);
+  S2(3,0) = S(0,3);
+  S2(0,1) = S(1,0);
+  S2(1,1) = S(1,1);
+  S2(2,1) = S(1,2);
+  S2(3,1) = S(1,3);
+  fullprint << "S2 = " << S2 << std::endl;
+  Sample resultS1T(matrix32.getImplementation()->genSampleProd(S2, false, true, 'L'));
+  fullprint << "matrix32*S2^T = " << resultS1T << std::endl;
+  Sample resultS2T(matrix23.getImplementation()->genSampleProd(S2, true, true, 'L'));
+  fullprint << "matrix23^T*S2^T = " << resultS2T << std::endl;
+  Sample resultS3T(matrix43.getImplementation()->genSampleProd(S2, false, true, 'R'));
+  fullprint << "S2^T*matrix43 = " << resultS3T << std::endl;
+  Sample resultS4T(matrix34.getImplementation()->genSampleProd(S2, true, true, 'R'));
+  fullprint << "S2^T*matrix34^T = " << resultS4T << std::endl;
 
   return ExitCode::Success;
 }

--- a/lib/test/t_Matrix_std.expout
+++ b/lib/test/t_Matrix_std.expout
@@ -22,10 +22,10 @@ test number eight : substraction method
 diff = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0,-1,1,0]
 test number nine : matrix multiplication method
 prod = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[10,14,14,20]
-test number ten : multiplication with a numerical point method
+test number ten : multiplication with a point method
 pt = class=Point name=Unnamed dimension=2 values=[1,2]
 ptResult = class=Point name=Unnamed dimension=2 values=[7,10]
-test number eleven : multiplication and division by a numerical scalar methods
+test number eleven : multiplication and division by a scalar methods
 scalprod1 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[3,6,9,12]
 scalprod2 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[3,6,9,12]
 scalprod3 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[3,6,9,12]
@@ -40,9 +40,25 @@ matrix1 is empty = false
 matrix5 is empty = true
 matrix6 is empty = true
 matrix0 is empty = true
-test number fourteen : multiplication with a numerical point method
+test number fourteen : multiplication with a point method
 pt_test = class=Point name=Unnamed dimension=2 values=[1,2]
 A = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.5,-0.866025,0.866025,0.5]
 B = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.5,0.866025,-0.866025,0.5]
 id = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0,0,1]
 ptResult2 = class=Point name=Unnamed dimension=2 values=[1,2]
+test number fifteen : multiplication with a sample method
+matrix32 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=3 columns=2 values=[1,2,3,4,5,6]
+matrix23 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=3 values=[1,2,3,4,5,6]
+matrix34 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=3 columns=4 values=[1,2,3,4,5,6,7,8,9,10,11,12]
+matrix43 = class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=4 columns=3 values=[1,2,3,4,5,6,7,8,9,10,11,12]
+S = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=4 data=[[1,3,-1,-3],[-2,-5,3,1]]
+matrix32*S = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-7,-17,11,1],[-8,-19,13,-1],[-9,-21,15,-3]]
+matrix32*S = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-7,-17,11,1],[-8,-19,13,-1],[-9,-21,15,-3]]
+matrix23^T*S = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-3,-7,5,-1],[-5,-11,9,-5],[-7,-15,13,-9]]
+S*matrix43 = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[-8,-8,-8],[1,-11,-23]]
+S*matrix34^T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[-24,-24,-24],[9,6,3]]
+S2 = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=2 data=[[1,-2],[3,-5],[-1,3],[-3,1]]
+matrix32*S2^T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-7,-17,11,1],[-8,-19,13,-1],[-9,-21,15,-3]]
+matrix23^T*S2^T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-3,-7,5,-1],[-5,-11,9,-5],[-7,-15,13,-9]]
+S2^T*matrix43 = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[-8,-8,-8],[1,-11,-23]]
+S2^T*matrix34^T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[-24,-24,-24],[9,6,3]]

--- a/python/test/t_Matrix_std.expout
+++ b/python/test/t_Matrix_std.expout
@@ -42,3 +42,7 @@ A =  class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 
 B =  class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.5,0.866025,-0.866025,0.5]
 id =  class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0,0,1]
 ptResult2 =  class=Point name=Unnamed dimension=2 values=[1,2]
+test number fifteen : multiplication with a sample
+matrix32 =  class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=3 columns=2 values=[1,2,3,4,5,6]
+s =  class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=4 data=[[1,3,-1,-3],[-2,-5,3,1]]
+matrix32*s =  class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=4 data=[[-7,-17,11,1],[-8,-19,13,-1],[-9,-21,15,-3]]

--- a/python/test/t_Matrix_std.py
+++ b/python/test/t_Matrix_std.py
@@ -178,6 +178,17 @@ try:
     print("B = ", repr(B))
     print("id = ", repr(id))
     print("ptResult2 = ", repr(ptResult2))
+
+    # TEST NUMBER FIFTEEN : MULTIPLICATION WITH A SAMPLE
+    print(
+        "test number fifteen : multiplication with a sample")
+    s = Sample([[1.0, 3.0, -1.0, -3.0], [-2.0, -5.0, 3.0, 1.0]])
+    matrix32 = Matrix(3, 2, [1.0 + i for i in range(6)])
+    print("matrix32 = ", repr(matrix32))
+    print("s = ", repr(s))
+    sampleResult1 = matrix32 * s
+    print("matrix32*s = ", repr(sampleResult1))
+
 except:
     import sys
     print("t_Matrix_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
New method `MatrixImplementation::genSampleProd()` to compute `matrix*sample`
or `sample*matrix` multiplications as if sample was a `MatrixImplementation`
stored in row-major order.  Result is directly stored into a `Sample`, thus
two copies are avoided.

Add `Matrix::operator*(Sample)`.

Deprecate `Sample{,Implementation}::operator*(SquareMatrix)` and
`operator/(SquareMatrix)`.