### PR TITLE
New Mesh::computeKDTree method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@
  * Deprecated SpectralModel::getDimension, getSpatialDimension, getSpatialCorrelation
  * Deprecated TruncatedDistribution single bound accessors in favor of setBounds/getBounds
  * Deprecated remaining analytical & database Function ctors
+ * Mesh constructor no longer builds a KDTree, new method Mesh::computeKDTree must be called explicitly
 
 === Python module ===
 

--- a/lib/src/Base/Func/P1LagrangeEvaluation.cxx
+++ b/lib/src/Base/Func/P1LagrangeEvaluation.cxx
@@ -99,6 +99,7 @@ void P1LagrangeEvaluation::setMesh(const Mesh & mesh)
 {
   if (mesh.getVerticesNumber() != values_.getSize()) throw InvalidArgumentException(HERE) << "Error: expected a mesh with =" << values_.getSize() << " vertices, got " << mesh_.getVerticesNumber() << " vertices";
   mesh_ = mesh;
+  mesh_.computeKDTree();
   // Check for pending vertices
   Mesh::IndicesCollection verticesToSimplices(mesh_.getVerticesToSimplicesMap());
   Indices pendingVertices(0);
@@ -120,6 +121,7 @@ Mesh P1LagrangeEvaluation::getMesh() const
 void P1LagrangeEvaluation::setVertices(const Sample & vertices)
 {
   mesh_.setVertices(vertices);
+  mesh_.computeKDTree();
 }
 
 Sample P1LagrangeEvaluation::getVertices() const

--- a/lib/src/Base/Geom/Mesh.cxx
+++ b/lib/src/Base/Geom/Mesh.cxx
@@ -97,8 +97,13 @@ void Mesh::setVertices(const Sample & vertices)
 {
   isAlreadyComputedVolume_ = false;
   vertices_ = vertices;
-  tree_ = KDTree(vertices_);
   if (vertices_.getDescription().isBlank()) vertices_.setDescription(Description::BuildDefault(vertices_.getDimension(), "t"));
+}
+
+/* Compute KDTree to speed-up searches */
+void Mesh::computeKDTree()
+{
+  tree_ = KDTree(vertices_);
 }
 
 /* Vertex accessor */

--- a/lib/src/Base/Geom/RegularGrid.cxx
+++ b/lib/src/Base/Geom/RegularGrid.cxx
@@ -139,6 +139,11 @@ Bool RegularGrid::isRegular() const
   return true;
 }
 
+void RegularGrid::computeKDTree()
+{
+  // Do nothing, RegularGrid::getNearestVertexIndex does not need a KDTree
+}
+
 /* Get the index of the nearest vertex */
 UnsignedInteger RegularGrid::getNearestVertexIndex(const Point & point) const
 {

--- a/lib/src/Base/Geom/openturns/Mesh.hxx
+++ b/lib/src/Base/Geom/openturns/Mesh.hxx
@@ -75,10 +75,10 @@ public:
   UnsignedInteger getSimplicesNumber() const;
 
   /** Add a KDTree to speed-up nearest vertex searches */
-  void computeKDTree();
+  virtual void computeKDTree();
 
   /** Get the index of the nearest vertex */
-  UnsignedInteger getNearestVertexIndex(const Point & point) const;
+  virtual UnsignedInteger getNearestVertexIndex(const Point & point) const;
 
   /** Get the index of the nearest vertex and the index of the containing simplex if any */
   Indices getNearestVertexAndSimplexIndicesWithCoordinates(const Point & point,

--- a/lib/src/Base/Geom/openturns/Mesh.hxx
+++ b/lib/src/Base/Geom/openturns/Mesh.hxx
@@ -74,6 +74,9 @@ public:
   /** Get the number of simplices */
   UnsignedInteger getSimplicesNumber() const;
 
+  /** Add a KDTree to speed-up nearest vertex searches */
+  void computeKDTree();
+
   /** Get the index of the nearest vertex */
   UnsignedInteger getNearestVertexIndex(const Point & point) const;
 

--- a/lib/src/Base/Geom/openturns/RegularGrid.hxx
+++ b/lib/src/Base/Geom/openturns/RegularGrid.hxx
@@ -88,6 +88,9 @@ public:
   /** Tells if it is regular */
   Bool isRegular() const;
 
+  /** Add a KDTree to speed-up nearest vertex searches */
+  void computeKDTree();
+
   /** Get the index of the nearest vertex */
   UnsignedInteger getNearestVertexIndex(const Point & point) const;
 

--- a/lib/src/Base/Stat/FieldImplementation.cxx
+++ b/lib/src/Base/Stat/FieldImplementation.cxx
@@ -69,6 +69,7 @@ FieldImplementation::FieldImplementation(const Mesh & mesh,
   , inputMean_(dim)
   , isAlreadyComputedInputMean_(false)
 {
+  mesh_.computeKDTree();
   // Build the default description
   Description description(mesh_.getVertices().getDescription());
   description.add(values_.getDescription());
@@ -86,6 +87,7 @@ FieldImplementation::FieldImplementation(const Mesh & mesh,
   , isAlreadyComputedInputMean_(false)
 {
   if (mesh.getVerticesNumber() != values.getSize()) throw InvalidArgumentException(HERE) << "Error: cannot build a Field with a number of values=" << values.getSize() << " different from the number of vertices=" << mesh.getVerticesNumber();
+  mesh_.computeKDTree();
   Description description(mesh_.getVertices().getDescription());
   description.add(values_.getDescription());
   setDescription(description);

--- a/lib/src/Base/Stat/UserDefinedCovarianceModel.cxx
+++ b/lib/src/Base/Stat/UserDefinedCovarianceModel.cxx
@@ -40,6 +40,7 @@ UserDefinedCovarianceModel::UserDefinedCovarianceModel()
   , p_mesh_(RegularGrid().clone())
 {
   outputDimension_ = 0;
+  p_mesh_->computeKDTree();
 }
 
 // For a non stationary model, we need N x N covariance functions with N the number of vertices in the mesh
@@ -56,6 +57,7 @@ UserDefinedCovarianceModel::UserDefinedCovarianceModel(const Mesh & mesh,
     throw InvalidArgumentException(HERE) << "Error: for a non stationary covariance model, sizes are incoherent:"
                                          << " mesh size=" << N << " and covariance function size=" << covarianceFunction.getSize() << " instead of " << size;
   p_mesh_ = mesh.clone();
+  p_mesh_->computeKDTree();
   inputDimension_ = mesh.getDimension();
   covarianceCollection_ = CovarianceMatrixCollection(size);
   // put the first element

--- a/lib/test/t_Mesh_std.cxx
+++ b/lib/test/t_Mesh_std.cxx
@@ -49,6 +49,7 @@ int main(int argc, char *argv[])
       simplicies[2][0] = 2;
       simplicies[2][1] = 3;
       Mesh mesh1D(vertices, simplicies);
+      mesh1D.computeKDTree();
       fullprint << "1D mesh=" << mesh1D << std::endl;
       fullprint << "Is empty? " << mesh1D.isEmpty() << std::endl;
       fullprint << "vertices=" << mesh1D.getVertices() << std::endl;
@@ -126,6 +127,7 @@ int main(int argc, char *argv[])
       simplicies[4][1] = 2;
       simplicies[4][2] = 5;
       Mesh mesh2D(vertices, simplicies);
+      mesh2D.computeKDTree();
       fullprint << "2D mesh=" << mesh2D << std::endl;
       Point point(2, 1.8);
       fullprint << "Nearest index(" << point << ")=" << mesh2D.getNearestVertexIndex(point) << std::endl;
@@ -211,6 +213,7 @@ int main(int argc, char *argv[])
       simplicies[5][3] = 6;
 
       Mesh mesh3D(vertices, simplicies);
+      mesh3D.computeKDTree();
       fullprint << "3D mesh=" << mesh3D << std::endl;
       Point point(3, 1.8);
       fullprint << "Nearest index(" << point << ")=" << mesh3D.getNearestVertexIndex(point) << std::endl;

--- a/python/src/Mesh_doc.i.in
+++ b/python/src/Mesh_doc.i.in
@@ -337,6 +337,11 @@ Examples
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::Mesh::computeKDTree
+"Compute a KDTree to speed-up nearest vertex searches."
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::Mesh::getNearestVertex
 "Get the nearest vertex of a given point.
 
@@ -356,6 +361,7 @@ Examples
 >>> vertices = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
 >>> simplices = [[0, 1, 2]]
 >>> mesh2d = ot.Mesh(vertices, simplices)
+>>> mesh2d.computeKDTree()
 >>> point = [0.9, 0.4]
 >>> print(mesh2d.getNearestVertex(point))
 [1,0]"
@@ -382,6 +388,7 @@ Examples
 >>> vertices = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
 >>> simplices = [[0, 1, 2]]
 >>> mesh2d = ot.Mesh(vertices, simplices)
+>>> mesh2d.computeKDTree()
 >>> point = [0.9, 0.4]
 >>> print(mesh2d.getNearestVertexIndex(point))
 1"
@@ -409,6 +416,7 @@ Examples
 >>> vertices = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
 >>> simplex = [[0, 1, 2]]
 >>> mesh2d = ot.Mesh(vertices, simplex)
+>>> mesh2d.computeKDTree()
 >>> # Create a point A inside the simplex
 >>> pointA = [0.6, 0.3]
 >>> print(mesh2d.getNearestVertexAndSimplexIndicesWithCoordinates(pointA))

--- a/python/test/t_Mesh_std.py
+++ b/python/test/t_Mesh_std.py
@@ -19,6 +19,7 @@ simplicies[0] = [0, 1]
 simplicies[1] = [1, 2]
 simplicies[2] = [2, 3]
 mesh1D = ot.Mesh(vertices, simplicies)
+mesh1D.computeKDTree()
 print("1D mesh=", mesh1D)
 print("Is empty? ", mesh1D.isEmpty())
 print("vertices=", mesh1D.getVertices())
@@ -43,6 +44,7 @@ vertices = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0],
 simplicies = [[0, 1, 2], [1, 2, 3], [2, 3, 4], [2, 4, 5], [0, 2, 5]]
 
 mesh2D = ot.Mesh(vertices, simplicies)
+mesh2D.computeKDTree()
 print("2D mesh=", mesh2D)
 point = [1.8] * 2
 print("Nearest index(", point, ")=", mesh2D.getNearestVertexIndex(point))
@@ -71,6 +73,7 @@ simplicies[4] = [1, 3, 5, 6]
 simplicies[5] = [1, 4, 5, 6]
 
 mesh3D = ot.Mesh(vertices, simplicies)
+mesh3D.computeKDTree()
 print("3D mesh=", mesh3D)
 point = [1.8] * 3
 print("Nearest index(", point, ")=", mesh3D.getNearestVertexIndex(point))


### PR DESCRIPTION
In Mesh constructor, do not build KDTree by default anymore.
Building a KDTree is useful only if getNearest* methods are called.
