### PR TITLE
Let LevelSetMesher::build really use gradient

### DIFF
--- a/lib/src/Base/Geom/LevelSetMesher.cxx
+++ b/lib/src/Base/Geom/LevelSetMesher.cxx
@@ -224,6 +224,7 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
               ComposedFunction levelFunction(function, shiftFunction);
               problem.setLevelFunction(levelFunction);
               solver_.setStartingPoint(delta);
+              solver_.setProblem(problem);
               OptimizationResult result;
               // Here we have to catch exceptions raised by the gradient
               try


### PR DESCRIPTION
Due to a bug, gradient was always falling back to
CenteredFiniteDifferenceGradient.

Rewrite IntervalMesher to not allocate objects in loops.
Avoid unnecessary Mesh assignments.
Replace Sample[i][j] by Sample(i, j).
