### PR TITLE
Deprecate several Domain methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@
  * Deprecated TruncatedDistribution single bound accessors in favor of setBounds/getBounds
  * Deprecated remaining analytical & database Function ctors
  * Mesh constructor no longer builds a KDTree, new method Mesh::computeKDTree must be called explicitly
+ * Deprecated Domain::numericallyContains, isEmpty, isNumericallyEmpty, getVolume, getNumericalVolume, computeVolume
 
 === Python module ===
 

--- a/TODO
+++ b/TODO
@@ -8,3 +8,7 @@ Remove deprecated TruncatedDistribution single bound accessors in favor of setBo
 Remove deprecated Function ctors in 1.12
 Remove deprecated Sample,SampleImplementation::operator*(SquareMatrix) and operator/(SquareMatrix) (and in-place operators) in 1.12
 Remove deprecated SampleImplementation::scale(SquareMatrix) in 1.12
+Remove deprecated Domain(a, b) constructor in 1.12
+Remove deprecated Domain,DomainImplementation::numericallyContains, isEmpty, isNumericallyEmpty, getVolume, getNumericalVolume, computeVolume in 1.12
+Remove deprecated DomainImplementation::volumeOld_, isAlreadyComputedVolumeOld_ members in 1.12
+Change Interval,Mesh::computeVolume to return void in 1.12

--- a/lib/src/Base/Geom/Domain.cxx
+++ b/lib/src/Base/Geom/Domain.cxx
@@ -21,6 +21,7 @@
 #include "openturns/Domain.hxx"
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Interval.hxx"
+#include "openturns/Log.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -37,7 +38,7 @@ Domain::Domain(const Point & a,
                const Point & b):
   TypedInterfaceObject<DomainImplementation>(new Interval(a, b))
 {
-  // Nothing to do
+  LOGWARN(OSS() << "Domain::Domain(const Point & a, const Point & b) is deprecated in favor of Interval constructor.");
 }
 
 /* Default constructor */
@@ -62,30 +63,35 @@ Bool Domain::contains(const Point & point) const
 /* Check if the given point is inside of the closed interval */
 Bool Domain::numericallyContains(const Point & point) const
 {
+  LOGWARN(OSS() << "Domain::numericallyContains is deprecated in favor of specific method in classes derived from DomainImplementation.");
   return getImplementation()->numericallyContains(point);
 }
 
 /* Check if the domain is empty, i.e if its numerical volume is zero */
 Bool Domain::isEmpty() const
 {
+  LOGWARN(OSS() << "Domain::isEmpty is deprecated in favor of specific method in classes derived from DomainImplementation.");
   return getImplementation()->isEmpty();
 }
 
 /* Check if the domain is numerically empty, i.e if its numerical volume is zero */
 Bool Domain::isNumericallyEmpty() const
 {
+  LOGWARN(OSS() << "Domain::isNumericallyEmpty is deprecated in favor of specific method in classes derived from DomainImplementation.");
   return getImplementation()->isNumericallyEmpty();
 }
 
 /* Get the volume of the domain */
 Scalar Domain::getVolume() const
 {
+  LOGWARN(OSS() << "Domain::getVolume is deprecated in favor of specific method in classes derived from DomainImplementation.");
   return getImplementation()->getVolume();
 }
 
 /* Get the numerical volume of the domain */
 Scalar Domain::getNumericalVolume() const
 {
+  LOGWARN(OSS() << "Domain::getNumericalVolume is deprecated in favor of specific method in classes derived from DomainImplementation.");
   return getImplementation()->getNumericalVolume();
 }
 

--- a/lib/src/Base/Geom/DomainImplementation.cxx
+++ b/lib/src/Base/Geom/DomainImplementation.cxx
@@ -34,8 +34,8 @@ static const Factory<DomainImplementation> Factory_DomainImplementation;
 DomainImplementation::DomainImplementation(UnsignedInteger dimension)
   : PersistentObject()
   , dimension_(dimension)
-  , volume_(0.0)
-  , isAlreadyComputedVolume_(false)
+  , volumeOld_(0.0)
+  , isAlreadyComputedVolumeOld_(false)
 {
   // Nothing to do
 }
@@ -69,37 +69,43 @@ Bool DomainImplementation::contains(const Point & point) const
 /* Check if the given point is inside of the discretization of the domain */
 Bool DomainImplementation::numericallyContains(const Point & point) const
 {
+  LOGWARN(OSS() << "DomainImplementation::numericallyContains is deprecated in favor of derived classes.");
   return contains(point);
 }
 
 /* Check if the domain is empty, i.e if its numerical volume is zero */
 Bool DomainImplementation::isEmpty() const
 {
+  LOGWARN(OSS() << "DomainImplementation::isEmpty is deprecated in favor of derived classes.");
   return isNumericallyEmpty();
 }
 
 /* Check if the domain is numerically empty, i.e if its numerical volume is zero */
 Bool DomainImplementation::isNumericallyEmpty() const
 {
+  LOGWARN(OSS() << "DomainImplementation::isNumericallyEmpty is deprecated in favor of derived classes.");
   return getNumericalVolume() <= ResourceMap::GetAsScalar("Domain-SmallVolume");
 }
 
 /* Get the volume of the domain */
 Scalar DomainImplementation::getVolume() const
 {
+  LOGWARN(OSS() << "DomainImplementation::getVolume is deprecated in favor of derived classes.");
   return getNumericalVolume();
 }
 
 /* Get the numerical volume of the domain */
 Scalar DomainImplementation::getNumericalVolume() const
 {
-  if (!isAlreadyComputedVolume_) computeVolume();
-  return volume_;
+  LOGWARN(OSS() << "DomainImplementation::getNumericalVolume is deprecated in favor of getVolume method in derived classes.");
+  if (!isAlreadyComputedVolumeOld_) volumeOld_ = computeVolume();
+  return volumeOld_;
 }
 
 /* Compute the volume of the mesh */
-void DomainImplementation::computeVolume() const
+Scalar DomainImplementation::computeVolume() const
 {
+  LOGWARN(OSS() << "DomainImplementation::computeVolume is deprecated in favor of derived classes.");
   throw NotYetImplementedException(HERE);
 }
 
@@ -126,6 +132,8 @@ void DomainImplementation::save(Advocate & adv) const
 {
   PersistentObject::save(adv);
   adv.saveAttribute("dimension_", dimension_);
+  adv.saveAttribute("volumeOld_", volumeOld_);
+  adv.saveAttribute("isAlreadyComputedVolumeOld_", isAlreadyComputedVolumeOld_);
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -133,6 +141,8 @@ void DomainImplementation::load(Advocate & adv)
 {
   PersistentObject::load(adv);
   adv.loadAttribute("dimension_", dimension_);
+  adv.loadAttribute("volumeOld_", volumeOld_);
+  adv.loadAttribute("isAlreadyComputedVolumeOld_", isAlreadyComputedVolumeOld_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Geom/openturns/Domain.hxx
+++ b/lib/src/Base/Geom/openturns/Domain.hxx
@@ -45,26 +45,26 @@ public:
   /** Copy-Standard constructors */
   Domain(const DomainImplementation & implementation);
 
-  /** Standard constructor based on Interval(a,b) */
+  /** @deprecated */
   Domain(const Point & a,
          const Point & b);
 
-  /** Check if the domain is empty, ie if its volume is zero */
+  /** @deprecated */
   Bool isEmpty() const;
 
-  /** Check if the mesh is numerically empty, i.e. if the volume of its discretization is zero */
+  /** @deprecated */
   Bool isNumericallyEmpty() const;
 
   /** Check if the closed domain contains a given point */
   virtual Bool contains(const Point & point) const;
 
-  /** Check if the given point is numerically inside of the domain, i.e. in its discretization */
+  /** @deprecated */
   Bool numericallyContains(const Point & point) const;
 
-  /** Get the numerical volume of the discretization of the domain */
+  /** @deprecated */
   Scalar getNumericalVolume() const;
 
-  /** Get the volume of the domain */
+  /** @deprecated */
   Scalar getVolume() const;
 
   /** Dimension accessors */

--- a/lib/src/Base/Geom/openturns/DomainImplementation.hxx
+++ b/lib/src/Base/Geom/openturns/DomainImplementation.hxx
@@ -45,23 +45,23 @@ public:
   /** Virtual constructor method */
   virtual DomainImplementation * clone() const;
 
-  /** Check if the domain is empty, ie if its volume is zero */
-  Bool isEmpty() const;
+  /** @deprecated */
+  virtual Bool isEmpty() const;
 
-  /** Check if the mesh is numerically empty, i.e. if the volume of its discretization is zero */
-  Bool isNumericallyEmpty() const;
+  /** @deprecated */
+  virtual Bool isNumericallyEmpty() const;
 
   /** Check if the closed domain contains a given point */
   virtual Bool contains(const Point & point) const;
 
-  /** Check if the given point is numerically inside of the domain, i.e. in its discretization */
-  Bool numericallyContains(const Point & point) const;
+  /** @deprecated */
+  virtual Bool numericallyContains(const Point & point) const;
 
-  /** Get the numerical volume of the discretization of the domain */
-  Scalar getNumericalVolume() const;
+  /** @deprecated */
+  virtual Scalar getNumericalVolume() const;
 
-  /** Get the volume of the domain */
-  Scalar getVolume() const;
+  /** @deprecated */
+  virtual Scalar getVolume() const;
 
   /** String converter */
   String __repr__() const;
@@ -83,17 +83,17 @@ public:
   virtual void load(Advocate & adv);
 
 protected:
-  // Compute the total volume of the domain
-  virtual void computeVolume() const;
+  // @deprecated
+  virtual Scalar computeVolume() const;
 
   /** The dimension of the DomainImplementation */
   UnsignedInteger dimension_;
 
-  // The global volume
-  mutable Scalar volume_;
+  // @deprecated
+  mutable Scalar volumeOld_;
 
-  // Flag to tell if the global volume has already been computed
-  mutable Bool isAlreadyComputedVolume_;
+  // @deprecated
+  mutable Bool isAlreadyComputedVolumeOld_;
 
 }; /* class DomainImplementation */
 

--- a/lib/src/Base/Geom/openturns/Interval.hxx
+++ b/lib/src/Base/Geom/openturns/Interval.hxx
@@ -67,6 +67,9 @@ public:
   /** Check if the interval is empty, i.e. if we have lowerBound >= upperBound for at least one component */
   Bool isEmpty() const;
 
+  /** Check if the interval is numerically empty, i.e. its volume is zero */
+  Bool isNumericallyEmpty() const;
+
   /** Check if the given point is inside of the closed interval */
   Bool contains(const Point & point) const;
 
@@ -107,6 +110,9 @@ public:
   using DomainImplementation::operator ==;
   using DomainImplementation::operator !=;
 
+  /** Volume accessor */
+  Scalar getVolume() const;
+
   /** Lower bound accessor */
   Point getLowerBound() const;
   void setLowerBound(const Point & lowerBound);
@@ -136,7 +142,7 @@ public:
 private:
 
   /** Get the numerical volume of the interval */
-  void computeVolume() const;
+  Scalar computeVolume() const;
 
   // An n-D intervall is defined as the cartesian product of n 1D intervalls ]low_1, up_1]x...x]low_n,up_n]
   Point lowerBound_;
@@ -147,6 +153,11 @@ private:
   BoolPersistentCollection finiteLowerBound_;
   BoolPersistentCollection finiteUpperBound_;
 
+  // Flag to tell if the global volume has already been computed
+  mutable Bool isAlreadyComputedVolume_;
+
+  // The global volume
+  mutable Scalar volume_;
 }; /* class Interval */
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Geom/openturns/Mesh.hxx
+++ b/lib/src/Base/Geom/openturns/Mesh.hxx
@@ -65,6 +65,12 @@ public:
   /** Check if the given point is inside of the closed mesh */
   Bool contains(const Point & point) const;
 
+  /** Get the numerical volume of the domain */
+  Scalar getVolume() const;
+
+  /** Check if the domain is empty, i.e if its volume is zero */
+  Bool isNumericallyEmpty() const;
+
   /** Get the description of the vertices */
   Description getDescription() const;
 
@@ -188,7 +194,7 @@ protected:
   SquareMatrix buildSimplexMatrix(const UnsignedInteger index) const;
 
   // Compute the total volume of the mesh
-  void computeVolume() const;
+  Scalar computeVolume() const;
 
   void checkValidity() const;
 
@@ -204,6 +210,12 @@ protected:
 
   // The vertices to simplices map
   mutable IndicesPersistentCollection verticesToSimplices_;
+
+  // Flag to tell if the global volume has already been computed
+  mutable Bool isAlreadyComputedVolume_;
+
+  // The global volume
+  mutable Scalar volume_;
 }; /* class Mesh */
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
+++ b/lib/src/Base/Stat/LowDiscrepancySequenceImplementation.cxx
@@ -137,7 +137,7 @@ Scalar LowDiscrepancySequenceImplementation::ComputeLocalDiscrepancy(const Sampl
     if (interval.numericallyContains(sample[j])) ++inPoints;
   // The local discrepancy is the absolute difference between the fraction of points
   // that fall into the given interval and its volume
-  return std::abs(static_cast<Scalar>(inPoints) / size - interval.getNumericalVolume());
+  return std::abs(static_cast<Scalar>(inPoints) / size - interval.getVolume());
 }
 
 /* Get the needed prime numbers */

--- a/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ConditionalDistribution.cxx
@@ -284,7 +284,7 @@ void ConditionalDistribution::setConditionedAndConditioningDistributionsAndLinkF
     setIntegrationNodesNumber(std::min(maximumNumber, candidateNumber));
     // Normalization factor for the weights
     // Not needed as the Mixture will be automatically normalized
-    // const Scalar normalizationFactor(Interval(continuousLowerBounds, continuousUpperBounds).getNumericalVolume());
+    // const Scalar normalizationFactor(Interval(continuousLowerBounds, continuousUpperBounds).getVolume());
     continuousAtomsNumber = continuousNodes_.getSize();
   } // continuousDimension > 0
 
@@ -530,7 +530,7 @@ Point ConditionalDistribution::computeExpectation(const Function & f,
       // Current contribution to the CDF
       result += (thetaPDF(i, 0) * continuousWeights_[i]) * fTheta[i];
     } // Continuous measure
-    result *= Interval(continuousLowerBounds_, subPoint).getNumericalVolume();
+    result *= Interval(continuousLowerBounds_, subPoint).getVolume();
     return result;
   } // No discrete marginal
 
@@ -586,7 +586,7 @@ Point ConditionalDistribution::computeExpectation(const Function & f,
       result += continuousWeights_[i % continuousAtomsNumber] * q;
     }
   }
-  result *= Interval(continuousLowerBounds_, subPoint).getNumericalVolume();
+  result *= Interval(continuousLowerBounds_, subPoint).getVolume();
   return result;
 }
 

--- a/python/src/DomainImplementation_doc.i.in
+++ b/python/src/DomainImplementation_doc.i.in
@@ -1,17 +1,5 @@
 %define OT_Domain_doc
-"Domain.
-
-Available constructors:
-    Domain(*lowerBound, upperBound*)
-
-Parameters
-----------
-lowerBound, upperBound : sequence of float of dimension *dim*
-    Define a finite :class:`interval <openturns.Interval>`
-    :math:`[lowerBound_0, upperBound_0]\times \dots \times [lowerBound_{dim-1}, upperBound_{dim-1}]`.
-    It is allowed to have :math:`lowerBound_i \geq upperBound_i` for some
-    :math:`i`: it simply defines an empty interval.
-    By default, an empty interval is created.
+"Base class for domain objects.
 
 Notes
 -----
@@ -23,18 +11,7 @@ A Domain object can be created through its derived classes:
 
 - :class:`~openturns.Interval`
 
-- :class:`~openturns.LevelSet`
-
-Examples
---------
->>> import openturns as ot
->>> # Create the interval [a, b]
->>> a = 1
->>> b = 3
->>> print(ot.Domain([a], [b]))
-[1, 3]
->>> print(ot.Domain(ot.Interval(a, b)))
-[1, 3]"
+- :class:`~openturns.LevelSet`"
 %enddef
 %feature("docstring") OT::DomainImplementation
 OT_Domain_doc
@@ -85,20 +62,6 @@ OT_Domain_getLowerBound_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_Domain_getNumericalVolume_doc
-"Get the volume of the domain.
-
-Returns
--------
-volume : float
-    Volume of the underlying mesh which is the discretization of the domain.
-    For now, by default, it is equal to the geometrical volume."
-%enddef
-%feature("docstring") OT::DomainImplementation::getNumericalVolume
-OT_Domain_getNumericalVolume_doc
-
-// ---------------------------------------------------------------------
-
 %define OT_Domain_getUpperBound_doc
 "Get the upper bound of the domain.
 
@@ -110,71 +73,3 @@ upper : :class:`~openturns.Point`
 %feature("docstring") OT::DomainImplementation::getUpperBound
 OT_Domain_getUpperBound_doc
 
-// ---------------------------------------------------------------------
-
-%define OT_Domain_getVolume_doc
-"Get the geometric volume of the domain.
-
-Returns
--------
-volume : float
-    Geometrical volume of the domain."
-%enddef
-%feature("docstring") OT::DomainImplementation::getVolume
-OT_Domain_getVolume_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_Domain_isEmpty_doc
-"Test whether the domain is empty or not.
-
-Returns
--------
-isInside : bool
-    *True* if the interior of the geometric domain is empty."
-%enddef
-%feature("docstring") OT::DomainImplementation::isEmpty
-OT_Domain_isEmpty_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_Domain_isNumericallyEmpty_doc
-"Check if the domain is numerically empty.
-
-Returns
--------
-isInside : bool
-    Flag telling whether the domain is numerically empty, i.e. if its numerical
-    volume is inferior or equal to :math:`\epsilon` (defined in the
-    :class:`~openturns.ResourceMap`:
-    :math:`\epsilon` = DomainImplementation-SmallVolume).
-
-Examples
---------
->>> import openturns as ot
->>> domain = ot.Domain([1.0, 2.0], [1.0, 2.0]) 
->>> print(domain.isNumericallyEmpty())
-True"
-%enddef
-%feature("docstring") OT::DomainImplementation::isNumericallyEmpty
-OT_Domain_isNumericallyEmpty_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_Domain_numericallyContains_doc
-"Check if the given point is inside of the discretization of the domain.
-
-Parameters
-----------
-point : sequence of float
-    Point with the same dimension as the current domain's dimension.
-
-Returns
--------
-isInside : bool
-    Flag telling whether the point is inside the discretized domain associated
-    to the domain. For now, by default, the discretized domain is equal to the
-    geometrical domain."
-%enddef
-%feature("docstring") OT::DomainImplementation::numericallyContains
-OT_Domain_numericallyContains_doc

--- a/python/src/Domain_doc.i.in
+++ b/python/src/Domain_doc.i.in
@@ -8,15 +8,5 @@ OT_Domain_contains_doc
 OT_Domain_getDimension_doc
 %feature("docstring") OT::Domain::getLowerBound
 OT_Domain_getLowerBound_doc
-%feature("docstring") OT::Domain::getNumericalVolume
-OT_Domain_getNumericalVolume_doc
 %feature("docstring") OT::Domain::getUpperBound
 OT_Domain_getUpperBound_doc
-%feature("docstring") OT::Domain::getVolume
-OT_Domain_getVolume_doc
-%feature("docstring") OT::Domain::isEmpty
-OT_Domain_isEmpty_doc
-%feature("docstring") OT::Domain::isNumericallyEmpty
-OT_Domain_isNumericallyEmpty_doc
-%feature("docstring") OT::Domain::numericallyContains
-OT_Domain_numericallyContains_doc

--- a/python/src/Interval_doc.i.in
+++ b/python/src/Interval_doc.i.in
@@ -69,6 +69,77 @@ Examples
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::Interval::isEmpty
+"Check if the interval is empty.
+
+Returns
+-------
+isEmpty : bool
+    *True* if the interior of the interval is empty.
+
+Examples
+--------
+>>> import openturns as ot
+>>> interval = ot.Interval([1.0, 2.0], [1.0, 2.0])
+>>> interval.setFiniteLowerBound([True, False])
+>>> print(interval.isEmpty())
+False"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Interval::isNumericallyEmpty
+"Check if the interval is numerically empty.
+
+Returns
+-------
+isEmpty : bool
+    Flag telling whether the interval is numerically empty, i.e. if its numerical
+    volume is inferior or equal to :math:`\epsilon` (defined in the
+    :class:`~openturns.ResourceMap`:
+    :math:`\epsilon` = Domain-SmallVolume).
+
+Examples
+--------
+>>> import openturns as ot
+>>> interval = ot.Interval([1.0, 2.0], [1.0, 2.0])
+>>> print(interval.isNumericallyEmpty())
+True"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Interval::numericallyContains
+"Check if the given point is inside of the discretization of the interval.
+
+Parameters
+----------
+point : sequence of float
+    Point with the same dimension as the current domain's dimension.
+
+Returns
+-------
+isInside : bool
+    Flag telling whether the point is inside the interval bounds, not taking
+    into account whether bounds are finite or not."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Interval::getVolume
+"Get the volume of the interval.
+
+Returns
+-------
+volume : float
+    Volume contained within interval bounds.
+
+Examples
+--------
+>>> import openturns as ot
+>>> interval = ot.Interval([2.0, 3.0], [4.0, 5.0], [True, False], [True, True])
+>>> print(interval.getVolume())
+4.0"
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::Interval::getFiniteLowerBound
 "Tell for each component of the lower bound whether it is finite or not.
 

--- a/python/src/Mesh_doc.i.in
+++ b/python/src/Mesh_doc.i.in
@@ -53,6 +53,30 @@ mesh : :class:`~openturns.Mesh`
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::Mesh::isNumericallyEmpty
+"Check if the mesh is numerically empty.
+
+Returns
+-------
+isEmpty : bool
+    Flag telling whether the mesh is numerically empty, i.e. if its numerical
+    volume is inferior or equal to :math:`\epsilon` (defined in the
+    :class:`~openturns.ResourceMap`:
+    :math:`\epsilon` = Domain-SmallVolume).
+
+Examples
+--------
+>>> import openturns as ot
+>>> vertices = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
+>>> simplex = [[0, 1, 2]]
+>>> mesh2d = ot.Mesh(vertices, simplex)
+>>> print(mesh2d.isNumericallyEmpty())
+False"
+
+// ---------------------------------------------------------------------
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::Mesh::checkPointInSimplex
 "Check if a point is inside a simplex.
 


### PR DESCRIPTION
Deprecate numericallyContains, isEmpty, isNumericallyEmpty, getVolume,
getNumericalVolume and computeVolume.

Some of these methods are defined in derived classes, when they make sense:
  * Interval: isEmpty, isNumericallyEmpty, numericallyContains,
              getVolume, computeVolume
  * Mesh: isNumericallyEmpty, getVolume, computeVolume

Rename DomainImplementation::volume_ member into volumeOld_ to avoid name
conflict with derived classes, likewise for isAlreadyComputedVolume_.

In order to support these deprecated methods, protected method
DomainImplementation::computeVolume has been modified to return a Scalar.
When it is dropped, {Mesh,Interval}::computeVolume can be modified again
to not return a value.