### PR TITLE
Speed-up Mesh::contains

### DIFF
--- a/lib/src/Base/Geom/openturns/Mesh.hxx
+++ b/lib/src/Base/Geom/openturns/Mesh.hxx
@@ -212,6 +212,10 @@ protected:
   // The vertices to simplices map
   mutable IndicesPersistentCollection verticesToSimplices_;
 
+  // The bounding boxes of simplices
+  mutable Sample lowerBoundingBoxSimplices_;
+  mutable Sample upperBoundingBoxSimplices_;
+
   // Flag to tell if the global volume has already been computed
   mutable Bool isAlreadyComputedVolume_;
 


### PR DESCRIPTION
Several tests have been added to Mesh::contains in order to exit early if
result is known to be false:
 * If point is outside Mesh bounding box, result is false
 * Simplices containing the nearest vertex are searched first; if point is
   not contained in any such simplices, all simplices are searched for.
 * checkPointInSimplexWithCoordinates() is modified too to return false
   early if point is not contained in simplex bounding bounds.  Those
   bounding boxes are precomputed.