### PR TITLE
Fix Saltelli estimator

### DIFF
--- a/lib/src/Uncertainty/Algorithm/Sensitivity/SaltelliSensitivityAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/SaltelliSensitivityAlgorithm.cxx
@@ -78,8 +78,9 @@ Sample SaltelliSensitivityAlgorithm::computeIndices(const Sample & sample,
   const Sample yA(sample, 0, size);
   const Point muA(yA.computeMean());
 
-  // Compute cross mean term
-  const Point crossSquareMean(computeSumDotSamples(sample, size_, 0, size_) / size_);
+  // Compute muB
+  const Sample yB(sample, size, 2 * size);
+  const Point muB(yB.computeMean());
 
   for (UnsignedInteger p = 0; p < inputDimension; ++p)
   {
@@ -91,7 +92,7 @@ Sample SaltelliSensitivityAlgorithm::computeIndices(const Sample & sample,
 
     for (UnsignedInteger q = 0; q < outputDimension; ++q)
     {
-      varianceI[q][p] +=  yEDotyB[q]  / (size - 1.0) -  crossSquareMean[q];
+      varianceI[q][p] +=  yEDotyB[q]  / (size - 1.0) -  muA[q] * muB[q];
       // Vti = Var - V_{-i}
       VTi[q][p] += muA[q] * muA[q] + referenceVariance_[q] - yEDotyA[q]  / (size - 1.0);
     }

--- a/lib/test/t_SobolIndicesAlgorithm_std.expout
+++ b/lib/test/t_SobolIndicesAlgorithm_std.expout
@@ -1,8 +1,8 @@
 Method = SaltelliSensitivityAlgorithm
-First order Sobol indice of Y|X1 = 0.293134
+First order Sobol indice of Y|X1 = 0.302751
 Total order Sobol indice of Y|X3 = 0.256687
-Second order Sobol indice of Y|X1,X3 = 0.24049
-Confidence interval of first order Y|X1 = [0.272983, 0.309189]
+Second order Sobol indice of Y|X1,X3 = 0.221256
+Confidence interval of first order Y|X1 = [0.283606, 0.320897]
 Confidence interval of total order Y|X3 = [0.227016, 0.281488]
 Method = JansenSensitivityAlgorithm
 First order Sobol indice of Y|X1 = 0.322419

--- a/python/src/JansenSensitivityAlgorithm_doc.i.in
+++ b/python/src/JansenSensitivityAlgorithm_doc.i.in
@@ -39,7 +39,7 @@ These last ones are respectively given as follows:
 .. math::
 
    \begin{array}{ccc}
-   \hat{V_i} & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k)^2 - G_0^2 - \frac{1}{2n} \sum_{k=1}^{n} \left( G(E_k) - G(B_k) \right)^2 \\
+   \hat{V_i} & = & \Var{G(A_k)} - \frac{1}{2n} \sum_{k=1}^{n} \left( G(E_k) - G(B_k) \right)^2 \\
    \hat{VT_{i}} & = & \frac{1}{2n} \sum_{k=1}^{n} \left( G(A_k) -  G(E_k) \right)^2
    \end{array}
 

--- a/python/src/SaltelliSensitivityAlgorithm_doc.i.in
+++ b/python/src/SaltelliSensitivityAlgorithm_doc.i.in
@@ -39,7 +39,7 @@ These last ones are respectively given as follows:
 .. math::
 
    \begin{array}{ccc}
-   \hat{V_i} & = & \frac{1}{n}\sum_{k=1}^{n} G(B_k)  G(E_k) - G_0^2 \\
+   \hat{V_i} & = & \frac{1}{n}\sum_{k=1}^{n} G(B_k)  G(E_k) - (\frac{1}{n} \sum_{k=1}^{n} G(A_k)) (\frac{1}{n} \sum_{k=1}^{n} G(B_k)) \\
    \hat{V_{-i}} & = & \frac{1}{n}\sum_{k=1}^{n} G(A_k)  G(E_k) - G_0^2
    \end{array}
 
@@ -63,5 +63,5 @@ Examples
 >>> # sensitivity analysis algorithm
 >>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
-[0.182857,0.357745,-0.128457]"
+[0.249402,0.42429,-0.0619125]"
 

--- a/python/test/t_SobolIndicesAlgorithm_std.expout
+++ b/python/test/t_SobolIndicesAlgorithm_std.expout
@@ -1,5 +1,5 @@
 Method of evaluation= Saltelli
-First order indices =  [0.293134,0.451208,-0.00292283]
+First order indices =  [0.302751,0.460825,0.00669407]
 Total order indices =  [0.57499,0.427147,0.256687]
 Method of evaluation= Jansen
 First order indices =  [0.322419,0.457314,0.0260925]
@@ -27,4 +27,4 @@ First order indices interval =  [0.308335, 0.309469]
 Total order indices interval =  [0.567276, 0.568296]
 [0.43033, 0.431178]
 [0.244024, 0.244562]
-[0.0101493,0.60453,0.304954]
+[0.081853,0.676234,0.376658]

--- a/python/test/t_SobolIndicesAlgorithm_std.py
+++ b/python/test/t_SobolIndicesAlgorithm_std.py
@@ -2,10 +2,8 @@
 
 from __future__ import print_function
 import openturns as ot
-# from openturns.viewer import PlotSensitivity
 
 ot.TESTPREAMBLE()
-ot.RandomGenerator.SetSeed(0)
 
 try:
     input_dimension = 3


### PR DESCRIPTION
The numerator constant of the Saltelli first order index was computed as mean of product of G(A), G(B) whereas it should be the product of means as recommended by saltelli02
This was not consistent with the documentation either where noted as G_0^2, so we explicited it also.
The variance is larger (the estimator is worse after), but it is not a duplicate of Mauntz anymore.

before:
![g-sobol-saltellisensitivityalgorithm](https://user-images.githubusercontent.com/3832365/36303604-f43ea08c-130c-11e8-8bf8-5a430ba7fba8.png)

after:
![g-sobol-saltellisensitivityalgorithm](https://user-images.githubusercontent.com/3832365/36303582-e365496e-130c-11e8-8985-ac640be1a3ce.png)

