### PR TITLE
Add TypedInterfaceObject::operator!=

### DIFF
--- a/lib/src/Base/Common/openturns/TypedInterfaceObject.hxx
+++ b/lib/src/Base/Common/openturns/TypedInterfaceObject.hxx
@@ -103,6 +103,13 @@ public:
     return *getImplementation() == *(other.getImplementation());
   }
 
+  /** Comparison Operator */
+  inline virtual
+  Bool operator != (const TypedInterfaceObject & other) const
+  {
+    return !operator==(other);
+  }
+
 
 protected:
 


### PR DESCRIPTION
This operator is already defined in PersistentObject.hxx, but
interface classes inherit from TypedInterfaceObject.

Without this operator, we could have have (a==b) and (a!=b) both
return true (either in C++ or Python).