### PR TITLE
Add SymbolicParser::operator()(Sample)

### DIFF
--- a/lib/src/Base/Func/SymbolicEvaluation.cxx
+++ b/lib/src/Base/Func/SymbolicEvaluation.cxx
@@ -111,11 +111,15 @@ Point SymbolicEvaluation::operator() (const Point & inP) const
 /* Operator () */
 Sample SymbolicEvaluation::operator() (const Sample & inS) const
 {
-  UnsignedInteger size = inS.getSize();
-  Sample outSample(size, getOutputDimension());
-  for (UnsignedInteger i = 0; i < size; ++ i) outSample[i] = operator()(inS[i]);
-  outSample.setDescription(getOutputDescription());
-  return outSample;
+  Sample result(parser_(inS));
+  result.setDescription(getOutputDescription());
+  callsNumber_ += inS.getSize();
+  if (isHistoryEnabled_)
+  {
+    inputStrategy_.store(inS);
+    outputStrategy_.store(result);
+  }
+  return result;
 }
 
 /* Accessor for input point dimension */

--- a/lib/src/Base/Func/SymbolicEvaluation.cxx
+++ b/lib/src/Base/Func/SymbolicEvaluation.cxx
@@ -112,13 +112,13 @@ Point SymbolicEvaluation::operator() (const Point & inP) const
 Sample SymbolicEvaluation::operator() (const Sample & inS) const
 {
   Sample result(parser_(inS));
-  result.setDescription(getOutputDescription());
   callsNumber_ += inS.getSize();
   if (isHistoryEnabled_)
   {
     inputStrategy_.store(inS);
     outputStrategy_.store(result);
   }
+  result.setDescription(getOutputDescription());
   return result;
 }
 

--- a/lib/src/Base/Func/SymbolicParser.cxx
+++ b/lib/src/Base/Func/SymbolicParser.cxx
@@ -81,8 +81,8 @@ void SymbolicParser::initialize() const
 {
   const UnsignedInteger inputDimension = inputVariablesNames_.getSize();
   const UnsignedInteger outputDimension = formulas_.getSize();
-  inputStack_ = Point(inputDimension);
   if (parsers_.getSize() == outputDimension) return;
+  inputStack_ = Point(inputDimension);
   parsers_ = Collection<Pointer<MuParser> >(outputDimension);
   try
   {
@@ -123,6 +123,37 @@ Point SymbolicParser::operator() (const Point & inP) const
       if (!SpecFunc::IsNormal(value))
         throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << inP.__str__();
       result[outputIndex] = value;
+    }
+  }
+  catch (mu::Parser::exception_type & ex)
+  {
+    throw InternalException(HERE) << ex.GetMsg();
+  }
+  return result;
+}
+
+Sample SymbolicParser::operator() (const Sample & inS) const
+{
+  const UnsignedInteger inputDimension = inputVariablesNames_.getSize();
+  const UnsignedInteger outputDimension = formulas_.getSize();
+  if (inS.getDimension() != inputDimension)
+    throw InvalidArgumentException(HERE) << "Error: invalid input dimension (" << inS.getDimension() << ") expected " << inputDimension;
+  initialize();
+  const UnsignedInteger size = inS.getSize();
+  Sample result(size, outputDimension);
+  try
+  {
+    for (UnsignedInteger i = 0; i < size; ++i)
+    {
+      std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+      for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+      {
+        const Scalar value = parsers_[outputIndex].get()->Eval();
+        // By default muParser is not compiled with MUP_MATH_EXCEPTIONS enabled and does not throw on domain/division errors
+        if (!SpecFunc::IsNormal(value))
+          throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << Point(inS[i]).__str__();
+        result(i, outputIndex) = value;
+      }
     }
   }
   catch (mu::Parser::exception_type & ex)

--- a/lib/src/Base/Func/SymbolicParser.cxx
+++ b/lib/src/Base/Func/SymbolicParser.cxx
@@ -111,6 +111,7 @@ Point SymbolicParser::operator() (const Point & inP) const
   const UnsignedInteger outputDimension = formulas_.getSize();
   if (inP.getDimension() != inputDimension)
     throw InvalidArgumentException(HERE) << "Error: invalid input dimension (" << inP.getDimension() << ") expected " << inputDimension;
+  if (outputDimension == 0) return Point();
   initialize();
   std::copy(inP.begin(), inP.end(), inputStack_.begin());
   Point result(outputDimension);
@@ -138,6 +139,7 @@ Sample SymbolicParser::operator() (const Sample & inS) const
   const UnsignedInteger outputDimension = formulas_.getSize();
   if (inS.getDimension() != inputDimension)
     throw InvalidArgumentException(HERE) << "Error: invalid input dimension (" << inS.getDimension() << ") expected " << inputDimension;
+  if (outputDimension == 0) return Sample(inS.getSize(), 0);
   initialize();
   const UnsignedInteger size = inS.getSize();
   Sample result(size, outputDimension);

--- a/lib/src/Base/Func/openturns/SymbolicParser.hxx
+++ b/lib/src/Base/Func/openturns/SymbolicParser.hxx
@@ -37,6 +37,7 @@ public:
   SymbolicParser();
 
   Point operator()(const Point & inP) const;
+  Sample operator()(const Sample & inS) const;
 
   void setVariablesFormulas(const Description & inputVariablesNames,
                             const Description & formulas);


### PR DESCRIPTION
 This speeds up SymbolicEvaluation::operator()(Sample).

On a script Python with a Sample of size 32M and dimension 3, evaluation takes 1.5s instead of 5.2s.  I did not make more benchmarks, I expect gain to be larger with C++, but smaller with smaller size, which is more typical.