### PR TITLE
Fix {KDTree,NaiveNearestNeighbour}::__str__ definition

### DIFF
--- a/lib/src/Base/Algo/KDTree.cxx
+++ b/lib/src/Base/Algo/KDTree.cxx
@@ -318,8 +318,9 @@ String KDTree::__repr__() const
          << " root=" << (p_root_ ? p_root_->__repr__() : "NULL");
 }
 
-String KDTree::__str__() const
+String KDTree::__str__(const String & offset) const
 {
+  (void)offset;
   return OSS(false) << "class=" << GetClassName()
          << " root=" << (p_root_ ? p_root_->__repr__() : "NULL");
 }

--- a/lib/src/Base/Algo/NaiveNearestNeighbour.cxx
+++ b/lib/src/Base/Algo/NaiveNearestNeighbour.cxx
@@ -217,8 +217,9 @@ String NaiveNearestNeighbour::__repr__() const
          << " sample=" << points_;
 }
 
-String NaiveNearestNeighbour::__str__() const
+String NaiveNearestNeighbour::__str__(const String & offset) const
 {
+  (void)offset;
   return OSS(false) << "class=" << GetClassName()
          << " sample=" << points_;
 }

--- a/lib/src/Base/Algo/NearestNeighbourAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/NearestNeighbourAlgorithmImplementation.cxx
@@ -100,6 +100,7 @@ String NearestNeighbourAlgorithmImplementation::__repr__() const
 /* String converter */
 String NearestNeighbourAlgorithmImplementation::__str__(const String & offset) const
 {
+  (void)offset;
   OSS oss(false);
   oss << "class=" << NearestNeighbourAlgorithmImplementation::GetClassName();
   return oss;

--- a/lib/src/Base/Algo/openturns/KDTree.hxx
+++ b/lib/src/Base/Algo/openturns/KDTree.hxx
@@ -63,7 +63,7 @@ public:
 
   /** String converter */
   virtual String __repr__() const;
-  virtual String __str__() const;
+  virtual String __str__(const String & offset = "") const;
 
   /** Get the index of the nearest neighbour of the given point */
   UnsignedInteger query(const Point & x) const;

--- a/lib/src/Base/Algo/openturns/NaiveNearestNeighbour.hxx
+++ b/lib/src/Base/Algo/openturns/NaiveNearestNeighbour.hxx
@@ -62,7 +62,7 @@ public:
 
   /** String converter */
   virtual String __repr__() const;
-  virtual String __str__() const;
+  virtual String __str__(const String & offset = "") const;
 
   /** Get the index of the nearest neighbour of the given point */
   UnsignedInteger query(const Point & x) const;


### PR DESCRIPTION
It must match `NearestNeighbourAlgorithmImplementation::__str__`.

Also fix a compiler warning about unused argument in
`NearestNeighbourAlgorithmImplementation::__str__`.