### PR TITLE
Speed-up evaluation of a PythonFunction on a Sample

### DIFF
--- a/lib/src/Base/Stat/Sample.cxx
+++ b/lib/src/Base/Stat/Sample.cxx
@@ -67,6 +67,7 @@ String Sample::streamToRFormat() const
 /* Default constructor */
 Sample::Sample()
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(0, 1))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -75,6 +76,7 @@ Sample::Sample()
 Sample::Sample(const UnsignedInteger size,
                const UnsignedInteger dim)
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(size, dim))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -82,6 +84,7 @@ Sample::Sample(const UnsignedInteger size,
 /* Constructor from implementation */
 Sample::Sample(const SampleImplementation & implementation)
   : TypedInterfaceObject<SampleImplementation>(implementation.clone())
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -89,6 +92,7 @@ Sample::Sample(const SampleImplementation & implementation)
 /* Constructor from implementation */
 Sample::Sample(const Implementation & implementation)
   : TypedInterfaceObject<SampleImplementation>(implementation)
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -97,6 +101,7 @@ Sample::Sample(const Implementation & implementation)
 Sample::Sample(const UnsignedInteger size,
                const Point & point)
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(size, point))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -106,6 +111,7 @@ Sample::Sample(const Sample other,
                const UnsignedInteger first,
                const UnsignedInteger last)
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(*other.getImplementation(), other.getImplementation()->begin() + first, other.getImplementation()->begin() + last))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -113,6 +119,7 @@ Sample::Sample(const Sample other,
 /* Constructor from a collection of Point */
 Sample::Sample(const Collection<Point> & coll)
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(coll))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }
@@ -120,6 +127,7 @@ Sample::Sample(const Collection<Point> & coll)
 /* Constructor from a collection of Indices */
 Sample::Sample(const Collection<Indices> & coll)
   : TypedInterfaceObject<SampleImplementation>(new SampleImplementation(coll))
+  , pyObjSample_(0)
 {
   // Nothing to do
 }

--- a/lib/src/Base/Stat/openturns/Sample.hxx
+++ b/lib/src/Base/Stat/openturns/Sample.hxx
@@ -354,6 +354,9 @@ public:
   /** Sets the pointer to the underlying implementation object */
   virtual void setImplementationAsPersistentObject(const ImplementationAsPersistentObject & obj);
 
+  // This member is only intended to be used by SWIG, DO NOT use!
+  // INTENTIONALY NOT DOCUMENTED
+  void * pyObjSample_;
 }; /* class Sample */
 
 #ifndef SWIG

--- a/python/src/Function.i
+++ b/python/src/Function.i
@@ -87,6 +87,10 @@ class OpenTURNSPythonFunction(object):
         Dimension of the input vector
     outputDim : positive int
         Dimension of the output vector
+    copy : bool, optional
+        If True, input sample is converted into a Python 2-d sequence before calling
+        _exec_sample.  Otherwise, it is passed directy to _exec_sample.
+        Default is False.
 
     Notes
     -----
@@ -121,7 +125,7 @@ class OpenTURNSPythonFunction(object):
 
     >>> myFunc = Function(F)
     """
-    def __init__(self, n=0, p=0):
+    def __init__(self, n=0, p=0, copy=False):
         try:
             self.__n = int(n)
         except:
@@ -132,6 +136,7 @@ class OpenTURNSPythonFunction(object):
             raise TypeError('outputDim argument is not an integer.')
         self.__descIn = ['x' + str(i) for i in range(n)]
         self.__descOut = ['y' + str(i) for i in range(p)]
+        self._copy = copy
 
     def setInputDescription(self, descIn):
         if (len(descIn) != self.__n):
@@ -233,17 +238,17 @@ class PythonFunction(Function):
         Dimension of the input vector
     outputDim : positive int
         Dimension of the output vector
-    func : a callable python object
-        called on a single point.
+    func : a callable python object, optional
+        Called when evaluated on a single point.
         Default is None.
-    func_sample : a callable python object
-        called on multiple points at once.
+    func_sample : a callable python object, optional
+        Called when evaluated on multiple points at once.
         Default is None.
-    gradient : a callable python objects
-        returns the gradient as a 2-d sequence of float.
+    gradient : a callable python objects, optional
+        Returns the gradient as a 2-d sequence of float.
         Default is None (uses finite-difference).
-    hessian : a callable python object
-        returns the hessian as a 3-d sequence of float.
+    hessian : a callable python object, optional
+        Returns the hessian as a 3-d sequence of float.
         Default is None (uses finite-difference).
     n_cpus : integer
         Number of cpus on which func should be distributed using multiprocessing.
@@ -251,6 +256,10 @@ class PythonFunction(Function):
         and func_sample are both given as arguments, n_cpus will be ignored and
         samples will be handled by func_sample.
         Default is None.
+    copy : bool, optional
+        If True, input sample is converted into a Python 2-d sequence before calling
+        func_sample.  Otherwise, it is passed directy to func_sample.
+        Default is False.
 
     Notes
     -----
@@ -282,10 +291,10 @@ class PythonFunction(Function):
     [[  3 ]
      [ -1 ]]
     """
-    def __new__(self, n, p, func=None, func_sample=None, gradient=None, hessian=None, n_cpus=None):
+    def __new__(self, n, p, func=None, func_sample=None, gradient=None, hessian=None, n_cpus=None, copy=False):
         if func == None and func_sample == None:
             raise RuntimeError('no func nor func_sample given.')
-        instance = OpenTURNSPythonFunction(n, p)
+        instance = OpenTURNSPythonFunction(n, p, copy)
         import collections
         if func != None:
             if not isinstance(func, collections.Callable):

--- a/python/src/Sample.i
+++ b/python/src/Sample.i
@@ -20,11 +20,14 @@
   if (! SWIG_IsOK(SWIG_ConvertPtr($input, (void **) &$1, $1_descriptor, 0))) {
     try {
       temp = OT::convert<OT::_PySequence_,OT::Sample>( $input );
+      temp.pyObjSample_ = $input;
       $1 = &temp;
     } catch (OT::InvalidArgumentException &) {
       SWIG_exception(SWIG_TypeError, "Object passed as argument is not convertible to a Sample");
     }
   }
+  else
+    $1->pyObjSample_ = $input;
 }
 
 %typemap(typecheck,precedence=OT_TYPECHECK_NUMERICALSAMPLE) const Sample & {
@@ -438,7 +441,9 @@ Sample(const Sample & other)
 
 Sample(PyObject * pyObj)
 {
-  return new OT::Sample( OT::convert< OT::_PySequence_, OT::Sample>(pyObj) );  
+  OT::Sample newSample( OT::convert< OT::_PySequence_, OT::Sample>(pyObj) );
+  newSample.pyObjSample_ = pyObj;
+  return new OT::Sample(newSample);
 }
 
 Sample(PyObject * pyObj, UnsignedInteger dimension)
@@ -451,11 +456,12 @@ Sample(PyObject * pyObj, UnsignedInteger dimension)
   for ( OT::UnsignedInteger i = 0; i < size; ++ i ) {
     for ( OT::UnsignedInteger j = 0; j < dimension; ++ j ) {
       if ( k < pointSize ) {
-        sample[i][j] = point[k];
+        sample(i, j) = point[k];
         ++ k;
       }
     }
   }
+  sample.pyObjSample_ = pyObj;
   return new OT::Sample( sample );
 }
 

--- a/python/test/t_Function_python.expout
+++ b/python/test/t_Function_python.expout
@@ -9,17 +9,6 @@ class=Point name=Unnamed dimension=1 values=[21]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=2 data=[[0,0],[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7],[8,8],[9,9]]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[8],[10],[12],[14],[16],[18]]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=1 description=[T] data=[[200],[202],[204]]
-calls = 15 hits = 0
-T = class=Point name=Unnamed dimension=1 values=[4]
-calls = 16 hits = 0
-T = class=Point name=Unnamed dimension=1 values=[4]
-calls = 16 hits = 1
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 24 hits = 2
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 24 hits = 12
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 33 hits = 0
 exec
     [ y0  ]
 0 : [ 200 ]

--- a/python/test/t_Function_python.py
+++ b/python/test/t_Function_python.py
@@ -57,37 +57,6 @@ print((repr(outSample)))
 outSample = myFunc(((100., 100.), (101., 101.), (102., 102.)))
 print((repr(outSample)))
 
-# Test cache behavior
-myFunc.enableCache()
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outPt = myFunc(inPt)
-print(('T = ' + repr(outPt)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outPt = myFunc(inPt)
-print(('T = ' + repr(outPt)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
-# duplicate one value
-inSample[4] = inSample[5]
-
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
-myFunc.clearCache()
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
 # test PythonFunction
 
 


### PR DESCRIPTION
Here is what happens when a PythonFunction is evaluated
on a Sample:
 1. If argument X is a 2d Python sequence, it is converted by SWIG
    into a Python Sample X1.  Otherwise X is a Python Sample
 2. `PythonEvaluation::operator()(const Sample &inS)` is called on the
    Sample wrapped by X (or X1).
 3. This method converts inS into a Python sequence P1.
 4. `OpenTURNSPythonFunction.__call__(P1)` is called
 5. It tries to convert P1 into a Point (with a copy), this
    fails and it converts P1 into a Python Sample S1 (with another
    copy).
 6. `OpenTURNSPythonFunction._exec_sample(S1)` is called and evaluated.

Dispatch at step 5 is already performed by `PythonEvaluation::operator()`
overloads, this part of this commit can be applied independantly.

With this commit, a reference is added at step 1 into the Sample object
to point to the underlying Python object.  Step 3 can then be avoided,
we call _exec_sample directly on the Python object.

This works only when called directly from Python.  If this PythonFunction
is called from C++ classes, there is no Python object associated to argument,
and step 3 is called as before.

An optional 'copy' argument is added to PythonFunction, to revert to old
code if something goes wrong.  Normally this should not happen, but who
knows?  It also allows to compute the cost of step 3.

Cache is removed, it prevents this optimization.