### PR TITLE
Improve kl algorithms

### DIFF
--- a/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
@@ -126,21 +126,20 @@ void KarhunenLoeveP1Algorithm::run()
   eigenPairs = eigenPairs.sortAccordingToAComponent(augmentedDimension);
   SquareMatrix eigenVectors(augmentedDimension);
   Point eigenValues(augmentedDimension);
+  Scalar cumulatedVariance = 0.0;
   for (UnsignedInteger i = 0; i < augmentedDimension; ++i)
   {
     for (UnsignedInteger j = 0; j < augmentedDimension; ++j) eigenVectors(i, j) = eigenPairs[j][i];
     eigenValues[i] = -eigenPairs[i][augmentedDimension];
+    cumulatedVariance += eigenValues[i];
   }
   LOGDEBUG(OSS(false) << "eigenVectors=\n" << eigenVectors << ", eigenValues=" << eigenValues);
   LOGINFO("Extract the relevant eigenpairs");
+  // Start at 0 if the given threshold is large (ie greater than 0)
   UnsignedInteger K = 0;
-  Scalar cumulatedVariance = std::abs(eigenValues[0]);
   // Find the cut-off in the eigenvalues
-  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance))
-  {
-    cumulatedVariance += eigenValues[K];
-    ++K;
-  }
+  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance)) ++K;
+  LOGINFO(OSS() << "Selected " << K << " eigenvalues");
   // Reduce and rescale the eigenvectors
   MatrixImplementation transposedProjection(augmentedDimension, K);
   Point selectedEV(K);

--- a/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
@@ -179,18 +179,19 @@ void KarhunenLoeveSVDAlgorithm::run()
   MatrixImplementation Vt;
   const Point svd(designMatrix.computeSVD(U, Vt));
   LOGDEBUG(OSS(false) << "U=\n" << U << ", singular values=" << svd);
+  Scalar cumulatedVariance = 0.0;
   Point eigenValues(svd.getDimension());
   for (UnsignedInteger i = 0; i < svd.getDimension(); ++i)
-    eigenValues[i] = svd[i] * svd[i];
+    {
+      eigenValues[i] = svd[i] * svd[i];
+      cumulatedVariance += eigenValues[i];
+    }
   LOGINFO("Extract the relevant eigenpairs");
+  // Start at 0 if the given threshold is large (ie greater than 0)
   UnsignedInteger K = 0;
-  Scalar cumulatedVariance = std::abs(eigenValues[0]);
   // Find the cut-off in the eigenvalues
-  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance))
-  {
-    cumulatedVariance += eigenValues[K];
-    ++K;
-  }
+  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance)) ++K;
+  LOGINFO(OSS() << "Selected " << K << " eigenvalues");
   LOGINFO("Create eigenmodes values");
   // Stores the eigenmodes values in-place to avoid wasting memory
   MatrixImplementation & eigenModesValues = U;

--- a/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
+++ b/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
@@ -321,19 +321,17 @@ void KarhunenLoeveQuadratureAlgorithm::run()
     eigenPairs[i][augmentedDimension] = -eigenValues[i];
   }
   eigenPairs = eigenPairs.sortAccordingToAComponent(augmentedDimension);
+  Scalar cumulatedVariance = 0.0;
   for (UnsignedInteger i = 0; i < augmentedDimension; ++i)
   {
     for (UnsignedInteger j = 0; j < augmentedDimension; ++j) eigenVectors(i, j) = eigenPairs[j][i];
     eigenValues[i] = -eigenPairs[i][augmentedDimension];
+    cumulatedVariance += eigenValues[i];
   }
+  // Start at 0 if the given threshold is large (ie greater than 0)
   UnsignedInteger K = 0;
-  Scalar cumulatedVariance = std::abs(eigenValues[0]);
   // Find the cut-off in the eigenvalues
-  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance))
-  {
-    cumulatedVariance += eigenValues[K];
-    ++K;
-  }
+  while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance)) ++K;
   LOGINFO(OSS() << "Selected " << K << " eigenvalues");
   // Reduce and rescale the eigenvectors
   MatrixImplementation transposedProjection(nodesNumber * dimension, K);

--- a/lib/test/t_PointToPointConnection_std.expout
+++ b/lib/test/t_PointToPointConnection_std.expout
@@ -8,13 +8,13 @@ myFunc(point)=class=Point name=Unnamed dimension=1 values=[0.514395]
 myFunc.gradient(point)=class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[-0.721606]
 myFunc.hessian(point)=class=SymmetricTensor implementation=class=TensorImplementation name=Unnamed rows=1 columns=1 sheets=1 values=[-0.827568]
 called 6 times
-myFunc=class=PointToPointConnection name=Unnamed evaluation=class=PointToPointEvaluation name=Unnamed isFunctionComposition=false leftFunction=class=Function name=Unnamed implementation=class=FunctionImplementation name=Unnamed description=[] evaluationImplementation=class=NoEvaluation name=Unnamed gradientImplementation=class=NoGradient name=Unnamed hessianImplementation=class=NoHessian name=Unnamed rightFunction=class=Function name=Unnamed implementation=class=FunctionImplementation name=Unnamed description=[] evaluationImplementation=class=NoEvaluation name=Unnamed gradientImplementation=class=NoGradient name=Unnamed hessianImplementation=class=NoHessian name=Unnamed fieldToPoint=class=FieldToPointFunction name=Unnamed implementation=class=KarhunenLoeveProjection name=Unnamed input description=[v0] output description=[xi0,xi1,xi2,xi3,xi4] number of calls=0 pointToField=class=PointToFieldFunction name=Unnamed implementation=class=KarhunenLoeveLifting name=Unnamed input description=[xi0,xi1,xi2,xi3,xi4] output description=[v0] number of calls=0
-myFunc input description=[xi0,xi1,xi2,xi3,xi4]
-myFunc output description=[xi0,xi1,xi2,xi3,xi4]
-myFunc input dimension=5
-myFunc output dimension=5
-point=class=Point name=Unnamed dimension=5 values=[1,1,1,1,1]
-myFunc(point)=class=Point name=Unnamed dimension=5 values=[1,1,1,1,1]
-myFunc.gradient(point)=class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=5 columns=5 values=[1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1]
-myFunc.hessian(point)=class=Tensor implementation=class=TensorImplementation name=Unnamed rows=5 columns=5 sheets=5 values=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-called 62 times
+myFunc=class=PointToPointConnection name=Unnamed evaluation=class=PointToPointEvaluation name=Unnamed isFunctionComposition=false leftFunction=class=Function name=Unnamed implementation=class=FunctionImplementation name=Unnamed description=[] evaluationImplementation=class=NoEvaluation name=Unnamed gradientImplementation=class=NoGradient name=Unnamed hessianImplementation=class=NoHessian name=Unnamed rightFunction=class=Function name=Unnamed implementation=class=FunctionImplementation name=Unnamed description=[] evaluationImplementation=class=NoEvaluation name=Unnamed gradientImplementation=class=NoGradient name=Unnamed hessianImplementation=class=NoHessian name=Unnamed fieldToPoint=class=FieldToPointFunction name=Unnamed implementation=class=KarhunenLoeveProjection name=Unnamed input description=[v0] output description=[xi0,xi1,xi2,xi3,xi4,xi5] number of calls=0 pointToField=class=PointToFieldFunction name=Unnamed implementation=class=KarhunenLoeveLifting name=Unnamed input description=[xi0,xi1,xi2,xi3,xi4,xi5] output description=[v0] number of calls=0
+myFunc input description=[xi0,xi1,xi2,xi3,xi4,xi5]
+myFunc output description=[xi0,xi1,xi2,xi3,xi4,xi5]
+myFunc input dimension=6
+myFunc output dimension=6
+point=class=Point name=Unnamed dimension=6 values=[1,1,1,1,1,1]
+myFunc(point)=class=Point name=Unnamed dimension=6 values=[1,1,1,1,1,1]
+myFunc.gradient(point)=class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=6 columns=6 values=[1,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,1]
+myFunc.hessian(point)=class=Tensor implementation=class=TensorImplementation name=Unnamed rows=6 columns=6 sheets=6 values=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+called 86 times

--- a/python/doc/math_notations.sty
+++ b/python/doc/math_notations.sty
@@ -5,8 +5,8 @@
 \usepackage{amssymb}
 
 % For matrixes and vectors
-\newcommand{\vect}[1]{{\underline{#1}}}
-\newcommand{\mat}[1]{{\underline{\underline{#1}}}}
+\newcommand{\vect}[1]{{\mathbf{\boldsymbol{{#1}}}}}
+\newcommand{\mat}[1]{{\vect{\vect{#1}}}}
 \newcommand{\Tr}[1]{{#1}^\top}
 
 % Bold letters 
@@ -100,17 +100,17 @@
 \newcommand{\Diff}{{\mathrm{d}}}
 
 % short commands
-\newcommand{\un}[1]{\underline{#1}}
+\newcommand{\un}[1]{\vect{#1}}
 \newcommand{\dpl}[1]{\displaystyle{#1}}
-\newcommand{\uw}{\underline{w}}
-\newcommand{\uW}{\underline{W}}
-\newcommand{\ux}{\underline{x}}
-\newcommand{\uX}{\underline{X}}
-\newcommand{\uy}{\underline{y}}
-\newcommand{\uY}{\underline{Y}}
-\newcommand{\uz}{\underline{z}}
-\newcommand{\uZ}{\underline{Z}}
-\newcommand{\muX}{\underline{\mu}_{\:X}}
+\newcommand{\uw}{\vect{w}}
+\newcommand{\uW}{\vect{W}}
+\newcommand{\ux}{\vect{x}}
+\newcommand{\uX}{\vect{X}}
+\newcommand{\uy}{\vect{y}}
+\newcommand{\uY}{\vect{Y}}
+\newcommand{\uz}{\vect{z}}
+\newcommand{\uZ}{\vect{Z}}
+\newcommand{\muX}{\vect{\mu}_{\:X}}
 \newcommand{\Var}[1]{{\rm Var}\left[ #1 \right]}
 \newcommand{\Cov}[1]{{\rm Cov}\left[ #1 \right]}
 \newcommand{\Expect}[1]{{\mathbb E}\left[ #1 \right]}
@@ -126,7 +126,7 @@
 \newcommand{\di}[1] {{\,\mathrm{d}#1}}
 \newcommand{\norm}[1] {\left\|#1\right\|}
 \newcommand{\tendto}[2]{\xrightarrow[#1\rightarrow#2]{}}
-\newcommand{\matr}[1]{\underline{\underline{#1}}}
+\newcommand{\matr}[1]{\vect{\vect{#1}}}
 \newcommand{\idx}{\vect{\alpha}}
 \newcommand{\NM}{\Nset^{n_X}}
 

--- a/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
@@ -34,12 +34,12 @@ The Mercer theorem shows that the covariance function  :math:`C` writes:
     \mat{C}(\vect{s},\vect{t}) = \sum_{k=1}^{+\infty} \lambda_k \vect{\varphi}_k(\vect{s}) \Tr{\vect{\varphi}}_k(\vect{t}) \quad \forall (\vect{s}, \vect{t}) \in \cD \times \cD
 
 
-The threshold :math:`s` is used in order to select the most significant eigenvalues, ie all the eigenvalues such that: 
+The threshold :math:`s` is used in order to select the most significant eigenvalues, ie all the eigenvalues such that (the infinite sum on the right being replaced by the sum of all computed eigenvalues in numerical algoritms): 
 
 .. math::
     :label: thresholdK
 
-    K = \max \{k \in \Nset \, | \, \lambda_k < s \sum_{i=1}^{k-1} \}
+    K = \max \left\{k \in \Nset \, | \, \lambda_k \leq s \sum_{i\geq 1}\lambda_i \right\}
 
 
 To solve :eq:`fredholm`, we use the functional basis :math:`(\theta_p)_{1 \leq p \leq P}` of :math:`L^2(\cD, \Rset)` with :math:`P` elements defined on :math:`\cD`. We search the solutions of type:

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -37,7 +37,7 @@ The SVD approach is used when the covariance function is not explicitely known b
 
 It consists in :
 
-    - approximating :math:`\mat{C}` by its empirical estimator  :math:`\dfrac{1}{\tilde{K}} \mat{X}\, \Tr{\mat{X}}` where :math:`\mat{X}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\tilde{K}=K` if the process is centered and :math:`\tilde{K}=K-1` otherwise;
+    - approximating :math:`\mat{C}` by its empirical estimator  :math:`\dfrac{1}{\tilde{K}} \tilde{\mat{X}}\, \Tr{\tilde{\mat{X}}}` where :math:`\tilde{\mat{X}}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\tilde{K}=K` if the process is centered and :math:`\tilde{\mat{X}}~=~(\vect{X}_1 - \vect{\mu} | \dots | \vect{X}_K - \vect{\mu})`:math:`\tilde{K}=K-1` otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
     - taking the :math:`L` vertices of the mesh of :math:`\vect{X}` as the :math:`L` quadrature points.
 
 We suppose now that :math:`K < dL`, and we note :math:`\mat{Y} = \sqrt{\mat{W}} \,\mat{X}`.

--- a/python/test/t_PointToPointConnection_std.expout
+++ b/python/test/t_PointToPointConnection_std.expout
@@ -10,49 +10,62 @@ myFunc.hessian(point)= sheet #0
 [[ -0.827568 ]]
 called  6  times
 myFunc= (FieldToPointFunction :
-  class=KarhunenLoeveProjection name=Unnamed input description=[v0] output description=[xi0,xi1,xi2,xi3,xi4] number of calls=0)o(PointToFieldFunction :
-  class=KarhunenLoeveLifting name=Unnamed input description=[xi0,xi1,xi2,xi3,xi4] output description=[v0] number of calls=0)
-myFunc input description= [xi0,xi1,xi2,xi3,xi4]
-myFunc output description= [xi0,xi1,xi2,xi3,xi4]
-myFunc input dimension= 5
-myFunc output dimension= 5
-point= [1.0, 1.0, 1.0, 1.0, 1.0]
-myFunc(point)= [1,1,1,1,1]
-myFunc.gradient(point)= 5x5
-[[ 1 0 0 0 0 ]
- [ 0 1 0 0 0 ]
- [ 0 0 1 0 0 ]
- [ 0 0 0 1 0 ]
- [ 0 0 0 0 1 ]]
-myFunc.hessian(point)= 5x5x5
+  class=KarhunenLoeveProjection name=Unnamed input description=[v0] output description=[xi0,xi1,xi2,xi3,xi4,xi5] number of calls=0)o(PointToFieldFunction :
+  class=KarhunenLoeveLifting name=Unnamed input description=[xi0,xi1,xi2,xi3,xi4,xi5] output description=[v0] number of calls=0)
+myFunc input description= [xi0,xi1,xi2,xi3,xi4,xi5]
+myFunc output description= [xi0,xi1,xi2,xi3,xi4,xi5]
+myFunc input dimension= 6
+myFunc output dimension= 6
+point= [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+myFunc(point)= [1,1,1,1,1,1]
+myFunc.gradient(point)= 6x6
+[[ 1 0 0 0 0 0 ]
+ [ 0 1 0 0 0 0 ]
+ [ 0 0 1 0 0 0 ]
+ [ 0 0 0 1 0 0 ]
+ [ 0 0 0 0 1 0 ]
+ [ 0 0 0 0 0 1 ]]
+myFunc.hessian(point)= 6x6x6
 sheet #0
-[[ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]]
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
 sheet #1
-[[ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]]
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
 sheet #2
-[[ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]]
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
 sheet #3
-[[ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]]
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
 sheet #4
-[[ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]
- [ 0 0 0 0 0 ]]
-called  62  times
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
+sheet #5
+[[ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]
+ [ 0 0 0 0 0 0 ]]
+called  86  times


### PR DESCRIPTION
The selection of the cut-off eigenvalue is now based on the full sum of eigenvalues, as they are already computed before the selection.

Several improvements have been made in the various Karhunen-Loeve algorithms:
  * now the sorting is done without moving the eigenvectors
  * the reuse of computations has been improved in the quadrature method
  * the log messages are more consistent from one algorithm to the other

I also propose to switch to a more conventional notation for vectors and matrices, using boldface instead of underline. This commit can be dropped if it causes more trouble than others.