### PR TITLE
[RFC] Speed-up evaluation of a PythonFunction on a Sample

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -885,6 +885,19 @@ foreach (module ${OPENTURNS_PYTHON_MODULES})
          )
 endforeach ()
 
+
+# Build and install openturns.memoryview
+add_library( memoryview MODULE PythonReadOnlyBuffer.c )
+if (LINK_PYTHON_LIBRARY)
+  target_link_libraries (memoryview ${PYTHON_LIBRARIES})
+endif ()
+set_target_properties(memoryview PROPERTIES NO_SONAME ON PREFIX "")
+if(WIN32 AND NOT CYGWIN)
+  set_target_properties(memoryview PROPERTIES SUFFIX ".pyd")
+endif()
+install (TARGETS memoryview LIBRARY DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns)
+
+
 set (EXTRA_PYTHON_FILES __init__.py dist.py viewer.py coupling_tools.py)
 install (FILES ${EXTRA_PYTHON_FILES}
           DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns

--- a/python/src/PythonEvaluation.cxx
+++ b/python/src/PythonEvaluation.cxx
@@ -42,7 +42,11 @@ static const Factory<PythonEvaluation> Factory_PythonEvaluation;
 /* Default constructor */
 PythonEvaluation::PythonEvaluation()
   : EvaluationImplementation()
-  , pyObj_(0)
+  , pyObj_(NULL)
+  , pyBufferClass_(NULL)
+  , pyObj_has_exec_(false)
+  , pyObj_has_exec_sample_(false)
+  , pyObj_discard_openturns_memoryview_(false)
 {
   // Nothing to do
 }
@@ -52,8 +56,14 @@ PythonEvaluation::PythonEvaluation()
 PythonEvaluation::PythonEvaluation(PyObject * pyCallable)
   : EvaluationImplementation()
   , pyObj_(pyCallable)
+  , pyBufferClass_(NULL)
+  , pyObj_has_exec_(false)
+  , pyObj_has_exec_sample_(false)
+  , pyObj_discard_openturns_memoryview_(false)
 {
   Py_XINCREF(pyCallable);
+
+  initializePythonState();
 
   // Set the name of the object as its Python classname
   ScopedPyObjectPointer cls(PyObject_GetAttrString (pyObj_,
@@ -61,8 +71,6 @@ PythonEvaluation::PythonEvaluation(PyObject * pyCallable)
   ScopedPyObjectPointer name(PyObject_GetAttrString(cls.get(),
                              const_cast<char *>("__name__" )));
   setName(convert< _PyString_, String >(name.get()));
-
-
 
   const UnsignedInteger inputDimension  = getInputDimension();
   const UnsignedInteger outputDimension = getOutputDimension();
@@ -105,6 +113,8 @@ PythonEvaluation::PythonEvaluation(PyObject * pyCallable)
 /* Virtual constructor */
 PythonEvaluation * PythonEvaluation::clone() const
 {
+  Py_XINCREF(pyObj_);
+  Py_XINCREF(pyBufferClass_);
   return new PythonEvaluation(*this);
 }
 
@@ -112,14 +122,17 @@ PythonEvaluation * PythonEvaluation::clone() const
 PythonEvaluation::PythonEvaluation(const PythonEvaluation & other)
   : EvaluationImplementation(other)
   , pyObj_(other.pyObj_)
+  , pyBufferClass_(other.pyBufferClass_)
 {
   Py_XINCREF(pyObj_);
+  Py_XINCREF(pyBufferClass_);
 }
 
 /* Destructor */
 PythonEvaluation::~PythonEvaluation()
 {
   Py_XDECREF(pyObj_);
+  Py_XDECREF(pyBufferClass_);
 }
 
 /* Comparison operator */
@@ -167,43 +180,87 @@ Point PythonEvaluation::operator() (const Point & inP) const
     throw InvalidDimensionException(HERE) << "Input point has incorrect dimension. Got " << dimension << ". Expected " << getInputDimension();
 
   Point outP;
-  CacheKeyType inKey(inP.getCollection());
-  if (p_cache_->isEnabled() && p_cache_->hasKey(inKey))
+  ++ callsNumber_;
+
+  ScopedPyObjectPointer result;
+
+  if (pyObj_discard_openturns_memoryview_)
   {
-    outP = Point::ImplementationType(p_cache_->find(inKey));
+    // Force a memory copy of inP into a Python list
+    ScopedPyObjectPointer point(convert< Point, _PySequence_ >(inP));
+    ScopedPyObjectPointer execName(convert< String, _PyString_ >("_exec"));
+    result = PyObject_CallMethodObjArgs(pyObj_, execName.get(), point.get(), NULL);
+    if (! result.get())
+      PyErr_SetString(PyExc_RuntimeError, "_exec did not return any value");
+    else if (! PySequence_Check(result.get()))
+      PyErr_SetString(PyExc_TypeError, "_exec return value is not a sequence");
   }
   else
   {
-    ++ callsNumber_;
+    // Wrap inP into a memoryview.Buffer object:
+    //    openturns.memoryview.Buffer((int(&inP[0]), False), (inP.getSize(),))
+    // First argument
+    ScopedPyObjectPointer ptrTuple(PyTuple_New(2));
+    PyTuple_SetItem(ptrTuple.get(), 0, PyLong_FromVoidPtr(static_cast<void *>(const_cast<double*>(&inP[0]))));
+    PyTuple_SetItem(ptrTuple.get(), 1, PyBool_FromLong(0));  // We do not own memory
 
-    ScopedPyObjectPointer point(convert< Point, _PySequence_ >(inP));
-    ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj_, point.get(), NULL));
+    // Second argument
+    ScopedPyObjectPointer shapeTuple(PyTuple_New(1));
+    PyTuple_SetItem(shapeTuple.get(), 0, convert< UnsignedInteger, _PyInt_ > (inP.getSize()));
 
-    if (result.isNull())
+    // Call openturns.memoryview.Buffer() to create a read-only buffer
+    ScopedPyObjectPointer readOnlyBufferObj(PyObject_CallObject(pyBufferClass_, Py_BuildValue("OO", ptrTuple.get(), shapeTuple.get())));
+
+    // Pass this buffer to _exec function if it has been defined by user, otherwise call _exec_sample(Buffer.augment())[0]
+    // If both pyObj_has_exec_ and pyObj_has_exec_sample_ are false, this is not a PythonFunction but a Function(OpenTURNSPythonFunction).
+    if (pyObj_has_exec_ || ! pyObj_has_exec_sample_)
     {
-      handleException();
+      ScopedPyObjectPointer execName(convert< String, _PyString_ >("_exec"));
+      result = PyObject_CallMethodObjArgs(pyObj_, execName.get(), readOnlyBufferObj.get(), NULL);
     }
-
-    try
+    else
     {
-      outP = convert< _PySequence_, Point >(result.get());
-    }
-    catch (InvalidArgumentException &)
-    {
-      throw InvalidArgumentException(HERE) << "Output value for " << getName() << "._exec() method is not a sequence object (list, tuple, Point, etc.)";
-    }
-
-    if (outP.getDimension() != getOutputDimension())
-    {
-      throw InvalidDimensionException(HERE) << "Output point has incorrect dimension. Got " << outP.getDimension() << ". Expected " << getOutputDimension();
-    }
-
-    if (p_cache_->isEnabled())
-    {
-      CacheValueType outValue(outP.getCollection());
-      p_cache_->add(inKey, outValue);
+      // Only _exec_sample is defined, not _exec
+      ScopedPyObjectPointer augmentName(convert< String, _PyString_ >("augment"));
+      ScopedPyObjectPointer sampleObj(PyObject_CallMethodObjArgs(readOnlyBufferObj.get(), augmentName.get(), NULL));
+      if (sampleObj.get())
+      {
+        ScopedPyObjectPointer execSampleName(convert< String, _PyString_ >("_exec_sample"));
+        ScopedPyObjectPointer sampleResult(PyObject_CallMethodObjArgs(pyObj_, execSampleName.get(), sampleObj.get(), NULL));
+        if (sampleResult.get())
+        {
+          if (PySequence_Check(sampleResult.get()))
+            result = PySequence_ITEM(sampleResult.get(), 0);
+          else
+            PyErr_SetString(PyExc_TypeError, "_exec_sample return value is not a sequence");
+        }
+        else
+          PyErr_SetString(PyExc_RuntimeError, "_exec_sample did not return any value");
+      }
+      else
+        PyErr_SetString(PyExc_RuntimeError, "openturns.memoryview.Buffer.augment did not return any value");
     }
   }
+
+  if (result.isNull())
+  {
+    handleException();
+  }
+
+  try
+  {
+    outP = convert< _PySequence_, Point >(result.get());
+  }
+  catch (InvalidArgumentException &)
+  {
+    throw InvalidArgumentException(HERE) << "Output value for " << getName() << "._exec() method is not a sequence object (list, tuple, Point, etc.)";
+  }
+
+  if (outP.getDimension() != getOutputDimension())
+  {
+    throw InvalidDimensionException(HERE) << "Output point has incorrect dimension. Got " << outP.getDimension() << ". Expected " << getOutputDimension();
+  }
+
   return outP;
 }
 
@@ -218,128 +275,114 @@ Sample PythonEvaluation::operator() (const Sample & inS) const
 
   const UnsignedInteger size = inS.getSize();
   const UnsignedInteger outDim = getOutputDimension();
-  const bool useCache = p_cache_->isEnabled();
 
-  Sample outS(size, outDim);
-  Sample toDo(0, inDim);
-  if (useCache)
+  Sample outS(0, outDim);
+  if (size > 0)
   {
-    std::set<Point> uniqueValues;
-    for (UnsignedInteger i = 0; i < size; ++ i)
+    callsNumber_ += size;
+
+    ScopedPyObjectPointer result;
+
+    if (pyObj_discard_openturns_memoryview_)
     {
-      CacheKeyType inKey(inS[i].getCollection());
-      if (p_cache_->hasKey(inKey))
+      // Force a memory copy of inS into a Python list
+      ScopedPyObjectPointer inTuple(PyTuple_New(size));
+      for (UnsignedInteger i = 0; i < size; ++ i)
       {
-        outS[i] = Point::ImplementationType(p_cache_->find(inKey));
+        PyObject * eltTuple = PyTuple_New(inDim);
+        for (UnsignedInteger j = 0; j < inDim; ++ j) PyTuple_SetItem(eltTuple, j, convert< Scalar, _PyFloat_ > (inS(i, j)));
+        PyTuple_SetItem(inTuple.get(), i, eltTuple);
+      }
+      ScopedPyObjectPointer execSampleName(convert< String, _PyString_ >("_exec_sample"));
+      result = PyObject_CallMethodObjArgs(pyObj_, execSampleName.get(), inTuple.get(), NULL);
+    }
+    else
+    {
+      // Wrap inS into a memoryview.Buffer object:
+      //    openturns.memoryview.Buffer((int(inS.__baseaddress__()), False), (inS.getSize(), inS.getDimension()))
+      // First argument
+      ScopedPyObjectPointer ptrTuple(PyTuple_New(2));
+      PyTuple_SetItem(ptrTuple.get(), 0, PyLong_FromVoidPtr(static_cast<void *>(const_cast<Scalar*>(inS.__baseaddress__()))));
+      PyTuple_SetItem(ptrTuple.get(), 1, PyBool_FromLong(0));  // We do not own memory
+
+      // Second argument
+      ScopedPyObjectPointer shapeTuple(PyTuple_New(2));
+      PyTuple_SetItem(shapeTuple.get(), 0, convert< UnsignedInteger, _PyInt_ > (size));
+      PyTuple_SetItem(shapeTuple.get(), 1, convert< UnsignedInteger, _PyInt_ > (inDim));
+
+      // Call openturns.memoryview.Buffer() to create a read-only buffer
+      ScopedPyObjectPointer readOnlyBufferObj(PyObject_CallObject(pyBufferClass_, Py_BuildValue("OO", ptrTuple.get(), shapeTuple.get())));
+
+      // Pass this buffer to _exec_sample function if it has been defined by user, otherwise loop on Buffer on call _exec
+      // If both pyObj_has_exec_ and pyObj_has_exec_sample_ are false, this is not a PythonFunction but a Function(OpenTURNSPythonFunction).
+      if (pyObj_has_exec_sample_ || ! pyObj_has_exec_)
+      {
+        ScopedPyObjectPointer execSampleName(convert< String, _PyString_ >("_exec_sample"));
+        result = PyObject_CallMethodObjArgs(pyObj_, execSampleName.get(), readOnlyBufferObj.get(), NULL);
       }
       else
       {
-        uniqueValues.insert(inS[i]);
+        // Only _exec is defined, not _exec_sample
+        ScopedPyObjectPointer execName(convert< String, _PyString_ >("_exec"));
+        result = PyTuple_New(size);
+        if (execName.get() && result.get())
+        {
+          for(UnsignedInteger i = 0; i < size; ++i)
+          {
+            ScopedPyObjectPointer itemObj(Py_TYPE(readOnlyBufferObj.get())->tp_as_sequence->sq_item(readOnlyBufferObj.get(), i));
+            PyTuple_SetItem(result.get(), i, PyObject_CallMethodObjArgs(pyObj_, execName.get(), itemObj.get(), NULL));
+          }
+        }
       }
     }
-    for(std::set<Point>::const_iterator it = uniqueValues.begin(); it != uniqueValues.end(); ++ it)
-    {
-      // store unique values
-      toDo.add(*it);
-    }
-  }
-  else
-  {
-    // compute all values, including duplicates
-    toDo = inS;
-  }
-
-  UnsignedInteger toDoSize = toDo.getSize();
-  CacheType tempCache(toDoSize);
-  if (useCache) tempCache.enable();
-
-  if (toDoSize > 0)
-  {
-    callsNumber_ += toDoSize;
-
-    ScopedPyObjectPointer inTuple(PyTuple_New(toDoSize));
-
-    for (UnsignedInteger i = 0; i < toDoSize; ++ i)
-    {
-      PyObject * eltTuple = PyTuple_New(inDim);
-      for (UnsignedInteger j = 0; j < inDim; ++ j) PyTuple_SetItem(eltTuple, j, convert< Scalar, _PyFloat_ > (toDo(i, j)));
-      PyTuple_SetItem(inTuple.get(), i, eltTuple);
-    }
-    ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj_, inTuple.get(), NULL));
 
     if (result.isNull())
     {
       handleException();
     }
 
-    if (PySequence_Check(result.get()))
+    try
     {
-      const UnsignedInteger lengthResult = PySequence_Size(result.get());
-      if (lengthResult == toDoSize)
-      {
-        for (UnsignedInteger i = 0; i < toDoSize; ++ i)
-        {
-          ScopedPyObjectPointer elt(PySequence_GetItem(result.get(), i));
-          if (PySequence_Check(elt.get()))
-          {
-            const UnsignedInteger lengthElt = PySequence_Size(elt.get());
-            if (lengthElt == outDim)
-            {
-              if (useCache)
-              {
-                Point outP(outDim);
-                for (UnsignedInteger j = 0; j < outDim; ++ j)
-                {
-                  ScopedPyObjectPointer val(PySequence_GetItem(elt.get(), j));
-                  outP[j] = convert< _PyFloat_, Scalar >(val.get());
-                }
-                tempCache.add(toDo[i].getCollection(), outP.getCollection());
-              }
-              else
-              {
-                for (UnsignedInteger j = 0; j < outDim; ++j)
-                {
-                  ScopedPyObjectPointer val(PySequence_GetItem(elt.get(), j));
-                  outS(i, j) = convert< _PyFloat_, Scalar >(val.get());
-                }
-              }
-            }
-            else
-            {
-              throw InvalidArgumentException(HERE) << "Python Function returned an sequence object with incorrect dimension (at position "
-                                                   << i << ")";
-            }
-          }
-          else
-          {
-            throw InvalidArgumentException(HERE) << "Python Function returned an object which is NOT a sequence (at position "
-                                                 << i << ")";
-          }
-        }
-      }
-      else
-      {
-        throw InvalidArgumentException(HERE) << "Python Function returned an sequence object with incorrect size (got "
-                                             << lengthResult << ", expected " << toDoSize << ")";
-      }
+      outS = convert< _PySequence_, Sample >(result.get());
     }
-  }
-
-  if (useCache)
-  {
-    // fill all the output values
-    for(UnsignedInteger i = 0; i < size; ++ i)
+    catch (InvalidArgumentException &)
     {
-      CacheKeyType inKey(inS[i].getCollection());
-      if (tempCache.hasKey(inKey))
-      {
-        outS[i] = Point::ImplementationType(tempCache.find(inKey));
-      }
+      throw InvalidArgumentException(HERE) << "Output value for " << getName() << "._exec_sample() method is not a 2d-sequence object";
     }
-    p_cache_->merge(tempCache);
+    if (outS.getSize() != size)
+      throw InvalidArgumentException(HERE) << "Python Function returned a sequence object with incorrect size (got "
+                                           << outS.getSize() << ", expected " << size << ")";
+    if (outS.getDimension() != outDim)
+      throw InvalidArgumentException(HERE) << "Python Function returned a sequence object with incorrect dimension (got "
+                                           << outS.getDimension() << ", expected " << outDim << ")";
   }
   outS.setDescription(getOutputDescription());
   return outS;
+}
+
+/* Accessor for input point dimension */
+void PythonEvaluation::initializePythonState()
+{
+  // Check whether PythonFunction object define these members
+  pyObj_has_exec_ = PyObject_HasAttrString( pyObj_, "__has_exec" );
+  pyObj_has_exec_sample_ = PyObject_HasAttrString( pyObj_, "__has_exec_sample" );
+  pyObj_discard_openturns_memoryview_ = PyObject_HasAttrString( pyObj_, "__discard_openturns_memoryview" );
+
+  // We do not copy, get a reference to openturns.memoryview.Buffer class
+  if (! pyObj_discard_openturns_memoryview_)
+  {
+    ScopedPyObjectPointer memoryWrapperModule(PyImport_ImportModule("openturns.memoryview"));
+    if (memoryWrapperModule.isNull())
+    {
+      handleException();
+    }
+    pyBufferClass_ = PyObject_GetAttrString(memoryWrapperModule.get(), const_cast<char *>("Buffer"));
+    if (pyBufferClass_ == NULL)
+    {
+      handleException();
+    }
+    Py_INCREF(pyBufferClass_);
+  }
 }
 
 
@@ -380,6 +423,7 @@ void PythonEvaluation::load(Advocate & adv)
   EvaluationImplementation::load(adv);
 
   pickleLoad(adv, pyObj_);
+  initializePythonState();
 }
 
 

--- a/python/src/PythonReadOnlyBuffer.c
+++ b/python/src/PythonReadOnlyBuffer.c
@@ -1,0 +1,613 @@
+/*                                               -*- C -*-  */
+/**
+ * @brief Python module to wrap Point and Sample without copy
+ *
+ *  Copyright 2005-2018 Airbus-EDF-IMACS-Phimeca
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <Python.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define OT_BUFFER_MAX_DIMS 10
+
+typedef struct
+{
+  double *data;
+  Py_ssize_t itemsize;
+  Py_ssize_t length;
+  Py_ssize_t shape[OT_BUFFER_MAX_DIMS];
+  Py_ssize_t strides[OT_BUFFER_MAX_DIMS];
+  int ndim;
+  char own;
+} BufferView;
+
+typedef struct
+{
+  PyObject_HEAD
+  BufferView bufferview;
+} Buffer;
+
+
+static int
+Buffer_init(Buffer *self, PyObject *args, PyObject *kwds)
+{
+  PyObject * addrObj = NULL;
+  PyObject * shapeObj = NULL;
+  PyObject * ownObj = NULL;
+  Py_ssize_t shapeLength;
+  Py_ssize_t bufferLength;
+  int i;
+  char own;
+  double * data = NULL;
+
+  /* Constructor is never called directly by user, only from PythonEvaluation or when unpickling */
+  (void) kwds;
+
+  memset(&self->bufferview, 0, sizeof(BufferView));
+  if (PyArg_ParseTuple(args, (char*) "n:Buffer", &bufferLength))
+  {
+    /* Unpickling: allocate an empty data memory block, it will be filled up by Buffer_setstate */
+    self->bufferview.itemsize = sizeof(double);
+    self->bufferview.length = bufferLength / self->bufferview.itemsize;
+    self->bufferview.data = (double*) calloc(self->bufferview.length, self->bufferview.itemsize);
+    self->bufferview.own = '\1';
+    return 0;
+  }
+  PyErr_Clear();
+
+  if (! PyArg_ParseTuple(args, (char*) "(OO!)O!:Buffer", &addrObj, &PyBool_Type, &ownObj, &PyTuple_Type, &shapeObj))
+  {
+    return -1;
+  }
+
+  data = (double*) PyLong_AsVoidPtr(addrObj);
+
+  own = PyObject_IsTrue(ownObj);
+
+  shapeLength = PyTuple_Size(shapeObj);
+  if (shapeLength < 0 || shapeLength >= OT_BUFFER_MAX_DIMS)
+  {
+    return -1;
+  }
+
+  self->bufferview.own = own;
+  self->bufferview.itemsize = sizeof(double);
+  self->bufferview.ndim = shapeLength;
+  if (shapeLength == 0)
+  {
+    /* Is this really useful?  Maybe we should return -1 */
+    self->bufferview.data = data;
+    self->bufferview.shape[0] = 0;
+    self->bufferview.strides[0] = self->bufferview.itemsize;
+    self->bufferview.length = 0;
+    return 0;
+  }
+
+  for(i = 0; i < shapeLength; ++i)
+  {
+    self->bufferview.shape[i] = PyLong_AsLong(PyTuple_GET_ITEM(shapeObj, i));
+  }
+
+  self->bufferview.strides[shapeLength - 1] = self->bufferview.itemsize;
+  for(i = shapeLength - 2; i >= 0; --i)
+    self->bufferview.strides[i] = self->bufferview.strides[i + 1] * self->bufferview.shape[i + 1];
+
+  self->bufferview.length = self->bufferview.shape[0] * self->bufferview.strides[0] / self->bufferview.itemsize;
+  if (self->bufferview.own == '\0')
+  {
+    self->bufferview.data = data;
+  }
+  else
+  {
+    self->bufferview.data = (double*) calloc(self->bufferview.length, self->bufferview.itemsize);
+    memcpy(self->bufferview.data, data, self->bufferview.length * self->bufferview.itemsize);
+  }
+
+  return 0;
+}
+
+static void
+Buffer_dealloc(Buffer* self)
+{
+  if (self->bufferview.own)
+    free(self->bufferview.data);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static char*
+dim_repr(Py_ssize_t* dims, int size)
+{
+  /* log10(2**63) = 18, and one for comma */
+  char* s = malloc(size*19);
+  char *ptr = s;
+  int i;
+
+  ptr += sprintf(s, "%ld", dims[0]);
+  for(i = 1; i < size; ++i)
+    ptr += sprintf(ptr, ",%ld", dims[i]);
+  return s;
+}
+
+static PyObject *
+Buffer_repr(Buffer * self)
+{
+  char * r = dim_repr(self->bufferview.shape, self->bufferview.ndim);
+  char * s = malloc(100 + strlen(r));
+  PyObject * result = NULL;
+
+  sprintf(s, "<read-only buffer at 0x%x shape=(%s)>", self->bufferview.data, r);
+  free(r);
+
+#if PY_VERSION_HEX >= 0x03010000
+  result = PyUnicode_DecodeUTF8(s, (Py_ssize_t) strlen(s), "surrogateescape");
+#elif PY_VERSION_HEX >= 0x03000000
+  result = PyUnicode_FromStringAndSize(s, (Py_ssize_t) strlen(s));
+#else
+  result = PyString_FromStringAndSize(s, (Py_ssize_t) strlen(s));
+#endif
+  free(s);
+  return result;
+}
+
+static PyObject *
+Buffer_iter(PyObject *obj)
+{
+  Buffer* self = (Buffer*)obj;
+
+  if (self->bufferview.ndim == 0)
+  {
+    PyErr_SetString(PyExc_TypeError, "cannot iterate over a 0-d array");
+    return NULL;
+  }
+  return PySeqIter_New(obj);
+}
+
+static int
+Buffer_getbuffer(PyObject *obj, Py_buffer *view, int flags)
+{
+  Buffer* self = (Buffer*)obj;
+  if (view == NULL) {
+    PyErr_SetString(PyExc_ValueError, "NULL view in getbuffer");
+    return -1;
+  }
+
+  view->obj = (PyObject*)self;
+  view->buf = (void*)self->bufferview.data;
+  view->len = self->bufferview.length * self->bufferview.itemsize;
+  view->readonly = 1;
+  view->itemsize = self->bufferview.itemsize;
+  view->format = "d";
+  view->ndim = self->bufferview.ndim;
+  view->shape = self->bufferview.shape;
+  view->strides = self->bufferview.strides;
+  view->suboffsets = NULL;
+  view->internal = NULL;
+
+  Py_INCREF(self);
+  return 0;
+}
+
+static Py_ssize_t
+Buffer_getreadbuffer(PyObject *obj, Py_ssize_t segment, void **ptrptr)
+{
+  Buffer* self = (Buffer*)obj;
+  if (segment != 0)
+  {
+    PyErr_SetString(PyExc_ValueError, "invalid segment");
+    return -1;
+  }
+  *ptrptr = self->bufferview.data;
+  return self->bufferview.length * self->bufferview.itemsize;
+}
+
+static Py_ssize_t
+Buffer_getsegcount(PyObject *obj, Py_ssize_t *lenp)
+{
+  Buffer* self = (Buffer*)obj;
+  if (lenp)
+  {
+    *lenp = self->bufferview.length * self->bufferview.itemsize;
+  }
+  return 1;
+}
+
+static Py_ssize_t
+Buffer_getcharbuffer(PyObject *obj, Py_ssize_t segment, char **ptrptr)
+{
+  Buffer* self = (Buffer*)obj;
+  if (segment != 0)
+  {
+    PyErr_SetString(PyExc_ValueError, "invalid segment");
+    return -1;
+  }
+  *ptrptr = (void*) self->bufferview.data;
+  return self->bufferview.length * self->bufferview.itemsize;
+}
+
+
+static PyBufferProcs Buffer_as_buffer = {
+#if PY_VERSION_HEX < 0x03000000
+  (readbufferproc)    Buffer_getreadbuffer,
+  (writebufferproc)   0,
+  (segcountproc)      Buffer_getsegcount,
+  (charbufferproc)    Buffer_getcharbuffer,
+#endif
+  (getbufferproc)     Buffer_getbuffer,
+  (releasebufferproc) 0
+};
+
+/* Forward declaration.
+   This method is defined after Buffer_item because it does the opposite job. */
+static PyObject * Buffer_augment(PyObject *obj);
+
+
+/* This routine is used for pickling; it must return a tuple with 2 to 5 arguments:
+   + obj: a callable object, which knows how to reconstruct the object.  We use
+     the Buffer class itself, Buffer_init can create empty objects.
+   + args: arguments passed to obj (we pass array length to check consistency in setstate)
+   + state (optional): arguments passed to Buffer_setstate
+   + 2 other arguments, not used here
+ */
+static PyObject *
+Buffer_reduce(PyObject *obj, PyObject *args)
+{
+  Buffer* self = (Buffer*)obj;
+  int i;
+  PyObject * shapeTuple = NULL;
+  PyObject * strideTuple = NULL;
+  PyObject * rawObj = NULL;
+  (void) args;
+
+  shapeTuple = PyTuple_New(self->bufferview.ndim);
+  if (shapeTuple == NULL)
+  {
+    return NULL;
+  }
+  for(i = 0; i < self->bufferview.ndim; ++i)
+    PyTuple_SET_ITEM(shapeTuple, i, PyLong_FromSsize_t(self->bufferview.shape[i]));
+
+  strideTuple = PyTuple_New(self->bufferview.ndim);
+  if (strideTuple == NULL)
+  {
+    Py_DECREF(shapeTuple);
+    return NULL;
+  }
+  for(i = 0; i < self->bufferview.ndim; ++i)
+    PyTuple_SET_ITEM(strideTuple, i, PyLong_FromSsize_t(self->bufferview.strides[i]));
+
+#if PY_VERSION_HEX >= 0x03000000
+  rawObj = PyBytes_FromStringAndSize((const char*)self->bufferview.data, self->bufferview.itemsize * self->bufferview.length);
+#else
+  rawObj = PyString_FromStringAndSize((const char*)self->bufferview.data, self->bufferview.itemsize * self->bufferview.length);
+#endif
+
+  return Py_BuildValue("O(n)(NNN)",
+             /* We use Buffer type to build its own instance */
+             (PyObject*) Py_TYPE(self),
+             /* Arguments passed to object above, converted into a tuple */
+             self->bufferview.length * self->bufferview.itemsize,
+             /* Tuple arguments passed to Buffer_setstate */
+             shapeTuple, strideTuple, rawObj);
+}
+
+static PyObject *
+Buffer_setstate(PyObject *obj, PyObject *args)
+{
+  Buffer* self = (Buffer*)obj;
+  PyObject * shapeObj = NULL;
+  PyObject * strideObj = NULL;
+  PyObject * rawObj = NULL;
+  char * rawData;
+  long length = 0;
+  Py_ssize_t shapeLength;
+  Py_ssize_t strideLength;
+  int i;
+
+  if (!self->bufferview.own)
+  {
+    PyErr_SetString(PyExc_TypeError, "cannot populate a Buffer we do not own");
+    return NULL;
+  }
+  if (! PyArg_ParseTuple(args, (char*) "(O!O!s#):__setstate__", &PyTuple_Type, &shapeObj, &PyTuple_Type, &strideObj, &rawData, &length))
+    return NULL;
+
+  if (length != self->bufferview.length * self->bufferview.itemsize)
+  {
+    PyErr_SetString(PyExc_TypeError, "invalid dimensions");
+    return NULL;
+  }
+  shapeLength = PyTuple_Size(shapeObj);
+  strideLength = PyTuple_Size(strideObj);
+  if (shapeLength < 0 || shapeLength >= OT_BUFFER_MAX_DIMS || strideLength < 0 || strideLength >= OT_BUFFER_MAX_DIMS || shapeLength != strideLength)
+  {
+    return NULL;
+  }
+  self->bufferview.ndim = shapeLength;
+  for(i = 0; i < shapeLength; ++i)
+  {
+    self->bufferview.shape[i] = PyLong_AsLong(PyTuple_GET_ITEM(shapeObj, i));
+    self->bufferview.strides[i] = PyLong_AsLong(PyTuple_GET_ITEM(strideObj, i));
+  }
+  memcpy(self->bufferview.data, rawData, length);
+  Py_RETURN_NONE;
+}
+
+static struct PyMethodDef Buffer_methods[] = {
+    {"augment", (PyCFunction)Buffer_augment, METH_NOARGS, NULL},
+    /* These ones are required to pickle/unpickle */
+    {"__reduce__", (PyCFunction)Buffer_reduce, METH_VARARGS, NULL},
+    {"__setstate__", (PyCFunction)Buffer_setstate, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL}
+};
+
+/* Forward declaration */
+static PySequenceMethods Buffer_as_sequence;
+
+static const char Buffer_doc[] =                                          \
+"openturns.memoryview.Buffer class.\n\n"                                  \
+"This class allows wrapping OpenTURNS containers (Point, Sample, etc.)\n" \
+"into Python objects without copy.  A Buffer object can be indexed,\n"    \
+"or converted into a Sample or a numpy array.";
+
+static PyTypeObject BufferType = {
+#if PY_VERSION_HEX >= 0x03000000
+    PyVarObject_HEAD_INIT(NULL, 0)
+#else
+    PyObject_HEAD_INIT(NULL)
+    0,                            /* ob_size */
+#endif
+    "openturns.memoryview.Buffer",/* tp_name */
+    sizeof(Buffer),               /* tp_basicsize */
+    0,                            /* tp_itemsize */
+    (destructor)Buffer_dealloc,   /* tp_dealloc */
+    0,                            /* tp_print */
+    0,                            /* tp_getattr */
+    0,                            /* tp_setattr */
+    0,                            /* tp_reserved */
+    (reprfunc) Buffer_repr,       /* tp_repr */
+    0,                            /* tp_as_number */
+    &Buffer_as_sequence,          /* tp_as_sequence */
+    0,                            /* tp_as_mapping */
+    0,                            /* tp_hash  */
+    0,                            /* tp_call */
+    (reprfunc) Buffer_repr,       /* tp_str */
+    0,                            /* tp_getattro */
+    0,                            /* tp_setattro */
+    &Buffer_as_buffer,            /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,           /* tp_flags */
+    Buffer_doc,                   /* tp_doc */
+    0,                            /* tp_traverse */
+    0,                            /* tp_clear */
+    0,                            /* tp_richcompare */
+    0,                            /* tp_weaklistoffset */
+    (getiterfunc) Buffer_iter,    /* tp_iter */
+    0,                            /* tp_iternext */
+    Buffer_methods,               /* tp_methods */
+    0,                            /* tp_members */
+    0,                            /* tp_getset */
+    0,                            /* tp_base */
+    0,                            /* tp_dict */
+    0,                            /* tp_descr_get */
+    0,                            /* tp_descr_set */
+    0,                            /* tp_dictoffset */
+    (initproc)Buffer_init         /* tp_init */
+};
+
+Py_ssize_t
+Buffer_length(PyObject *obj)
+{
+  Buffer* self = (Buffer*)obj;
+  if (self->bufferview.ndim == 0)
+    return 0;
+  return self->bufferview.shape[0];
+}
+
+static PyObject *
+Buffer_item(PyObject *obj, Py_ssize_t index)
+{
+  int i;
+  PyObject * newView;
+  Buffer * newSelf;
+
+  Buffer* self = (Buffer*)obj;
+  if (self->bufferview.ndim == 0 || index < 0 || index >= self->bufferview.shape[0])
+  {
+    PyErr_SetString(PyExc_IndexError, "Buffer index out of range");
+    return NULL;
+  }
+  else if (self->bufferview.ndim == 1)
+  {
+    double value = self->bufferview.data[index];
+    return PyFloat_FromDouble(value);
+  }
+
+  /* Create another view of the same object with these changes:
+       + data points to &data[index]
+       + length is updated
+       + ndim is decremented
+       + shape is shifted: shape[i] = shape[i+1]
+       + strides is shifted: strides[i] = strides[i+1]   */
+  newView = PyType_GenericAlloc(&BufferType, 1);
+  newSelf = (Buffer*)newView;
+  memcpy(&newSelf->bufferview, &self->bufferview, sizeof(BufferView));
+  newSelf->bufferview.data += index * newSelf->bufferview.strides[0] / newSelf->bufferview.itemsize;
+  newSelf->bufferview.length /= self->bufferview.shape[0];
+  --newSelf->bufferview.ndim;
+  for(i = 0; i < newSelf->bufferview.ndim; ++i)
+  {
+    newSelf->bufferview.shape[i] = self->bufferview.shape[i + 1];
+    newSelf->bufferview.strides[i] = self->bufferview.strides[i + 1];
+  }
+  return newView;
+}
+
+static PyObject *
+Buffer_augment(PyObject *obj)
+{
+  int j;
+  Buffer* self = (Buffer*)obj;
+  PyObject * newView;
+  Buffer * newSelf;
+
+  if (self->bufferview.ndim == 0)
+  {
+    PyErr_SetString(PyExc_IndexError, "Cannot augment an empty Buffer");
+    return NULL;
+  }
+  if (self->bufferview.ndim >= OT_BUFFER_MAX_DIMS)
+  {
+    PyErr_SetString(PyExc_IndexError, "Buffer maximum dimension reached");
+    return NULL;
+  }
+
+  /* Create another view of the same object with some changes:
+       + data points to data[index]
+       + length is recomputed
+       + ndim is incremented
+       + shape is shifted: shape[i+1] = shape[i]
+       + strides is shifted: strides[i+1] = strides[i]   */
+  newView = PyType_GenericAlloc(&BufferType, 1);
+  newSelf = (Buffer*)newView;
+  memcpy(&newSelf->bufferview, &self->bufferview, sizeof(BufferView));
+
+  for(j = newSelf->bufferview.ndim; j > 0; --j)
+  {
+    newSelf->bufferview.shape[j] = self->bufferview.shape[j - 1];
+    newSelf->bufferview.strides[j] = self->bufferview.strides[j - 1];
+  }
+  newSelf->bufferview.shape[0] = 1;
+  newSelf->bufferview.strides[0] = newSelf->bufferview.strides[1];
+  ++newSelf->bufferview.ndim;
+  return newView;
+}
+
+static PySequenceMethods Buffer_as_sequence = {
+    (lenfunc)Buffer_length,                 /*sq_length*/
+    (binaryfunc)NULL,                       /*sq_concat*/
+    (ssizeargfunc)NULL,                     /*sq_repeat*/
+    (ssizeargfunc)Buffer_item,              /*sq_item*/
+    (ssizessizeargfunc)NULL,                /*sq_slice*/
+    (ssizeobjargproc)NULL,                  /*sq_ass_item*/
+    (ssizessizeobjargproc)NULL,             /*sq_ass_slice*/
+    (objobjproc)NULL,                       /*sq_contains*/
+    (binaryfunc) NULL,                      /*sq_inplace_concat*/
+    (ssizeargfunc)NULL,                     /*sq_inplace_repeat*/
+};
+
+
+#define openturns_memoryview_module_name "openturns.memoryview"
+
+/*
+  Module creation, adapted from https://docs.python.org/3/howto/cporting.html
+
+  Minor changes may be required in PyModuleDef definition to support Python 3.0 and 3.1.
+*/
+struct module_state {
+    PyObject *error;
+};
+
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+static PyObject *
+error_out(PyObject *m) {
+    struct module_state *st = GETSTATE(m);
+    PyErr_SetString(st->error, "something bad happened");
+    return NULL;
+}
+
+static PyMethodDef memoryview_methods[] = {
+    {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
+    {NULL, NULL}
+};
+
+#if PY_MAJOR_VERSION >= 3
+
+static int memoryview_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int memoryview_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef openturns_memoryview_module = {
+  PyModuleDef_HEAD_INIT,
+  openturns_memoryview_module_name,
+  Buffer_doc,
+  sizeof(struct module_state),
+  memoryview_methods,
+  NULL,
+  memoryview_traverse,
+  memoryview_clear,
+  NULL
+};
+
+#define INITERROR return NULL
+
+PyMODINIT_FUNC
+PyInit_memoryview(void)
+
+#else
+
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+
+#define INITERROR return
+
+void
+initmemoryview(void)
+#endif
+{
+  PyObject *module;
+  struct module_state *st;
+
+  BufferType.tp_new = PyType_GenericNew;
+  if (PyType_Ready(&BufferType) < 0)
+      INITERROR;
+
+#if PY_MAJOR_VERSION >= 3
+  module = PyModule_Create(&openturns_memoryview_module);
+#else
+  module = Py_InitModule(openturns_memoryview_module_name, NULL);
+#endif
+
+  if (module == NULL)
+      INITERROR;
+
+  st = GETSTATE(module);
+  st->error = PyErr_NewException(openturns_memoryview_module_name ".Error", NULL, NULL);
+  if (st->error == NULL) {
+      Py_DECREF(module);
+      INITERROR;
+  }
+
+  Py_INCREF(&BufferType);
+  PyModule_AddObject(module, "Buffer", (PyObject *)&BufferType);
+
+#if PY_MAJOR_VERSION >= 3
+  return module;
+#endif
+}

--- a/python/src/Sample.i
+++ b/python/src/Sample.i
@@ -451,7 +451,7 @@ Sample(PyObject * pyObj, UnsignedInteger dimension)
   for ( OT::UnsignedInteger i = 0; i < size; ++ i ) {
     for ( OT::UnsignedInteger j = 0; j < dimension; ++ j ) {
       if ( k < pointSize ) {
-        sample[i][j] = point[k];
+        sample(i, j) = point[k];
         ++ k;
       }
     }

--- a/python/src/openturns/PythonEvaluation.hxx
+++ b/python/src/openturns/PythonEvaluation.hxx
@@ -92,8 +92,19 @@ private:
   /** Default constructor */
   PythonEvaluation();
 
+  /** Set pyBufferClass_ and pyObj_*_ members */
+  void initializePythonState();
+
   /** The underlying Python callable object */
   PyObject * pyObj_;
+
+  /** Tell whether Python callable object define these members */
+  Bool pyObj_has_exec_;
+  Bool pyObj_has_exec_sample_;
+  Bool pyObj_discard_openturns_memoryview_;
+
+  /** Python openturns.memoryview.Buffer class */
+  PyObject * pyBufferClass_;
 
 }; /* class PythonEvaluation */
 

--- a/python/test/t_Function_python.expout
+++ b/python/test/t_Function_python.expout
@@ -9,17 +9,6 @@ class=Point name=Unnamed dimension=1 values=[21]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=2 data=[[0,0],[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7],[8,8],[9,9]]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[8],[10],[12],[14],[16],[18]]
 class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=3 dimension=1 description=[T] data=[[200],[202],[204]]
-calls = 15 hits = 0
-T = class=Point name=Unnamed dimension=1 values=[4]
-calls = 16 hits = 0
-T = class=Point name=Unnamed dimension=1 values=[4]
-calls = 16 hits = 1
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 24 hits = 2
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 24 hits = 12
-T = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[T] data=[[0],[2],[4],[6],[10],[10],[12],[14],[16],[18]]
-calls = 33 hits = 0
 exec
     [ y0  ]
 0 : [ 200 ]

--- a/python/test/t_Function_python.py
+++ b/python/test/t_Function_python.py
@@ -57,37 +57,6 @@ print((repr(outSample)))
 outSample = myFunc(((100., 100.), (101., 101.), (102., 102.)))
 print((repr(outSample)))
 
-# Test cache behavior
-myFunc.enableCache()
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outPt = myFunc(inPt)
-print(('T = ' + repr(outPt)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outPt = myFunc(inPt)
-print(('T = ' + repr(outPt)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
-# duplicate one value
-inSample[4] = inSample[5]
-
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
-myFunc.clearCache()
-outSample = myFunc(inSample)
-print(('T = ' + repr(outSample)))
-print(('calls = ' + str(myFunc.getEvaluationCallsNumber())
-       + ' hits = ' + str(myFunc.getCacheHits())))
-
 # test PythonFunction
 
 


### PR DESCRIPTION
This is a revised version of #695, and is a work in progress.  This PR is there to gather comments.

Here is what happens when a PythonFunction is evaluated
on a Sample:

 1. If argument X is a 2d Python sequence, it is converted by SWIG
    into a Python Sample X1.  Otherwise X is a Python Sample
 2. `PythonEvaluation::operator()(const Sample &inS)` is called on the 
    Sample wrapped by X (or X1).
 3. This method converts inS into a Python sequence P1. 
 4. `OpenTURNSPythonFunction.__call__(P1)` is called
 5. It tries to convert P1 into a Point (with a copy), this
    fails and it converts P1 into a Python Sample S1 (with another
    copy).
 6. `OpenTURNSPythonFunction._exec_sample(S1)` is called and evaluated.

This commit uses the new openturns.MemoryView.Buffer class to wrap OT objects
into Python more efficiently.  In step 2, a Buffer is created, and passed to _exec_sample
method directly.

The downside is that _exec_sample Python function now receives a Buffer object,
and no more a Sample.  For efficiency reasons, I propose to also remove
_exec_point_on_exec_sample and implement it in C via this Buffer.

An optional 'copy' argument is added to PythonFunction, to revert to old 
code if something goes wrong.  Normally this should not happen, but who 
knows?  It also allows to compute the cost of step 3.

Cache is removed, it prevents this optimization.
