### PR TITLE
Improve KarhunenLoeveResult::project(ProcessSample)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -61,6 +61,7 @@
  * Changed RandomVector::getAntecedent,getMarginal to return a RandomVector instead of Pointer<RandomVectorImplementation>
  * Changed all {get,set}{Evaluation,Gradient,Hessian} methods to work on Evaluation/Gradient/Hessian instead of Pointer
  * Removed Field::[gs]etValueAtNearestPosition
+ * Removed KarhunenLoeveResult::project(Basis), use project(Function) on an AggregatedFunction instead
 
 === Python module ===
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -61,7 +61,6 @@
  * Changed RandomVector::getAntecedent,getMarginal to return a RandomVector instead of Pointer<RandomVectorImplementation>
  * Changed all {get,set}{Evaluation,Gradient,Hessian} methods to work on Evaluation/Gradient/Hessian instead of Pointer
  * Removed Field::[gs]etValueAtNearestPosition
- * Removed KarhunenLoeveResult::project(Basis), use project(Function) on an AggregatedFunction instead
 
 === Python module ===
 

--- a/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
@@ -137,7 +137,7 @@ void KarhunenLoeveP1Algorithm::run()
   while ((K < eigenValues.getSize()) && (eigenValues[K] >= threshold_ * cumulatedVariance)) ++K;
   LOGINFO(OSS() << "Selected " << K << " eigenvalues");
   // Reduce and rescale the eigenvectors
-  MatrixImplementation transposedProjection(augmentedDimension, K);
+  MatrixImplementation projection(K, augmentedDimension);
   Point selectedEV(K);
   Basis modes(0);
   ProcessSample modesAsProcessSample(mesh_, 0, dimension);
@@ -149,7 +149,6 @@ void KarhunenLoeveP1Algorithm::run()
     evaluation1D = new PiecewiseLinearEvaluation(mesh_.getVertices().getImplementation()->getData(), values);
   else
     evaluationXD = new P1LagrangeEvaluation(Field(mesh_, dimension));
-  UnsignedInteger indexProjection = 0;
   Point a(augmentedDimension);
   for (UnsignedInteger k = 0; k < K; ++k)
   {
@@ -174,12 +173,12 @@ void KarhunenLoeveP1Algorithm::run()
       modes.add(*evaluationXD);
     }
 
-    // Build the relevant column of the transposed projection matrix
+    // Build the relevant row of the projection matrix
     const Point b(Ga * (factor / sqrt(selectedEV[k])));
-    std::copy(b.begin(), b.end(), transposedProjection.begin() + indexProjection);
-    indexProjection += augmentedDimension;
+    for(UnsignedInteger i = 0; i < augmentedDimension; ++i)
+      projection(k, i) = b[i];
   }
-  result_ = KarhunenLoeveResultImplementation(covariance_, threshold_, selectedEV, modes, modesAsProcessSample, transposedProjection.transpose());
+  result_ = KarhunenLoeveResultImplementation(covariance_, threshold_, selectedEV, modes, modesAsProcessSample, projection);
 }
 
 /* Mesh accessor */

--- a/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveP1Algorithm.cxx
@@ -150,15 +150,15 @@ void KarhunenLoeveP1Algorithm::run()
   else
     evaluationXD = new P1LagrangeEvaluation(Field(mesh_, dimension));
   UnsignedInteger indexProjection = 0;
-  MatrixImplementation a(augmentedDimension, 1);
+  Point a(augmentedDimension);
   for (UnsignedInteger k = 0; k < K; ++k)
   {
     selectedEV[k] = eigenValues[k];
     const UnsignedInteger initialColumn = eigenPairs[k].second;
     for (UnsignedInteger i = 0; i < augmentedDimension; ++i)
-      a(i, 0) = eigenVectorsComplex(i, initialColumn).real();
-    const MatrixImplementation Ga(G.getImplementation()->genProd(a));
-    const Scalar norm = std::sqrt(a.genProd(Ga, true, false)[0]);
+      a[i] = eigenVectorsComplex(i, initialColumn).real();
+    const Point Ga(G * a);
+    const Scalar norm = std::sqrt(dot(a, Ga));
     const Scalar factor = a[0] < 0.0 ? -1.0 / norm : 1.0 / norm;
     // Store the eigen modes in two forms
     values.setData(a * factor);
@@ -175,7 +175,7 @@ void KarhunenLoeveP1Algorithm::run()
     }
 
     // Build the relevant column of the transposed projection matrix
-    const MatrixImplementation b(Ga * (factor / sqrt(selectedEV[k])));
+    const Point b(Ga * (factor / sqrt(selectedEV[k])));
     std::copy(b.begin(), b.end(), transposedProjection.begin() + indexProjection);
     indexProjection += augmentedDimension;
   }

--- a/lib/src/Base/Algo/KarhunenLoeveResult.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResult.cxx
@@ -106,9 +106,9 @@ Point KarhunenLoeveResult::project(const Field & field) const
   return getImplementation()->project(field);
 }
 
-Sample KarhunenLoeveResult::project(const Basis & basis) const
+Sample KarhunenLoeveResult::project(const FunctionCollection & functionCollection) const
 {
-  return getImplementation()->project(basis);
+  return getImplementation()->project(functionCollection);
 }
 
 Sample KarhunenLoeveResult::project(const ProcessSample & sample) const

--- a/lib/src/Base/Algo/KarhunenLoeveResult.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResult.cxx
@@ -106,6 +106,11 @@ Point KarhunenLoeveResult::project(const Field & field) const
   return getImplementation()->project(field);
 }
 
+Sample KarhunenLoeveResult::project(const Basis & basis) const
+{
+  return getImplementation()->project(basis);
+}
+
 Sample KarhunenLoeveResult::project(const ProcessSample & sample) const
 {
   return getImplementation()->project(sample);

--- a/lib/src/Base/Algo/KarhunenLoeveResult.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResult.cxx
@@ -106,11 +106,6 @@ Point KarhunenLoeveResult::project(const Field & field) const
   return getImplementation()->project(field);
 }
 
-Sample KarhunenLoeveResult::project(const Basis & basis) const
-{
-  return getImplementation()->project(basis);
-}
-
 Sample KarhunenLoeveResult::project(const ProcessSample & sample) const
 {
   return getImplementation()->project(sample);

--- a/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
@@ -131,13 +131,13 @@ Matrix KarhunenLoeveResultImplementation::getProjectionMatrix() const
 }
 
 /* Projection method */
-Sample KarhunenLoeveResultImplementation::project(const Basis & basis) const
+Sample KarhunenLoeveResultImplementation::project(const FunctionCollection & functionCollection) const
 {
-  const UnsignedInteger size = basis.getSize();
+  const UnsignedInteger size = functionCollection.getSize();
   const Sample vertices(modesAsProcessSample_.getMesh().getVertices());
   Sample functionValues(size, projection_.getNbColumns());
   for(UnsignedInteger i = 0; i < size; ++i)
-    functionValues[i] = (basis.build(i)(vertices)).getImplementation()->getData();
+    functionValues[i] = (functionCollection[i](vertices)).getImplementation()->getData();
   return projection_.getImplementation()->genSampleProd(functionValues, true, false, 'R');
 }
 

--- a/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
@@ -131,6 +131,16 @@ Matrix KarhunenLoeveResultImplementation::getProjectionMatrix() const
 }
 
 /* Projection method */
+Sample KarhunenLoeveResultImplementation::project(const Basis & basis) const
+{
+  const UnsignedInteger size = basis.getSize();
+  const Sample vertices(modesAsProcessSample_.getMesh().getVertices());
+  Sample functionValues(size, projection_.getNbColumns());
+  for(UnsignedInteger i = 0; i < size; ++i)
+    functionValues[i] = (basis.build(i)(vertices)).getImplementation()->getData();
+  return projection_.getImplementation()->genSampleProd(functionValues, true, false, 'R');
+}
+
 Point KarhunenLoeveResultImplementation::project(const Function & function) const
 {
   // Evaluate the function over the vertices of the mesh and cast it into a Point

--- a/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveResultImplementation.cxx
@@ -145,65 +145,38 @@ Point KarhunenLoeveResultImplementation::project(const Field & field) const
   return project(Function(P1LagrangeEvaluation(field).clone()));
 }
 
-struct ProjectBasisPolicy
-{
-  const Basis & basis_;
-  Sample & output_;
-  const KarhunenLoeveResultImplementation & result_;
-
-  ProjectBasisPolicy( const Basis & basis,
-                      Sample & output,
-                      const KarhunenLoeveResultImplementation & result)
-    : basis_(basis)
-    , output_(output)
-    , result_(result)
-  {}
-
-  inline void operator()( const TBB::BlockedRange<UnsignedInteger> & r ) const
-  {
-    for (UnsignedInteger i = r.begin(); i != r.end(); ++ i) output_[i] = result_.project(basis_.build(i));
-  }
-
-}; /* end struct ProjectBasisPolicy */
-
-Sample KarhunenLoeveResultImplementation::project(const Basis & basis) const
-{
-  const UnsignedInteger size = basis.getSize();
-  Sample result(size, projection_.getNbRows());
-  const ProjectBasisPolicy policy( basis, result, *this );
-  TBB::ParallelFor( 0, size, policy );
-  return result;
-}
-
-struct ProjectSamplePolicy
-{
-  const ProcessSample & sample_;
-  Sample & output_;
-  const KarhunenLoeveResultImplementation & result_;
-
-  ProjectSamplePolicy( const ProcessSample & sample,
-                       Sample & output,
-                       const KarhunenLoeveResultImplementation & result)
-    : sample_(sample)
-    , output_(output)
-    , result_(result)
-  {}
-
-  inline void operator()( const TBB::BlockedRange<UnsignedInteger> & r ) const
-  {
-    for (UnsignedInteger i = r.begin(); i != r.end(); ++ i)
-      output_[i] = result_.project(sample_.getField(i));
-  }
-
-}; /* end struct ProjectSamplePolicy */
-
 Sample KarhunenLoeveResultImplementation::project(const ProcessSample & sample) const
 {
   const UnsignedInteger size = sample.getSize();
-  Sample result(size, projection_.getNbRows());
-  const ProjectSamplePolicy policy( sample, result, *this );
-  TBB::ParallelFor( 0, size, policy );
-  return result;
+  if (!(size != 0)) return Sample();
+  const UnsignedInteger dimension = sample.getDimension();
+  const UnsignedInteger length = modesAsProcessSample_.getMesh().getVerticesNumber();
+  if (sample.getMesh() == modesAsProcessSample_.getMesh())
+  {
+    // result[i] = projection_ * sample.data_[i] if sample.data_ is viewed as a
+    //   Sample(size, length * dimension) and result[i] as a Point of dimension rows(projection_)
+    // This can be rewritten with matrix multiplication:
+    //   transposed(result) = transposed(sample.data_) * transposed(projection_)
+    // As result and sample.data_ are stored as Sample and not Matrix, we have
+    //   result = sample.data_ * transposed(projection_)
+    Sample values(size, length * dimension);
+    for(UnsignedInteger i = 0; i < size; ++i)
+      std::copy(&sample[i](0, 0), &sample[i](0, 0) + length * dimension, &values(i, 0));
+    return projection_.getImplementation()->genSampleProd(values, true, false, 'R');
+  }
+  else
+  {
+    // We build a P1LagrangeEvaluation as if ProcessSample was an aggregated Field.
+    P1LagrangeEvaluation evaluation(sample);
+    // values is Sample(length, size * dimension)
+    const Sample values(evaluation(modesAsProcessSample_.getMesh().getVertices()));
+    // Dispatch values so that it can be multiplied by projection_ like above
+    Sample dispatched(size, length * dimension);
+    for(UnsignedInteger i = 0; i < size; ++i)
+      for(UnsignedInteger j = 0; j < length; ++j)
+        std::copy(&values(j, i * dimension), &values(j, i * dimension) + dimension, &dispatched(i, j * dimension));
+    return projection_.getImplementation()->genSampleProd(dispatched, true, false, 'R');
+  }
 }
 
 /* Lift method */

--- a/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
@@ -178,7 +178,10 @@ void KarhunenLoeveSVDAlgorithm::run()
   MatrixImplementation U;
   MatrixImplementation Vt;
   // The singular values are given in decreasing order
-  const Point svd(designMatrix.computeSVD(U, Vt));
+  // Last two arguments are:
+  //   * fullSVD = false, we only want kTilde columns of U
+  //   * keepIntact = false, designMatrix is no more used afterwards
+  const Point svd(designMatrix.computeSVD(U, Vt,  false, false));
   LOGDEBUG(OSS(false) << "U=\n" << U << ", singular values=" << svd);
   Scalar cumulatedVariance = 0.0;
   Point eigenValues(svd.getDimension());

--- a/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
+++ b/lib/src/Base/Algo/KarhunenLoeveSVDAlgorithm.cxx
@@ -214,7 +214,7 @@ void KarhunenLoeveSVDAlgorithm::run()
     } // j
   } // !uniformVerticesWeights_
   // Reduce and rescale the eigenvectors
-  MatrixImplementation transposedProjection(augmentedDimension, K);
+  MatrixImplementation projection(K, augmentedDimension);
   Point selectedEV(K);
   Basis modes(0);
   ProcessSample modesAsProcessSample(sample_.getMesh(), 0, dimension);
@@ -226,7 +226,6 @@ void KarhunenLoeveSVDAlgorithm::run()
     evaluation1D = new PiecewiseLinearEvaluation(sample_.getMesh().getVertices().getImplementation()->getData(), values);
   else
     evaluationXD = new P1LagrangeEvaluation(Field(sample_.getMesh(), dimension));
-  UnsignedInteger index = 0;
   LOGINFO("Create modes and projection");
   for (UnsignedInteger k = 0; k < K; ++k)
   {
@@ -253,28 +252,26 @@ void KarhunenLoeveSVDAlgorithm::run()
     if (uniformVerticesWeights_)
     {
       a *= verticesWeights_[0] / sqrt(selectedEV[k]);
-      std::copy(a.begin(), a.end(), transposedProjection.begin() + index);
-      index += augmentedDimension;
+      // Build the relevant row of the projection matrix
+      for(UnsignedInteger i = 0; i < augmentedDimension; ++i)
+        projection(k, i) = a[i];
     } // uniformVerticesWeights_
     else
     {
       const Scalar inverseSqrtLambda = 1.0 / sqrt(selectedEV[k]);
-      UnsignedInteger shift = 0;
       for (UnsignedInteger i = 0; i < verticesNumber; ++i)
       {
         const Scalar coefficient = verticesWeights_[i] * inverseSqrtLambda;
         for (UnsignedInteger j = 0; j < dimension; ++j)
         {
-          transposedProjection[index] = coefficient * a[shift];
-          ++shift;
-          ++index;
+          projection(k, i * dimension + j) = coefficient * a[i * dimension + j];
         } // j
       } // i
     } // !uniformVerticesWeights_
   } // k
   LOGINFO("Create KL result");
   covariance_ = RankMCovarianceModel(selectedEV, modes);
-  result_ = KarhunenLoeveResultImplementation(covariance_, threshold_, selectedEV, modes, modesAsProcessSample, transposedProjection.transpose());
+  result_ = KarhunenLoeveResultImplementation(covariance_, threshold_, selectedEV, modes, modesAsProcessSample, projection);
 }
 
 /* Sample accessor */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
@@ -72,6 +72,7 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
+  Sample project(const Basis & basis) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
@@ -72,7 +72,6 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
-  Sample project(const Basis & basis) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResult.hxx
@@ -39,6 +39,7 @@ class OT_API KarhunenLoeveResult
 public:
 
   typedef TypedInterfaceObject<KarhunenLoeveResultImplementation>::Implementation Implementation;
+  typedef KarhunenLoeveResultImplementation::FunctionCollection  FunctionCollection;
 
   /** Default constructor */
   KarhunenLoeveResult();
@@ -72,7 +73,7 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
-  Sample project(const Basis & basis) const;
+  Sample project(const FunctionCollection & functionCollection) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
@@ -82,6 +82,7 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
+  Sample project(const Basis & basis) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
@@ -44,6 +44,7 @@ class OT_API KarhunenLoeveResultImplementation
 
 public:
 
+  typedef Collection<Function> FunctionCollection;
 
   /** Default constructor */
   KarhunenLoeveResultImplementation();
@@ -82,7 +83,7 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
-  Sample project(const Basis & basis) const;
+  Sample project(const FunctionCollection & basis) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/KarhunenLoeveResultImplementation.hxx
@@ -82,7 +82,6 @@ public:
   /** Projection method */
   Point project(const Function & function) const;
   Point project(const Field & field) const;
-  Sample project(const Basis & basis) const;
   Sample project(const ProcessSample & sample) const;
 
   /** Lift method */

--- a/lib/src/Base/Func/P1LagrangeEvaluation.cxx
+++ b/lib/src/Base/Func/P1LagrangeEvaluation.cxx
@@ -39,11 +39,33 @@ P1LagrangeEvaluation::P1LagrangeEvaluation()
   // Nothing to do
 }
 
-/* Default constructor */
+/* Parameters constructor */
 P1LagrangeEvaluation::P1LagrangeEvaluation(const Field & field)
   : EvaluationImplementation()
 {
   setField(field);
+}
+
+
+/* Parameters constructor */
+P1LagrangeEvaluation::P1LagrangeEvaluation(const ProcessSample & sample)
+  : EvaluationImplementation()
+{
+  const Mesh mesh(sample.getMesh());
+  const UnsignedInteger length = mesh.getVerticesNumber();
+  if (!(length > 0)) throw InvalidArgumentException(HERE) << "Error: expected a non-empty ProcessSample";
+  const UnsignedInteger size = sample.getSize();
+  const UnsignedInteger dimension = sample.getDimension();
+  // Copy values in expected order
+  values_ = Sample(length, size * dimension);
+  for(UnsignedInteger i = 0; i < size; ++i)
+  {
+    const Sample dataI(sample[i]);
+    for(UnsignedInteger l = 0; l < length; ++l)
+      std::copy(&dataI(l, 0), &dataI(l, 0) + dimension, &values_(l, i * dimension));
+  }
+  // To check for pending vertices
+  setMesh(mesh);
 }
 
 

--- a/lib/src/Base/Func/openturns/P1LagrangeEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/P1LagrangeEvaluation.hxx
@@ -25,6 +25,7 @@
 #include "openturns/PersistentCollection.hxx"
 #include "openturns/Field.hxx"
 #include "openturns/NearestNeighbourAlgorithm.hxx"
+#include "openturns/ProcessSample.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -45,8 +46,11 @@ public:
   /** Default constructor */
   P1LagrangeEvaluation();
 
-  /** Default constructor */
+  /** Parameters constructor */
   explicit P1LagrangeEvaluation(const Field & field);
+
+  /** Parameters constructor */
+  explicit P1LagrangeEvaluation(const ProcessSample & sample);
 
   /** Virtual constructor */
   virtual P1LagrangeEvaluation * clone() const;

--- a/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
+++ b/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
@@ -339,7 +339,7 @@ void KarhunenLoeveQuadratureAlgorithm::run()
   ProcessSample modesAsProcessSample(Mesh(nodes), 0, dimension);
   SampleImplementation values(nodesNumber, dimension);
   UnsignedInteger indexProjection = 0;
-  MatrixImplementation a(augmentedDimension, 1);
+  Point a(augmentedDimension, 1);
   const UnsignedInteger omegaASize = nodesNumber * dimension;
   Point modeValues(omegaASize);
   for (UnsignedInteger k = 0; k < K; ++k)
@@ -349,7 +349,7 @@ void KarhunenLoeveQuadratureAlgorithm::run()
     std::copy(eigenVectors.getImplementation()->begin() + initialColumn * augmentedDimension, eigenVectors.getImplementation()->begin() + (initialColumn + 1) * augmentedDimension, a.begin());
     // Store the eigen modes in two forms
     // modeValues = omega.a
-    Point omegaA(omega.getImplementation()->genProd(a));
+    Point omegaA(omega * a);
     const Scalar norm = omegaA.norm();
     const Scalar factor = omegaA[0] < 0.0 ? -1.0 / norm : 1.0 / norm;
     // Scale a

--- a/python/src/KarhunenLoeveResultImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveResultImplementation_doc.i.in
@@ -201,8 +201,6 @@ Available constructors:
 
     project(*field*)
 
-    project(*basis*)
-
     project(*fieldSample*)
 
 Parameters
@@ -211,10 +209,8 @@ function : :class:`~openturns.Function`
     A function.
 field :  :class:`~openturns.Field`
     A field.
-basis :  :class:`~openturns.Basis`
-    A collection f functions.
 fieldSample :  :class:`~openturns.ProcessSample`
-    A collection f fields.
+    A collection of fields.
 
 
 Returns

--- a/python/src/KarhunenLoeveResultImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveResultImplementation_doc.i.in
@@ -199,6 +199,8 @@ OT_KarhunenLoeveResult_getProjectionMatrix_doc
 Available constructors:
     project(*function*)
 
+    project(*functions*)
+
     project(*field*)
 
     project(*fieldSample*)
@@ -207,6 +209,8 @@ Parameters
 ----------
 function : :class:`~openturns.Function`
     A function.
+functions : list of :class:`~openturns.Function`
+    A list of functions.
 field :  :class:`~openturns.Field`
     A field.
 fieldSample :  :class:`~openturns.ProcessSample`


### PR DESCRIPTION
Computations with TBB were buggy.
Rewrite project() to perform matrix-matrix multiplications without TBB,
this is much faster than TBB wih matrix-vector multiplications, and as
a bonus gives the right result.

Remove project(Basis), it is very likely that it was buggy too because
of TBB usage, and it was also very slow.