### PR TITLE
Speed-up RankMCovarianceModel::operator()(s,t)

### DIFF
--- a/lib/src/Base/Stat/RankMCovarianceModel.cxx
+++ b/lib/src/Base/Stat/RankMCovarianceModel.cxx
@@ -116,8 +116,8 @@ CovarianceMatrix RankMCovarianceModel::operator() (const Point & s,
   {
     MatrixImplementation phiS(outputDimension_, size);
     MatrixImplementation phiT(outputDimension_, size);
-    Collection<Scalar>::iterator itPhiS = phiS.begin();;
-    Collection<Scalar>::iterator itPhiT = phiT.begin();;
+    Collection<Scalar>::iterator itPhiS = phiS.begin();
+    Collection<Scalar>::iterator itPhiT = phiT.begin();
     for (UnsignedInteger i = 0; i < size; ++i)
     {
       const Point evalPhiS(functions_[i](s));
@@ -129,7 +129,7 @@ CovarianceMatrix RankMCovarianceModel::operator() (const Point & s,
     }
     for (UnsignedInteger i = 0; i < size; ++i)
     {
-      itPhiT = phiT.begin();;
+      itPhiT = phiT.begin();
       for (UnsignedInteger j = 0; j < size; ++j)
       {
         const Point ptPhiT(Point(Collection<Scalar>(itPhiT, itPhiT + outputDimension_)) * covariance_(i, j));

--- a/lib/src/Base/Stat/RankMCovarianceModel.cxx
+++ b/lib/src/Base/Stat/RankMCovarianceModel.cxx
@@ -198,8 +198,10 @@ void RankMCovarianceModel::setBasis(const Basis & basis)
   functions_ = Basis::FunctionCollection(size);
   for (UnsignedInteger i = 0; i < size; ++i)
     functions_[i] = basis.build(i);
-  scale_ = Point(functions_[0].getInputDimension(), 1.0);
-  amplitude_ = Point(functions_[0].getOutputDimension(), 1.0);
+  inputDimension_ = functions_[0].getInputDimension();
+  scale_ = Point(inputDimension_, 1.0);
+  outputDimension_ = functions_[0].getOutputDimension();
+  amplitude_ = Point(outputDimension_, 1.0);
   basis_ = basis;
 }
 

--- a/lib/src/Base/Stat/RankMCovarianceModel.cxx
+++ b/lib/src/Base/Stat/RankMCovarianceModel.cxx
@@ -114,27 +114,23 @@ CovarianceMatrix RankMCovarianceModel::operator() (const Point & s,
     }
   else
   {
-    MatrixImplementation phiS(outputDimension_, size);
     MatrixImplementation phiT(outputDimension_, size);
-    Collection<Scalar>::iterator itPhiS = phiS.begin();
     Collection<Scalar>::iterator itPhiT = phiT.begin();
     for (UnsignedInteger i = 0; i < size; ++i)
     {
-      const Point evalPhiS(functions_[i](s));
-      std::copy(evalPhiS.begin(), evalPhiS.end(), itPhiS);
-      itPhiS += outputDimension_;
       const Point evalPhiT(functions_[i](t));
       std::copy(evalPhiT.begin(), evalPhiT.end(), itPhiT);
       itPhiT += outputDimension_;
     }
     for (UnsignedInteger i = 0; i < size; ++i)
     {
+      const Point phiS(functions_[i](s));
       itPhiT = phiT.begin();
       for (UnsignedInteger j = 0; j < size; ++j)
       {
         const Point ptPhiT(Point(Collection<Scalar>(itPhiT, itPhiT + outputDimension_)) * covariance_(i, j));
         dger_(&dim, &dim, &plusOne,
-            const_cast<double*>(&phiS(0, i)), &increment,
+            const_cast<double*>(&phiS[0]), &increment,
             const_cast<double*>(&ptPhiT[0]), &increment,
             &result[0], &dim);
         itPhiT += outputDimension_;


### PR DESCRIPTION
Functions on t were evaluated several times, and remove matrix scaling.

Fix RankMCovarianceModel for input or output dimension > 1.