### PR TITLE
Deprecate Evaluation::operator()(inP,parameter)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,9 @@
  * Deprecated Mesh::computeSimplexVolume, use Mesh::computeSimplicesVolume instead
  * Deprecated Mesh,Interval::computeVolume
  * Deprecated FunctionalChaosRandomVector::getSobol* methods in favor of FunctionalChaosSensitivity ones
+ * DeprecatedEvaluation,EvaluationImplementation,EvaluationProxy,Function,FunctionImplementation,ParametricEvaluation::operator()(inP,parameter)
+ * Deprecated Gradient,GradientImplementation,ParametricGradient::gradient(inP,parameter)
+ * Deprecated Hessian,HessianImplementation,ParametricHessian::hessian(inP,parameter)
 
 === Python module ===
 

--- a/TODO
+++ b/TODO
@@ -15,3 +15,6 @@ Remove deprecated Domain,DomainImplementation::getLowerBound, getUpperBound in 1
 Remove deprecated SobolIndicesAlgorithm::[sg]etBootstrapConfidenceLevel in 1.12
 Remove deprecated Mesh::getVerticesToSimplicesMap,computeSimplexVolume in 1.12
 Remove deprecated FunctionalChaosRandomVector::getSobol* in 1.13
+Remove deprecated Evaluation,EvaluationImplementation,EvaluationProxy,Function,FunctionImplementation,ParametricEvaluation::operator(inP,parameter) in 1.12
+Remove deprecated Gradient,GradientImplementation,ParametricGradient::gradient(inP,parameter) in 1.12
+Remove deprecated Hessian,HessianImplementation,ParametricHessian::operator(inP,parameter) in 1.12

--- a/lib/src/Base/Func/EvaluationImplementation.cxx
+++ b/lib/src/Base/Func/EvaluationImplementation.cxx
@@ -264,9 +264,13 @@ Matrix EvaluationImplementation::parameterGradient(const Point & inP) const
   {
     inS(1 + i, i) += epsilon;
   }
-  // operator()(x, theta) is non-const as it sets the parameter
+  Sample outS(parameterDimension + 1, getOutputDimension());
   Pointer<EvaluationImplementation> p_evaluation(clone());
-  Sample outS(p_evaluation->operator()(inP, inS));
+  for (UnsignedInteger i = 0; i < parameterDimension + 1; ++ i)
+  {
+    p_evaluation->setParameter(inS[i]);
+    outS[i] = p_evaluation->operator()(inP);
+  }
 
   Matrix grad(parameterDimension, outputDimension);
   for (UnsignedInteger i = 0; i < parameterDimension; ++ i)
@@ -311,6 +315,7 @@ Point EvaluationImplementation::operator() (const Point & inP) const
 Point EvaluationImplementation::operator() (const Point & inP,
     const Point & parameter)
 {
+  LOGWARN("EvaluationImplementation::operator()(inP,parameter) is deprecated, use setParameter(parameter) and operator()(inP)");
   setParameter(parameter);
   return (*this)(inP);
 }
@@ -318,6 +323,7 @@ Point EvaluationImplementation::operator() (const Point & inP,
 Sample EvaluationImplementation::operator() (const Point & inP,
     const Sample & parameters)
 {
+  LOGWARN("EvaluationImplementation::operator()(inP,parameters) is deprecated, use setParameter(parameter) and operator()(inP)");
   const UnsignedInteger size = parameters.getSize();
   Sample outS(size, getOutputDimension());
   for (UnsignedInteger i = 0; i < size; ++ i)

--- a/lib/src/Base/Func/FunctionImplementation.cxx
+++ b/lib/src/Base/Func/FunctionImplementation.cxx
@@ -318,6 +318,7 @@ Matrix FunctionImplementation::parameterGradient(const Point & inP) const
 Matrix FunctionImplementation::parameterGradient(const Point & inP,
     const Point & parameter)
 {
+  LOGWARN("FunctionImplementation::parameterGradient(inP,parameter) is deprecated, use setParameter(parameter) and parameterGradient(inP)");
   setParameter(parameter);
   return evaluation_.parameterGradient(inP);
 }
@@ -355,6 +356,7 @@ Point FunctionImplementation::operator() (const Point & inP) const
 Point FunctionImplementation::operator() (const Point & inP,
     const Point & parameter)
 {
+  LOGWARN("FunctionImplementation::operator()(inP,parameter) is deprecated, use setParameter(parameter) and operator()(inP)");
   setParameter(parameter);
   return evaluation_.operator()(inP);
 }
@@ -362,6 +364,7 @@ Point FunctionImplementation::operator() (const Point & inP,
 Sample FunctionImplementation::operator() (const Point & inP,
     const Sample & parameters)
 {
+  // Deprecated, but already issues a LOGWARN
   return evaluation_.operator()(inP, parameters);
 }
 
@@ -406,6 +409,7 @@ Matrix FunctionImplementation::gradient(const Point & inP,
                                         const Point & parameters)
 {
   if (useDefaultGradientImplementation_) LOGWARN(OSS() << "You are using a default implementation for the gradient. Be careful, your computation can be severely wrong!");
+  LOGWARN("FunctionImplementation::gradient()(inP,parameters) is deprecated, use setParameter(parameters) and gradient(inP)");
   setParameter(parameters);
   return gradient_.gradient(inP);
 }
@@ -439,6 +443,7 @@ SymmetricTensor FunctionImplementation::hessian(const Point & inP,
     const Point & parameters)
 {
   if (useDefaultHessianImplementation_) LOGWARN(OSS() << "You are using a default implementation for the hessian. Be careful, your computation can be severely wrong!");
+  LOGWARN("FunctionImplementation::hessian()(inP,parameters) is deprecated, use setParameter(parameters) and hessian(inP)");
   setParameter(parameters);
   return hessian_.hessian(inP);
 }

--- a/lib/src/Base/Func/GradientImplementation.cxx
+++ b/lib/src/Base/Func/GradientImplementation.cxx
@@ -90,6 +90,7 @@ Matrix GradientImplementation::gradient(const Point & inP) const
 Matrix GradientImplementation::gradient (const Point & inP,
     const Point & parameter)
 {
+  LOGWARN("GradientImplementation::gradient(inP,parameter) is deprecated, use setParameter(parameter) and gradient(inP)");
   setParameter(parameter);
   return gradient(inP);
 }

--- a/lib/src/Base/Func/HessianImplementation.cxx
+++ b/lib/src/Base/Func/HessianImplementation.cxx
@@ -89,6 +89,7 @@ SymmetricTensor HessianImplementation::hessian(const Point & inP) const
 SymmetricTensor HessianImplementation::hessian(const Point & inP,
     const Point & parameters)
 {
+  LOGWARN("HessianImplementation::gradient(inP,parameters) is deprecated, use setParameter(parameters) and hessian(inP)");
   setParameter(parameters);
   return hessian(inP);
 }

--- a/lib/src/Base/Func/ParametricEvaluation.cxx
+++ b/lib/src/Base/Func/ParametricEvaluation.cxx
@@ -179,6 +179,7 @@ Sample ParametricEvaluation::operator() (const Sample & inSample) const
 Sample ParametricEvaluation::operator() (const Point & point,
     const Sample & parameters)
 {
+  LOGWARN("ParametricEvaluation::operator()(point,parameters) is deprecated, use setParameter(parameters) and operator()(point)");
   const UnsignedInteger size = parameters.getSize();
   const UnsignedInteger inputDimension = function_.getInputDimension();
   const UnsignedInteger pointDimension = inputPositions_.getSize();

--- a/lib/src/Base/Func/ParametricGradient.cxx
+++ b/lib/src/Base/Func/ParametricGradient.cxx
@@ -62,6 +62,7 @@ ParametricGradient * ParametricGradient::clone() const
 Matrix ParametricGradient::gradient(const Point & point,
                                     const Point & parameters) const
 {
+  LOGWARN("ParametricGradient::gradient(point,parameters) is deprecated, use setParameter(parameters) and gradient(point)");
   const UnsignedInteger parametersDimension = parameters.getDimension();
   if (parametersDimension != p_evaluation_->getParametersPositions().getSize()) throw InvalidArgumentException(HERE) << "Error: expected a parameters of dimension=" << p_evaluation_->getParametersPositions().getSize() << ", got dimension=" << parametersDimension;
   const UnsignedInteger inputDimension = p_evaluation_->getFunction().getInputDimension();
@@ -86,8 +87,24 @@ Matrix ParametricGradient::gradient(const Point & point,
 /* Gradient operator */
 Matrix ParametricGradient::gradient(const OT::Point & point) const
 {
-  // Use the current parameters value
-  return gradient(point, p_evaluation_->getParameter());
+  const UnsignedInteger parametersDimension = p_evaluation_->getParameterDimension();
+  const UnsignedInteger inputDimension = p_evaluation_->getFunction().getInputDimension();
+  const UnsignedInteger pointDimension = point.getDimension();
+  if (pointDimension + parametersDimension != inputDimension) throw InvalidArgumentException(HERE) << "Error: expected a point of dimension=" << inputDimension - parametersDimension << ", got dimension=" << pointDimension;
+  Point x(inputDimension);
+  for (UnsignedInteger i = 0; i < parametersDimension; ++i) x[p_evaluation_->parametersPositions_[i]] = p_evaluation_->parameter_[i];
+  for (UnsignedInteger i = 0; i < pointDimension; ++i) x[p_evaluation_->inputPositions_[i]] = point[i];
+  const UnsignedInteger outputDimension = getOutputDimension();
+  const Matrix fullGradient(p_evaluation_->getFunction().gradient(x));
+  // The gradient wrt x corresponds to the inputPositions rows of the full gradient
+  Matrix result(pointDimension, outputDimension);
+  for (UnsignedInteger i = 0; i < pointDimension; ++i)
+  {
+    const UnsignedInteger i0 = p_evaluation_->inputPositions_[i];
+    for (UnsignedInteger j = 0; j < outputDimension; ++j)
+      result(i, j) = fullGradient(i0, j);
+  }
+  return result;
 }
 
 /* Dimension accessors */

--- a/lib/src/Base/Func/openturns/Evaluation.hxx
+++ b/lib/src/Base/Func/openturns/Evaluation.hxx
@@ -111,14 +111,18 @@ public:
 
   /** Operator () */
   Point operator() (const Point & inP) const;
-  Point operator() (const Point & inP,
-                    const Point & parameter);
-  Sample operator() (const Point & point,
-                     const Sample & parameters);
 
   Sample operator() (const Sample & inS) const;
 
   Field operator() (const Field & inTS) const;
+
+  /* @deprecated */
+  Point operator() (const Point & inP,
+                    const Point & parameter);
+
+  /* @deprecated */
+  Sample operator() (const Point & point,
+                     const Sample & parameters);
 
 
   /** Accessor for input point dimension */

--- a/lib/src/Base/Func/openturns/EvaluationImplementation.hxx
+++ b/lib/src/Base/Func/openturns/EvaluationImplementation.hxx
@@ -120,16 +120,20 @@ public:
 
   /** Operator () */
   virtual Point operator() (const Point & inP) const;
-  virtual Point operator() (const Point & inP,
-                            const Point & parameters);
-  virtual Sample operator() (const Point & point,
-                             const Sample & parameters);
 
   /** Operator () on a sample, not pure virtual because a generic implementation is given */
   virtual Sample operator() (const Sample & inSample) const;
 
   /** Operator () on a time series, not pure virtual because a generic implementation is given */
   virtual Field operator() (const Field & inField) const;
+
+  /* @deprecated */
+  virtual Point operator() (const Point & inP,
+                            const Point & parameters);
+
+  /* @deprecated */
+  virtual Sample operator() (const Point & point,
+                             const Sample & parameters);
 
   /** Accessor for input point dimension */
   virtual UnsignedInteger getInputDimension() const;

--- a/lib/src/Base/Func/openturns/EvaluationProxy.hxx
+++ b/lib/src/Base/Func/openturns/EvaluationProxy.hxx
@@ -105,16 +105,20 @@ public:
 
   /** Operator () */
   virtual Point operator() (const Point & inP) const;
-  virtual Point operator() (const Point & inP,
-                            const Point & parameters);
-  virtual Sample operator() (const Point & point,
-                             const Sample & parameters);
 
   /** Operator () on a sample, not pure virtual because a generic implementation is given */
   virtual Sample operator() (const Sample & inSample) const;
 
   /** Operator () on a time series, not pure virtual because a generic implementation is given */
   virtual Field operator() (const Field & inField) const;
+
+  /* @deprecated */
+  virtual Point operator() (const Point & inP,
+                            const Point & parameters);
+
+  /* @deprecated */
+  virtual Sample operator() (const Point & point,
+                             const Sample & parameters);
 
   /** Accessor for input point dimension */
   virtual UnsignedInteger getInputDimension() const;

--- a/lib/src/Base/Func/openturns/Function.hxx
+++ b/lib/src/Base/Func/openturns/Function.hxx
@@ -168,28 +168,38 @@ public:
 
   /** Operator () */
   Point operator() (const Point & inP) const;
-  Point operator() (const Point & inP,
-                    const Point & parameter);
-  Sample operator() (const Point & point,
-                     const Sample & parameters);
 
   Sample operator() (const Sample & inS) const;
 
   Field operator() (const Field & inTS) const;
 
+  /* @deprecated */
+  Point operator() (const Point & inP,
+                    const Point & parameter);
+
+  /* @deprecated */
+  Sample operator() (const Point & point,
+                     const Sample & parameters);
+
 
   /** Method gradient() returns the Jacobian transposed matrix of the function at point */
   Matrix gradient(const Point & inP) const;
+
+  /* @deprecated */
   Matrix gradient(const Point & inP,
                   const Point & parameters);
 
   /** Method hessian() returns the symmetric tensor of the function at point */
   SymmetricTensor hessian(const Point & inP) const;
+
+  /* @deprecated */
   SymmetricTensor hessian(const Point & inP,
                           const Point & parameters);
 
   /** Gradient according to the marginal parameters */
   virtual Matrix parameterGradient(const Point & inP) const;
+
+  /* @deprecated */
   virtual Matrix parameterGradient(const Point & inP,
                                    const Point & parameters);
 

--- a/lib/src/Base/Func/openturns/FunctionImplementation.hxx
+++ b/lib/src/Base/Func/openturns/FunctionImplementation.hxx
@@ -157,28 +157,37 @@ public:
   /** Operator () */
   virtual Point operator() (const Point & inP) const;
 
-  virtual Point operator()(const Point & inP,
-                           const Point & parameter);
-  virtual Sample operator() (const Point & point,
-                             const Sample & parameters);
-
   virtual Sample operator() (const Sample & inS) const;
 
   virtual Field operator() (const Field & inField) const;
 
+  /* @deprecated */
+  virtual Point operator()(const Point & inP,
+                           const Point & parameter);
+
+  /* @deprecated */
+  virtual Sample operator() (const Point & point,
+                             const Sample & parameters);
+
 
   /** Method gradient() returns the Jacobian transposed matrix of the function at point */
   virtual Matrix gradient(const Point & inP) const;
+
+  /* @deprecated */
   virtual Matrix gradient(const Point & inP,
                           const Point & parameter);
 
   /** Method hessian() returns the symmetric tensor of the function at point */
   virtual SymmetricTensor hessian(const Point & inP) const;
+
+  /* @deprecated */
   virtual SymmetricTensor hessian(const Point & inP,
                                   const Point & parameter);
 
   /** Gradient according to the marginal parameters */
   virtual Matrix parameterGradient(const Point & inP) const;
+
+  /* @deprecated */
   virtual Matrix parameterGradient(const Point & inP,
                                    const Point & parameter);
 

--- a/lib/src/Base/Func/openturns/Gradient.hxx
+++ b/lib/src/Base/Func/openturns/Gradient.hxx
@@ -73,6 +73,8 @@ public:
 
   /** Gradient method */
   virtual Matrix gradient(const Point & inP) const;
+
+  /* @deprecated */
   virtual Matrix gradient(const Point & inP,
                           const Point & parameters);
 

--- a/lib/src/Base/Func/openturns/GradientImplementation.hxx
+++ b/lib/src/Base/Func/openturns/GradientImplementation.hxx
@@ -79,6 +79,8 @@ public:
 
   /** Gradient method */
   virtual Matrix gradient(const Point & inP) const;
+
+  /* @deprecated */
   virtual Matrix gradient(const Point & inP,
                           const Point & parameters);
 

--- a/lib/src/Base/Func/openturns/Hessian.hxx
+++ b/lib/src/Base/Func/openturns/Hessian.hxx
@@ -73,6 +73,8 @@ public:
 
   /** Hessian method */
   virtual SymmetricTensor hessian(const Point & inP) const;
+
+  /* @deprecated */
   virtual SymmetricTensor hessian(const Point & inP,
                                   const Point & parameters);
 

--- a/lib/src/Base/Func/openturns/HessianImplementation.hxx
+++ b/lib/src/Base/Func/openturns/HessianImplementation.hxx
@@ -76,6 +76,8 @@ public:
 
   /** Hessian method */
   virtual SymmetricTensor hessian(const Point & inP) const;
+
+  /* @deprecated */
   virtual SymmetricTensor hessian(const Point & inP,
                                   const Point & parameter);
 

--- a/lib/src/Base/Func/openturns/ParametricEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/ParametricEvaluation.hxx
@@ -54,10 +54,12 @@ public:
   /** Evaluation operator */
   using EvaluationImplementation::operator();
   Point operator() (const Point & point) const;
-  Sample operator() (const Point & point,
-                     const Sample & parameters);
+
   Sample operator() (const Sample & inS) const;
 
+  /* @deprecated */
+  Sample operator() (const Point & point,
+                     const Sample & parameters);
   /** Parameters positions accessor */
   Indices getParametersPositions() const;
 

--- a/lib/src/Base/Func/openturns/ParametricGradient.hxx
+++ b/lib/src/Base/Func/openturns/ParametricGradient.hxx
@@ -56,6 +56,8 @@ public:
   /** Gradient operator */
   using GradientImplementation::gradient;
   Matrix gradient(const Point & point) const;
+
+  /* @deprecated */
   Matrix gradient(const Point & point,
                   const Point & parameters) const;
 

--- a/lib/src/Base/Func/openturns/ParametricHessian.hxx
+++ b/lib/src/Base/Func/openturns/ParametricHessian.hxx
@@ -57,6 +57,8 @@ public:
   /** Hessian operator */
   using HessianImplementation::hessian;
   SymmetricTensor hessian(const Point & point) const;
+
+  /* @deprecated */
   SymmetricTensor hessian(const Point & point,
                           const Point & parameters) const;
 


### PR DESCRIPTION
Likewise for gradient and hessian.

Changing parameters has a cost, functions must be cloned, this should not
be hidden.