### PR TITLE
Fix EnclosingSimplexAlgorithm constructor

### DIFF
--- a/lib/src/Base/Algo/EnclosingSimplexAlgorithm.cxx
+++ b/lib/src/Base/Algo/EnclosingSimplexAlgorithm.cxx
@@ -59,7 +59,7 @@ EnclosingSimplexAlgorithm::EnclosingSimplexAlgorithm(const Sample & vertices, co
     }
     if (standardSimplices)
     {
-      Mesh mesh(vertices);
+      Mesh mesh(vertices, simplices);
       if (mesh.isRegular())
         p_implementation_ = new RegularGridEnclosingSimplex(mesh);
       else


### PR DESCRIPTION
When there are no simplices, Mesh::isRegular() does not check
vertex position, and thus always return true.