### PR TITLE
Added a flag to tell if the symbolic parsers have to check their output

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -37,7 +37,8 @@
   <SpecFunc-Precision value="2.0e-16" />
 
   <!-- OT::SymbolicParser parameters -->
-  <SymbolicParser-Backend value="@SYMBOLICPARSER_DEFAULT_BACKEND@" />
+  <SymbolicParser-Backend     value="@SYMBOLICPARSER_DEFAULT_BACKEND@" />
+  <SymbolicParser-CheckResult value="true" />
 
   <!-- OT::DesignProxy parameters -->
   <DesignProxy-DefaultCacheSize value="16777216" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -301,6 +301,7 @@ void ResourceMap::loadDefaultConfiguration()
 
   // SymbolicParser parameters
   set( "SymbolicParser-Backend", SYMBOLICPARSER_DEFAULT_BACKEND );
+  setAsBool( "SymbolicParser-CheckResult", true );
 
   // GramProxy parameters
   setAsUnsignedInteger( "DesignProxy-DefaultCacheSize", 16777216 );// 2^24=16777216=128 Mio

--- a/lib/src/Base/Func/SymbolicParserImplementation.cxx
+++ b/lib/src/Base/Func/SymbolicParserImplementation.cxx
@@ -35,6 +35,7 @@ SymbolicParserImplementation::SymbolicParserImplementation()
   : PersistentObject()
   , inputVariablesNames_()
   , formulas_()
+  , checkResult_(ResourceMap::GetAsBool("SymbolicParser-CheckResult"))
 {
   // Nothing to do
 }
@@ -89,6 +90,7 @@ void SymbolicParserImplementation::save(Advocate & adv) const
   PersistentObject::save(adv);
   adv.saveAttribute( "inputVariablesNames_", inputVariablesNames_ );
   adv.saveAttribute( "formulas_", formulas_ );
+  adv.saveAttribute( "checkResult_", checkResult_ );
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -97,6 +99,7 @@ void SymbolicParserImplementation::load(Advocate & adv)
   PersistentObject::load(adv);
   adv.loadAttribute( "inputVariablesNames_", inputVariablesNames_ );
   adv.loadAttribute( "formulas_", formulas_ );
+  adv.loadAttribute( "checkResult_", checkResult_ );
 }
 
 

--- a/lib/src/Base/Func/SymbolicParserMuParser.cxx
+++ b/lib/src/Base/Func/SymbolicParserMuParser.cxx
@@ -120,14 +120,22 @@ Point SymbolicParserMuParser::operator() (const Point & inP) const
   Point result(outputDimension);
   try
   {
-    for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
-    {
-      const Scalar value = parsers_[outputIndex].get()->Eval();
-      // By default muParser is not compiled with MUP_MATH_EXCEPTIONS enabled and does not throw on domain/division errors
-      if (!SpecFunc::IsNormal(value))
-        throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << inP.__str__();
-      result[outputIndex] = value;
-    }
+    if (checkResult_)
+      {
+	for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+	  {
+	    const Scalar value = parsers_[outputIndex].get()->Eval();
+	    // By default muParser is not compiled with MUP_MATH_EXCEPTIONS enabled and does not throw on domain/division errors
+	    if (!SpecFunc::IsNormal(value))
+	      throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << inP.__str__();
+	    result[outputIndex] = value;
+	  } // outputIndex
+      } // checkResult_
+    else
+      {
+	for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+	  result[outputIndex] = parsers_[outputIndex].get()->Eval();
+      } // !checkResult
   }
   catch (mu::Parser::exception_type & ex)
   {
@@ -148,18 +156,30 @@ Sample SymbolicParserMuParser::operator() (const Sample & inS) const
   Sample result(size, outputDimension);
   try
   {
-    for (UnsignedInteger i = 0; i < size; ++i)
-    {
-      std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
-      for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+    if (checkResult_)
       {
-        const Scalar value = parsers_[outputIndex].get()->Eval();
-        // By default muParser is not compiled with MUP_MATH_EXCEPTIONS enabled and does not throw on domain/division errors
-        if (!SpecFunc::IsNormal(value))
-          throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << Point(inS[i]).__str__();
-        result(i, outputIndex) = value;
-      }
-    }
+	for (UnsignedInteger i = 0; i < size; ++i)
+	  {
+	    std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+	    for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+	      {
+		const Scalar value = parsers_[outputIndex].get()->Eval();
+		// By default muParser is not compiled with MUP_MATH_EXCEPTIONS enabled and does not throw on domain/division errors
+		if (!SpecFunc::IsNormal(value))
+		  throw InternalException(HERE) << "Cannot evaluate " << formulas_[outputIndex] << " at " << inputVariablesNames_.__str__() << "=" << Point(inS[i]).__str__();
+		result(i, outputIndex) = value;
+	      } // outputIndex
+	  } // i
+      } // checkResult_
+    else
+      {
+	for (UnsignedInteger i = 0; i < size; ++i)
+	  {
+	    std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+	    for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
+	      result(i, outputIndex) = parsers_[outputIndex].get()->Eval();
+	  } // i
+      } // !checkResult
   }
   catch (mu::Parser::exception_type & ex)
   {

--- a/lib/src/Base/Func/openturns/SymbolicParserImplementation.hxx
+++ b/lib/src/Base/Func/openturns/SymbolicParserImplementation.hxx
@@ -62,7 +62,7 @@ public:
 protected:
   Description inputVariablesNames_;
   Description formulas_;
-
+  Bool checkResult_;
 }; /* class SymbolicParserImplementation */
 
 END_NAMESPACE_OPENTURNS

--- a/lib/test/t_SymbolicFunction_muparser.cxx
+++ b/lib/test/t_SymbolicFunction_muparser.cxx
@@ -384,6 +384,29 @@ int main(int argc, char *argv[])
     catch (NotYetImplementedException &)
     {
     }
+    // Check exceptional values
+    {
+      SymbolicFunction f("x", "sqrt(x)");
+      fullprint << "Trying to evaluate f=" << f.__str__() << " at x=-1.0" << std::endl;
+      Point x(1, -1.0);
+      fullprint << "Result is ";
+      try
+	{
+	  fullprint << f(x) << std::endl;
+	}
+      catch(...)
+	{
+	  fullprint << "undefined" << std::endl;
+	}
+    }
+    // Disable check for exceptional values
+    {
+      ResourceMap::SetAsBool("SymbolicParser-CheckResult", false);
+      SymbolicFunction f("x", "sqrt(x)");
+      fullprint << "Trying to evaluate f=" << f.__str__() << " at x=-1.0" << std::endl;
+      Point x(1, -1.0);
+      fullprint << "Result is normal? " << SpecFunc::IsNormal(f(x)[0]) << std::endl;
+    }
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_SymbolicFunction_muparser.expout
+++ b/lib/test/t_SymbolicFunction_muparser.expout
@@ -168,3 +168,7 @@ First result calculated : 2.8794e+00
 [x,y]->[x * y], f([2, 3])=class=Point name=Unnamed dimension=1 values=[6]
 [x,y]->[x / y], f([2, 3])=class=Point name=Unnamed dimension=1 values=[0.666667]
 [x,y]->[x ^ y], f([2, 3])=class=Point name=Unnamed dimension=1 values=[8]
+Trying to evaluate f=[x]->[sqrt(x)] at x=-1.0
+Result is undefined
+Trying to evaluate f=[x]->[sqrt(x)] at x=-1.0
+Result is normal? false

--- a/lib/test/t_SymbolicFunction_std.cxx
+++ b/lib/test/t_SymbolicFunction_std.cxx
@@ -321,6 +321,29 @@ int main(int argc, char *argv[])
       x[3] = 5.0;
       fullprint << f.__str__() << ", f([2, 3, 4, 5])=" << f(x) << std::endl;
     }
+    // Check exceptional values
+    {
+      SymbolicFunction f("x", "sqrt(x)");
+      fullprint << "Trying to evaluate f=" << f.__str__() << " at x=-1.0" << std::endl;
+      Point x(1, -1.0);
+      fullprint << "Result is ";
+      try
+	{
+	  fullprint << f(x) << std::endl;
+	}
+      catch(...)
+	{
+	  fullprint << "undefined" << std::endl;
+	}
+    }
+    // Disable check for exceptional values
+    {
+      ResourceMap::SetAsBool("SymbolicParser-CheckResult", false);
+      SymbolicFunction f("x", "sqrt(x)");
+      fullprint << "Trying to evaluate f=" << f.__str__() << " at x=-1.0" << std::endl;
+      Point x(1, -1.0);
+      fullprint << "Result is normal? " << SpecFunc::IsNormal(f(x)[0]) << std::endl;
+    }
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_SymbolicFunction_std.expout
+++ b/lib/test/t_SymbolicFunction_std.expout
@@ -150,3 +150,7 @@ First result calculated : 2.8794e+00
 [x,y]->[x / y], f([2, 3])=class=Point name=Unnamed dimension=1 values=[0.666667]
 [x,y]->[x ^ y], f([2, 3])=class=Point name=Unnamed dimension=1 values=[8]
 [x,y,z,t]->[a := t; b := z-y; c := x], f([2, 3, 4, 5])=class=Point name=Unnamed dimension=3 values=[5,1,2]
+Trying to evaluate f=[x]->[sqrt(x)] at x=-1.0
+Result is undefined
+Trying to evaluate f=[x]->[sqrt(x)] at x=-1.0
+Result is normal? false

--- a/python/test/t_SymbolicFunction_muparser.expout
+++ b/python/test/t_SymbolicFunction_muparser.expout
@@ -211,3 +211,5 @@ OK
 [x,y]->[x * y] , f([2, 3])= [6]
 [x,y]->[x / y] , f([2, 3])= [0.666667]
 [x,y]->[x ^ y] , f([2, 3])= [8]
+[x]->[sqrt(x)] , f([-1]) not defined
+[x]->[sqrt(x)] , f([-1]) is normal? False

--- a/python/test/t_SymbolicFunction_muparser.py
+++ b/python/test/t_SymbolicFunction_muparser.py
@@ -198,3 +198,13 @@ f = ot.SymbolicFunction(["x", "y"], ["x / y"])
 print(f, ", f([2, 3])=", f([2.0, 3.0]))
 f = ot.SymbolicFunction(["x", "y"], ["x ^ y"])
 print(f, ", f([2, 3])=", f([2.0, 3.0]))
+# Check for exceptional output
+f = ot.SymbolicFunction("x", "sqrt(x)")
+try:
+    print(f, ", f([-1])=", f([-1.0]))
+except:
+    print(f, ", f([-1]) not defined")
+
+ot.ResourceMap.SetAsBool("SymbolicParser-CheckResult", False)
+f = ot.SymbolicFunction("x", "sqrt(x)")
+print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(f([-1.0])[0]))

--- a/python/test/t_SymbolicFunction_std.expout
+++ b/python/test/t_SymbolicFunction_std.expout
@@ -192,3 +192,5 @@ OK
 [x,y]->[x * y] , f([2, 3])= [6]
 [x,y]->[x / y] , f([2, 3])= [0.666667]
 [x,y]->[x ^ y] , f([2, 3])= [8]
+[x]->[sqrt(x)] , f([-1]) not defined
+[x]->[sqrt(x)] , f([-1]) is normal? False

--- a/python/test/t_SymbolicFunction_std.py
+++ b/python/test/t_SymbolicFunction_std.py
@@ -175,3 +175,13 @@ f = ot.SymbolicFunction(["x", "y"], ["x / y"])
 print(f, ", f([2, 3])=", f([2.0, 3.0]))
 f = ot.SymbolicFunction(["x", "y"], ["x ^ y"])
 print(f, ", f([2, 3])=", f([2.0, 3.0]))
+# Check for exceptional output
+f = ot.SymbolicFunction("x", "sqrt(x)")
+try:
+    print(f, ", f([-1])=", f([-1.0]))
+except:
+    print(f, ", f([-1]) not defined")
+
+ot.ResourceMap.SetAsBool("SymbolicParser-CheckResult", False)
+f = ot.SymbolicFunction("x", "sqrt(x)")
+print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(f([-1.0])[0]))


### PR DESCRIPTION
In some circumstances it is desirable to let symbolic parsers produce NaNs or Infs when they are evaluated over a sample and then to filter out the result afterward instead of throwing an exception at the first nonnoral result encountered.