### PR TITLE
[To integrate in 1.11] Relax empirical bernstein copula tests

### DIFF
--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -36,7 +36,7 @@ static const Factory<EmpiricalBernsteinCopula> Factory_EmpiricalBernsteinCopula;
 
 /* Default constructor */
 EmpiricalBernsteinCopula::EmpiricalBernsteinCopula()
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(0, 1)
   , binNumber_(1)
   , logBetaFactors_(0)
@@ -53,7 +53,7 @@ EmpiricalBernsteinCopula::EmpiricalBernsteinCopula()
 EmpiricalBernsteinCopula::EmpiricalBernsteinCopula(const Sample & copulaSample,
     const UnsignedInteger binNumber,
     const Bool isEmpiricalCopulaSample)
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(0, 1)
   , binNumber_(binNumber)
   , logBetaFactors_(0)
@@ -71,7 +71,7 @@ EmpiricalBernsteinCopula::EmpiricalBernsteinCopula(const Sample & copulaSample,
     const UnsignedInteger binNumber,
     const SampleImplementation & logBetaMarginalFactors,
     const SampleImplementation & logFactors)
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(copulaSample)
   , binNumber_(binNumber)
   , logBetaMarginalFactors_(logBetaMarginalFactors)
@@ -148,7 +148,7 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
   if (dimension == 0) throw InvalidArgumentException(HERE) << "Error: expected a sample of dimension>0.";
   const UnsignedInteger remainder = size % binNumber_;
   // If the given sample is an empirical copula sample of a compatible size
-  if (isEmpiricalCopulaSample && remainder == 0)
+  if (isEmpiricalCopulaSample)
     copulaSample_ = copulaSample;
   else
   {
@@ -164,6 +164,7 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
     copulaSample_ /= 1.0 * (size - remainder);
   } // !(isEmpiricalCopulaSample && remainder == 0)
   setDimension(dimension);
+  isCopula_ = (remainder == 0);
   // Now the sample is correct, compute the by-products
   update();
   computeRange();
@@ -409,7 +410,7 @@ void EmpiricalBernsteinCopula::update()
 /* Method save() stores the object through the StorageManager */
 void EmpiricalBernsteinCopula::save(Advocate & adv) const
 {
-  CopulaImplementation::save(adv);
+  ContinuousDistribution::save(adv);
   adv.saveAttribute( "copulaSample_", copulaSample_ );
   adv.saveAttribute( "binNumber_", binNumber_ );
 }
@@ -417,7 +418,7 @@ void EmpiricalBernsteinCopula::save(Advocate & adv) const
 /* Method load() reloads the object from the StorageManager */
 void EmpiricalBernsteinCopula::load(Advocate & adv)
 {
-  CopulaImplementation::load(adv);
+  ContinuousDistribution::load(adv);
   adv.loadAttribute( "copulaSample_", copulaSample_ );
   adv.loadAttribute( "binNumber_", binNumber_ );
   update();

--- a/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
@@ -21,7 +21,7 @@
 #ifndef OPENTURNS_EMPIRICALBERNSTEINCOPULA_HXX
 #define OPENTURNS_EMPIRICALBERNSTEINCOPULA_HXX
 
-#include "openturns/CopulaImplementation.hxx"
+#include "openturns/ContinuousDistribution.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
  * made from the empirical compula and a Bernstein approximation
  */
 class OT_API EmpiricalBernsteinCopula
-  : public CopulaImplementation
+  : public ContinuousDistribution
 {
   CLASSNAME
 public:
@@ -77,22 +77,22 @@ public:
   Sample getSample(const UnsignedInteger size) const;
 
   /** Get the PDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computePDF;
+  using ContinuousDistribution::computePDF;
   Scalar computePDF(const Point & point) const;
 
   /** Get the log-PDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computeLogPDF;
+  using ContinuousDistribution::computeLogPDF;
   Scalar computeLogPDF(const Point & point) const;
 
   /** Get the CDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computeCDF;
+  using ContinuousDistribution::computeCDF;
   Scalar computeCDF(const Point & point) const;
 
   /** Get the probability content of an interval */
   Scalar computeProbability(const Interval & interval) const;
 
   /** Get the distribution of the marginal distribution corresponding to indices dimensions */
-  using CopulaImplementation::getMarginal;
+  using ContinuousDistribution::getMarginal;
   Distribution getMarginal(const Indices & indices) const;
 
   /** Get the Spearman correlation of the distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
@@ -38,9 +38,6 @@ class OT_API Mixture
   : public DistributionImplementation
 {
   CLASSNAME
-  // Make the BernsteinCopulaFactory class a friend of Mixture as it has to
-  // set the isCopula_ attribute directly
-  friend class BernsteinCopulaFactory;
 
 public:
 

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -3102,10 +3102,7 @@ Scalar DistributionImplementation::computeDensityGeneratorSecondDerivative(const
 /* Get the i-th marginal distribution */
 Distribution DistributionImplementation::getMarginal(const UnsignedInteger i) const
 {
-  if (!(i < dimension_)) throw InvalidArgumentException(HERE) << "Marginal index cannot exceed dimension";
-  if (dimension_ == 1) return clone();
-  if (isCopula()) return new Uniform(0.0, 1.0);
-  return new MarginalDistribution(*this, i);
+  return getMarginal(Indices(1, i));
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */

--- a/python/test/t_EmpiricalBernsteinCopula_std.expout
+++ b/python/test/t_EmpiricalBernsteinCopula_std.expout
@@ -55,20 +55,20 @@ beta= [0.974525]
 Unilateral confidence interval (upper tail)= [0.0254747, 1]
 [0.0254747, 1]
 beta= [0.974525]
-margin= class=IndependentCopula name=IndependentCopula dimension=1
+margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X0] data=[[0.833333],[0.583333],[0.166667],[0.666667],[0.916667],[0.5],[0.0833333],[0.25],[1],[0.416667],[0.75],[0.333333]] binNumber=3
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.70259]
-margin= class=IndependentCopula name=IndependentCopula dimension=1
+margin realization= class=Point name=Unnamed dimension=1 values=[0.354782]
+margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X1] data=[[0.166667],[0.916667],[0.583333],[1],[0.833333],[0.5],[0.0833333],[0.416667],[0.333333],[0.666667],[0.75],[0.25]] binNumber=3
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.268608]
+margin realization= class=Point name=Unnamed dimension=1 values=[0.739996]
 indices= [1,0]
 margins= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=2 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=2 description=[X1,X0] data=[[0.166667,0.833333],[0.916667,0.583333],[0.583333,0.166667],[1,0.666667],[0.833333,0.916667],[0.5,0.5],[0.0833333,0.0833333],[0.416667,0.25],[0.333333,1],[0.666667,0.416667],[0.75,0.75],[0.25,0.333333]] binNumber=3
 margins PDF=1.095703
 margins CDF=0.076782
 margins quantile= class=Point name=Unnamed dimension=2 values=[0.974525,0.974525]
 margins CDF(qantile)=0.950000
-margins realization= class=Point name=Unnamed dimension=2 values=[0.739996,0.466049]
+margins realization= class=Point name=Unnamed dimension=2 values=[0.565228,0.790266]


### PR DESCRIPTION
This PR fixes [ticket #947](http://trac.openturns.org/ticket/947#ticket). It allows to build an EmpiricalBernsteinCopula object even if the resulting distribution is not a copula, for statistical estimation purpose. It may be strange to name a distribution an EmpiricalBernsteinCopula even when it is not a proper copula, but the name is in the literature since 2004 and the fact that an arithmetic condition is mandatory to get a proper copula has been proved only in 2017!