### PR TITLE
Relax empirical bernstein copula

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -134,6 +134,7 @@
  * #944 (Inline plots crash in notebooks if too many points)
  * #945 (build fails with cmake 3.11)
  * #946 (OT via anaconda, usage of ot.HypothesisTest error: R_EXECUTABLE-NOTFOUND)
+ * #950 (Circular call to getShape() in Copula)
 
 == 1.10 release (2017-11-13) == #release-1.10
 

--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -36,7 +36,7 @@ static const Factory<EmpiricalBernsteinCopula> Factory_EmpiricalBernsteinCopula;
 
 /* Default constructor */
 EmpiricalBernsteinCopula::EmpiricalBernsteinCopula()
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(0, 1)
   , binNumber_(1)
   , logBetaFactors_(0)
@@ -53,7 +53,7 @@ EmpiricalBernsteinCopula::EmpiricalBernsteinCopula()
 EmpiricalBernsteinCopula::EmpiricalBernsteinCopula(const Sample & copulaSample,
     const UnsignedInteger binNumber,
     const Bool isEmpiricalCopulaSample)
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(0, 1)
   , binNumber_(binNumber)
   , logBetaFactors_(0)
@@ -71,7 +71,7 @@ EmpiricalBernsteinCopula::EmpiricalBernsteinCopula(const Sample & copulaSample,
     const UnsignedInteger binNumber,
     const SampleImplementation & logBetaMarginalFactors,
     const SampleImplementation & logFactors)
-  : CopulaImplementation()
+  : ContinuousDistribution()
   , copulaSample_(copulaSample)
   , binNumber_(binNumber)
   , logBetaMarginalFactors_(logBetaMarginalFactors)
@@ -148,7 +148,7 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
   if (dimension == 0) throw InvalidArgumentException(HERE) << "Error: expected a sample of dimension>0.";
   const UnsignedInteger remainder = size % binNumber_;
   // If the given sample is an empirical copula sample of a compatible size
-  if (isEmpiricalCopulaSample && remainder == 0)
+  if (isEmpiricalCopulaSample)
     copulaSample_ = copulaSample;
   else
   {
@@ -164,6 +164,7 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
     copulaSample_ /= 1.0 * (size - remainder);
   } // !(isEmpiricalCopulaSample && remainder == 0)
   setDimension(dimension);
+  isCopula_ = (remainder == 0);
   // Now the sample is correct, compute the by-products
   update();
   computeRange();
@@ -409,7 +410,7 @@ void EmpiricalBernsteinCopula::update()
 /* Method save() stores the object through the StorageManager */
 void EmpiricalBernsteinCopula::save(Advocate & adv) const
 {
-  CopulaImplementation::save(adv);
+  ContinuousDistribution::save(adv);
   adv.saveAttribute( "copulaSample_", copulaSample_ );
   adv.saveAttribute( "binNumber_", binNumber_ );
 }
@@ -417,7 +418,7 @@ void EmpiricalBernsteinCopula::save(Advocate & adv) const
 /* Method load() reloads the object from the StorageManager */
 void EmpiricalBernsteinCopula::load(Advocate & adv)
 {
-  CopulaImplementation::load(adv);
+  ContinuousDistribution::load(adv);
   adv.loadAttribute( "copulaSample_", copulaSample_ );
   adv.loadAttribute( "binNumber_", binNumber_ );
   update();

--- a/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
@@ -21,7 +21,7 @@
 #ifndef OPENTURNS_EMPIRICALBERNSTEINCOPULA_HXX
 #define OPENTURNS_EMPIRICALBERNSTEINCOPULA_HXX
 
-#include "openturns/CopulaImplementation.hxx"
+#include "openturns/ContinuousDistribution.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -32,7 +32,7 @@ BEGIN_NAMESPACE_OPENTURNS
  * made from the empirical compula and a Bernstein approximation
  */
 class OT_API EmpiricalBernsteinCopula
-  : public CopulaImplementation
+  : public ContinuousDistribution
 {
   CLASSNAME
 public:
@@ -77,22 +77,22 @@ public:
   Sample getSample(const UnsignedInteger size) const;
 
   /** Get the PDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computePDF;
+  using ContinuousDistribution::computePDF;
   Scalar computePDF(const Point & point) const;
 
   /** Get the log-PDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computeLogPDF;
+  using ContinuousDistribution::computeLogPDF;
   Scalar computeLogPDF(const Point & point) const;
 
   /** Get the CDF of the EmpiricalBernsteinCopula */
-  using CopulaImplementation::computeCDF;
+  using ContinuousDistribution::computeCDF;
   Scalar computeCDF(const Point & point) const;
 
   /** Get the probability content of an interval */
   Scalar computeProbability(const Interval & interval) const;
 
   /** Get the distribution of the marginal distribution corresponding to indices dimensions */
-  using CopulaImplementation::getMarginal;
+  using ContinuousDistribution::getMarginal;
   Distribution getMarginal(const Indices & indices) const;
 
   /** Get the Spearman correlation of the distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Mixture.hxx
@@ -38,9 +38,6 @@ class OT_API Mixture
   : public DistributionImplementation
 {
   CLASSNAME
-  // Make the BernsteinCopulaFactory class a friend of Mixture as it has to
-  // set the isCopula_ attribute directly
-  friend class BernsteinCopulaFactory;
 
 public:
 

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -3102,10 +3102,7 @@ Scalar DistributionImplementation::computeDensityGeneratorSecondDerivative(const
 /* Get the i-th marginal distribution */
 Distribution DistributionImplementation::getMarginal(const UnsignedInteger i) const
 {
-  if (!(i < dimension_)) throw InvalidArgumentException(HERE) << "Marginal index cannot exceed dimension";
-  if (dimension_ == 1) return clone();
-  if (isCopula()) return new Uniform(0.0, 1.0);
-  return new MarginalDistribution(*this, i);
+  return getMarginal(Indices(1, i));
 }
 
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2817,19 +2817,85 @@ CorrelationMatrix DistributionImplementation::getSpearmanCorrelation() const
   return getCopula().getSpearmanCorrelation();
 }
 
+struct DistributionImplementationKendallTauWrapper
+{
+  DistributionImplementationKendallTauWrapper(const Distribution & distribution)
+    : distribution_(distribution)
+  {
+    if (!distribution.isCopula())
+      {
+	const UnsignedInteger dimension = distribution.getDimension();
+	marginalCollection_ = Collection<Distribution>(dimension);
+	for (UnsignedInteger i = 0; i < dimension; ++i)
+	  marginalCollection_[i] = distribution.getMarginal(i);
+      }
+  }
+
+  Point kernelForCopula(const Point & point) const
+  {
+    return Point(1, distribution_.computeCDF(point) * distribution_.computePDF(point));
+  }
+
+  Point kernelForDistribution(const Point & point) const
+  {
+    const UnsignedInteger dimension = distribution_.getDimension();
+    Point x(dimension);
+    Scalar factor = 1.0;
+    for (UnsignedInteger i = 0; i < dimension; ++i)
+      {
+	const Point xi(marginalCollection_[i].computeQuantile(point[i]));
+	x[i] = xi[0];
+	factor *= marginalCollection_[i].computePDF(xi);
+	if (std::abs(factor) < SpecFunc::Precision) return Point(1, 0.0);
+      }
+    return Point(1, distribution_.computeCDF(point) * distribution_.computePDF(x) / factor);
+  }
+
+  const Distribution & distribution_;
+  Collection<Distribution> marginalCollection_;
+}; // DistributionImplementationKendallTauWrapperx
+
 /* Get the Kendall concordance of the distribution */
 CorrelationMatrix DistributionImplementation::getKendallTau() const
 {
-  if (isElliptical())
+  CorrelationMatrix tau(dimension_);
+  // First special case: independent marginals
+  if (hasIndependentCopula()) return tau;
+  // Second special case: elliptical distribution
+  if (hasEllipticalCopula())
   {
-    const CorrelationMatrix shape(getCorrelation());
-    CorrelationMatrix tau(dimension_);
+    const CorrelationMatrix shape(getShapeMatrix());
     for (UnsignedInteger i = 0; i < dimension_; ++i)
       for(UnsignedInteger j = 0; j < i; ++j)
         tau(i, j) = std::asin(shape(i, j)) * (2.0 / M_PI);
     return tau;
   }
-  return getCopula().getKendallTau();
+  // General case
+  const IteratedQuadrature integrator;
+  const Interval square(2);
+  // Performs the integration in the strictly lower triangle of the tau matrix
+  Indices indices(2);
+  for(UnsignedInteger rowIndex = 0; rowIndex < dimension_; ++rowIndex)
+  {
+    indices[0] = rowIndex;
+    for (UnsignedInteger columnIndex = rowIndex + 1; columnIndex < dimension_; ++columnIndex)
+    {
+      indices[1] = columnIndex;
+      const Distribution marginalDistribution(getMarginal(indices).getImplementation());
+      if (!marginalDistribution.hasIndependentCopula())
+      {
+        // Build the integrand
+	const DistributionImplementationKendallTauWrapper functionWrapper(marginalDistribution);
+	Function function;
+	if (isCopula())
+	    function = (bindMethod<DistributionImplementationKendallTauWrapper, Point, Point>(functionWrapper, &DistributionImplementationKendallTauWrapper::kernelForCopula, 2, 1));
+	else
+	    function = (bindMethod<DistributionImplementationKendallTauWrapper, Point, Point>(functionWrapper, &DistributionImplementationKendallTauWrapper::kernelForDistribution, 2, 1));
+        tau(rowIndex, columnIndex) = integrator.integrate(function, square)[0];
+      }
+    } // loop over column indices
+  } // loop over row indices
+  return tau;
 }
 
 /* Get the shape matrix of the distribution, ie the correlation matrix
@@ -2837,7 +2903,11 @@ CorrelationMatrix DistributionImplementation::getKendallTau() const
 CorrelationMatrix DistributionImplementation::getShapeMatrix() const
 {
   if (!hasEllipticalCopula()) throw NotDefinedException(HERE) << "Error: the shape matrix is defined only for distributions with elliptical copulas.";
-  return getCopula().getShapeMatrix();
+  // Easy case: elliptical distribution
+  if (isElliptical()) return getCorrelation();
+  // Difficult case: elliptical distribution with nonelliptical marginals
+  const Collection<Distribution> ellipticalMarginals(dimension_, getStandardDistribution().getMarginal(0));
+  return ComposedDistribution(ellipticalMarginals, getCopula()).getCorrelation();
 }
 
 /* Cholesky factor of the correlation matrix accessor */

--- a/lib/src/Uncertainty/Model/SklarCopula.cxx
+++ b/lib/src/Uncertainty/Model/SklarCopula.cxx
@@ -423,8 +423,7 @@ Distribution SklarCopula::getDistribution() const
 /* Get the Kendall concordance of the copula */
 CorrelationMatrix SklarCopula::getKendallTau() const
 {
-  if (distribution_.isElliptical()) return distribution_.getKendallTau();
-  return CopulaImplementation::getKendallTau();
+  return distribution_.getKendallTau();
 }
 
 /* Compute the covariance of the copula */

--- a/lib/src/Uncertainty/Model/openturns/CopulaImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/CopulaImplementation.hxx
@@ -56,9 +56,6 @@ public:
   /** Get the Spearman correlation of the copula */
   CorrelationMatrix getSpearmanCorrelation() const;
 
-  /** Get the Kendall concordance of the copula */
-  CorrelationMatrix getKendallTau() const;
-
   /** Get the standard deviation of the copula */
   Point getStandardDeviation() const;
 

--- a/lib/test/t_EmpiricalBernsteinCopula_std.expout
+++ b/lib/test/t_EmpiricalBernsteinCopula_std.expout
@@ -78,21 +78,21 @@ beta=0.974525
 covariance=class=CovarianceMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[0.08333,0.01042,0.01042,0.08333]
 correlation=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.125,0.125,1]
 spearman=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.125,0.125,1]
-kendall=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.2713,0.2713,1]
-margin=class=IndependentCopula name=IndependentCopula dimension=1
+kendall=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.2712,0.2712,1]
+margin=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X0] data=[[0.833333],[0.583333],[0.166667],[0.666667],[0.916667],[0.5],[0.0833333],[0.25],[1],[0.416667],[0.75],[0.333333]] binNumber=3
 margin PDF=1
 margin CDF=0.25
 margin quantile=class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization=class=Point name=Unnamed dimension=1 values=[0.29616]
-margin=class=IndependentCopula name=IndependentCopula dimension=1
+margin realization=class=Point name=Unnamed dimension=1 values=[0.960577]
+margin=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X1] data=[[0.166667],[0.916667],[0.583333],[1],[0.833333],[0.5],[0.0833333],[0.416667],[0.333333],[0.666667],[0.75],[0.25]] binNumber=3
 margin PDF=1
 margin CDF=0.25
 margin quantile=class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization=class=Point name=Unnamed dimension=1 values=[0.989184]
+margin realization=class=Point name=Unnamed dimension=1 values=[0.0182254]
 indices=[1,0]
 margins=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=2 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=2 description=[X1,X0] data=[[0.166667,0.833333],[0.916667,0.583333],[0.583333,0.166667],[1,0.666667],[0.833333,0.916667],[0.5,0.5],[0.0833333,0.0833333],[0.416667,0.25],[0.333333,1],[0.666667,0.416667],[0.75,0.75],[0.25,0.333333]] binNumber=3
 margins PDF=1.0957
 margins CDF=0.0767822
 margins quantile=class=Point name=Unnamed dimension=2 values=[0.974525,0.974525]
 margins CDF(quantile)=0.95
-margins realization=class=Point name=Unnamed dimension=2 values=[0.970706,0.981775]
+margins realization=class=Point name=Unnamed dimension=2 values=[0.944591,0.804734]

--- a/python/test/t_EmpiricalBernsteinCopula_std.expout
+++ b/python/test/t_EmpiricalBernsteinCopula_std.expout
@@ -55,20 +55,20 @@ beta= [0.974525]
 Unilateral confidence interval (upper tail)= [0.0254747, 1]
 [0.0254747, 1]
 beta= [0.974525]
-margin= class=IndependentCopula name=IndependentCopula dimension=1
+margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X0] data=[[0.833333],[0.583333],[0.166667],[0.666667],[0.916667],[0.5],[0.0833333],[0.25],[1],[0.416667],[0.75],[0.333333]] binNumber=3
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.70259]
-margin= class=IndependentCopula name=IndependentCopula dimension=1
+margin realization= class=Point name=Unnamed dimension=1 values=[0.354782]
+margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X1] data=[[0.166667],[0.916667],[0.583333],[1],[0.833333],[0.5],[0.0833333],[0.416667],[0.333333],[0.666667],[0.75],[0.25]] binNumber=3
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.268608]
+margin realization= class=Point name=Unnamed dimension=1 values=[0.739996]
 indices= [1,0]
 margins= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=2 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=2 description=[X1,X0] data=[[0.166667,0.833333],[0.916667,0.583333],[0.583333,0.166667],[1,0.666667],[0.833333,0.916667],[0.5,0.5],[0.0833333,0.0833333],[0.416667,0.25],[0.333333,1],[0.666667,0.416667],[0.75,0.75],[0.25,0.333333]] binNumber=3
 margins PDF=1.095703
 margins CDF=0.076782
 margins quantile= class=Point name=Unnamed dimension=2 values=[0.974525,0.974525]
 margins CDF(qantile)=0.950000
-margins realization= class=Point name=Unnamed dimension=2 values=[0.739996,0.466049]
+margins realization= class=Point name=Unnamed dimension=2 values=[0.565228,0.790266]


### PR DESCRIPTION
This PR fixes ticket #947. It allows to build an EmpiricalBernsteinCopula object even if the resulting distribution is not a copula, for statistical estimation purpose. It may be strange to name a distribution an EmpiricalBernsteinCopula even when it is not a proper copula, but the name is in the literature since 2004 and the fact that an arithmetic condition is mandatory to get a proper copula has been proved only in 2017!
I finally succeeded in fixing the circular dependency between CopulaImplementation and DistributionImplementation, so the PR should be ok now...