### PR TITLE
Fix segfault in symbolic parser

### DIFF
--- a/lib/src/Base/Func/SymbolicParserExprTk.cxx
+++ b/lib/src/Base/Func/SymbolicParserExprTk.cxx
@@ -113,7 +113,7 @@ Sample SymbolicParserExprTk::operator() (const Sample & inS) const
     // One formula by marginal
     for (UnsignedInteger i = 0; i < size; ++i)
     {
-      std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+      std::copy(&inS(i, 0), &inS(i, 0) + inputDimension, inputStack_.begin());
 
       for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
       {
@@ -132,7 +132,7 @@ Sample SymbolicParserExprTk::operator() (const Sample & inS) const
       // Single formula
       for (UnsignedInteger i = 0; i < size; ++i)
       {
-        std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+        std::copy(&inS(i, 0), &inS(i, 0) + inputDimension, inputStack_.begin());
         // Evaluate expression
         (void) expressions_[0]->value();
 
@@ -149,7 +149,7 @@ Sample SymbolicParserExprTk::operator() (const Sample & inS) const
       // Single formula
       for (UnsignedInteger i = 0; i < size; ++i)
       {
-        std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+        std::copy(&inS(i, 0), &inS(i, 0) + inputDimension, inputStack_.begin());
         // Evaluate expression
         (void) expressions_[0]->value();
 

--- a/lib/src/Base/Func/SymbolicParserMuParser.cxx
+++ b/lib/src/Base/Func/SymbolicParserMuParser.cxx
@@ -160,7 +160,7 @@ Sample SymbolicParserMuParser::operator() (const Sample & inS) const
     {
       for (UnsignedInteger i = 0; i < size; ++i)
       {
-        std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+        std::copy(&inS(i, 0), &inS(i, 0) + inputDimension, inputStack_.begin());
         for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
         {
           const Scalar value = parsers_[outputIndex].get()->Eval();
@@ -175,7 +175,7 @@ Sample SymbolicParserMuParser::operator() (const Sample & inS) const
     {
       for (UnsignedInteger i = 0; i < size; ++i)
       {
-        std::copy(&inS(i, 0), &inS(i, inputDimension), inputStack_.begin());
+        std::copy(&inS(i, 0), &inS(i, 0) + inputDimension, inputStack_.begin());
         for (UnsignedInteger outputIndex = 0; outputIndex < outputDimension; ++ outputIndex)
           result(i, outputIndex) = parsers_[outputIndex].get()->Eval();
       } // i


### PR DESCRIPTION
Show up on Fedora 28 (gcc 8.0.1) with the distro compilation options:
CXXFLAGS='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
  -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1
  -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic
  -fasynchronous-unwind-tables -fstack-clash-protection -mcet -fcf-protection'