### PR TITLE
Memoize to preserve useDefaultGrad|Hess attributes

### DIFF
--- a/lib/src/Base/Func/MemoizeFunction.cxx
+++ b/lib/src/Base/Func/MemoizeFunction.cxx
@@ -41,7 +41,8 @@ MemoizeFunction::MemoizeFunction (const Function & function, const HistoryStrate
                            function.getGradient(),
                            function.getHessian())
 {
-  // Nothing to do
+  setUseDefaultGradientImplementation(function.getUseDefaultGradientImplementation());
+  setUseDefaultHessianImplementation(function.getUseDefaultHessianImplementation());
 }
 
 /** Operator () */


### PR DESCRIPTION
We use that to detect if default finite difference method is used