### PR TITLE
Speed-up Sample::computeQuantilePerComponent

### DIFF
--- a/lib/src/Base/Stat/Sample.cxx
+++ b/lib/src/Base/Stat/Sample.cxx
@@ -530,10 +530,20 @@ Point Sample::computeQuantilePerComponent(const Scalar prob) const
   return getImplementation()->computeQuantilePerComponent(prob);
 }
 
+Sample Sample::computeQuantilePerComponent(const Point & prob) const
+{
+  return getImplementation()->computeQuantilePerComponent(prob);
+}
+
 /*
  * Method computeQuantile() gives the N-dimension quantile of the sample
  */
 Point Sample::computeQuantile(const Scalar prob) const
+{
+  return getImplementation()->computeQuantile(prob);
+}
+
+Sample Sample::computeQuantile(const Point & prob) const
 {
   return getImplementation()->computeQuantile(prob);
 }

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -1733,8 +1733,19 @@ Point SampleImplementation::computeQuantilePerComponent(const Scalar prob) const
     for (UnsignedInteger i = 0; i < size_; ++i)
       component[i] = operator()(i, j);
 
-    TBB::ParallelSort(component.begin(), component.end());
-
+    // Find index-th and (index+1)-th elements.
+    // We call nth_element twice, and select the right order so that second
+    // call operates on the smallest subset.
+    if (2 * index > size_)
+    {
+      std::nth_element(component.begin(), component.begin() + index, component.end());
+      std::nth_element(component.begin() + index, component.begin() + index + 1, component.end());
+    }
+    else
+    {
+      std::nth_element(component.begin(), component.begin() + index + 1, component.end());
+      std::nth_element(component.begin(), component.begin() + index, component.begin() + index + 1);
+    }
     // Interpolation between the two adjacent empirical quantiles
     quantile[j] = alpha * component[index] + beta * component[index + 1];
   } // end for

--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -1754,6 +1754,96 @@ Point SampleImplementation::computeQuantilePerComponent(const Scalar prob) const
 }
 
 /*
+ * Gives the quantile per component of the sample
+ */
+SampleImplementation SampleImplementation::computeQuantilePerComponent(const Point & prob) const
+{
+  if (size_ == 0) throw InternalException(HERE) << "Error: cannot compute the quantile per component of an empty sample.";
+  const UnsignedInteger probSize = prob.getSize();
+  if (probSize == 0) throw InternalException(HERE) << "Error: cannot compute the quantile per component with an empty argument.";
+
+  // Check that prob is inside bounds
+  for (UnsignedInteger p = 0; p < probSize; ++p)
+    if (!(prob[p] >= 0.0) || !(prob[p] <= 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a quantile for a probability level outside of [0, 1]";
+
+  // Check that prob is sorted; we could accept unsorted argument, but we would have to
+  // sort it and rearrange output; code is already ugly enough
+  for (UnsignedInteger p = 1; p < prob.getSize(); ++p)
+    if (!(prob[p - 1] <= prob[p])) throw InvalidArgumentException(HERE) << "Error: argument of computeQuantilePerComponent must be sorted in ascending order";
+
+  // Compute the list of pivots and coefficients
+  Indices pivots(probSize);
+  Point betas(probSize);
+  for (UnsignedInteger p = 0; p < probSize; ++p)
+  {
+    Scalar scalarIndex = prob[p] * size_ - 0.5;
+    UnsignedInteger index = static_cast<UnsignedInteger>( floor( scalarIndex) );
+    Scalar beta = scalarIndex - index;
+    // Special case for extremum cases
+    if (scalarIndex >= size_ - 1)
+    {
+      beta = 0.0;
+      index = size_ - 1;
+    }
+    else if (scalarIndex <= 0.0)
+    {
+      beta = 0.0;
+      // Ensure that index does not overflow
+      index = 0;
+    }
+    pivots[p] = index;
+    betas[p] = beta;
+  }
+
+  SampleImplementation quantile(probSize, dimension_);
+  Point component(size_);
+  for (UnsignedInteger j = 0; j < dimension_; ++j)
+  {
+    for (UnsignedInteger i = 0; i < size_; ++i)
+      component[i] = operator()(i, j);
+
+    UnsignedInteger lastIndex = 0;
+    for (UnsignedInteger p = 0; p < probSize; ++p)
+    {
+      // Find index-th and (index+1)-th elements.
+      // We call nth_element twice, and select the right order so that second
+      // call operates on the smallest subset.
+      const UnsignedInteger index = pivots[p];
+      const Scalar beta = betas[p];
+      const Scalar alpha = 1.0 - beta;
+      if (beta == 0.0)
+      {
+        // We use a special case here to avoid using an indefinite value if index is the last element
+        std::nth_element(component.begin() + lastIndex, component.begin() + index, component.end());
+        quantile(p, j) = component[index];
+      }
+      else if (lastIndex == index && p > 0)
+      {
+        // Same index, but alpha and beta may have changed
+        quantile(p, j) = alpha * component[index] + beta * component[index + 1];
+      }
+      else if (2 * index > size_ + lastIndex)
+      {
+        std::nth_element(component.begin() + lastIndex, component.begin() + index, component.end());
+        std::nth_element(component.begin() + index, component.begin() + index + 1, component.end());
+        // Interpolation between the two adjacent empirical quantiles
+        quantile(p, j) = alpha * component[index] + beta * component[index + 1];
+      }
+      else
+      {
+        std::nth_element(component.begin() + lastIndex, component.begin() + index + 1, component.end());
+        std::nth_element(component.begin() + lastIndex, component.begin() + index, component.begin() + index + 1);
+        // Interpolation between the two adjacent empirical quantiles
+        quantile(p, j) = alpha * component[index] + beta * component[index + 1];
+      }
+      lastIndex = index;
+    }
+  }
+
+  return quantile;
+}
+
+/*
  * Gives the N-dimension quantile of the sample
  */
 Point SampleImplementation::computeQuantile(const Scalar prob) const
@@ -1762,6 +1852,14 @@ Point SampleImplementation::computeQuantile(const Scalar prob) const
 
   if (getDimension() == 1) return computeQuantilePerComponent(prob);
   throw NotYetImplementedException(HERE) << "In SampleImplementation::computeQuantile(const Scalar prob) const";
+}
+
+SampleImplementation SampleImplementation::computeQuantile(const Point & prob) const
+{
+  if (size_ == 0) throw InternalException(HERE) << "Error: cannot compute the quantile of an empty sample.";
+
+  if (getDimension() == 1) return computeQuantilePerComponent(prob);
+  throw NotYetImplementedException(HERE) << "In SampleImplementation::computeQuantile(const Point & prob) const";
 }
 
 struct CDFPolicy

--- a/lib/src/Base/Stat/openturns/Sample.hxx
+++ b/lib/src/Base/Stat/openturns/Sample.hxx
@@ -262,11 +262,13 @@ public:
    * Method computeQuantilePerComponent() gives the quantile per component of the sample
    */
   Point computeQuantilePerComponent(const Scalar prob) const;
+  Sample computeQuantilePerComponent(const Point & prob) const;
 
   /**
    * Method computeQuantile() gives the N-dimension quantile of the sample
    */
   Point computeQuantile(const Scalar prob) const;
+  Sample computeQuantile(const Point & prob) const;
 
   /**
    * Get the empirical CDF of the sample

--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -715,11 +715,13 @@ public:
    * Gives the quantile per component of the sample
    */
   virtual Point computeQuantilePerComponent(const Scalar prob) const;
+  virtual SampleImplementation computeQuantilePerComponent(const Point & prob) const;
 
   /**
    * Gives the N-dimension quantile of the sample
    */
   Point computeQuantile(const Scalar prob) const;
+  SampleImplementation computeQuantile(const Point & prob) const;
 
   /**
    * Get the empirical CDF of the sample

--- a/lib/test/t_Sample_computation.cxx
+++ b/lib/test/t_Sample_computation.cxx
@@ -79,6 +79,9 @@ int main(int argc, char *argv[])
     probs[0] = 0.25;
     probs[1] = 0.75;
     fullprint << "Quantile per component(" << probs << ")=" << sample.computeQuantilePerComponent(probs) << std::endl;
+    probs[0] = 0.75;
+    probs[1] = 0.25;
+    fullprint << "Quantile per component(" << probs << ")=" << sample.computeQuantilePerComponent(probs) << std::endl;
     Point pointCDF(sample.getDimension(), 0.25);
     fullprint << "Empirical CDF(" << pointCDF << "=" << sample.computeEmpiricalCDF(pointCDF) << std::endl;
     UnsignedInteger dim = 3;

--- a/lib/test/t_Sample_computation.cxx
+++ b/lib/test/t_Sample_computation.cxx
@@ -75,6 +75,10 @@ int main(int argc, char *argv[])
     Scalar prob = 0.25;
     fullprint << "Quantile per component(" << prob << ")=" << sample.computeQuantilePerComponent(prob) << std::endl;
     //    fullprint << "Quantile(" << prob << ")=" << sample.computeQuantile(prob) << std::endl;
+    Point probs(2);
+    probs[0] = 0.25;
+    probs[1] = 0.75;
+    fullprint << "Quantile per component(" << probs << ")=" << sample.computeQuantilePerComponent(probs) << std::endl;
     Point pointCDF(sample.getDimension(), 0.25);
     fullprint << "Empirical CDF(" << pointCDF << "=" << sample.computeEmpiricalCDF(pointCDF) << std::endl;
     UnsignedInteger dim = 3;

--- a/lib/test/t_Sample_computation.expout
+++ b/lib/test/t_Sample_computation.expout
@@ -29,7 +29,8 @@ Rank=class=Sample name=Unnamed implementation=class=SampleImplementation name=Un
 Sort=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Sort according to component 0=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Quantile per component(0.25)=class=Point name=Unnamed dimension=3 values=[1.5,0.5,3.5]
-Quantile per component(class=Point name=Unnamed dimension=2 values=[0.25,0.75])=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[1.5,0.5,3.5],[5.5,5,8.5]]
+Quantile per component(class=Point name=Unnamed dimension=2 values=[0.25,0.75])=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 description=[q0,q1,q2] data=[[1.5,0.5,3.5],[5.5,5,8.5]]
+Quantile per component(class=Point name=Unnamed dimension=2 values=[0.75,0.25])=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 description=[q0,q1,q2] data=[[5.5,5,8.5],[1.5,0.5,3.5]]
 Empirical CDF(class=Point name=Unnamed dimension=3 values=[0.25,0.25,0.25]=0
 Pearson correlation (exact)=class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.25,0,0.25,1,0.25,0,0.25,1]
 Spearman correlation (exact)=class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.239359,0,0.239359,1,0.239359,0,0.239359,1]

--- a/lib/test/t_Sample_computation.expout
+++ b/lib/test/t_Sample_computation.expout
@@ -29,6 +29,7 @@ Rank=class=Sample name=Unnamed implementation=class=SampleImplementation name=Un
 Sort=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Sort according to component 0=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Quantile per component(0.25)=class=Point name=Unnamed dimension=3 values=[1.5,0.5,3.5]
+Quantile per component(class=Point name=Unnamed dimension=2 values=[0.25,0.75])=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[1.5,0.5,3.5],[5.5,5,8.5]]
 Empirical CDF(class=Point name=Unnamed dimension=3 values=[0.25,0.25,0.25]=0
 Pearson correlation (exact)=class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.25,0,0.25,1,0.25,0,0.25,1]
 Spearman correlation (exact)=class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.239359,0,0.239359,1,0.239359,0,0.239359,1]

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -470,12 +470,13 @@ Examples
 
 Parameters
 ----------
-p : float, :math:`0 \leq p \leq 1`
-    Input probability level.
+p : float, :math:`0 \leq p \leq 1`, or sequence of float
+    Input probability level.  When a sequence is given, it must be sorted
+    in ascending order.
 
 Returns
 -------
-quantile : :class:`~openturns.Point`
+quantile : :class:`~openturns.Point` or :class:`~openturns.Sample`
     Quantile of the joint distribution at probability level :math:`p`,
     estimated from the sample.
 
@@ -502,12 +503,13 @@ Examples
 
 Parameters
 ----------
-p : float, :math:`0 \leq p \leq 1`
-    Input probability level.
+p : float, :math:`0 \leq p \leq 1`, or sequence of float
+    Input probability level.  When a sequence is given, it must be sorted
+    in ascending order.
 
 Returns
 -------
-quantile : :class:`~openturns.Point`
+quantile : :class:`~openturns.Point` or :class:`~openturns.Sample`
     Componentwise quantile at probability level :math:`p`, estimated from the
     sample.
 

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -471,8 +471,7 @@ Examples
 Parameters
 ----------
 p : float, :math:`0 \leq p \leq 1`, or sequence of float
-    Input probability level.  When a sequence is given, it must be sorted
-    in ascending order.
+    Input probability level.
 
 Returns
 -------
@@ -504,8 +503,7 @@ Examples
 Parameters
 ----------
 p : float, :math:`0 \leq p \leq 1`, or sequence of float
-    Input probability level.  When a sequence is given, it must be sorted
-    in ascending order.
+    Input probability level.
 
 Returns
 -------

--- a/python/test/t_Sample_computation.expout
+++ b/python/test/t_Sample_computation.expout
@@ -29,6 +29,7 @@ Rank= class=Sample name=Unnamed implementation=class=SampleImplementation name=U
 Sort= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Sort according to component 0= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Quantile per component( 0.25 )= class=Point name=Unnamed dimension=3 values=[1.5,0.5,3.5]
+Quantile per component( [0.25, 0.75] )= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[1.5,0.5,3.5],[5.5,5,8.5]]
 Empirical CDF( class=Point name=Unnamed dimension=3 values=[0.25,0.25,0.25] = 0.0
 Pearson correlation (exact)= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.25,0,0.25,1,0.25,0,0.25,1]
 Spearman correlation (exact)= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.239359,0,0.239359,1,0.239359,0,0.239359,1]

--- a/python/test/t_Sample_computation.expout
+++ b/python/test/t_Sample_computation.expout
@@ -29,7 +29,8 @@ Rank= class=Sample name=Unnamed implementation=class=SampleImplementation name=U
 Sort= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Sort according to component 0= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=4 dimension=3 data=[[1,0,9],[2,3,5],[5,1,8],[6,7,2]]
 Quantile per component( 0.25 )= class=Point name=Unnamed dimension=3 values=[1.5,0.5,3.5]
-Quantile per component( [0.25, 0.75] )= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 data=[[1.5,0.5,3.5],[5.5,5,8.5]]
+Quantile per component( [0.25, 0.75] )= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 description=[q0,q1,q2] data=[[1.5,0.5,3.5],[5.5,5,8.5]]
+Quantile per component( [0.75, 0.25] )= class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=2 dimension=3 description=[q0,q1,q2] data=[[5.5,5,8.5],[1.5,0.5,3.5]]
 Empirical CDF( class=Point name=Unnamed dimension=3 values=[0.25,0.25,0.25] = 0.0
 Pearson correlation (exact)= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.25,0,0.25,1,0.25,0,0.25,1]
 Spearman correlation (exact)= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.239359,0,0.239359,1,0.239359,0,0.239359,1]

--- a/python/test/t_Sample_computation.py
+++ b/python/test/t_Sample_computation.py
@@ -45,6 +45,9 @@ try:
     prob = 0.25
     print("Quantile per component(", prob, ")=", repr(
         sample.computeQuantilePerComponent(prob)))
+    probs = [0.25, 0.75]
+    print("Quantile per component(", probs, ")=", repr(
+        sample.computeQuantilePerComponent(probs)))
     pointCDF = Point(sample.getDimension(), 0.25)
     print(
         "Empirical CDF(", repr(pointCDF), "=", sample.computeEmpiricalCDF(pointCDF))

--- a/python/test/t_Sample_computation.py
+++ b/python/test/t_Sample_computation.py
@@ -48,6 +48,9 @@ try:
     probs = [0.25, 0.75]
     print("Quantile per component(", probs, ")=", repr(
         sample.computeQuantilePerComponent(probs)))
+    probs = [0.75, 0.25]
+    print("Quantile per component(", probs, ")=", repr(
+        sample.computeQuantilePerComponent(probs)))
     pointCDF = Point(sample.getDimension(), 0.25)
     print(
         "Empirical CDF(", repr(pointCDF), "=", sample.computeEmpiricalCDF(pointCDF))


### PR DESCRIPTION
Use std::nth_element, this is faster than sorting the whole Sample, even with TBB on very large Sample.

Add method Sample::computeQuantilePerComponent(Point). This allows to compute several quantiles at once, this is a little faster than consecutive calls.
<s>Argument must be sorted in ascending order, otherwise an exception is raised.</s> EDITED: argument can now be unsorted
