### PR TITLE
Speed-up ProcessSample::computeQuantilePerComponent

### DIFF
--- a/lib/src/Base/Stat/ProcessSample.cxx
+++ b/lib/src/Base/Stat/ProcessSample.cxx
@@ -167,6 +167,11 @@ Field ProcessSample::computeQuantilePerComponent(const Scalar prob) const
   return getImplementation()->computeQuantilePerComponent(prob);
 }
 
+ProcessSample ProcessSample::computeQuantilePerComponent(const Point & prob) const
+{
+  return getImplementation()->computeQuantilePerComponent(prob);
+}
+
 /* Get the i-th marginal process sample */
 ProcessSample ProcessSample::getMarginal(const UnsignedInteger index) const
 {

--- a/lib/src/Base/Stat/openturns/ProcessSample.hxx
+++ b/lib/src/Base/Stat/openturns/ProcessSample.hxx
@@ -107,6 +107,7 @@ public:
 
   /**  Method computeQuantilePerComponent() gives the quantile per component of the sample */
   Field computeQuantilePerComponent(const Scalar prob) const;
+  ProcessSample computeQuantilePerComponent(const Point & prob) const;
 
   /** Get the i-th marginal sample */
   ProcessSample getMarginal(const UnsignedInteger index) const;

--- a/lib/src/Base/Stat/openturns/ProcessSampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/ProcessSampleImplementation.hxx
@@ -102,6 +102,7 @@ public:
 
   /**  Method computeQuantilePerComponent() gives the quantile per component of the sample */
   Field computeQuantilePerComponent(const Scalar prob) const;
+  ProcessSampleImplementation computeQuantilePerComponent(const Point & prob) const;
 
   /** Get the i-th marginal sample */
   ProcessSampleImplementation getMarginal(const UnsignedInteger index) const;

--- a/python/src/ProcessSampleImplementation_doc.i.in
+++ b/python/src/ProcessSampleImplementation_doc.i.in
@@ -149,12 +149,12 @@ OT_ProcessSample_computeTemporalMean_doc
 
 Parameters
 ----------
-p : float, :math:`0 \leq p \leq 1`
+p : float, :math:`0 \leq p \leq 1`, or sequence of float
     Order of the quantile.
 
 Returns
 -------
-quantileField : :class:`~openturns.Field`
+quantile : :class:`~openturns.Field` or :class:`~openturns.ProcessSample`
     This field has the same size and the same dimension as the fields
     of the collection. At each vertex of the mesh, we estimate the
     component-wise quantile of order `p`, using the empirical quantile.


### PR DESCRIPTION
In master, each trajectory is extracted from the ProcessSample, copied into a Sample, and Sample::computeQuantilePerComponent is called.

In this PR, the ProcessSample is duplicated and transposed so that trajectories become contiguous in memory.  This is faster, benchmarks are provided below, but requires more memory since ProcessSample is duplicated.

A new method ProcessSample::computeQuantilePerComponent(Point) is added, so that this copy is performed only once when computing several quantiles.