### PR TITLE
Change evaluation order in NonCenteredFiniteDifferenceGradient::gradient

### DIFF
--- a/lib/src/Base/Diff/CenteredFiniteDifferenceHessian.cxx
+++ b/lib/src/Base/Diff/CenteredFiniteDifferenceHessian.cxx
@@ -101,7 +101,7 @@ SymmetricTensor CenteredFiniteDifferenceHessian::hessian(const Point & inP) cons
   if (inputDimension != step.getDimension()) throw InvalidArgumentException(HERE) << "Invalid input dimension";
   /* At which points do we have to compute the evaluation for the centered finite difference. We need 2*dim^2+1 points. */
   Sample gridPoints(2 * inputDimension * inputDimension + 1, inP);
-  UnsignedInteger index = 0;
+  UnsignedInteger index = 1;
   for(UnsignedInteger i = 1; i < inputDimension; ++i)
     for(UnsignedInteger j = 0; j < i; ++j)
     {
@@ -130,13 +130,13 @@ SymmetricTensor CenteredFiniteDifferenceHessian::hessian(const Point & inP) cons
   /* Evaluate the evaluation */
   Sample gridValues(evaluation_.operator()(gridPoints));
   /* Get the center value */
-  Point center(gridValues[gridValues.getSize() - 1]);
+  Point center(gridValues[0]);
   /* Compute the hessian */
   UnsignedInteger outputDimension = evaluation_.getOutputDimension();
   SymmetricTensor result(inputDimension, outputDimension);
-  UnsignedInteger diagonalOffset = 2 * inputDimension * (inputDimension - 1);
+  UnsignedInteger diagonalOffset = 1 + 2 * inputDimension * (inputDimension - 1);
   Scalar scale = -1.0;
-  UnsignedInteger offDiagonalOffset = 0;
+  UnsignedInteger offDiagonalOffset = 1;
   for (UnsignedInteger i = 0; i < inputDimension; ++i)
   {
     // Diagonal term

--- a/lib/src/Base/Diff/NonCenteredFiniteDifferenceGradient.cxx
+++ b/lib/src/Base/Diff/NonCenteredFiniteDifferenceGradient.cxx
@@ -94,17 +94,17 @@ Matrix NonCenteredFiniteDifferenceGradient::gradient(const Point & inP) const
   if (inputDimension != step.getDimension()) throw InvalidArgumentException(HERE) << "Invalid input dimension";
   /* At which points do we have to compute the evaluation for the decentered finite difference. We need 1+dim pionts. */
   Sample gridPoints(inputDimension + 1, inP);
-  for(UnsignedInteger i = 0; i < inputDimension; ++i) gridPoints(i, i) += step[i];
+  for(UnsignedInteger i = 0; i < inputDimension; ++i) gridPoints(i + 1, i) += step[i];
   /* Evaluate the evaluation */
   Sample gridValues(evaluation_.operator()(gridPoints));
   /* Get the value at the center of the grid */
-  Point center(gridValues[inputDimension]);
+  Point center(gridValues[0]);
   /* Compute the gradient */
   Matrix result(evaluation_.getInputDimension(), evaluation_.getOutputDimension());
   for (UnsignedInteger i = 0; i < result.getNbRows(); ++i)
     for (UnsignedInteger j = 0; j < result.getNbColumns(); ++j)
       /* result(i, j) = (f_j(x + e_i) - f_j(x)) / e_i ~ df_j / dx_i */
-      result(i, j) = (gridValues(i, j) - center[j]) / step[i];
+      result(i, j) = (gridValues(i + 1, j) - center[j]) / step[i];
   return result;
 }
 


### PR DESCRIPTION
We currently evaluate functions on shifted points, and last on center point.
This commit switches evaluation order to first evaluate on center point.

The reason is that the most common case is to perform evaluation then
gradient at the same location, so new evaluation order is better in order
to benefit from an LRU cache, or from a cache with a very small size.