### PR TITLE
Speed-up CovarianceModel::discretizeHMatrix

### DIFF
--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -187,6 +187,13 @@ Scalar CovarianceModelImplementation::computeAsScalar (const Point & s,
   return outputCovariance_(0, 0) * computeStandardRepresentative(s, t);
 }
 
+Scalar CovarianceModelImplementation::computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
+    const Collection<Scalar>::const_iterator & t_begin) const
+{
+  if (outputDimension_ != 1) throw NotDefinedException(HERE) << "Error: the covariance model is of dimension=" << outputDimension_ << ", expected dimension=1.";
+  return outputCovariance_(0, 0) * computeStandardRepresentative(s_begin, t_begin);
+}
+
 /* Computation of the covariance function */
 CovarianceMatrix CovarianceModelImplementation::operator() (const Scalar tau) const
 {

--- a/lib/src/Base/Stat/HMatrix.cxx
+++ b/lib/src/Base/Stat/HMatrix.cxx
@@ -46,6 +46,12 @@ HMatrix::HMatrix(const HMatrixImplementation & i)
   // Nothing to do
 }
 
+/** Copy matrix */
+HMatrix HMatrix::copy() const
+{
+  return HMatrix(new HMatrixImplementation(*getImplementation()));
+}
+
 void HMatrix::assemble(const HMatrixRealAssemblyFunction& f, char symmetry)
 {
   copyOnWrite();

--- a/lib/src/Base/Stat/HMatrixImplementation.cxx
+++ b/lib/src/Base/Stat/HMatrixImplementation.cxx
@@ -522,4 +522,72 @@ String HMatrixImplementation::__str__(const String & offset) const
   return oss;
 }
 
+CovarianceAssemblyFunction::CovarianceAssemblyFunction(const CovarianceModel & covarianceModel, const Sample & vertices, double epsilon)
+  : HMatrixRealAssemblyFunction()
+  , covarianceModel_(covarianceModel)
+  , definesComputeStandardRepresentative_(false)
+  , vertices_(vertices)
+  , verticesBegin_(vertices.getImplementation()->data_begin())
+  , inputDimension_(vertices.getDimension())
+  , covarianceDimension_(covarianceModel.getOutputDimension())
+  , epsilon_(epsilon)
+{
+  if (vertices_.getSize() == 0) return;
+  try {
+    (void) covarianceModel_.computeStandardRepresentative(vertices_[0], vertices_[0]);
+    definesComputeStandardRepresentative_ = true;
+  } catch (NotYetImplementedException &) {
+    // Do nothing
+  }
+}
+
+Scalar CovarianceAssemblyFunction::operator()(UnsignedInteger i, UnsignedInteger j) const
+{
+  if (definesComputeStandardRepresentative_)
+    return covarianceModel_.getImplementation()->computeAsScalar(verticesBegin_ + i * inputDimension_, verticesBegin_ + j * inputDimension_) + (i != j ? 0.0 : epsilon_);
+
+  const UnsignedInteger rowIndex = i / covarianceDimension_;
+  const UnsignedInteger columnIndex = j / covarianceDimension_;
+  const CovarianceMatrix localCovarianceMatrix(covarianceModel_( vertices_[rowIndex],  vertices_[columnIndex] ));
+  const UnsignedInteger rowIndexLocal = i % covarianceDimension_;
+  const UnsignedInteger columnIndexLocal = j % covarianceDimension_;
+  return localCovarianceMatrix(rowIndexLocal, columnIndexLocal) + (i != j ? 0.0 : epsilon_);
+}
+
+CovarianceBlockAssemblyFunction::CovarianceBlockAssemblyFunction(const CovarianceModel & covarianceModel, const Sample & vertices, double epsilon)
+  : HMatrixTensorRealAssemblyFunction(covarianceModel.getOutputDimension())
+  , covarianceModel_(covarianceModel)
+  , definesComputeStandardRepresentative_(false)
+  , vertices_(vertices)
+  , verticesBegin_(vertices.getImplementation()->data_begin())
+  , inputDimension_(vertices.getDimension())
+  , epsilon_(epsilon)
+{
+  Matrix eps = epsilon_ * IdentityMatrix(covarianceModel.getOutputDimension());
+  Pointer<MatrixImplementation> impl = eps.getImplementation();
+  epsilonId_ = CovarianceMatrix(covarianceModel.getOutputDimension(), *impl.get());
+  if (vertices.getSize() == 0) return;
+  try {
+    (void) covarianceModel_.computeStandardRepresentative(vertices_[0], vertices_[0]);
+    definesComputeStandardRepresentative_ = true;
+  } catch (NotYetImplementedException &) {
+    // Do nothing
+  }
+}
+
+void CovarianceBlockAssemblyFunction::compute(UnsignedInteger i, UnsignedInteger j, Matrix* localValues) const
+{
+  if (definesComputeStandardRepresentative_)
+  {
+    localValues->getImplementation()->operator[](0) = covarianceModel_.getImplementation()->computeAsScalar(verticesBegin_ + i * inputDimension_, verticesBegin_ + j * inputDimension_) + (i != j ? 0.0 : epsilon_);
+  }
+  else
+  {
+    CovarianceMatrix localResult(covarianceModel_( vertices_[i],  vertices_[j] ));
+    if (i == j && epsilon_ != 0.0)
+      localResult = localResult + epsilonId_;
+    memcpy( &localValues->getImplementation()->operator[](0), &localResult.getImplementation()->operator[](0), dimension_ * dimension_ * sizeof(Scalar) );
+  }
+}
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -83,12 +83,18 @@ public:
 
 #ifndef SWIG
   virtual Scalar computeStandardRepresentative(const Collection<Scalar>::const_iterator & s_begin,
-      const Collection<Scalar>::const_iterator & t_begin) const;
+                                               const Collection<Scalar>::const_iterator & t_begin) const;
 #endif
 
   // Special case for 1D model
   virtual Scalar computeAsScalar (const Point & s,
                                   const Point & t) const;
+
+#ifndef SWIG
+  // Special case for 1D model
+  virtual Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
+                                 const Collection<Scalar>::const_iterator & t_begin) const;
+#endif
 
   virtual CovarianceMatrix operator() (const Scalar tau) const;
   virtual CovarianceMatrix operator() (const Point & tau) const;

--- a/lib/src/Base/Stat/openturns/HMatrix.hxx
+++ b/lib/src/Base/Stat/openturns/HMatrix.hxx
@@ -53,6 +53,9 @@ class OT_API HMatrix :
   /** Number of columns */
   UnsignedInteger getNbColumns() const;
 
+  /** Copy matrix and its cluster trees */
+  HMatrix copy() const;
+
   void assemble(const HMatrixRealAssemblyFunction& f, char symmetry);
 
   void assemble(const HMatrixTensorRealAssemblyFunction& f, char symmetry);

--- a/python/src/HMatrix.i
+++ b/python/src/HMatrix.i
@@ -54,8 +54,6 @@ private:
 
 %include HMatrix_doc.i
 
-%ignore OT::HMatrix::assemble;
-
 %template(HMatrixImplementationTypedInterfaceObject) OT::TypedInterfaceObject<OT::HMatrixImplementation>;
 %template(pairlonglong) std::pair< size_t, size_t >;
 

--- a/python/src/HMatrixImplementation_doc.i.in
+++ b/python/src/HMatrixImplementation_doc.i.in
@@ -47,13 +47,13 @@ be performed:
 
 3. Assembly: coefficients computations
    The hierarchical structure of the matrix has been computed during step 2.
-   To compute coefficients, we call the assembleReal method and provide a
-   callable to compute interaction between two nodes.  Full blocks are computed
-   by calling this callable for the whole block.  If compression method is
-   'SVD', low-rank approximation is computed by first computing the whole
-   block, then finding its singular value decomposition, and rank is truncated
-   so that error does not exceed assemblyEpsilon.  This method is precise, but
-   very costly.  If compression method is a variant of ACA, only few rows and
+   To compute coefficients, we call the assemble method and provide a callable
+   to compute interaction between two nodes.  Full blocks are computed by
+   calling this callable for the whole block.  If compression method is 'SVD',
+   low-rank approximation is computed by first computing the whole block, then
+   finding its singular value decomposition, and rank is truncated so that
+   error does not exceed assemblyEpsilon.  This method is precise, but very
+   costly.  If compression method is a variant of ACA, only few rows and
    columns are computed.  This is much more efficient, but error may be larger
    than expected on some problems.
 
@@ -119,6 +119,53 @@ OT_HMatrix_norm_doc
 %enddef
 %feature("docstring") OT::HMatrixImplementation::transpose
 OT_HMatrix_transpose_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_HMatrix_assemble_doc
+"Assemble matrix.
+
+Parameters
+----------
+f : :class:`~openturns.HMatrixRealAssemblyFunction` or :class:`~openturns.HMatrixTensorRealAssemblyFunction`
+    Assembly function.
+symmetry : str
+    Symmetry flag, either N or L"
+%enddef
+%feature("docstring") OT::HMatrixImplementation::assemble
+OT_HMatrix_assemble_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_HMatrix_assembleReal_doc
+"Assemble matrix.
+
+Parameters
+----------
+f : assembly function
+    Callable that takes i,j int parameters and returns a float
+symmetry : str
+    Symmetry flag, either N or L"
+%enddef
+%feature("docstring") OT::HMatrixImplementation::assembleReal
+OT_HMatrix_assembleReal_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_HMatrix_assembleTensor_doc
+"Assemble matrix by block.
+
+Parameters
+----------
+f : assembly function
+    Callable that takes i,j int parameters and returns a Matrix
+outputDimension : int
+    Block dimension
+symmetry : str
+    Symmetry flag, either N or L"
+%enddef
+%feature("docstring") OT::HMatrixImplementation::assembleTensor
+OT_HMatrix_assembleTensor_doc
 
 // ---------------------------------------------------------------------
 
@@ -283,35 +330,3 @@ beta : float
 %enddef
 %feature("docstring") OT::HMatrixImplementation::gemm
 OT_HMatrix_gemm_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_HMatrix_assembleReal_doc
-"Assemble matrix.
-
-Parameters
-----------
-f : assembly function
-    Callable that takes i,j int parameters and returns a float
-symmetry : str
-    Symmetry flag, either N or L"
-%enddef
-%feature("docstring") OT::HMatrixImplementation::assembleReal
-OT_HMatrix_assembleReal_doc
-
-// ---------------------------------------------------------------------
-
-%define OT_HMatrix_assembleTensor_doc
-"Assemble matrix by block.
-
-Parameters
-----------
-f : assembly function
-    Callable that takes i,j int parameters and returns a Matrix
-outputDimension : int
-    Block dimension
-symmetry : str
-    Symmetry flag, either N or L"
-%enddef
-%feature("docstring") OT::HMatrixImplementation::assembleTensor
-OT_HMatrix_assembleTensor_doc

--- a/python/src/HMatrix_doc.i.in
+++ b/python/src/HMatrix_doc.i.in
@@ -4,6 +4,17 @@ OT_HMatrix_doc
 OT_HMatrix_getDiagonal_doc
 %feature("docstring") OT::HMatrix::dump
 OT_HMatrix_dump_doc
+%feature("docstring") OT::HMatrix::copy
+"Copy matrix.
+
+As factorization overwrites matrix contents, this method
+is useful to get a copy of assembled matrix before it is
+factorized.
+
+Returns
+-------
+matrix : :class:`~openturns.HMatrix`
+    Matrix copy."
 %feature("docstring") OT::HMatrix::transpose
 OT_HMatrix_transpose_doc
 %feature("docstring") OT::HMatrix::norm

--- a/python/src/HMatrix_doc.i.in
+++ b/python/src/HMatrix_doc.i.in
@@ -12,6 +12,12 @@ OT_HMatrix_norm_doc
 OT_HMatrix_getNbRows_doc
 %feature("docstring") OT::HMatrix::getNbColumns
 OT_HMatrix_getNbColumns_doc
+%feature("docstring") OT::HMatrix::assemble
+OT_HMatrix_assemble_doc
+%feature("docstring") OT::HMatrix::assembleReal
+OT_HMatrix_assembleReal_doc
+%feature("docstring") OT::HMatrix::assembleTensor
+OT_HMatrix_assembleTensor_doc
 %feature("docstring") OT::HMatrix::factorize
 OT_HMatrix_factorize_doc
 %feature("docstring") OT::HMatrix::solve
@@ -28,7 +34,3 @@ OT_HMatrix_scale_doc
 OT_HMatrix_gemv_doc
 %feature("docstring") OT::HMatrix::gemm
 OT_HMatrix_gemm_doc
-%feature("docstring") OT::HMatrix::assembleReal
-OT_HMatrix_assembleReal_doc
-%feature("docstring") OT::HMatrix::assembleTensor
-OT_HMatrix_assembleTensor_doc


### PR DESCRIPTION
`CovarianceModel::discretize` method had been made faster in PR #492 and #599.  This PR applies similar tricks for HMatrix, and timings look much better now.