### PR TITLE
Fix Sample.__str__ ellipsis condition

### DIFF
--- a/lib/src/Base/Stat/SampleImplementation.cxx
+++ b/lib/src/Base/Stat/SampleImplementation.cxx
@@ -896,7 +896,7 @@ String SampleImplementation::__str__(const String & offset) const
 
   const UnsignedInteger printEllipsisThreshold = ResourceMap::GetAsUnsignedInteger("Sample-PrintEllipsisThreshold");
   const UnsignedInteger printEllipsisSize = ResourceMap::GetAsUnsignedInteger("Sample-PrintEllipsisSize");
-  const Bool ellipsis = (data_.getSize() > printEllipsisThreshold);
+  const Bool ellipsis = (size_ >= printEllipsisThreshold);
 
   size_t twidth = 0; // column title max width
   size_t lwidth = 0; // LHS number max width


### PR DESCRIPTION
size_ must be used, not data.getSize(), which is the global number of
elements, also chose to use '>=' instead of '>'.