### PR TITLE
Fix BurrFactory error checking

### DIFF
--- a/lib/src/Uncertainty/Distribution/BurrFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/BurrFactory.cxx
@@ -75,8 +75,8 @@ struct BurrFactoryParameterConstraint
       sumLogXC += log1p(xC);
     }
     /* MLE second parameter */
+    if (!SpecFunc::IsNormal(sumLogXC)) throw InvalidArgumentException(HERE) << "Error: cannot estimate the k parameter";
     const Scalar k = size / sumLogXC;
-    if (!SpecFunc::IsNormal(k)) throw InvalidArgumentException(HERE) << "Error: cannot estimate the k parameter";
 
     /* MLE equation first parameter */
     const Scalar relation = 1.0 + (c / size) * (sumRatio - k * sumScaledRatio);


### PR DESCRIPTION
It's best to check that sumLog is not inf as n/inf returns 0
(sumRatio=-nan at the same time)