### PR TITLE
Fix composed distributions description warnings

### DIFF
--- a/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedCopula.cxx
@@ -131,7 +131,16 @@ void ComposedCopula::setCopulaCollection(const CopulaCollection & coll)
   isAlreadyComputedCovariance_ = false;
   // One MUST set the dimension BEFORE the description, else an error occurs
   setDimension(dimension);
+
+  // avoid description warning with identical entries
+  Description test(description);
+  Description::const_iterator it = std::unique(test.begin(), test.end());
+  if (it != test.end())
+  {
+    description = Description::BuildDefault(dimension_, "X");
+  }
   setDescription(description);
+
   computeRange();
 }
 

--- a/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/ComposedDistribution.cxx
@@ -201,7 +201,16 @@ void ComposedDistribution::setDistributionCollection(const DistributionCollectio
   distributionCollection_ = coll;
   isAlreadyComputedMean_ = false;
   isAlreadyComputedCovariance_ = false;
+
+  // avoid description warning with identical entries
+  Description test(description);
+  Description::const_iterator it = std::unique(test.begin(), test.end());
+  if (it != test.end())
+  {
+    description = Description::BuildDefault(dimension_, "X");
+  }
   setDescription(description);
+
   setRange(Interval(lowerBound, upperBound, finiteLowerBound, finiteUpperBound));
 }
 


### PR DESCRIPTION
The warning from (https://github.com/openturns/openturns/pull/794/commits/4a0012a109d2b33552f86abc1484df967e32cccf) is really common with ComposedDistribution.