### PR TITLE
[RFC] Added a Robbins Monro based estimation of quantile in ProcessSample

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -208,6 +208,12 @@
   <!-- OT::ReverseHaltonSequence parameters -->
   <ReverseHaltonSequence-InitialSeed value_int="1" />
 
+  <!-- OT::ProcessSample parameters -->
+  <ProcessSample-UseRobbinsMonroQuantile        value_bool="false" />
+  <ProcessSample-RobbinsMonroProximalFactor     value_float="1.0" />
+  <ProcessSample-RobbinsMonroExponent           value_float="0.75" />
+  <ProcessSample-RobbinsMonroProximalIterations value_int="10"  />
+
   <!-- OT::SobolSequence parameters -->
   <SobolSequence-InitialSeed value_int="1" />
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -725,6 +725,12 @@ void ResourceMap::loadDefaultConfiguration()
   // ReverseHaltonSequence parameters //
   setAsUnsignedInteger( "ReverseHaltonSequence-InitialSeed", 1 );
 
+  // ProcessSample parameters //
+  setAsBool( "ProcessSample-UseRobbinsMonroQuantile", false );
+  setAsScalar( "ProcessSample-RobbinsMonroProximalFactor", 1.0 );
+  setAsScalar( "ProcessSample-RobbinsMonroExponent", 0.75 );
+  setAsUnsignedInteger( "ProcessSample-RobbinsMonroProximalIterations", 10 );
+
   // SobolSequence parameters //
   setAsUnsignedInteger( "SobolSequence-InitialSeed", 1 );
 

--- a/lib/src/Base/Stat/ProcessSample.cxx
+++ b/lib/src/Base/Stat/ProcessSample.cxx
@@ -172,6 +172,11 @@ ProcessSample ProcessSample::computeQuantilePerComponent(const Point & prob) con
   return getImplementation()->computeQuantilePerComponent(prob);
 }
 
+Field ProcessSample::computeQuantilePerComponentRobbinsMonroBasic(const Scalar prob) const
+{
+  return getImplementation()->computeQuantilePerComponentRobbinsMonroBasic(prob);
+}
+
 /* Get the i-th marginal process sample */
 ProcessSample ProcessSample::getMarginal(const UnsignedInteger index) const
 {

--- a/lib/src/Base/Stat/ProcessSampleImplementation.cxx
+++ b/lib/src/Base/Stat/ProcessSampleImplementation.cxx
@@ -264,6 +264,8 @@ Field ProcessSampleImplementation::computeQuantilePerComponent(const Scalar prob
   const UnsignedInteger size = getSize();
   if (size == 0) return Field();
   if (size == 1) return Field(mesh_, data_[0]);
+  if (ResourceMap::GetAsBool("ProcessSample-UseRobbinsMonroQuantile")) return Field(mesh_, computeQuantilePerComponentRobbinsMonro(prob));
+  
   const UnsignedInteger dimension = data_[0].getDimension();
   const UnsignedInteger length = data_[0].getSize();
   const UnsignedInteger sampleSize = dimension * length;
@@ -304,6 +306,13 @@ ProcessSampleImplementation ProcessSampleImplementation::computeQuantilePerCompo
   const UnsignedInteger size = getSize();
   if (size == 0) return ProcessSampleImplementation();
   if (size == 1) return *this;
+  if (ResourceMap::GetAsBool("ProcessSample-UseRobbinsMonroQuantile"))
+    {
+      ProcessSampleImplementation output(mesh_, prob.getSize(), getDimension());
+      for (UnsignedInteger i = 0; i < prob.getSize(); ++i)
+	output[i] = computeQuantilePerComponentRobbinsMonro(prob[i]);
+      return output;
+    }
 
   // Check that prob is inside bounds
   const UnsignedInteger probSize = prob.getSize();
@@ -349,6 +358,67 @@ ProcessSampleImplementation ProcessSampleImplementation::computeQuantilePerCompo
     result.add(output);
   }
   return result;
+}
+
+/*
+ * Method computeQuantilePerComponent() gives the quantile per component of the sample using Robbins Monro approximation
+ */
+Sample ProcessSampleImplementation::computeQuantilePerComponentRobbinsMonro(const Scalar prob) const
+{
+  const UnsignedInteger size = getSize();
+  if (size == 0) return Sample();
+  if (size == 1) return data_[0];
+  const UnsignedInteger K = ResourceMap::GetAsUnsignedInteger("ProcessSample-RobbinsMonroProximalIterations");
+  const Scalar a1 = ResourceMap::GetAsScalar("ProcessSample-RobbinsMonroProximalFactor");
+  const Scalar gamma = ResourceMap::GetAsScalar("ProcessSample-RobbinsMonroExponent");
+  const UnsignedInteger dimension = data_[0].getDimension();
+  const UnsignedInteger length = data_[0].getSize();
+  const UnsignedInteger flatSize = length * dimension;
+  Point quantiles(data_[0].getImplementation()->getData());
+  for (UnsignedInteger i = 1; i < size; ++i)
+    {
+      const Point & Xi = data_[i].getImplementation()->getData();
+      const Scalar tau = 1.0 / pow(i + 1.0, gamma);
+      for (UnsignedInteger j = 0; j < flatSize; ++j)
+	{
+	  const Scalar theta0 = quantiles[j];
+	  const Scalar xij = Xi[j];
+	  Scalar thetaj = theta0;
+	  for (UnsignedInteger k = 0; k < K; ++k)
+	    {
+	      const Scalar ak = 1.0 / std::pow(k + 1.0, gamma);
+	      thetaj -= ak * (tau * (int(xij <= thetaj) - prob) + thetaj - theta0);
+	    }
+	  //quantiles[j] = thetaj;
+	  quantiles[j] -= tau * (int(Xi[j] <= thetaj) - prob);
+	} // j
+    } // i
+  SampleImplementation result(length, dimension);
+  result.setData(quantiles);
+  result.setDescription(Description::BuildDefault(dimension, "q"));
+  return result;
+}
+
+Field ProcessSampleImplementation::computeQuantilePerComponentRobbinsMonroBasic(const Scalar prob) const
+{
+  const UnsignedInteger size = getSize();
+  if (size == 0) return Field();
+  if (size == 1) return Field(mesh_, data_[0]);
+  const UnsignedInteger dimension = data_[0].getDimension();
+  const UnsignedInteger length = data_[0].getSize();
+  const UnsignedInteger flatSize = length * dimension;
+  Point quantiles(data_[0].getImplementation()->getData());
+  const Scalar gamma = ResourceMap::GetAsScalar("ProcessSample-RobbinsMonroExponent");
+  for (UnsignedInteger i = 1; i < size; ++i)
+    {
+      const Point & Xi = data_[i].getImplementation()->getData();
+      const Scalar tau = std::pow(i + 1.0, -gamma);
+      for (UnsignedInteger j = 0; j < flatSize; ++j)
+	quantiles[j] -= tau * (int(Xi[j] <= quantiles[j]) - prob);
+    } // i
+  SampleImplementation result(length, dimension);
+  result.setData(quantiles);
+  return Field(mesh_, result);
 }
 
 /* Get the i-th marginal process sample */

--- a/lib/src/Base/Stat/openturns/ProcessSample.hxx
+++ b/lib/src/Base/Stat/openturns/ProcessSample.hxx
@@ -109,6 +109,9 @@ public:
   Field computeQuantilePerComponent(const Scalar prob) const;
   ProcessSample computeQuantilePerComponent(const Point & prob) const;
 
+  /** For comparison/debugging purpose */
+  Field computeQuantilePerComponentRobbinsMonroBasic(const Scalar prob) const;
+
   /** Get the i-th marginal sample */
   ProcessSample getMarginal(const UnsignedInteger index) const;
 

--- a/lib/src/Base/Stat/openturns/ProcessSampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/ProcessSampleImplementation.hxx
@@ -104,6 +104,14 @@ public:
   Field computeQuantilePerComponent(const Scalar prob) const;
   ProcessSampleImplementation computeQuantilePerComponent(const Point & prob) const;
 
+ private:
+  /**  Method computeQuantilePerComponent() gives the quantile per component of the sample using Robbins Monro approximation, nested version */
+  Sample computeQuantilePerComponentRobbinsMonro(const Scalar prob) const;
+ public:
+  
+  /**  Method computeQuantilePerComponent() gives the quantile per component of the sample using Robbins Monro approximation, basic version */
+  Field computeQuantilePerComponentRobbinsMonroBasic(const Scalar prob) const;
+  
   /** Get the i-th marginal sample */
   ProcessSampleImplementation getMarginal(const UnsignedInteger index) const;
 


### PR DESCRIPTION
This algorithm is described in https://projecteuclid.org/download/pdf_1/euclid.aoms/1177729586. It provides a consistent estimator of the quantile without the need to sort the data, and is much more memory-friendly than the empirical quantile estimation. It implements the nested procedure described in https://arxiv.org/abs/1510.00967. Note that the reference contains typos, not sure to have fixed all of them.