### PR TITLE
Docstring fixes

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosSobolIndices.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosSobolIndices.cxx
@@ -19,10 +19,8 @@
  *
  */
 #include <algorithm>
-
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/FunctionalChaosSobolIndices.hxx"
-#include "openturns/FunctionalChaosRandomVector.hxx"
 #include "openturns/EnumerateFunction.hxx"
 #include "openturns/SpecFunc.hxx"
 
@@ -72,7 +70,6 @@ String FunctionalChaosSobolIndices::summary() const
   const UnsignedInteger inputDimension = functionalChaosResult_.getDistribution().getDimension();
   const UnsignedInteger outputDimension = functionalChaosResult_.getMetaModel().getOutputDimension();
   OSS oss;
-  FunctionalChaosRandomVector randomVector(functionalChaosResult_);
 
   const Indices indices(functionalChaosResult_.getIndices());
   const Sample coefficients(functionalChaosResult_.getCoefficients());
@@ -80,12 +77,15 @@ String FunctionalChaosSobolIndices::summary() const
 
   // compute the variance
   Point variance(outputDimension);
+  Point mean(outputDimension);
   for (UnsignedInteger i = 0; i < outputDimension; ++i)
   {
     for (UnsignedInteger k = 0; k < basisSize; ++ k)
       // Take into account only non-zero indices as the null index is the mean of the vector
       if (indices[k] > 0)
         variance[i] += coefficients(k, i) * coefficients(k, i);
+      else
+        mean[i] = coefficients(k, i);
   }
 
   // standard deviation
@@ -97,7 +97,7 @@ String FunctionalChaosSobolIndices::summary() const
   oss << " input dimension: " << inputDimension << "\n"
       << " output dimension: " << outputDimension << "\n"
       << " basis size: " << functionalChaosResult_.getReducedBasis().getSize() << "\n"
-      << " mean: " << randomVector.getMean().__str__() << "\n"
+      << " mean: " << mean.__str__() << "\n"
       << " std-dev: " << stdDev.__str__() << "\n";
   oss << String(60, '-') << "\n";
   String st;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelValidation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelValidation.cxx
@@ -97,9 +97,10 @@ void MetaModelValidation::initialize() const
   // Initialize
   // We compute first the residual sample
   // This last one is stored and retured by getResidualSample method
-  // From this, it dervies also the Q2 factor
+  // From this, it derives also the predictive factor i.e. 1 - RSS/SS,
+  // RSS = Residual Sum of Squares, SS = Sum of Squares
   residual_ = outputSample_ - metaModel_(inputSample_);
-  q2_ = 1.0 - residual_.computeVariance()[0] / outputSample_.computeVariance()[0];
+  q2_ = 1.0 - residual_.computeRawMoment(2)[0] / outputSample_.computeCenteredMoment(2)[0];
   isInitialized_ = true;
 }
 

--- a/lib/test/t_MetaModelValidation_std.expout
+++ b/lib/test/t_MetaModelValidation_std.expout
@@ -2,5 +2,5 @@ Sparse chaos scoring
 Q2 = 1.000
 Residual sample = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[y0] data=[[0.0413],[-0.0962],[0.0821],[0.0285],[-0.0101],[0.0476],[0.0148],[0.00718],[-0.0501],[0.114]]
 Kriging scoring
-Q2 = 0.956
+Q2 = 0.955
 Residual sample = class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[y0] data=[[0.82],[-0.065],[-2.1],[0.31],[-0.066],[0.29],[0.64],[-1],[0.35],[0.31]]

--- a/python/doc/theory/reliability_sensitivity/taylor_importance_factors.rst
+++ b/python/doc/theory/reliability_sensitivity/taylor_importance_factors.rst
@@ -20,7 +20,7 @@ which can be re written :
 
   .. math::
 
-     1 \approx \sum_{i=1}^{n_X}\frac{\partial h(\muX)}{\partial X^i}\times\frac{  \sum_{j=1}^{n_X} \frac{\partial h(\muX)}{\partial x^j}.(\Cov \uX)_{ij} }{\Var Y} \approx & \cF_1 + \cF_2 + \ldots + \cF_{n_X}
+     1 \approx \sum_{i=1}^{n_X}\frac{\partial h(\muX)}{\partial X^i}\times\frac{  \sum_{j=1}^{n_X} \frac{\partial h(\muX)}{\partial x^j}.(\Cov \uX)_{ij} }{\Var Z} \approx & \cF_1 + \cF_2 + \ldots + \cF_{n_X}
 
 
   .. math::
@@ -30,7 +30,7 @@ which can be re written :
 
   .. math::
 
-     \cF_i = \frac{\partial h(\muX)}{\partial x^i} \times \frac{\sum_{j=1}^{n_X} \frac{\partial h(\muX)}{\partial x^j}.(\Cov \uX)_{ij} }{\Var Y}
+     \cF_i = \frac{\partial h(\muX)}{\partial x^i} \times \frac{\sum_{j=1}^{n_X} \frac{\partial h(\muX)}{\partial x^j}.(\Cov \uX)_{ij} }{\Var Z}
 
 
 where:

--- a/python/src/MetaModelValidation_doc.i.in
+++ b/python/src/MetaModelValidation_doc.i.in
@@ -86,9 +86,7 @@ Notes
 The predictivity factor :math:`Q_2` is given by :
 
 .. math::
-    Q_2 = 1 - \frac{Var(\epsilon)}{Var(Y)}
-
-with :math:`\epsilon` the residual."
+    Q_2 = 1 - \frac{\sum_{l=1}^{N} (Y_{l} -\hat{f}(X_l))^2}{Var(Y)}"
 
 // ---------------------------------------------------------------------
 

--- a/python/src/SobolIndicesAlgorithmImplementation_doc.i.in
+++ b/python/src/SobolIndicesAlgorithmImplementation_doc.i.in
@@ -92,8 +92,8 @@ It follows that :math:`V_{i}` and :math:`V_{i,j}` terms are defined as follow:
 .. math::
 
    \begin{array}{ccc}
-    V_i & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k) G(C_k) - V_i - V_j - G_0^2 \\
-    V_{i,j} & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k) G(D_k) - G_0^2 \\
+    V_i & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k) G(C_k) - G_0^2 \\
+    V_{i,j} & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k) G(D_k) - V_i - V_j - G_0^2 \\
     G_0 & = & \frac{1}{n} \sum_{k=1}^{n} G(A_k)
    \end{array}
 

--- a/python/test/t_MetaModelValidation_std.expout
+++ b/python/test/t_MetaModelValidation_std.expout
@@ -1,8 +1,8 @@
 
 Sparse chaos scoring
-Q2 =  0.99979
+Q2 =  0.99977
 Residual sample =  class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[y0] data=[[0.0413],[-0.0962],[0.0821],[0.0285],[-0.0101],[0.0476],[0.0148],[0.00718],[-0.0501],[0.114]]
 
 Kriging scoring
-Q2 =  0.956
+Q2 =  0.955
 Residual sample =  class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=10 dimension=1 description=[y0] data=[[0.82],[-0.065],[-2.1],[0.31],[-0.066],[0.29],[0.64],[-1],[0.35],[0.31]]


### PR DESCRIPTION
In #836 , we set a wrong definition of predictive factor in `MetaModelValidation` docstring.
The previous one was more accurate and requires updating the library.

It is done here.

We also fix SobolIndicesAlgorithm/Taylor importance factors docstrings