### PR TITLE
Fix 1-d NormalCopula::getParametersCollection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -67,6 +67,7 @@
  * #964 (Study does not load LogNormalMuSigma variables from XML)
  * #965 (A RandomVector from a RandomVector can make OT crash)
  * #968 (Empty legend make OT crash)
+ * #970 (Composing gaussian copulas can crash the chaos)
 
 == 1.11 release (2018-05-11) == #release-1.11
 

--- a/lib/src/Uncertainty/Distribution/NormalCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/NormalCopula.cxx
@@ -493,36 +493,6 @@ Bool NormalCopula::hasIndependentCopula() const
   return normal_.hasIndependentCopula();
 }
 
-/* Parameters value and description accessor */
-NormalCopula::PointWithDescriptionCollection NormalCopula::getParametersCollection() const
-{
-  const UnsignedInteger dimension = getDimension();
-  PointWithDescriptionCollection parameters(0);
-  if (dimension > 1)
-  {
-    // Put the dependence parameters
-    const UnsignedInteger parametersDimension = dimension * (dimension - 1) / 2;
-    PointWithDescription point(parametersDimension);
-    Description description(parametersDimension);
-    point.setName(getName());
-    UnsignedInteger dependenceIndex = 0;
-    for (UnsignedInteger i = 0; i < dimension; ++i)
-    {
-      for (UnsignedInteger j = 0; j < i; ++j)
-      {
-        point[dependenceIndex] = correlation_(i, j);
-        OSS oss;
-        oss << "R_" << i + 1 << "_" << j + 1;
-        description[dependenceIndex] = oss;
-        ++dependenceIndex;
-      }
-    }
-    point.setDescription(description);
-    parameters.add(point);
-  } // dimension > 1
-  return parameters;
-} // getParametersCollection
-
 void NormalCopula::setParametersCollection(const PointCollection & parametersCollection)
 {
   // Check if the given parameters are ok

--- a/lib/src/Uncertainty/Distribution/openturns/NormalCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/NormalCopula.hxx
@@ -134,7 +134,6 @@ public:
   Bool hasIndependentCopula() const;
 
   /** Parameters value and description accessor */
-  PointWithDescriptionCollection getParametersCollection() const;
   using CopulaImplementation::setParametersCollection;
   void setParametersCollection(const PointCollection & parametersCollection);
 

--- a/python/test/t_NormalCopula_std.expout
+++ b/python/test/t_NormalCopula_std.expout
@@ -41,3 +41,4 @@ margins CDF(qantile)=0.950000
 margins realization= class=Point name=Unnamed dimension=2 values=[0.265472,0.397787]
 Normal copula correlation= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.261052,0,0.261052,1,0.261052,0,0.261052,1]  from the Spearman correlation= class=CorrelationMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,0.25,0,0.25,1,0.25,0,0.25,1]
 prob=0.027802
+[[]]

--- a/python/test/t_NormalCopula_std.py
+++ b/python/test/t_NormalCopula_std.py
@@ -123,6 +123,7 @@ try:
     prob = copula.computeProbability(interval)
     print("prob=%.6f" % prob)
 
+    print(NormalCopula(1).getParametersCollection())
 except:
     import sys
     print("t_NormalCopula_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
It's better to use DistributionImplementation::getParametersCollection
as it relies on getParameter which returns an empty point in NormalCopula.

Now NormalCopula(1).getParametersCollection() returns a collection with
an empty point instead of an empty collection and fixes http://trac.openturns.org/ticket/970