### PR TITLE
CI: Use IPython <7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y cmake gfortran bison flex libmuparser-dev liblapack-dev libxml2-dev libboost-math-dev libtbb-dev libnlopt-dev r-base-core
             sudo apt-get install -y python3-pip python3-dev python3-scipy python3-matplotlib texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra pandoc
-            sudo rm -r /opt/circleci/.pyenv && sudo pip3 install setuptools --upgrade && pip3 install chaospy "matplotlib<3" sphinx numpydoc nbsphinx jupyter_client ipython --user --upgrade
+            sudo rm -r /opt/circleci/.pyenv && sudo pip3 install setuptools --upgrade && pip3 install chaospy "matplotlib<3" sphinx numpydoc nbsphinx jupyter_client "ipython<7" --user --upgrade
             git clone https://github.com/swig/swig.git && cd swig && ./autogen.sh && ./configure --prefix=$HOME/.local --without-alllang && make -j2 && make install
             git clone https://github.com/jeromerobert/hmat-oss.git && cd hmat-oss && cmake -DCMAKE_INSTALL_PREFIX=~/.local . && make install -j2
       - run:


### PR DESCRIPTION
IPython 7 only supports Python 3.5+, and trusty uses 3.4, so examples
are disabled