### PR TITLE
Fix crash in Python conversions

### DIFF
--- a/lib/src/Base/Stat/openturns/SampleImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/SampleImplementation.hxx
@@ -587,11 +587,11 @@ public:
   // INTENTIONALY NOT DOCUMENTED
   const Scalar * __baseaddress__ () const
   {
-    return &data_[0];
+    return (data_.getSize() > 0) ? &data_[0] : 0;
   }
   UnsignedInteger __elementsize__ () const
   {
-    return sizeof( Scalar );
+    return sizeof(Scalar);
   }
 
   /** Virtual constructor */

--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -648,8 +648,8 @@ convert< _PySequence_, Point >(PyObject * pyObj)
         // 1-d contiguous array, we can directly copy memory chunk
         const Scalar* data = static_cast<const Scalar*>(view.buf);
         const UnsignedInteger size = view.shape[0];
-        Point point( size );
-        std::copy(data, data + size, &point[0]);
+        Point point(size);
+        std::copy(data, data + size, (size > 0) ? &point[0] : 0);
         PyBuffer_Release(&view);
         return point;
       }
@@ -717,8 +717,8 @@ convert<_PySequence_, Collection<Complex> >(PyObject * pyObj)
         // 1-d contiguous array, we can directly copy memory chunk
         const Complex* data = static_cast<const Complex*>(view.buf);
         const UnsignedInteger size = view.shape[0];
-        Collection<Complex> result( size );
-        std::copy(data, data + size, &result[0]);
+        Collection<Complex> result(size);
+        std::copy(data, data + size, (size > 0) ? &result[0] : 0);
         PyBuffer_Release(&view);
         return result;
       }
@@ -799,11 +799,11 @@ convert< _PySequence_, Sample >(PyObject * pyObj)
         const Scalar* data = static_cast<const Scalar*>(view.buf);
         const UnsignedInteger size = view.shape[0];
         const UnsignedInteger dimension = view.shape[1];
-        Sample sample( size, dimension );
+        Sample sample(size, dimension);
         if (PyBuffer_IsContiguous(&view, 'C'))
         {
           // 2-d contiguous array in C notation, we can directly copy memory chunk
-          std::copy(data, data + size * dimension, &sample(0, 0));
+          std::copy(data, data + size * dimension, (Scalar *)sample.__baseaddress__());
         }
         else
         {

--- a/python/test/t_Matrix_numpy.expout
+++ b/python/test/t_Matrix_numpy.expout
@@ -329,3 +329,5 @@ with transpose, matrix [[ 1.0+3.0j  4.0-9.0j]
  [ 3.0+7.0j  6.0-13.0j]] => ComplexMatrix [[   (1,3)  (4,-9) ]
  [  (2,-5)  (5,11) ]
  [   (3,7) (6,-13) ]]
+empty array => sample class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=0 dimension=3 data=[]
+sample => array [] (0,)

--- a/python/test/t_Matrix_numpy.py
+++ b/python/test/t_Matrix_numpy.py
@@ -415,6 +415,12 @@ try:
     m0 = ComplexMatrix(a0.transpose())
     print("with transpose, matrix", a0.transpose(), "=> ComplexMatrix", m0)
 
+    # empty array
+    a0 = np.zeros((0, 3))
+    s0 = Sample(a0)
+    print('empty array => sample', repr(s0))
+    a1 = np.array(s0)
+    print('sample => array', a1, a1.shape)
 except:
     import sys
     import traceback


### PR DESCRIPTION
Fixes empty array conversions crashes with GLIBCXX_ASSERTIONS when accessing &std::vector[0]