### PR TITLE
Link swig modules with dynamic lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,10 @@ if (POLICY CMP0068)
   # RPATH settings on macOS do not affect install_name
   cmake_policy (SET CMP0068 NEW)
 endif ()
+if (POLICY CMP0078)
+  # swig standard target names
+  cmake_policy(SET CMP0078 NEW)
+endif ()
 
 try_compile(OPENTURNS_UNSIGNEDLONG_SAME_AS_UINT64
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ option (USE_COTIRE                   "Use cotire for unity builds"              
 
 option (BUILD_PYTHON                 "Build the python module for the library"                               ON)
 option (BUILD_VALIDATION             "Build the validation files of the library"                             ON)
-option (LINK_PYTHON_LIBRARY          "Link python modules against python library"                            ON)
 option (BUILD_SHARED_LIBS            "Build shared libraries"                                                ON)
 
 if (MSVC)
@@ -444,6 +443,7 @@ if (BUILD_PYTHON)
   endif ()
   if (SWIG_FOUND)
     include (${SWIG_USE_FILE})
+    include (TargetLinkLibrariesWithDynamicLookup)
   endif ()
 
   find_package (PythonInterp)

--- a/cmake/TargetLinkLibrariesWithDynamicLookup.cmake
+++ b/cmake/TargetLinkLibrariesWithDynamicLookup.cmake
@@ -1,0 +1,99 @@
+#
+# - This module provides the function
+# target_link_libraries_with_dynamic_lookup which can be used to
+# "weakly" link loadable module.
+#
+# Link a library to a target such that the symbols are resolved at
+# run-time not link-time. This should be used when compiling a
+# loadable module when the symbols should be resolve from the run-time
+# environment where the module is loaded, and not a specific system
+# library.
+#
+# Specifically, for OSX it uses undefined dynamic_lookup. This is
+# similar to using "-shared" on Linux where undefined symbols are
+# ignored.
+#
+# Additionally, the linker is checked to see if it supports undefined
+# symbols when linking a shared library. If it does then the library
+# is not linked when specified with this function.
+#
+# http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/
+#
+
+# Function: _CheckUndefinedSymbolsAllowed
+#
+# Check if the linker allows undefined symbols for shared libraries.
+#
+# UNDEFINED_SYMBOLS_ALLOWED - true if the linker will allow
+#   undefined symbols for shared libraries
+#
+
+function(_CheckUndefinedSymbolsAllowed)
+
+  set(VARIABLE "UNDEFINED_SYMBOLS_ALLOWED")
+  set(cache_var "${VARIABLE}_hash")
+
+
+  # hash the CMAKE_FLAGS passed and check cache to know if we need to rerun
+  string(MD5 cmake_flags_hash "${CMAKE_SHARED_LINKER_FLAGS}")
+
+  if(NOT DEFINED "${cache_var}" )
+    unset("${VARIABLE}" CACHE)
+  elseif(NOT "${${cache_var}}" STREQUAL "${cmake_flags_hash}" )
+    unset("${VARIABLE}" CACHE)
+  endif()
+
+  if(NOT DEFINED "${VARIABLE}")
+    set(test_project_dir "${PROJECT_BINARY_DIR}/CMakeTmp/${VARIABLE}")
+
+    file(WRITE "${test_project_dir}/CMakeLists.txt"
+"
+project(undefined C)
+add_library(foo SHARED \"foo.c\")
+")
+
+    file(WRITE "${test_project_dir}/foo.c"
+"
+extern int bar(void);
+int foo(void) {return bar()+1;}
+")
+
+    if(APPLE AND ${CMAKE_VERSION} VERSION_GREATER 2.8.11)
+      set( _rpath_arg  "-DCMAKE_MACOSX_RPATH='${CMAKE_MACOSX_RPATH}'" )
+    else()
+      set( _rpath_arg )
+    endif()
+
+    try_compile(${VARIABLE}
+      "${test_project_dir}"
+      "${test_project_dir}"
+      undefined
+      CMAKE_FLAGS
+        "-DCMAKE_SHARED_LINKER_FLAGS='${CMAKE_SHARED_LINKER_FLAGS}'"
+        ${_rpath_arg}
+      OUTPUT_VARIABLE output)
+
+    set(${cache_var} "${cmake_flags_hash}" CACHE INTERNAL  "hashed try_compile flags")
+
+    if(${VARIABLE})
+      message(STATUS "Performing Test ${VARIABLE} - Success")
+    else()
+      message(STATUS "Performing Test ${VARIABLE} - Failed")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Performing Test ${VARIABLE} failed with the following output:\n"
+        "${OUTPUT}\n")
+    endif()
+  endif()
+endfunction()
+
+_CheckUndefinedSymbolsAllowed()
+
+macro( target_link_libraries_with_dynamic_lookup target )
+  if ( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
+    set_target_properties( ${target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup" )
+  elseif(UNDEFINED_SYMBOLS_ALLOWED)
+    # linker allows undefined symbols, let's just not link
+  else()
+    target_link_libraries ( ${target} ${ARGN}  )
+  endif()
+endmacro()

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -77,7 +77,6 @@ cmake-configure-%:
             -DLIB_VERSION=0.13.0 \
             -DOPENTURNS_SYSCONFIG_PATH:PATH=/etc/openturns-1.12 \
             -DINSTALL_DESTDIR:PATH=$(CURDIR)/debian/tmp \
-            -DLINK_PYTHON_LIBRARY:BOOL=OFF \
             -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python$* \
             -DPYTHON_INCLUDE_DIR:PATH=$$(python$*-config --includes | sed -e 's/ .*//' -e 's/^-I//') \
             -DPYTHON_INCLUDE_DIR2:PATH=$$(python$*-config --includes | sed -e 's/ .*//' -e 's/^-I//') \

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -64,19 +64,33 @@ macro (ot_add_python_module MODULENAME SOURCEFILE)
     swig_add_library (${MODULENAME} LANGUAGE python SOURCES ${SOURCEFILE} ${swig_other_sources})
   endif ()
 
-  add_dependencies (${SWIG_MODULE_${MODULENAME}_REAL_NAME} generate_swig_runtime)
+  # UseSWIG generates now standard target names
+  if (CMAKE_VERSION VERSION_LESS 3.13)
+    set (module_target ${SWIG_MODULE_${MODULENAME}_REAL_NAME})
+  else ()
+    set (module_target ${MODULENAME})
+  endif ()
+
+  add_dependencies (${module_target} generate_swig_runtime)
   swig_link_libraries (${MODULENAME} OT)
 
   if (LINK_PYTHON_LIBRARY)
     swig_link_libraries (${MODULENAME} ${PYTHON_LIBRARIES})
   endif ()
 
-  set_target_properties (${SWIG_MODULE_${MODULENAME}_REAL_NAME} PROPERTIES NO_SONAME ON)
+  if (CMAKE_VERSION VERSION_LESS 3.1)
+    set_target_properties (${module_target} PROPERTIES NO_SONAME ON)
+  endif ()
 
   # allows to pass compile flags like -O1 to reduce memory usage
   if (DEFINED SWIG_COMPILE_FLAGS)
-    set_target_properties (${SWIG_MODULE_${MODULENAME}_REAL_NAME} PROPERTIES COMPILE_FLAGS ${SWIG_COMPILE_FLAGS})
+    set_target_properties (${module_target} PROPERTIES COMPILE_FLAGS ${SWIG_COMPILE_FLAGS})
   endif ()
+
+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${MODULENAME}.py
+           DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns)
+  install (TARGETS ${module_target}
+            LIBRARY DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns)
 
   list (APPEND OPENTURNS_PYTHON_MODULES ${MODULENAME})
 endmacro (ot_add_python_module)
@@ -908,15 +922,6 @@ ot_add_python_module(testing testing_module.i
                     )
 
 set (OPENTURNS_PYTHON_MODULES ${OPENTURNS_PYTHON_MODULES} PARENT_SCOPE) # for the docstring test
-
-foreach (module ${OPENTURNS_PYTHON_MODULES})
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${module}.py
-            DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns
-           )
-  install (TARGETS _${module}
-            LIBRARY DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns
-         )
-endforeach ()
 
 
 # Build and install openturns.memoryview

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -74,9 +74,7 @@ macro (ot_add_python_module MODULENAME SOURCEFILE)
   add_dependencies (${module_target} generate_swig_runtime)
   swig_link_libraries (${MODULENAME} OT)
 
-  if (LINK_PYTHON_LIBRARY)
-    swig_link_libraries (${MODULENAME} ${PYTHON_LIBRARIES})
-  endif ()
+  target_link_libraries_with_dynamic_lookup (${module_target} ${PYTHON_LIBRARIES})
 
   if (CMAKE_VERSION VERSION_LESS 3.1)
     set_target_properties (${module_target} PROPERTIES NO_SONAME ON)
@@ -926,13 +924,11 @@ set (OPENTURNS_PYTHON_MODULES ${OPENTURNS_PYTHON_MODULES} PARENT_SCOPE) # for th
 
 # Build and install openturns.memoryview
 add_library (memoryview MODULE PythonReadOnlyBuffer.c)
-if (LINK_PYTHON_LIBRARY)
-  target_link_libraries (memoryview ${PYTHON_LIBRARIES})
-endif ()
+target_link_libraries_with_dynamic_lookup (memoryview ${PYTHON_LIBRARIES})
 set_target_properties(memoryview PROPERTIES NO_SONAME ON PREFIX "")
-if(WIN32 AND NOT CYGWIN)
+if (WIN32 AND NOT CYGWIN)
   set_target_properties(memoryview PROPERTIES SUFFIX ".pyd")
-endif()
+endif ()
 install (TARGETS memoryview LIBRARY DESTINATION ${OPENTURNS_PYTHON_MODULE_PATH}/openturns)
 
 


### PR DESCRIPTION
On osx/py3 we have to weak link the python libs otherwise we get:
Fatal Python error: PyThreadState_Get: no current thread
    
On windows undefined symbols are not allowed and on
osx a specific flag is required (-undefined dynamic_lookup) so we add
the macro from vtk: https://gitlab.kitware.com/vtk/vtk/merge_requests/1511
