### PR TITLE
Bugfix in EmpiricalBernsteinCopula

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -96,6 +96,7 @@
  * #968 (Empty legend make OT crash)
  * #970 (Composing gaussian copulas can crash the chaos)
  * #972 (FittingTest::ChiSquared slow and buggy)
+ * #975 (EmpiricalBernsteinCopula is a copula as sample is truncated)
 
 == 1.11 release (2018-05-11) == #release-1.11
 

--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -149,9 +149,15 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
   const UnsignedInteger remainder = size % binNumber_;
   // If the given sample is an empirical copula sample of a compatible size
   if (isEmpiricalCopulaSample)
+  {
     copulaSample_ = copulaSample;
+    isCopula_ = (remainder == 0);
+  }
   else
   {
+    // Here we remove last point such as we build a copula
+    // Thus isCopula_ is necessary true
+    isCopula_ = true;
     if (remainder == 0)
       copulaSample_ = copulaSample.rank();
     else
@@ -164,7 +170,6 @@ void EmpiricalBernsteinCopula::setCopulaSample(const Sample & copulaSample,
     copulaSample_ /= 1.0 * (size - remainder);
   } // !(isEmpiricalCopulaSample && remainder == 0)
   setDimension(dimension);
-  isCopula_ = (remainder == 0);
   // Now the sample is correct, compute the by-products
   update();
   computeRange();

--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -94,6 +94,9 @@ EmpiricalBernsteinCopula::EmpiricalBernsteinCopula(const Sample & copulaSample,
   setName("EmpiricalBernsteinCopula");
   setDimension(copulaSample.getDimension());
   computeRange();
+  // If the given sample is an empirical copula sample of a compatible size
+  const UnsignedInteger remainder = size % binNumber; 
+  isCopula_ = (remainder == 0);
 }
 
 /* Virtual constructor */

--- a/python/test/t_BernsteinCopulaFactory_std.expout
+++ b/python/test/t_BernsteinCopulaFactory_std.expout
@@ -1,21 +1,60 @@
 Reference copula GumbelCopula(theta = 3)
 Log-likelihood m= 17
 Max. error=0.03721
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 AMISE m= 5
 Max. error=0.07077
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 Penalized Csiszar divergence m= 92
 Max. error=0.02672
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
+
 Reference copula ClaytonCopula(theta = 3)
 Log-likelihood m= 19
 Max. error=0.02447
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 AMISE m= 5
 Max. error=0.07100
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 Penalized Csiszar divergence m= 4
 Max. error=0.08412
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
+
 Reference copula FrankCopula(theta = 3)
 Log-likelihood m= 10
 Max. error=0.02165
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 AMISE m= 5
 Max. error=0.03020
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
 Penalized Csiszar divergence m= 42
 Max. error=0.02709
+Is estimation a copula ? -->  True
+Maginal checking
+Is marginal 0 a copula ? --> True
+Is marginal 1 a copula ? --> True
+

--- a/python/test/t_BernsteinCopulaFactory_std.py
+++ b/python/test/t_BernsteinCopulaFactory_std.py
@@ -1,53 +1,68 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
-from openturns import *
+import openturns as ot
 
-TESTPREAMBLE()
-RandomGenerator.SetSeed(0)
+ot.TESTPREAMBLE()
+ot.RandomGenerator.SetSeed(0)
+
+def compute_max_error(ref_copula, est_copula):
+    """
+    Compute max error between ref_copula & estimated one
+    Error is evaluated in the set (u, v) where both belong to
+    {0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}
+    """
+    max_error = 0.0
+    for n in range(11):
+        for p in range(11):
+            point = [0.1 * n, 0.1 * p]
+            max_error = max(max_error, abs(ref_copula.computeCDF(
+                point) - est_copula.computeCDF(point)))
+    return max_error
+
+def check_bernstein_copula(est_copula):
+    """
+    Check if an estimated distribution of kind EmpiricalBernstein
+    is of type copula and all marginals are also.
+    """
+    print("Is estimation a copula ? --> ", est_copula.isCopula())
+    print("Maginal checking")
+    dimension = est_copula.getDimension()
+    for d in range(dimension):
+        print("Is marginal %d a copula ? --> %s"%(d,est_copula.isCopula()))
+
 
 try:
-    coll = [GumbelCopula(3.0), ClaytonCopula(3.0), FrankCopula(3.0)]
+    coll = [ot.GumbelCopula(3.0), ot.ClaytonCopula(3.0), ot.FrankCopula(3.0)]
     size = 100
-    for i in range(len(coll)):
+    for i, ref_copula in enumerate(coll):
         ref_copula = coll[i]
         print("Reference copula", str(ref_copula))
         sample = ref_copula.getSample(size)
         # Default method: log-likelihood
-        m = BernsteinCopulaFactory.ComputeLogLikelihoodBinNumber(sample)
+        m = ot.BernsteinCopulaFactory.ComputeLogLikelihoodBinNumber(sample)
         print("Log-likelihood m=", m)
-        est_copula = BernsteinCopulaFactory().build(sample, m)
-        max_error = 0.0
-        for n in range(11):
-            for p in range(11):
-                point = [0.1 * n, 0.1 * p]
-                max_error = max(max_error, abs(ref_copula.computeCDF(
-                    point) - est_copula.computeCDF(point)))
+        est_copula = ot.BernsteinCopulaFactory().build(sample, m)
+        max_error = compute_max_error(ref_copula, est_copula)
         print("Max. error=%.5f" % max_error)
+        check_bernstein_copula(est_copula)
         # AMISE method
-        m = BernsteinCopulaFactory.ComputeAMISEBinNumber(sample)
+        m = ot.BernsteinCopulaFactory.ComputeAMISEBinNumber(sample)
         print("AMISE m=", m)
-        est_copula = BernsteinCopulaFactory().build(sample, m)
-        max_error = 0.0
-        for n in range(11):
-            for p in range(11):
-                point = [0.1 * n, 0.1 * p]
-                max_error = max(max_error, abs(ref_copula.computeCDF(
-                    point) - est_copula.computeCDF(point)))
+        est_copula = ot.BernsteinCopulaFactory().build(sample, m)
+        max_error = compute_max_error(ref_copula, est_copula)
         print("Max. error=%.5f" % max_error)
+        check_bernstein_copula(est_copula)
         # Penalized Csiszar divergence method
-        f = SymbolicFunction("t", "-log(t)")
-        m = BernsteinCopulaFactory.ComputePenalizedCsiszarDivergenceBinNumber(
+        f = ot.SymbolicFunction("t", "-log(t)")
+        m = ot.BernsteinCopulaFactory.ComputePenalizedCsiszarDivergenceBinNumber(
             sample, f)
         print("Penalized Csiszar divergence m=", m)
-        est_copula = BernsteinCopulaFactory().build(sample, m)
-        max_error = 0.0
-        for n in range(11):
-            for p in range(11):
-                point = [0.1 * n, 0.1 * p]
-                max_error = max(max_error, abs(ref_copula.computeCDF(
-                    point) - est_copula.computeCDF(point)))
+        est_copula = ot.BernsteinCopulaFactory().build(sample, m)
+        max_error = compute_max_error(ref_copula, est_copula)
         print("Max. error=%.5f" % max_error)
+        check_bernstein_copula(est_copula)
+        print("")
 
 except:
     import sys


### PR DESCRIPTION
When building the EmpiricalBernsteinCopula, if provided sample is not a  "copula sample", we
enforce sample size to be multiple of binNumber, thus is becomes a copula.

This fixes http://trac.openturns.org/ticket/975