### PR TITLE
Optim: Track progress wrt eval number

### DIFF
--- a/lib/src/Base/Optim/AbdoRackwitz.cxx
+++ b/lib/src/Base/Optim/AbdoRackwitz.cxx
@@ -213,7 +213,7 @@ void AbdoRackwitz::run()
     // callbacks
     if (progressCallback_.first)
     {
-      progressCallback_.first((100.0 * iterationNumber) / getMaximumIterationNumber(), progressCallback_.second);
+      progressCallback_.first((100.0 * evaluationNumber) / getMaximumEvaluationNumber(), progressCallback_.second);
     }
     if (stopCallback_.first)
     {

--- a/lib/src/Base/Optim/Cobyla.cxx
+++ b/lib/src/Base/Optim/Cobyla.cxx
@@ -286,6 +286,10 @@ int Cobyla::ComputeObjectiveAndConstraint(int n,
   algorithm->evaluationInputHistory_.add(inPoint);
   algorithm->evaluationOutputHistory_.add(outPoint);
   int returnValue = 0;
+  if (algorithm->progressCallback_.first)
+  {
+    algorithm->progressCallback_.first((100.0 * algorithm->evaluationInputHistory_.getSize()) / algorithm->getMaximumEvaluationNumber(), algorithm->progressCallback_.second);
+  }
   if (algorithm->stopCallback_.first)
   {
     Bool stop = algorithm->stopCallback_.first(algorithm->stopCallback_.second);

--- a/lib/src/Base/Optim/NLopt.cxx
+++ b/lib/src/Base/Optim/NLopt.cxx
@@ -495,6 +495,10 @@ double NLopt::ComputeObjective(const std::vector<double> & x, std::vector<double
 
 #ifdef OPENTURNS_HAVE_NLOPT
   // callbacks
+  if (algorithm->progressCallback_.first)
+  {
+    algorithm->progressCallback_.first((100.0 * algorithm->evaluationInputHistory_.getSize()) / algorithm->getMaximumEvaluationNumber(), algorithm->progressCallback_.second);
+  }
   if (algorithm->stopCallback_.first)
   {
     Bool stop = algorithm->stopCallback_.first(algorithm->stopCallback_.second);

--- a/lib/src/Base/Optim/SQP.cxx
+++ b/lib/src/Base/Optim/SQP.cxx
@@ -258,7 +258,7 @@ void SQP::run()
     // callbacks
     if (progressCallback_.first)
     {
-      progressCallback_.first((100.0 * iterationNumber) / getMaximumIterationNumber(), progressCallback_.second);
+      progressCallback_.first((100.0 * evaluationNumber) / getMaximumEvaluationNumber(), progressCallback_.second);
     }
     if (stopCallback_.first)
     {

--- a/lib/src/Base/Optim/TNC.cxx
+++ b/lib/src/Base/Optim/TNC.cxx
@@ -441,6 +441,10 @@ int TNC::ComputeObjectiveAndGradient(double *x, double *f, double *g, void *stat
   algorithm->evaluationOutputHistory_.add(outPoint);
 
   // callbacks
+  if (algorithm->progressCallback_.first)
+  {
+    algorithm->progressCallback_.first((100.0 * algorithm->evaluationInputHistory_.getSize()) / algorithm->getMaximumEvaluationNumber(), algorithm->progressCallback_.second);
+  }
   if (algorithm->stopCallback_.first)
   {
     Bool stop = algorithm->stopCallback_.first(algorithm->stopCallback_.second);

--- a/python/test/t_MultiStart_std.py
+++ b/python/test/t_MultiStart_std.py
@@ -28,9 +28,11 @@ print('-- local search x*=', result.getOptimalPoint(),
 
 # multistart
 distribution = ot.Normal([0.0] * dim, [2.0] * dim, ot.CorrelationMatrix(dim))
-experiment = ot.LHSExperiment(distribution, 20)
+size = 20
+experiment = ot.LHSExperiment(distribution, size)
 startingPoints = experiment.generate()
 algo = ot.MultiStart(solver, startingPoints)
+algo.setMaximumEvaluationNumber(size*algo.getMaximumEvaluationNumber())
 algo.run()
 result = algo.getResult()
 print('-- multistart x*=', result.getOptimalPoint(),


### PR DESCRIPTION
In SQP, Abdorackwitz the number of iterations was used.
It was missing from TNC, Cobyla, NLopt.
For multistart the budget is the total of local searches.