### PR TITLE
NLopt: fix constraint error computation

### DIFF
--- a/lib/src/Base/Optim/NLopt.cxx
+++ b/lib/src/Base/Optim/NLopt.cxx
@@ -364,7 +364,7 @@ void NLopt::run()
       Point h(getProblem().getInequalityConstraint()(inP));
       for (UnsignedInteger k = 0; k < getProblem().getInequalityConstraint().getOutputDimension(); ++ k)
       {
-        h[k] = std::max(h[k], 0.0);// convention h(x)>=0 <=> admissibility
+        h[k] = std::min(h[k], 0.0);// convention h(x)>=0 <=> admissibility
       }
       constraintError = std::max(constraintError, h.normInf());
     }


### PR DESCRIPTION
Negative values should be checked for constraint violation since
positive values means feasibility.