### PR TITLE
Remove rot dependency in LinearModelTest

### DIFF
--- a/lib/src/Uncertainty/StatTests/openturns/LinearModelTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/LinearModelTest.hxx
@@ -99,12 +99,6 @@ public:
       const Scalar level = ResourceMap::GetAsScalar( "LinearModelTest-DefaultLevel" ));
 
 protected:
-  /** Generic invocation of a R script for testing a distribution against a sample */
-  static TestResult RunTwoSamplesALinearModelRTest(const Sample & firstSample,
-      const Sample & secondSample,
-      const LinearModel & linearModel,
-      const Scalar level,
-      const String & testName);
   LinearModelTest();
 }; /* class LinearModelTest */
 

--- a/lib/test/t_LinearModelTest_std.expout
+++ b/lib/test/t_LinearModelTest_std.expout
@@ -1,2 +1,2 @@
-LinearModelFisher=class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=1 description=[]
+LinearModelFisher=class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=6.40572e-08 description=[]
 LinearModelResidualMean=class=TestResult name=Unnamed type=ResidualMean binaryQualityMeasure=true p-value threshold=0.05 p-value=1 description=[]

--- a/python/src/LinearModelTest_doc.i.in
+++ b/python/src/LinearModelTest_doc.i.in
@@ -61,8 +61,8 @@ Examples
 >>> firstSample = sample
 >>> secondSample = func(sample) + ot.Normal().getSample(30)
 >>> test_result = ot.LinearModelTest.LinearModelFisher(firstSample, secondSample)
->>> print(test_result)
-class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=1 description=[]
+>>> print(test_result.getPValue())
+5.1...e-12
 "
 
 // ---------------------------------------------------------------------

--- a/python/test/t_LinearModelTest_std.expout
+++ b/python/test/t_LinearModelTest_std.expout
@@ -1,3 +1,3 @@
-LinearModelFisher= class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=1 description=[]
+LinearModelFisher= class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=6.40572e-08 description=[]
 LinearModelResidualMean= class=TestResult name=Unnamed type=ResidualMean binaryQualityMeasure=true p-value threshold=0.05 p-value=1 description=[]
 Durbin Watson =  class=TestResult name=Unnamed type=DurbinWatson binaryQualityMeasure=false p-value threshold=0.05 p-value=0.000219316 description=[H0: auto.cor=0]


### PR DESCRIPTION
We remove dependency to `rot` statistical test. `rot` is used only when using `LinearModelFactory` class
The `rot` implementation is bogus. Indeed Fisher test relies on the statistic which is a ratio of SSExplained and SSResiduals. This is now fixed