### PR TITLE
fix bug 982 : durbin watson for several inputs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 === Bug fixes ===
  * #979 (Viewer does not handle BarPlot's fillStyle)
  * #977 (HypothesisTest::ChiSquared is bogus)
+ * #982 (LinearModelTest::LinearModelDurbinWatson with several factors)
 
 == 1.12 release (2018-11-08) == #release-1.12
 

--- a/python/src/LinearModelTest_doc.i.in
+++ b/python/src/LinearModelTest_doc.i.in
@@ -300,7 +300,7 @@ class=TestResult name=Unnamed type=BreuschPagan binaryQualityMeasure=true p-valu
 Parameters
 ----------
 firstSample : 2-d sequence of float
-    First tested sample, of dimension 1.
+    First tested sample.
 secondSample : 2-d sequence of float
     Second tested sample, of dimension 1.
 linearModel : :class:`~openturns.LinearModel`
@@ -352,5 +352,5 @@ Examples
 >>> secondSample = func(sample) + ot.Normal().getSample(30)
 >>> test_result = ot.LinearModelTest.LinearModelDurbinWatson(firstSample, secondSample)
 >>> print(test_result)
-class=TestResult name=Unnamed type=DurbinWatson binaryQualityMeasure=true p-value threshold=0.05 p-value=0.653603 description=[Hypothesis test: autocorrelation equals 0.]
+class=TestResult name=Unnamed type=DurbinWatson binaryQualityMeasure=true p-value threshold=0.05 p-value=0.653603 description=[H0: auto.cor=0]
 "

--- a/python/test/t_LinearModelTest_std.expout
+++ b/python/test/t_LinearModelTest_std.expout
@@ -1,3 +1,3 @@
 LinearModelFisher= class=TestResult name=Unnamed type=Fisher binaryQualityMeasure=false p-value threshold=0.05 p-value=1 description=[]
 LinearModelResidualMean= class=TestResult name=Unnamed type=ResidualMean binaryQualityMeasure=true p-value threshold=0.05 p-value=1 description=[]
-Durbin Watson =  class=TestResult name=Unnamed type=DurbinWatson binaryQualityMeasure=false p-value threshold=0.05 p-value=0.000219316 description=[Hypothesis test: autocorrelation equals 0.]
+Durbin Watson =  class=TestResult name=Unnamed type=DurbinWatson binaryQualityMeasure=false p-value threshold=0.05 p-value=0.000219316 description=[H0: auto.cor=0]

--- a/validation/src/ValidDurbinWatson.py
+++ b/validation/src/ValidDurbinWatson.py
@@ -1,0 +1,92 @@
+import numpy as np
+from rpy2.robjects import Formula, r
+from rpy2.robjects.numpy2ri import numpy2ri, ri2py
+from rpy2.robjects.packages import importr                                
+import openturns as ot
+lmtest = importr('lmtest')  
+
+# to test the 3 hypothesis
+hypothesis_list = [{'R':'two.sided', 'ot':'Equal'},
+                   {'R':'greater', 'ot':'Less'},
+                   {'R':'less', 'ot':'Greater'}]
+
+for hypothesis in hypothesis_list:
+    print('')
+    print('-'*60)
+    print('')
+    print('Hypothesis H0: ', hypothesis['ot'])
+    print('')
+
+    ot.RandomGenerator.SetSeed(224)
+    n_points = 30
+    distribution = ot.Normal()
+    sample = distribution.getSample(n_points)
+    sample.stack(distribution.getSample(n_points))
+    func = ot.SymbolicFunction(['x1', 'x2'], ['2*x1 - x2 + 1'])
+    firstSample = sample
+    epsilon = ot.Normal().getSample(n_points)
+    secondSample = func(sample) + epsilon
+    test_result = ot.LinearModelTest.LinearModelDurbinWatson(firstSample,
+                                                             secondSample,
+                                                             hypothesis['ot'])
+    print('Result from OT :')
+    print('p-value :', test_result.getPValue())
+    print(test_result.getDescription()[0])
+    print('')
+
+    formula = Formula('y ~ x1 + x2') # take into account x1 and x2, not equal to the linear model
+    x1 = numpy2ri(np.array(firstSample)[:,0])
+    r.assign('x1', x1)
+
+    x2 = numpy2ri(np.array(firstSample)[:,1])
+    r.assign('x2', x2)
+
+    y = numpy2ri(np.array(secondSample))
+    r.assign('y', y)
+
+    dw_test_1 = lmtest.dwtest(formula, alternative=hypothesis['R'], exact=True) # greater, less, two.sided
+    print('Result from R :')
+    print('p-value :', dw_test_1[3][0])
+    print('Alternative hypothesis : ', dw_test_1[2][0])
+    print('dw stat : ', dw_test_1[0][0])
+
+
+    ################################################################################
+    ################################################################################
+    ################################################################################
+    # code with sample from R objects : it is easier if we want to compare directly in R
+
+    print('')
+    print('-'*10)
+    print('')
+    rnorm = r['rnorm']
+    set_seed = r['set.seed']
+
+    ## generate regressor and dependent variable
+    set_seed(0)
+    X1 = rnorm(n_points)
+    X2 = rnorm(n_points)
+    err1 = rnorm(n_points)
+    output = numpy2ri(ri2py(X1) + ri2py(X1) - ri2py(X2) + ri2py(err1) + 1)
+    r.assign('X1', X1)
+    r.assign('X2', X2)
+    r.assign('output', output)
+
+    ## perform Durbin-Watson test
+    formula = Formula('output ~ X1 + X2')
+    dw_test_1 = lmtest.dwtest(formula, alternative=hypothesis['R'], exact=True)
+    print('Result from R :')
+    print('p-value :', dw_test_1[3][0])
+    print('Alternative hypothesis : ', dw_test_1[2][0])
+    print('dw stat : ', dw_test_1[0][0])
+    print('')
+
+    # transformation into openturns objects
+    firstSample = ot.Sample(np.column_stack((ri2py(X1), ri2py(X2))))
+    secondSample = ot.Sample(np.vstack(ri2py(output)))
+    test_result = ot.LinearModelTest.LinearModelDurbinWatson(firstSample,
+                                                             secondSample,
+                                                             hypothesis['ot'])
+    print('Result from OT :')
+    print('p-value :', test_result.getPValue())
+    print(test_result.getDescription()[0])

--- a/validation/src/ValidDurbinWatson.txt
+++ b/validation/src/ValidDurbinWatson.txt
@@ -1,0 +1,72 @@
+
+------------------------------------------------------------
+
+Hypothesis H0:  Equal
+
+Result from OT :
+p-value : 0.23189413965453662
+H0: auto.cor=0
+
+Result from R :
+p-value : 0.24250597479451463
+Alternative hypothesis :  true autocorrelation is not 0
+dw stat :  2.417134963508616
+
+----------
+
+Result from R :
+p-value : 0.4987386173151879
+Alternative hypothesis :  true autocorrelation is not 0
+dw stat :  1.7873986690969137
+
+Result from OT :
+p-value : 0.4916002969527328
+H0: auto.cor=0
+
+------------------------------------------------------------
+
+Hypothesis H0:  Less
+
+Result from OT :
+p-value : 0.8840529301727317
+H0: auto.cor<0
+
+Result from R :
+p-value : 0.8787470126027427
+Alternative hypothesis :  true autocorrelation is greater than 0
+dw stat :  2.417134963508616
+
+----------
+
+Result from R :
+p-value : 0.24936930865759396
+Alternative hypothesis :  true autocorrelation is greater than 0
+dw stat :  1.7873986690969137
+
+Result from OT :
+p-value : 0.2458001484763664
+H0: auto.cor<0
+
+------------------------------------------------------------
+
+Hypothesis H0:  Greater
+
+Result from OT :
+p-value : 0.11594706982726831
+H0: auto.cor>0
+
+Result from R :
+p-value : 0.12125298739725732
+Alternative hypothesis :  true autocorrelation is less than 0
+dw stat :  2.417134963508616
+
+----------
+
+Result from R :
+p-value : 0.750630691342406
+Alternative hypothesis :  true autocorrelation is less than 0
+dw stat :  1.7873986690969137
+
+Result from OT :
+p-value : 0.7541998515236337
+H0: auto.cor>0


### PR DESCRIPTION
I forgot to take into account several factors when building the regression matrix.
I noticed also an error when computing the p-value, that I corrected.
A validation python file, comparing result with OT and R is provided in validation/src/ValidDurbinWatson.py

As an improvement, it could be nice to have the statistic value in the result object.