### PR TITLE
Fix TruncatedDistribution::setBounds

### DIFF
--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -541,6 +541,14 @@ void TruncatedDistribution::setBounds(const Interval & bounds)
   if (bounds_ != bounds)
   {
     bounds_ = bounds;
+    // Precompute some useful quantities for dimension=1
+    if (getDimension() == 1)
+    {
+      pdfLowerBound_ = distribution_.computePDF(bounds.getLowerBound());
+      pdfUpperBound_ = distribution_.computePDF(bounds.getUpperBound());
+      cdfLowerBound_ = distribution_.computeCDF(bounds.getLowerBound());
+      cdfUpperBound_ = distribution_.computeCDF(bounds.getUpperBound());
+    }
     isAlreadyComputedMean_ = false;
     isAlreadyComputedCovariance_ = false;
     isAlreadyCreatedGeneratingFunction_ = false;

--- a/python/test/t_TruncatedDistribution_std.expout
+++ b/python/test/t_TruncatedDistribution_std.expout
@@ -342,3 +342,4 @@ d= TruncatedDistribution(Uniform(a = 1, b = 2), bounds = [0.2, 2.4]) simplified=
 d= TruncatedDistribution(Exponential(lambda = 1, gamma = 2), bounds = [2.5, 65]) simplified= Exponential(lambda = 1, gamma = 2.5)
 d= TruncatedDistribution(TruncatedDistribution(Weibull(alpha = 1, beta = 1, gamma = 0), bounds = [1.5, 7.8]), bounds = [2.5, 6]) simplified= TruncatedDistribution(Weibull(alpha = 1, beta = 1, gamma = 0), bounds = [2.5, 6])
 d= TruncatedDistribution(Beta(r = 1.5, t = 7.8, a = -1, b = 2), bounds = [-2.5, 6]) simplified= Beta(r = 1.5, t = 7.8, a = -1, b = 2)
+after setbounds q@0.9= [29.628]

--- a/python/test/t_TruncatedDistribution_std.py
+++ b/python/test/t_TruncatedDistribution_std.py
@@ -191,3 +191,9 @@ intervals = [ot.Interval(-1.0, 4.0), ot.Interval(0.2, 2.4), ot.Interval(2.5, 65.
 for i in range(len(candidates)):
     d = ot.TruncatedDistribution(candidates[i], intervals[i])
     print("d=", d, "simplified=", d.getSimplifiedVersion())
+
+# Check that we can set the bounds independently
+truncated = ot.TruncatedDistribution()
+truncated.setDistribution(ot.Normal(20.0, 7.5))
+truncated.setBounds(ot.Interval([0], [80], [True], [False]))
+print('after setbounds q@0.9=', truncated.computeQuantile(0.9))


### PR DESCRIPTION
It was not updating (c|p)df(Lower|Upper)Bound_ attributes