### PR TITLE
Python: Avoid empty throws in conversion primitives

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,7 @@
  * #995 (Pip does not recognize conda install of openturns)
  * #1000 (SaltelliSensitivityAlgorithm with LowDiscrepancyExperiment produces wrong results)
  * #1024 (The unary operator is undefined for Normal distribution)
+ * #1025 (Empty throw in PythonWrappingFunctions)
 
 == 1.12 release (2018-11-08) == #release-1.12
 

--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -32,19 +32,19 @@ BEGIN_NAMESPACE_OPENTURNS
 class ScopedPyObjectPointer
 {
 public:
-  explicit ScopedPyObjectPointer( PyObject * pyObj = 0 )
+  explicit ScopedPyObjectPointer(PyObject * pyObj = 0)
     : pyObj_(pyObj)
   {
   }
 
   ~ScopedPyObjectPointer()
   {
-    Py_XDECREF( pyObj_ );
+    Py_XDECREF(pyObj_);
   }
 
   ScopedPyObjectPointer & operator=(PyObject * pyObj)
   {
-    Py_XDECREF( pyObj_ );
+    Py_XDECREF(pyObj_);
     pyObj_ = pyObj;
     return *this;
   }
@@ -91,7 +91,7 @@ struct _PyObject_ {};
 template <>
 inline
 int
-isAPython<_PyObject_>(PyObject * )
+isAPython<_PyObject_>(PyObject *)
 {
   return 1;
 }
@@ -195,7 +195,7 @@ struct traitsPythonType< UnsignedInteger >
 template <>
 inline
 bool
-canConvert< _PyInt_, UnsignedInteger >(PyObject * )
+canConvert< _PyInt_, UnsignedInteger >(PyObject *)
 {
   return true;
 }
@@ -346,7 +346,7 @@ convert< _PyBytes_, String >(PyObject * pyObj)
 template <>
 inline
 PyObject *
-convert< String, _PyBytes_ >( String s )
+convert< String, _PyBytes_ >(String s)
 {
 #if PY_MAJOR_VERSION >= 3
   return PyBytes_FromString(s.data());
@@ -447,7 +447,7 @@ convert< _PyString_, String >(PyObject * pyObj)
 template <>
 inline
 PyObject *
-convert< String, _PyString_ >( String s )
+convert< String, _PyString_ >(String s)
 {
 #if PY_MAJOR_VERSION >= 3
   return convert<String, _PyUnicode_>(s);
@@ -513,12 +513,12 @@ isAPythonSequenceOf(PyObject * pyObj)
 {
   int ok = isAPython<_PySequence_>(pyObj) && (! isAPython< _PyString_ >(pyObj));
 
-  if ( ok )
+  if (ok)
   {
     const UnsignedInteger size = PySequence_Size(pyObj);
-    for( UnsignedInteger i = 0; ok && (i < size); ++i )
+    for(UnsignedInteger i = 0; ok && (i < size); ++i)
     {
-      ScopedPyObjectPointer elt(PySequence_ITEM( pyObj, i ));
+      ScopedPyObjectPointer elt(PySequence_ITEM(pyObj, i));
       int elt_ok = elt.get() && isAPython<PYTHON_Type>(elt.get());
       ok *= elt_ok;
     }
@@ -567,13 +567,13 @@ canConvertCollectionObjectFromPySequence(PyObject * pyObj)
     return false;
   }
 
-  ScopedPyObjectPointer newPyObj(PySequence_Fast( pyObj, "" ));
+  ScopedPyObjectPointer newPyObj(PySequence_Fast(pyObj, ""));
 
-  const UnsignedInteger size = PySequence_Fast_GET_SIZE( newPyObj.get() );
+  const UnsignedInteger size = PySequence_Fast_GET_SIZE(newPyObj.get());
   for(UnsignedInteger i = 0; i < size; ++i)
   {
-    PyObject * elt = PySequence_Fast_GET_ITEM( newPyObj.get(), i );
-    if (!canConvert< typename traitsPythonType< T >::Type, T >( elt ))
+    PyObject * elt = PySequence_Fast_GET_ITEM(newPyObj.get(), i);
+    if (!canConvert< typename traitsPythonType< T >::Type, T >(elt))
     {
       return false;
     }
@@ -591,28 +591,28 @@ Collection<T> *
 buildCollectionFromPySequence(PyObject * pyObj, int sz = 0)
 {
   check<_PySequence_>(pyObj);
-  ScopedPyObjectPointer newPyObj(PySequence_Fast( pyObj, "" ));
+  ScopedPyObjectPointer newPyObj(PySequence_Fast(pyObj, ""));
   if (!newPyObj.get()) throw InvalidArgumentException(HERE) << "Not a sequence object";
-  const UnsignedInteger size = PySequence_Fast_GET_SIZE( newPyObj.get() );
+  const UnsignedInteger size = PySequence_Fast_GET_SIZE(newPyObj.get());
   if ((sz != 0) && (sz != (int)size))
   {
     throw InvalidArgumentException(HERE) << "Sequence object has incorrect size " << size << ". Must be " << sz << ".";
   }
-  Collection<T> * p_coll = new Collection< T >( size );
+  Collection<T> * p_coll = new Collection< T >(size);
 
   for(UnsignedInteger i = 0; i < size; ++i)
   {
-    PyObject * elt = PySequence_Fast_GET_ITEM( newPyObj.get(), i );
+    PyObject * elt = PySequence_Fast_GET_ITEM(newPyObj.get(), i);
     try
     {
-      check<typename traitsPythonType< T >::Type>( elt );
+      check<typename traitsPythonType< T >::Type>(elt);
     }
     catch (InvalidArgumentException &)
     {
       delete p_coll;
       throw;
     }
-    (*p_coll)[i] = convert< typename traitsPythonType< T >::Type, T >( elt );
+    (*p_coll)[i] = convert< typename traitsPythonType< T >::Type, T >(elt);
   }
 
   return p_coll;
@@ -660,7 +660,7 @@ convert< _PySequence_, Point >(PyObject * pyObj)
   }
 
   Pointer<Collection<Scalar> > ptr = buildCollectionFromPySequence<Scalar>(pyObj);
-  return Point( *ptr );
+  return Point(*ptr);
 }
 
 template <>
@@ -669,10 +669,10 @@ PyObject *
 convert< Point, _PySequence_ >(Point inP)
 {
   UnsignedInteger dimension = inP.getDimension();
-  PyObject * point = PyTuple_New( dimension );
-  for ( UnsignedInteger i = 0; i < dimension; ++ i )
+  PyObject * point = PyTuple_New(dimension);
+  for (UnsignedInteger i = 0; i < dimension; ++ i)
   {
-    PyTuple_SetItem( point, i, convert< Scalar, _PyFloat_ >( inP[i] ) );
+    PyTuple_SetItem(point, i, convert< Scalar, _PyFloat_ >(inP[i]));
   }
   return point;
 }
@@ -729,7 +729,7 @@ convert<_PySequence_, Collection<Complex> >(PyObject * pyObj)
   }
 
   Pointer<Collection<Complex> > ptr = buildCollectionFromPySequence<Complex>(pyObj);
-  return Collection<Complex>( *ptr );
+  return Collection<Complex>(*ptr);
 }
 
 inline
@@ -821,29 +821,29 @@ convert< _PySequence_, Sample >(PyObject * pyObj)
   }
 
   // use the same conversion function for numpy array/matrix, knowing numpy matrix is not a sequence
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("shape")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("shape")))
   {
-    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString( pyObj, "shape" ));
-    if ( !shapeObj.get() ) throw;
+    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString(pyObj, "shape"));
+    if (!shapeObj.get()) throw;
 
-    Indices shape( checkAndConvert< _PySequence_, Indices >( shapeObj.get() ) );
-    if ( shape.getSize() == 2 )
+    Indices shape(checkAndConvert< _PySequence_, Indices >(shapeObj.get()));
+    if (shape.getSize() == 2)
     {
       UnsignedInteger size = shape[0];
       UnsignedInteger dimension = shape[1];
       ScopedPyObjectPointer askObj(PyTuple_New(2));
       ScopedPyObjectPointer methodObj(convert< String, _PyString_ >("__getitem__"));
-      Sample sample( size, dimension );
-      for ( UnsignedInteger i = 0; i < size; ++ i )
+      Sample sample(size, dimension);
+      for (UnsignedInteger i = 0; i < size; ++ i)
       {
-        PyTuple_SetItem( askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i) );
-        for ( UnsignedInteger j = 0; j < dimension; ++ j )
+        PyTuple_SetItem(askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i));
+        for (UnsignedInteger j = 0; j < dimension; ++ j)
         {
-          PyTuple_SetItem( askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j) );
-          ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs( pyObj, methodObj.get(), askObj.get(), NULL));
+          PyTuple_SetItem(askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j));
+          ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs(pyObj, methodObj.get(), askObj.get(), NULL));
           if (elt.get())
           {
-            sample( i, j ) = checkAndConvert<_PyFloat_, Scalar>(elt.get());
+            sample(i, j) = checkAndConvert<_PyFloat_, Scalar>(elt.get());
           }
         }
       }
@@ -853,33 +853,33 @@ convert< _PySequence_, Sample >(PyObject * pyObj)
       throw InvalidArgumentException(HERE) << "Invalid array dimension: " << shape.getSize();
   }
   check<_PySequence_>(pyObj);
-  ScopedPyObjectPointer newPyObj(PySequence_Fast( pyObj, "" ));
+  ScopedPyObjectPointer newPyObj(PySequence_Fast(pyObj, ""));
   if (!newPyObj.get()) throw InvalidArgumentException(HERE) << "Not a sequence object";
-  const UnsignedInteger size = PySequence_Fast_GET_SIZE( newPyObj.get() );
+  const UnsignedInteger size = PySequence_Fast_GET_SIZE(newPyObj.get());
   if (size == 0) return Sample();
 
   // Get dimension of first point
-  PyObject * firstPoint = PySequence_Fast_GET_ITEM( newPyObj.get(), 0 );
-  check<_PySequence_>( firstPoint );
-  ScopedPyObjectPointer newPyFirstObj(PySequence_Fast( firstPoint, "" ));
-  const UnsignedInteger dimension = PySequence_Fast_GET_SIZE( newPyFirstObj.get() );
+  PyObject * firstPoint = PySequence_Fast_GET_ITEM(newPyObj.get(), 0);
+  check<_PySequence_>(firstPoint);
+  ScopedPyObjectPointer newPyFirstObj(PySequence_Fast(firstPoint, ""));
+  const UnsignedInteger dimension = PySequence_Fast_GET_SIZE(newPyFirstObj.get());
   // Allocate result Sample
-  Sample sample( size, dimension );
+  Sample sample(size, dimension);
   for(UnsignedInteger i = 0; i < size; ++i)
   {
-    PyObject * pointObj = PySequence_Fast_GET_ITEM( newPyObj.get(), i );
-    ScopedPyObjectPointer newPyPointObj(PySequence_Fast( pointObj, "" ));
+    PyObject * pointObj = PySequence_Fast_GET_ITEM(newPyObj.get(), i);
+    ScopedPyObjectPointer newPyPointObj(PySequence_Fast(pointObj, ""));
     if (i > 0)
     {
       // Check that object is a sequence, and has the right size
-      check<_PySequence_>( pointObj );
+      check<_PySequence_>(pointObj);
       const UnsignedInteger subDim = static_cast<UnsignedInteger>(PySequence_Fast_GET_SIZE(newPyPointObj.get()));
       if (subDim != dimension)
         throw InvalidArgumentException(HERE) << "Inner sequences must have the same dimension";
     }
     for(UnsignedInteger j = 0; j < dimension; ++j)
     {
-      PyObject * value = PySequence_Fast_GET_ITEM( newPyPointObj.get(), j );
+      PyObject * value = PySequence_Fast_GET_ITEM(newPyPointObj.get(), j);
       sample(i, j) = checkAndConvert<_PyFloat_, Scalar>(value);
     }
   }
@@ -911,7 +911,7 @@ convert< _PySequence_, Collection<UnsignedInteger> >(PyObject * pyObj)
         // 1-d contiguous array, we can directly copy memory chunk
         const UnsignedInteger* data = static_cast<const UnsignedInteger*>(view.buf);
         const UnsignedInteger size = view.shape[0];
-        Collection<UnsignedInteger> result( size );
+        Collection<UnsignedInteger> result(size);
         std::copy(data, data + size, &result[0]);
         PyBuffer_Release(&view);
         return result;
@@ -923,7 +923,7 @@ convert< _PySequence_, Collection<UnsignedInteger> >(PyObject * pyObj)
   }
 
   Pointer<Collection<UnsignedInteger> > ptr = buildCollectionFromPySequence<UnsignedInteger>(pyObj);
-  return Collection<UnsignedInteger>( ptr->begin(), ptr->end() );
+  return Collection<UnsignedInteger>(ptr->begin(), ptr->end());
 }
 
 
@@ -939,7 +939,7 @@ Indices
 convert< _PySequence_, Indices >(PyObject * pyObj)
 {
   Pointer<Collection<UnsignedInteger> > ptr = buildCollectionFromPySequence<UnsignedInteger>(pyObj);
-  return Indices( ptr->begin(), ptr->end() );
+  return Indices(ptr->begin(), ptr->end());
 }
 
 template <>
@@ -951,7 +951,7 @@ convert< Indices, _PySequence_ >(Indices inP)
   PyObject * point = PyTuple_New(dimension);
   for (UnsignedInteger i = 0; i < dimension; ++ i)
   {
-    PyTuple_SetItem( point, i, convert< UnsignedInteger, _PyInt_ >(inP[i]));
+    PyTuple_SetItem(point, i, convert< UnsignedInteger, _PyInt_ >(inP[i]));
   }
   return point;
 }
@@ -981,7 +981,7 @@ convert< _PySequence_, IndicesCollection >(PyObject * pyObj)
         const UnsignedInteger* data = static_cast<const UnsignedInteger*>(view.buf);
         const UnsignedInteger size = view.shape[0];
         const UnsignedInteger dimension = view.shape[1];
-        IndicesCollection indices( size, dimension );
+        IndicesCollection indices(size, dimension);
         if (PyBuffer_IsContiguous(&view, 'C'))
         {
           // 2-d contiguous array in C notation, we can directly copy memory chunk
@@ -1003,29 +1003,29 @@ convert< _PySequence_, IndicesCollection >(PyObject * pyObj)
   }
 
   // use the same conversion function for numpy array/matrix, knowing numpy matrix is not a sequence
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("shape")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("shape")))
   {
-    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString( pyObj, "shape" ));
+    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString(pyObj, "shape"));
     if (shapeObj.get())
     {
-      Indices shape( checkAndConvert< _PySequence_, Indices >( shapeObj.get() ) );
-      if ( shape.getSize() == 2 )
+      Indices shape(checkAndConvert< _PySequence_, Indices >(shapeObj.get()));
+      if (shape.getSize() == 2)
       {
         UnsignedInteger size = shape[0];
         UnsignedInteger dimension = shape[1];
         ScopedPyObjectPointer askObj(PyTuple_New(2));
         ScopedPyObjectPointer methodObj(convert< String, _PyString_ >("__getitem__"));
-        IndicesCollection indices( size, dimension );
-        for ( UnsignedInteger i = 0; i < size; ++ i )
+        IndicesCollection indices(size, dimension);
+        for (UnsignedInteger i = 0; i < size; ++ i)
         {
-          PyTuple_SetItem( askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i) );
-          for ( UnsignedInteger j = 0; j < dimension; ++ j )
+          PyTuple_SetItem(askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i));
+          for (UnsignedInteger j = 0; j < dimension; ++ j)
           {
-            PyTuple_SetItem( askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j) );
-            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs( pyObj, methodObj.get(), askObj.get(), NULL));
+            PyTuple_SetItem(askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j));
+            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs(pyObj, methodObj.get(), askObj.get(), NULL));
             if (elt.get())
             {
-              indices( i, j ) = checkAndConvert<_PyInt_, UnsignedInteger>(elt.get());
+              indices(i, j) = checkAndConvert<_PyInt_, UnsignedInteger>(elt.get());
             }
           }
         }
@@ -1037,23 +1037,23 @@ convert< _PySequence_, IndicesCollection >(PyObject * pyObj)
   }
   // This object is a sequence; unlike Matrix and Sample, dimension is not constant.
   check<_PySequence_>(pyObj);
-  ScopedPyObjectPointer newPyObj(PySequence_Fast( pyObj, "" ));
+  ScopedPyObjectPointer newPyObj(PySequence_Fast(pyObj, ""));
   if (!newPyObj.get()) throw InvalidArgumentException(HERE) << "Not a sequence object";
-  const UnsignedInteger size = PySequence_Fast_GET_SIZE( newPyObj.get() );
+  const UnsignedInteger size = PySequence_Fast_GET_SIZE(newPyObj.get());
   if (size == 0) return IndicesCollection();
   // Allocate a Collection of Indices
   Collection<Indices> coll(size);
   for(UnsignedInteger i = 0; i < size; ++i)
   {
-    PyObject * indicesObj = PySequence_Fast_GET_ITEM( newPyObj.get(), i );
-    ScopedPyObjectPointer newPyIndicesObj(PySequence_Fast( indicesObj, "" ));
+    PyObject * indicesObj = PySequence_Fast_GET_ITEM(newPyObj.get(), i);
+    ScopedPyObjectPointer newPyIndicesObj(PySequence_Fast(indicesObj, ""));
     // Check that object is a sequence
-    check<_PySequence_>( indicesObj );
-    const UnsignedInteger dimension = PySequence_Fast_GET_SIZE( newPyIndicesObj.get() );
+    check<_PySequence_>(indicesObj);
+    const UnsignedInteger dimension = PySequence_Fast_GET_SIZE(newPyIndicesObj.get());
     Indices newIndices(dimension);
     for(UnsignedInteger j = 0; j < dimension; ++j)
     {
-      PyObject * value = PySequence_Fast_GET_ITEM( newPyIndicesObj.get(), j );
+      PyObject * value = PySequence_Fast_GET_ITEM(newPyIndicesObj.get(), j);
       newIndices[j] = checkAndConvert<_PyInt_, UnsignedInteger>(value);
     }
     coll[i] = newIndices;
@@ -1074,7 +1074,7 @@ Description
 convert<_PySequence_, Description>(PyObject * pyObj)
 {
   Pointer<Collection<String> > ptr = buildCollectionFromPySequence<String>(pyObj);
-  return Description( *ptr );
+  return Description(*ptr);
 }
 
 
@@ -1115,7 +1115,7 @@ convert< _PySequence_, Collection<Scalar> >(PyObject * pyObj)
       PyErr_Clear();
   }
   Pointer<Collection<Scalar> > ptr = buildCollectionFromPySequence<Scalar>(pyObj);
-  return Collection<Scalar>( *ptr );
+  return Collection<Scalar>(*ptr);
 }
 
 
@@ -1148,7 +1148,7 @@ convert< _PySequence_, MatrixImplementation* >(PyObject * pyObj)
         const Scalar* data = static_cast<const Scalar*>(view.buf);
         const UnsignedInteger nbRows = view.shape[0];
         const UnsignedInteger nbColumns = view.shape[1];
-        p_implementation = new MatrixImplementation( nbRows, nbColumns );
+        p_implementation = new MatrixImplementation(nbRows, nbColumns);
         if (PyBuffer_IsContiguous(&view, 'F'))
         {
           // 2-d contiguous array in Fortran notation, we can directly copy memory chunk
@@ -1170,31 +1170,31 @@ convert< _PySequence_, MatrixImplementation* >(PyObject * pyObj)
   }
 
   // use the same conversion function for numpy array/matrix, knowing numpy matrix is not a sequence
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("shape")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("shape")))
   {
-    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString( pyObj, "shape" ));
-    if ( shapeObj.get() )
+    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString(pyObj, "shape"));
+    if (shapeObj.get())
     {
-      Indices shape( checkAndConvert< _PySequence_, Indices >( shapeObj.get() ) );
-      if ( shape.getSize() == 2 )
+      Indices shape(checkAndConvert< _PySequence_, Indices >(shapeObj.get()));
+      if (shape.getSize() == 2)
       {
         UnsignedInteger nbRows = shape[0];
         UnsignedInteger nbColumns = shape[1];
         ScopedPyObjectPointer askObj(PyTuple_New(2));
         ScopedPyObjectPointer methodObj(convert< String, _PyString_ >("__getitem__"));
-        p_implementation = new MatrixImplementation( nbRows, nbColumns );
-        for ( UnsignedInteger i = 0; i < nbRows; ++ i )
+        p_implementation = new MatrixImplementation(nbRows, nbColumns);
+        for (UnsignedInteger i = 0; i < nbRows; ++ i)
         {
-          PyTuple_SetItem( askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i) );
-          for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
+          PyTuple_SetItem(askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i));
+          for (UnsignedInteger j = 0; j < nbColumns; ++ j)
           {
-            PyTuple_SetItem( askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j) );
-            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs( pyObj, methodObj.get(), askObj.get(), NULL));
+            PyTuple_SetItem(askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j));
+            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs(pyObj, methodObj.get(), askObj.get(), NULL));
             if (elt.get())
             {
               try
               {
-                p_implementation->operator()( i, j ) = checkAndConvert<_PyFloat_, Scalar>(elt.get());
+                p_implementation->operator()(i, j) = checkAndConvert<_PyFloat_, Scalar>(elt.get());
               }
               catch (InvalidArgumentException &)
               {
@@ -1209,36 +1209,36 @@ convert< _PySequence_, MatrixImplementation* >(PyObject * pyObj)
         throw InvalidArgumentException(HERE) << "Invalid array dimension: " << shape.getSize();
     }
   }
-  else if ( PyObject_HasAttrString(pyObj, const_cast<char *>("getNbColumns")) )
+  else if (PyObject_HasAttrString(pyObj, const_cast<char *>("getNbColumns")))
   {
     // case of conversion from XMatrix to YMatrix
     // X could be Square,Triangular,Identity...
     // YMatrix might be Matrix of one of its inheritance types
-    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod ( pyObj,
-                                     const_cast<char *>( "getNbColumns" ),
-                                     const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer rowsObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getNbRows" ),
-                                  const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer implObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getImplementation" ),
-                                  const_cast<char *>( "()" ) ));
-    Pointer< Collection< Scalar > > ptr = buildCollectionFromPySequence< Scalar >( implObj.get() );
-    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >( colunmsObj.get() );
-    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >( rowsObj.get() );
-    p_implementation = new MatrixImplementation( nbRows, nbColumns, *ptr );
+    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod (pyObj,
+                                     const_cast<char *>("getNbColumns"),
+                                     const_cast<char *>("()")));
+    ScopedPyObjectPointer rowsObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getNbRows"),
+                                  const_cast<char *>("()")));
+    ScopedPyObjectPointer implObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getImplementation"),
+                                  const_cast<char *>("()")));
+    Pointer< Collection< Scalar > > ptr = buildCollectionFromPySequence< Scalar >(implObj.get());
+    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >(colunmsObj.get());
+    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >(rowsObj.get());
+    p_implementation = new MatrixImplementation(nbRows, nbColumns, *ptr);
   }
   else
   {
     // try to convert from a sequence of sequences
     Pointer< Collection< Point > > ptr = buildCollectionFromPySequence< Point >(pyObj);
-    Sample sample( *ptr );
+    Sample sample(*ptr);
     UnsignedInteger nbRows = sample.getSize();
     UnsignedInteger nbColumns = sample.getDimension();
-    p_implementation = new MatrixImplementation( nbRows, nbColumns );
-    for ( UnsignedInteger i = 0; i < nbRows; ++ i )
-      for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
-        p_implementation->operator()( i, j ) = sample(i, j);
+    p_implementation = new MatrixImplementation(nbRows, nbColumns);
+    for (UnsignedInteger i = 0; i < nbRows; ++ i)
+      for (UnsignedInteger j = 0; j < nbColumns; ++ j)
+        p_implementation->operator()(i, j) = sample(i, j);
   }
   return p_implementation;
 }
@@ -1251,7 +1251,7 @@ Matrix
 convert< _PySequence_, Matrix >(PyObject * pyObj)
 {
   MatrixImplementation *p_implementation = convert< _PySequence_, MatrixImplementation* >(pyObj);
-  return Matrix( p_implementation );
+  return Matrix(p_implementation);
 }
 
 
@@ -1262,9 +1262,9 @@ SquareMatrix
 convert< _PySequence_, SquareMatrix >(PyObject * pyObj)
 {
   MatrixImplementation *p_implementation = convert< _PySequence_, MatrixImplementation* >(pyObj);
-  if ( p_implementation->getNbRows() != p_implementation->getNbColumns() )
+  if (p_implementation->getNbRows() != p_implementation->getNbColumns())
     throw InvalidArgumentException(HERE) << "The matrix is not square";
-  return SquareMatrix( p_implementation );
+  return SquareMatrix(p_implementation);
 }
 
 
@@ -1277,7 +1277,7 @@ convert< _PySequence_, TriangularMatrix >(PyObject * pyObj)
   MatrixImplementation *p_implementation = convert< _PySequence_, MatrixImplementation* >(pyObj);
   if (!(p_implementation->isTriangular(true) || p_implementation->isTriangular(false)))
     throw InvalidArgumentException(HERE) << "The matrix is not triangular";
-  return TriangularMatrix( p_implementation, p_implementation->isTriangular(true) );
+  return TriangularMatrix(p_implementation, p_implementation->isTriangular(true));
 }
 
 
@@ -1290,7 +1290,7 @@ convert< _PySequence_, SymmetricMatrix >(PyObject * pyObj)
   MatrixImplementation *p_implementation = convert< _PySequence_, MatrixImplementation* >(pyObj);
   if (!p_implementation->isSymmetric())
     throw InvalidArgumentException(HERE) << "The matrix is not symmetric";
-  return SymmetricMatrix( p_implementation );
+  return SymmetricMatrix(p_implementation);
 }
 
 
@@ -1304,7 +1304,7 @@ convert< _PySequence_, CovarianceMatrix >(PyObject * pyObj)
   if (!p_implementation->isSymmetric())
     throw InvalidArgumentException(HERE) << "The matrix is not symmetric";
   // SPD check is too expensive
-  return CovarianceMatrix( p_implementation );
+  return CovarianceMatrix(p_implementation);
 }
 
 
@@ -1320,7 +1320,7 @@ convert< _PySequence_, CorrelationMatrix >(PyObject * pyObj)
   // SPD check is too expensive
   if (!p_implementation->hasUnitRange())
     throw InvalidArgumentException(HERE) << "The matrix range is not (-1;1)";
-  return CorrelationMatrix( p_implementation );
+  return CorrelationMatrix(p_implementation);
 }
 
 
@@ -1353,7 +1353,7 @@ convert< _PySequence_, TensorImplementation* >(PyObject * pyObj)
         const UnsignedInteger nbRows = view.shape[0];
         const UnsignedInteger nbColumns = view.shape[1];
         const UnsignedInteger nbSheets = view.shape[2];
-        TensorImplementation *p_implementation = new TensorImplementation( nbRows, nbColumns, nbSheets );
+        TensorImplementation *p_implementation = new TensorImplementation(nbRows, nbColumns, nbSheets);
         if (PyBuffer_IsContiguous(&view, 'F'))
         {
           // 3-d contiguous array in Fortran notation, we can directly copy memory chunk
@@ -1363,8 +1363,8 @@ convert< _PySequence_, TensorImplementation* >(PyObject * pyObj)
         {
           for(UnsignedInteger i = 0; i < nbRows; ++i)
             for (UnsignedInteger j = 0; j < nbColumns; ++j)
-              for (UnsignedInteger k = 0; k < nbSheets; ++k, ++data )
-                p_implementation->operator()( i, j, k ) = *data;
+              for (UnsignedInteger k = 0; k < nbSheets; ++k, ++data)
+                p_implementation->operator()(i, j, k) = *data;
         }
         PyBuffer_Release(&view);
         return p_implementation;
@@ -1379,11 +1379,11 @@ convert< _PySequence_, TensorImplementation* >(PyObject * pyObj)
   UnsignedInteger nbRows = ptr->getSize();
   UnsignedInteger nbColumns = ptr->getSize() > 0 ? (*ptr)[0].getSize() : 0;
   UnsignedInteger nbSheets = ptr->getSize() > 0 ? (*ptr)[0].getDimension() : 0;
-  TensorImplementation *p_implementation = new TensorImplementation( nbRows, nbColumns, nbSheets );
-  for ( UnsignedInteger i = 0; i < nbRows; ++ i )
-    for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
-      for ( UnsignedInteger k = 0; k < nbSheets; ++ k )
-        p_implementation->operator()( i, j, k ) = (*ptr)[i](j, k);
+  TensorImplementation *p_implementation = new TensorImplementation(nbRows, nbColumns, nbSheets);
+  for (UnsignedInteger i = 0; i < nbRows; ++ i)
+    for (UnsignedInteger j = 0; j < nbColumns; ++ j)
+      for (UnsignedInteger k = 0; k < nbSheets; ++ k)
+        p_implementation->operator()(i, j, k) = (*ptr)[i](j, k);
   return p_implementation;
 }
 
@@ -1395,7 +1395,7 @@ Tensor
 convert< _PySequence_, Tensor >(PyObject * pyObj)
 {
   TensorImplementation *p_implementation = convert<_PySequence_, TensorImplementation*>(pyObj);
-  return Tensor( p_implementation );
+  return Tensor(p_implementation);
 }
 
 
@@ -1408,7 +1408,7 @@ convert< _PySequence_, SymmetricTensor >(PyObject * pyObj)
   TensorImplementation *p_implementation = convert< _PySequence_, TensorImplementation* >(pyObj);
   if (!p_implementation->isSymmetric())
     throw InvalidArgumentException(HERE) << "The tensor is not symmetric";
-  return SymmetricTensor( p_implementation );
+  return SymmetricTensor(p_implementation);
 }
 
 
@@ -1440,7 +1440,7 @@ convert< _PySequence_, ComplexMatrixImplementation* >(PyObject * pyObj)
         const Complex* data = static_cast<const Complex*>(view.buf);
         const UnsignedInteger nbRows = view.shape[0];
         const UnsignedInteger nbColumns = view.shape[1];
-        ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation( nbRows, nbColumns );
+        ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation(nbRows, nbColumns);
         if (PyBuffer_IsContiguous(&view, 'F'))
         {
           // 2-d contiguous array in Fortran notation, we can directly copy memory chunk
@@ -1462,31 +1462,31 @@ convert< _PySequence_, ComplexMatrixImplementation* >(PyObject * pyObj)
   }
 
   // use the same conversion function for numpy array/matrix, knowing numpy matrix is not a sequence
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("shape")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("shape")))
   {
-    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString( pyObj, "shape" ));
+    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString(pyObj, "shape"));
     if (shapeObj.get())
     {
-      Indices shape( checkAndConvert< _PySequence_, Indices >( shapeObj.get() ) );
-      if ( shape.getSize() == 2 )
+      Indices shape(checkAndConvert< _PySequence_, Indices >(shapeObj.get()));
+      if (shape.getSize() == 2)
       {
         UnsignedInteger nbRows = shape[0];
         UnsignedInteger nbColumns = shape[1];
         ScopedPyObjectPointer askObj(PyTuple_New(2));
         ScopedPyObjectPointer methodObj(convert< String, _PyString_ >("__getitem__"));
-        ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation( nbRows, nbColumns );
-        for ( UnsignedInteger i = 0; i < nbRows; ++ i )
+        ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation(nbRows, nbColumns);
+        for (UnsignedInteger i = 0; i < nbRows; ++ i)
         {
-          PyTuple_SetItem( askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i) );
-          for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
+          PyTuple_SetItem(askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i));
+          for (UnsignedInteger j = 0; j < nbColumns; ++ j)
           {
-            PyTuple_SetItem( askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j) );
-            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs( pyObj, methodObj.get(), askObj.get(), NULL));
+            PyTuple_SetItem(askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j));
+            ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs(pyObj, methodObj.get(), askObj.get(), NULL));
             if (elt.get())
             {
               try
               {
-                p_implementation->operator()( i, j ) = checkAndConvert<_PyComplex_, Complex>(elt.get());
+                p_implementation->operator()(i, j) = checkAndConvert<_PyComplex_, Complex>(elt.get());
               }
               catch (InvalidArgumentException &)
               {
@@ -1506,21 +1506,21 @@ convert< _PySequence_, ComplexMatrixImplementation* >(PyObject * pyObj)
   // case of conversion from XMatrix to YMatrix
   // X could be Square,Triangular,Identity...
   // YMatrix might be Matrix of one of its inheritance types
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("getNbColumns")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("getNbColumns")))
   {
-    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod ( pyObj,
-                                     const_cast<char *>( "getNbColumns" ),
-                                     const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer rowsObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getNbRows" ),
-                                  const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer implObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getImplementation" ),
-                                  const_cast<char *>( "()" ) ));
-    Pointer< Collection< Complex > > ptr = buildCollectionFromPySequence< Complex >( implObj.get() );
-    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >( colunmsObj.get() );
-    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >( rowsObj.get() );
-    ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation( nbRows, nbColumns, *ptr );
+    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod (pyObj,
+                                     const_cast<char *>("getNbColumns"),
+                                     const_cast<char *>("()")));
+    ScopedPyObjectPointer rowsObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getNbRows"),
+                                  const_cast<char *>("()")));
+    ScopedPyObjectPointer implObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getImplementation"),
+                                  const_cast<char *>("()")));
+    Pointer< Collection< Complex > > ptr = buildCollectionFromPySequence< Complex >(implObj.get());
+    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >(colunmsObj.get());
+    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >(rowsObj.get());
+    ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation(nbRows, nbColumns, *ptr);
     return p_implementation;
   }
 
@@ -1528,10 +1528,10 @@ convert< _PySequence_, ComplexMatrixImplementation* >(PyObject * pyObj)
   Pointer< Collection< Collection< Complex > > > ptr = buildCollectionFromPySequence< Collection< Complex > >(pyObj);
   UnsignedInteger nbRows = ptr->getSize();
   UnsignedInteger nbColumns = ptr->getSize() > 0 ? (*ptr)[0].getSize() : 0;
-  ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation( nbRows, nbColumns );
-  for ( UnsignedInteger i = 0; i < nbRows; ++ i )
-    for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
-      p_implementation->operator()( i, j ) = (*ptr)[i][j];
+  ComplexMatrixImplementation *p_implementation = new ComplexMatrixImplementation(nbRows, nbColumns);
+  for (UnsignedInteger i = 0; i < nbRows; ++ i)
+    for (UnsignedInteger j = 0; j < nbColumns; ++ j)
+      p_implementation->operator()(i, j) = (*ptr)[i][j];
   return p_implementation;
 }
 
@@ -1543,7 +1543,7 @@ ComplexMatrix
 convert< _PySequence_, ComplexMatrix >(PyObject * pyObj)
 {
   ComplexMatrixImplementation *p_implementation = convert< _PySequence_, ComplexMatrixImplementation* >(pyObj);
-  return ComplexMatrix( p_implementation );
+  return ComplexMatrix(p_implementation);
 }
 
 
@@ -1554,9 +1554,9 @@ SquareComplexMatrix
 convert< _PySequence_, SquareComplexMatrix >(PyObject * pyObj)
 {
   ComplexMatrixImplementation *p_implementation = convert< _PySequence_, ComplexMatrixImplementation* >(pyObj);
-  if ( p_implementation->getNbRows() != p_implementation->getNbColumns() )
+  if (p_implementation->getNbRows() != p_implementation->getNbColumns())
     throw InvalidArgumentException(HERE) << "The matrix is not square";
-  return SquareComplexMatrix( p_implementation );
+  return SquareComplexMatrix(p_implementation);
 }
 
 
@@ -1568,9 +1568,9 @@ convert< _PySequence_, TriangularComplexMatrix >(PyObject * pyObj)
 {
   ComplexMatrixImplementation *p_implementation = convert< _PySequence_, ComplexMatrixImplementation* >(pyObj);
   Bool lower = p_implementation->isTriangular(true);
-  if ( !lower && !p_implementation->isTriangular(false) )
+  if (!lower && !p_implementation->isTriangular(false))
     throw InvalidArgumentException(HERE) << "The matrix is not triangular";
-  return TriangularComplexMatrix( p_implementation, lower );
+  return TriangularComplexMatrix(p_implementation, lower);
 }
 
 
@@ -1586,9 +1586,9 @@ HermitianMatrix
 convert< _PySequence_, HermitianMatrix >(PyObject * pyObj)
 {
   ComplexMatrixImplementation *p_implementation = convert< _PySequence_, ComplexMatrixImplementation* >(pyObj);
-  if ( !p_implementation->isHermitian() )
+  if (!p_implementation->isHermitian())
     throw InvalidArgumentException(HERE) << "The matrix is not hermitian";
-  return HermitianMatrix( p_implementation );
+  return HermitianMatrix(p_implementation);
 }
 
 template <>
@@ -1621,7 +1621,7 @@ convert< _PySequence_, ComplexTensorImplementation* >(PyObject * pyObj)
         const UnsignedInteger nbRows = view.shape[0];
         const UnsignedInteger nbColumns = view.shape[1];
         const UnsignedInteger nbSheets = view.shape[2];
-        p_implementation = new ComplexTensorImplementation( nbRows, nbColumns, nbSheets );
+        p_implementation = new ComplexTensorImplementation(nbRows, nbColumns, nbSheets);
         if (PyBuffer_IsContiguous(&view, 'F'))
         {
           // 3-d contiguous array in Fortran notation, we can directly copy memory chunk
@@ -1631,8 +1631,8 @@ convert< _PySequence_, ComplexTensorImplementation* >(PyObject * pyObj)
         {
           for(UnsignedInteger i = 0; i < nbRows; ++i)
             for (UnsignedInteger j = 0; j < nbColumns; ++j)
-              for (UnsignedInteger k = 0; k < nbSheets; ++k, ++data )
-                p_implementation->operator()( i, j, k ) = *data;
+              for (UnsignedInteger k = 0; k < nbSheets; ++k, ++data)
+                p_implementation->operator()(i, j, k) = *data;
         }
         PyBuffer_Release(&view);
         return p_implementation;
@@ -1643,35 +1643,35 @@ convert< _PySequence_, ComplexTensorImplementation* >(PyObject * pyObj)
       PyErr_Clear();
   }
   // use the same conversion function for numpy array/matrix, knowing numpy matrix is not a sequence
-  if ( PyObject_HasAttrString(pyObj, const_cast<char *>("shape")) )
+  if (PyObject_HasAttrString(pyObj, const_cast<char *>("shape")))
   {
-    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString( pyObj, "shape" ));
+    ScopedPyObjectPointer shapeObj(PyObject_GetAttrString(pyObj, "shape"));
     if (shapeObj.get())
     {
-      Indices shape( checkAndConvert< _PySequence_, Indices >( shapeObj.get() ) );
-      if ( shape.getSize() == 3 )
+      Indices shape(checkAndConvert< _PySequence_, Indices >(shapeObj.get()));
+      if (shape.getSize() == 3)
       {
         UnsignedInteger nbRows = shape[0];
         UnsignedInteger nbColumns = shape[1];
         UnsignedInteger nbSheets = shape[2];
         ScopedPyObjectPointer askObj(PyTuple_New(3));
         ScopedPyObjectPointer methodObj(convert< String, _PyString_ >("__getitem__"));
-        p_implementation = new ComplexTensorImplementation( nbRows, nbColumns, nbSheets );
-        for ( UnsignedInteger i = 0; i < nbRows; ++ i )
+        p_implementation = new ComplexTensorImplementation(nbRows, nbColumns, nbSheets);
+        for (UnsignedInteger i = 0; i < nbRows; ++ i)
         {
-          PyTuple_SetItem( askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i) );
-          for ( UnsignedInteger j = 0; j < nbColumns; ++ j )
+          PyTuple_SetItem(askObj.get(), 0, convert< UnsignedInteger, _PyInt_ >(i));
+          for (UnsignedInteger j = 0; j < nbColumns; ++ j)
           {
-            PyTuple_SetItem( askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j) );
-            for ( UnsignedInteger k = 0; k < nbSheets; ++ k )
+            PyTuple_SetItem(askObj.get(), 1, convert< UnsignedInteger, _PyInt_ >(j));
+            for (UnsignedInteger k = 0; k < nbSheets; ++ k)
             {
-              PyTuple_SetItem( askObj.get(), 2, convert< UnsignedInteger, _PyInt_ >(k) );
-              ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs( pyObj, methodObj.get(), askObj.get(), NULL));
+              PyTuple_SetItem(askObj.get(), 2, convert< UnsignedInteger, _PyInt_ >(k));
+              ScopedPyObjectPointer elt(PyObject_CallMethodObjArgs(pyObj, methodObj.get(), askObj.get(), NULL));
               if (elt.get())
               {
                 try
                 {
-                  p_implementation->operator()( i, j, k ) = checkAndConvert<_PyComplex_, Complex>(elt.get());
+                  p_implementation->operator()(i, j, k) = checkAndConvert<_PyComplex_, Complex>(elt.get());
                 }
                 catch (InvalidArgumentException &)
                 {
@@ -1687,26 +1687,26 @@ convert< _PySequence_, ComplexTensorImplementation* >(PyObject * pyObj)
         throw InvalidArgumentException(HERE) << "Invalid array dimension: " << shape.getSize();
     }
   }
-  else if ( PyObject_HasAttrString(pyObj, const_cast<char *>("getNbSheets")) )
+  else if (PyObject_HasAttrString(pyObj, const_cast<char *>("getNbSheets")))
   {
     // case of conversion from XTensor to YTensor
-    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod ( pyObj,
-                                     const_cast<char *>( "getNbColumns" ),
-                                     const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer rowsObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getNbRows" ),
-                                  const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer sheetsObj(PyObject_CallMethod ( pyObj,
-                                    const_cast<char *>( "getNbSheets" ),
-                                    const_cast<char *>( "()" ) ));
-    ScopedPyObjectPointer implObj(PyObject_CallMethod ( pyObj,
-                                  const_cast<char *>( "getImplementation" ),
-                                  const_cast<char *>( "()" ) ));
-    Pointer< Collection< Complex > > ptr = buildCollectionFromPySequence< Complex >( implObj.get() );
-    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >( colunmsObj.get() );
-    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >( rowsObj.get() );
-    UnsignedInteger nbSheets = checkAndConvert< _PyInt_, UnsignedInteger >( sheetsObj.get() );
-    p_implementation = new ComplexTensorImplementation( nbRows, nbColumns, nbSheets, *ptr );
+    ScopedPyObjectPointer colunmsObj(PyObject_CallMethod (pyObj,
+                                     const_cast<char *>("getNbColumns"),
+                                     const_cast<char *>("()")));
+    ScopedPyObjectPointer rowsObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getNbRows"),
+                                  const_cast<char *>("()")));
+    ScopedPyObjectPointer sheetsObj(PyObject_CallMethod (pyObj,
+                                    const_cast<char *>("getNbSheets"),
+                                    const_cast<char *>("()")));
+    ScopedPyObjectPointer implObj(PyObject_CallMethod (pyObj,
+                                  const_cast<char *>("getImplementation"),
+                                  const_cast<char *>("()")));
+    Pointer< Collection< Complex > > ptr = buildCollectionFromPySequence< Complex >(implObj.get());
+    UnsignedInteger nbColumns = checkAndConvert< _PyInt_, UnsignedInteger >(colunmsObj.get());
+    UnsignedInteger nbRows = checkAndConvert< _PyInt_, UnsignedInteger >(rowsObj.get());
+    UnsignedInteger nbSheets = checkAndConvert< _PyInt_, UnsignedInteger >(sheetsObj.get());
+    p_implementation = new ComplexTensorImplementation(nbRows, nbColumns, nbSheets, *ptr);
   }
   return p_implementation;
 }
@@ -1719,7 +1719,7 @@ ComplexTensor
 convert< _PySequence_, ComplexTensor >(PyObject * pyObj)
 {
   ComplexTensorImplementation *p_implementation = convert<_PySequence_, ComplexTensorImplementation*>(pyObj);
-  return ComplexTensor( p_implementation );
+  return ComplexTensor(p_implementation);
 }
 
 template <>
@@ -1731,7 +1731,7 @@ struct traitsPythonType< WhittleFactoryState >
 template <>
 inline
 WhittleFactoryState
-convert< _PySequence_, WhittleFactoryState >(PyObject * )
+convert< _PySequence_, WhittleFactoryState >(PyObject *)
 {
   return WhittleFactoryState();
 }
@@ -1754,40 +1754,40 @@ inline PySliceObject* SliceCast(PyObject* pyObj)
 inline
 void pickleSave(Advocate & adv, PyObject * pyObj)
 {
-  ScopedPyObjectPointer pickleModule(PyImport_ImportModule( "pickle" )); // new reference
-  assert( pickleModule.get() );
+  ScopedPyObjectPointer pickleModule(PyImport_ImportModule("pickle")); // new reference
+  assert(pickleModule.get());
 
-  PyObject * pickleDict = PyModule_GetDict( pickleModule.get() );
+  PyObject * pickleDict = PyModule_GetDict(pickleModule.get());
   assert(pickleDict);
 
-  PyObject * dumpsMethod = PyDict_GetItemString( pickleDict, "dumps" );
-  assert( dumpsMethod );
-  if ( ! PyCallable_Check( dumpsMethod ) )
+  PyObject * dumpsMethod = PyDict_GetItemString(pickleDict, "dumps");
+  assert(dumpsMethod);
+  if (! PyCallable_Check(dumpsMethod))
     throw InternalException(HERE) << "Python 'pickle' module has no 'dumps' method";
 
   assert(pyObj);
   ScopedPyObjectPointer rawDump(PyObject_CallFunctionObjArgs(dumpsMethod, pyObj, NULL)); // new reference
 
   handleException();
-  assert( rawDump.get() );
+  assert(rawDump.get());
 
-  ScopedPyObjectPointer base64Module(PyImport_ImportModule( "base64" )); // new reference
-  assert( base64Module.get() );
+  ScopedPyObjectPointer base64Module(PyImport_ImportModule("base64")); // new reference
+  assert(base64Module.get());
 
-  PyObject * base64Dict = PyModule_GetDict( base64Module.get() );
-  assert( base64Dict );
+  PyObject * base64Dict = PyModule_GetDict(base64Module.get());
+  assert(base64Dict);
 
-  PyObject * b64encodeMethod = PyDict_GetItemString( base64Dict, "standard_b64encode" );
-  assert( b64encodeMethod );
-  if ( ! PyCallable_Check( b64encodeMethod ) )
+  PyObject * b64encodeMethod = PyDict_GetItemString(base64Dict, "standard_b64encode");
+  assert(b64encodeMethod);
+  if (! PyCallable_Check(b64encodeMethod))
     throw InternalException(HERE) << "Python 'base64' module has no 'standard_b64encode' method";
 
   ScopedPyObjectPointer base64Dump(PyObject_CallFunctionObjArgs(b64encodeMethod, rawDump.get(), NULL)); // new reference
   handleException();
-  assert( base64Dump.get() );
+  assert(base64Dump.get());
 
-  String pyInstanceSt(convert< _PyBytes_, String >( base64Dump.get() ));
-  adv.saveAttribute( "pyInstance_", pyInstanceSt );
+  String pyInstanceSt(convert< _PyBytes_, String >(base64Dump.get()));
+  adv.saveAttribute("pyInstance_", pyInstanceSt);
 }
 
 
@@ -1795,35 +1795,35 @@ inline
 void pickleLoad(Advocate & adv, PyObject * & pyObj)
 {
   String pyInstanceSt;
-  adv.loadAttribute( "pyInstance_", pyInstanceSt );
+  adv.loadAttribute("pyInstance_", pyInstanceSt);
 
-  ScopedPyObjectPointer base64Dump(convert< String, _PyBytes_ >( pyInstanceSt )); // new reference
-  assert( base64Dump.get() );
+  ScopedPyObjectPointer base64Dump(convert< String, _PyBytes_ >(pyInstanceSt)); // new reference
+  assert(base64Dump.get());
 
-  ScopedPyObjectPointer base64Module(PyImport_ImportModule( "base64" )); // new reference
-  assert( base64Module.get() );
+  ScopedPyObjectPointer base64Module(PyImport_ImportModule("base64")); // new reference
+  assert(base64Module.get());
 
-  PyObject * base64Dict = PyModule_GetDict( base64Module.get() );
-  assert( base64Dict );
+  PyObject * base64Dict = PyModule_GetDict(base64Module.get());
+  assert(base64Dict);
 
-  PyObject * b64decodeMethod = PyDict_GetItemString( base64Dict, "standard_b64decode" );
-  assert( b64decodeMethod );
-  if ( ! PyCallable_Check( b64decodeMethod ) )
+  PyObject * b64decodeMethod = PyDict_GetItemString(base64Dict, "standard_b64decode");
+  assert(b64decodeMethod);
+  if (! PyCallable_Check(b64decodeMethod))
     throw InternalException(HERE) << "Python 'base64' module has no 'standard_b64decode' method";
 
   ScopedPyObjectPointer rawDump(PyObject_CallFunctionObjArgs(b64decodeMethod, base64Dump.get(), NULL)); // new reference
   handleException();
-  assert( rawDump.get() );
+  assert(rawDump.get());
 
-  ScopedPyObjectPointer pickleModule(PyImport_ImportModule( "pickle" )); // new reference
-  assert( pickleModule.get() );
+  ScopedPyObjectPointer pickleModule(PyImport_ImportModule("pickle")); // new reference
+  assert(pickleModule.get());
 
-  PyObject * pickleDict = PyModule_GetDict( pickleModule.get() );
-  assert( pickleDict );
+  PyObject * pickleDict = PyModule_GetDict(pickleModule.get());
+  assert(pickleDict);
 
-  PyObject * loadsMethod = PyDict_GetItemString( pickleDict, "loads" );
-  assert( loadsMethod );
-  if ( ! PyCallable_Check( loadsMethod ) )
+  PyObject * loadsMethod = PyDict_GetItemString(pickleDict, "loads");
+  assert(loadsMethod);
+  if (! PyCallable_Check(loadsMethod))
     throw InternalException(HERE) << "Python 'pickle' module has no 'loads' method";
 
   Py_XDECREF(pyObj);

--- a/python/test/t_Sample_std.expout
+++ b/python/test/t_Sample_std.expout
@@ -22,3 +22,4 @@ selection=     [ v0 ]
 <TR><TD>2</TD><TD>1000.0</TD><TD>2000.0</TD></TR>
 </TABLE>
 ok
+ok

--- a/python/test/t_Sample_std.py
+++ b/python/test/t_Sample_std.py
@@ -105,6 +105,11 @@ try:
     except:
         print('ok')
 
+    try:
+        # uneven points
+        s = Sample([[1.0, 2.0], [5.0]])
+    except:
+        print('ok')
 except:
     import sys
     print("t_Sample_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
Fixes #1025