### PR TITLE
getMarginal-related enhancements

### DIFF
--- a/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
@@ -327,6 +327,24 @@ Distribution MarginalDistribution::getStandardDistribution() const
   return distribution_.getStandardDistribution().getMarginal(indices_).getImplementation();
 }
 
+/* Parameters value and description accessor */
+MarginalDistribution::PointWithDescriptionCollection MarginalDistribution::getParametersCollection() const
+{
+  const PointWithDescriptionCollection allParameters(distribution_.getParametersCollection());
+  PointWithDescriptionCollection parametersCollection;
+  const UnsignedInteger size = indices_.getSize();
+  // marginal parameters, can be omitted (ComposedCopula)
+  if (allParameters.getSize() == distribution_.getDimension() + 1)
+    for (UnsignedInteger i = 0; i < size; ++ i)
+      parametersCollection.add(allParameters[indices_[i]]);
+  // dependency parameters, mandatory
+  if (distribution_.getDimension() > 1)
+  {
+    parametersCollection.add(allParameters[allParameters.getSize() - 1]);
+  }
+  return parametersCollection;
+} // getParametersCollection
+
 /* Tell if the distribution has independent copula */
 Bool MarginalDistribution::hasIndependentCopula() const
 {

--- a/lib/src/Uncertainty/Distribution/openturns/MarginalDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MarginalDistribution.hxx
@@ -125,6 +125,9 @@ public:
   /** Tell if the distribution has independent copula */
   Bool hasIndependentCopula() const;
 
+  /** Parameters value and description accessor */
+  PointWithDescriptionCollection getParametersCollection() const;
+
   /** Tell if the distribution has elliptical copula */
   Bool hasEllipticalCopula() const;
 

--- a/python/test/t_ComposedCopula_std.expout
+++ b/python/test/t_ComposedCopula_std.expout
@@ -44,3 +44,5 @@ isoprobabilistic transformation (single contributor)= (class=LinearEvaluation na
  [ 0        0.333333 ]])o(| y0 = Uniform(a = 0, b = 1) -> y0 : Student(nu = 3, mu = 1, sigma = 3)
 | y1 = Uniform(a = 0, b = 1) -> y1 : Student(nu = 3, mu = 1, sigma = 3)
 )
+ComposedCopula(NormalCopula(R = [[ 1 0 ]
+ [ 0 1 ]]), IndependentCopula(dimension = 2))

--- a/python/test/t_ComposedCopula_std.py
+++ b/python/test/t_ComposedCopula_std.py
@@ -147,6 +147,10 @@ try:
     sklarCopula = myEstimatedDist.getCopula()
     copulas.add(sklarCopula)
 
+    # test ComposedCopula.getMarginal in reverse
+    copula = ComposedCopula([IndependentCopula(2), NormalCopula(2)])
+    print(copula.getMarginal([3, 2, 1, 0]))
+
 except:
     import sys
     print("t_ComposedCopula.py", sys.exc_info()[0], sys.exc_info()[1])

--- a/python/test/t_DistributionTransformation_std.expout
+++ b/python/test/t_DistributionTransformation_std.expout
@@ -25,3 +25,8 @@ inverseTransformation= (| y0 = [x0]->[x0]
 | y1 = Triangular(a = -1, m = 0, b = 1) -> y1 : Uniform(a = 0, b = 1)
 ))
 ----------------------------------------------------------------------------------------------------
+(| y0 = [x0]->[x0]
+| y1 = [x1]->[x1]
+| y2 = [x2]->[x2]
+| y3 = [x3]->[x3]
+)o(NatafIndependentCopulaEvaluation(IndependentCopula(4)->Normal(4)))

--- a/python/test/t_DistributionTransformation_std.py
+++ b/python/test/t_DistributionTransformation_std.py
@@ -33,3 +33,8 @@ for left, right in coll:
     inverseTransformation = transformation.inverse()
     print('inverseTransformation=', inverseTransformation)
     print('-' * 100)
+
+# with marginaltransformation
+copula = ot.ComposedCopula([ot.IndependentCopula(2), ot.IndependentCopula(2)])
+distribution = ot.ComposedDistribution([ot.Normal()]*4, copula)
+print(ot.DistributionTransformation(ot.IndependentCopula(4), distribution.getMarginal([3,1,2,0])))


### PR DESCRIPTION
* Now ComposedCopula::getMarginal handles the copulas blocs to be visited
in any order:

```
# test ComposedCopula.getMarginal in reverse
copula = ComposedCopula([IndependentCopula(2), NormalCopula(2)])
print(copula.getMarginal([3, 2, 1, 0]))

ComposedCopula(NormalCopula(R = [[ 1 0 ]
 [ 0 1 ]]), IndependentCopula(dimension = 2))
```



* Also we Implement MarginalDist;::getParametersCollection to handle the non-contiguous case when used in iso-probabilistic transformations:

Else the parameters of the isoprobabilistic transformations involving
MarginalDistribution (from a ComposedCopula with non-contiguous blocs) cannot be retrieved:
```
import openturns as ot
copula = ot.ComposedCopula([ot.IndependentCopula(2), ot.IndependentCopula(2)])
distribution = ot.ComposedDistribution([ot.Normal()]*4, copula)
print(ot.DistributionTransformation(ot.IndependentCopula(4), distribution.getMarginal([3,1,2,0])))
```
