### PR TITLE
Fix iso-transformation parameter gradient

### DIFF
--- a/lib/src/Base/Func/AggregatedEvaluation.cxx
+++ b/lib/src/Base/Func/AggregatedEvaluation.cxx
@@ -209,7 +209,7 @@ UnsignedInteger AggregatedEvaluation::getOutputDimension() const
 
 
 /* Gradient according to the marginal parameters */
-Matrix AggregatedEvaluation::parameterGradient(const Point & ) const
+Matrix AggregatedEvaluation::parameterGradient(const Point & inP) const
 {
   Matrix result(getParameter().getDimension(), getOutputDimension());
   const UnsignedInteger size = functionsCollection_.getSize();
@@ -217,7 +217,7 @@ Matrix AggregatedEvaluation::parameterGradient(const Point & ) const
   UnsignedInteger columnShift = 0;
   for (UnsignedInteger i = 0; i < size; ++i)
   {
-    const Matrix currentGradient(functionsCollection_[i].parameterGradient(functionsCollection_[i].getParameter()));
+    const Matrix currentGradient(functionsCollection_[i].parameterGradient(inP));
     const UnsignedInteger currentRowDim = currentGradient.getNbRows();
     const UnsignedInteger currentColumnDim = currentGradient.getNbColumns();
     for (UnsignedInteger j = 0; j < currentRowDim; ++j)

--- a/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/InverseRosenblattEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/InverseRosenblattEvaluation.cxx
@@ -83,7 +83,8 @@ Point InverseRosenblattEvaluation::operator () (const Point & inP) const
  */
 Matrix InverseRosenblattEvaluation::parameterGradient(const Point & ) const
 {
-  throw NotYetImplementedException(HERE) << "In InverseRosenblattEvaluation::parameterGradient(const Point & inP) const";
+  Matrix grad(0, getOutputDimension());
+  return grad;
 }
 
 /* Accessor for input point dimension */

--- a/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/RosenblattEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/Rosenblatt/RosenblattEvaluation.cxx
@@ -75,7 +75,8 @@ Point RosenblattEvaluation::operator () (const Point & inP) const
 /* Gradient according to the marginal parameters. */
 Matrix RosenblattEvaluation::parameterGradient(const Point & ) const
 {
-  throw NotYetImplementedException(HERE) << "In RosenblattEvaluation::parameterGradient(const Point & inP) const";
+  Matrix grad(0, getOutputDimension());
+  return grad;
 }
 
 /* Accessor for input point dimension */

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -370,6 +370,7 @@ ot_pyinstallcheck_test (BoxCoxFactory_std)
 ot_pyinstallcheck_test (BoxCoxFactory_glm)
 ot_pyinstallcheck_test (TrendFactory_std)
 ot_pyinstallcheck_test (DistributionTransformation_std)
+ot_pyinstallcheck_test (InverseRosenblattEvaluation_std IGNOREOUT)
 
 ## Distribution
 ot_pyinstallcheck_test (AliMikhailHaqCopula_std)

--- a/python/test/t_InverseRosenblattEvaluation_std.py
+++ b/python/test/t_InverseRosenblattEvaluation_std.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+import openturns as ot
+
+ot.TESTPREAMBLE()
+
+model = ot.SymbolicFunction(['x0', 'x1', 'x2', 'x3'], ['-(6+x0^2-x1+x2+3*x3)'])
+dim = model.getInputDimension()
+marginals = [ot.Normal(5.0, 3.0) for i in range(dim)]
+distribution = ot.ComposedDistribution(marginals, ot.ComposedCopula([ot.ClaytonCopula(), ot.NormalCopula()]))
+#distribution = ot.Normal([5]*dim, [3]*dim, ot.CorrelationMatrix(dim))
+#distribution = ot.ComposedDistribution(marginals, ot.IndependentCopula(dim))
+distribution.setDescription(['marginal'+str(i) for i in range(dim)])
+vect = ot.RandomVector(distribution)
+output = ot.CompositeRandomVector(model, vect)
+event = ot.Event(output, ot.Greater(), 0.0)
+solver = ot.Cobyla()
+solver.setMaximumEvaluationNumber(200)
+solver.setMaximumAbsoluteError(1.0e-10)
+solver.setMaximumRelativeError(1.0e-10)
+solver.setMaximumResidualError(1.0e-10)
+solver.setMaximumConstraintError(1.0e-10)
+algo = ot.FORM(solver, event, distribution.getMean())
+algo.run()
+result = algo.getResult()
+hasoferReliabilityIndexSensitivity = result.getHasoferReliabilityIndexSensitivity()
+print(hasoferReliabilityIndexSensitivity)


### PR DESCRIPTION
I fixed the parameter gradient of the iso-transformation with the current state of marginal/copula parameters in transformation, as it failed on this example that uses the rosenblatt transformation:
```
import openturns as ot
model = ot.SymbolicFunction(['x0', 'x1', 'x2', 'x3'], ['-(6+x0^2-x1+x2+3*x3)'])
dim = model.getInputDimension()
marginals = [ot.Normal(5.0, 3.0) for i in range(dim)]
distribution = ot.ComposedDistribution(marginals, ot.ComposedCopula([ot.ClaytonCopula(), ot.NormalCopula()]))
#distribution = ot.Normal([5]*dim, [3]*dim, ot.CorrelationMatrix(dim))
#distribution = ot.ComposedDistribution(marginals, ot.IndependentCopula(dim))
distribution.setDescription(['marginal'+str(i) for i in range(dim)])
vect = ot.RandomVector(distribution)
output = ot.CompositeRandomVector(model, vect)
event = ot.Event(output, ot.Greater(), 0.0)
solver = ot.Cobyla()
solver.setMaximumEvaluationNumber(200)
solver.setMaximumAbsoluteError(1.0e-10)
solver.setMaximumRelativeError(1.0e-10)
solver.setMaximumResidualError(1.0e-10)
solver.setMaximumConstraintError(1.0e-10)
algo = ot.FORM(solver, event, distribution.getMean())
algo.run()
result = algo.getResult()
hasoferReliabilityIndexSensitivity = result.getHasoferReliabilityIndexSensitivity()
print(hasoferReliabilityIndexSensitivity)
```