### PR TITLE
Improve cloning python wrappers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -72,6 +72,7 @@
  * #1078 (KrigingAlgorithm documentation still references "inputTransformation")
  * #1090 (PythonFunction can make OT crash)
  * #1092 (The parameterGradient of a ParametricFunction can loss accuracy)
+ * #1099 (PythonDistribution does not work with ConditionalDistribution)
 
 == 1.12 release (2018-11-08) == #release-1.12
 

--- a/python/src/PythonDistribution.cxx
+++ b/python/src/PythonDistribution.cxx
@@ -931,6 +931,7 @@ void PythonDistribution::setParameter(const Point & parameter)
       handleException();
     }
   }
+  computeRange();
   // no else: DistributionImplementation::setParameter throws
 }
 

--- a/python/src/PythonDistribution.cxx
+++ b/python/src/PythonDistribution.cxx
@@ -88,8 +88,10 @@ PythonDistribution * PythonDistribution::clone() const
 /* Copy constructor */
 PythonDistribution::PythonDistribution(const PythonDistribution & other)
   : DistributionImplementation(other),
-    pyObj_(other.pyObj_)
+    pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF( pyObj_ );
 }
 

--- a/python/src/PythonEvaluation.cxx
+++ b/python/src/PythonEvaluation.cxx
@@ -116,9 +116,14 @@ PythonEvaluation * PythonEvaluation::clone() const
 /* Copy constructor */
 PythonEvaluation::PythonEvaluation(const PythonEvaluation & other)
   : EvaluationImplementation(other)
-  , pyObj_(other.pyObj_)
-  , pyBufferClass_(other.pyBufferClass_)
+  , pyObj_()
+  , pyBufferClass_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
+
+  ScopedPyObjectPointer pyBufferClone(deepCopy(other.pyBufferClass_));
+  pyBufferClass_ = pyBufferClone.get();
   Py_XINCREF(pyObj_);
   Py_XINCREF(pyBufferClass_);
 }

--- a/python/src/PythonEvaluation.cxx
+++ b/python/src/PythonEvaluation.cxx
@@ -417,8 +417,11 @@ UnsignedInteger PythonEvaluation::getOutputDimension() const
 void PythonEvaluation::save(Advocate & adv) const
 {
   EvaluationImplementation::save(adv);
-
   pickleSave(adv, pyObj_);
+  pickleSave(adv, pyBufferClass_, "pyBufferClass_");
+  adv.saveAttribute("pyObj_has_exec_", pyObj_has_exec_);
+  adv.saveAttribute("pyObj_has_exec_sample_", pyObj_has_exec_sample_);
+  adv.saveAttribute("pyObj_discard_openturns_memoryview_", pyObj_discard_openturns_memoryview_);
 }
 
 
@@ -426,9 +429,11 @@ void PythonEvaluation::save(Advocate & adv) const
 void PythonEvaluation::load(Advocate & adv)
 {
   EvaluationImplementation::load(adv);
-
   pickleLoad(adv, pyObj_);
-  initializePythonState();
+  pickleLoad(adv, pyBufferClass_, "pyBufferClass_");
+  adv.loadAttribute("pyObj_has_exec_", pyObj_has_exec_);
+  adv.loadAttribute("pyObj_has_exec_sample_", pyObj_has_exec_sample_);
+  adv.loadAttribute("pyObj_discard_openturns_memoryview_", pyObj_discard_openturns_memoryview_);
 }
 
 

--- a/python/src/PythonExperiment.cxx
+++ b/python/src/PythonExperiment.cxx
@@ -71,8 +71,10 @@ PythonExperiment * PythonExperiment::clone() const
 /* Copy constructor */
 PythonExperiment::PythonExperiment(const PythonExperiment & other)
   : ExperimentImplementation(other),
-    pyObj_(other.pyObj_)
+    pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonFieldFunction.cxx
+++ b/python/src/PythonFieldFunction.cxx
@@ -122,8 +122,10 @@ PythonFieldFunction * PythonFieldFunction::clone() const
 /* Copy constructor */
 PythonFieldFunction::PythonFieldFunction(const PythonFieldFunction & other)
   : FieldFunctionImplementation(other)
-  , pyObj_(other.pyObj_)
+  , pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonFieldToPointFunction.cxx
+++ b/python/src/PythonFieldToPointFunction.cxx
@@ -109,8 +109,10 @@ PythonFieldToPointFunction * PythonFieldToPointFunction::clone() const
 /* Copy constructor */
 PythonFieldToPointFunction::PythonFieldToPointFunction(const PythonFieldToPointFunction & other)
   : FieldToPointFunctionImplementation(other)
-  , pyObj_(other.pyObj_)
+  , pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonGradient.cxx
+++ b/python/src/PythonGradient.cxx
@@ -67,8 +67,10 @@ PythonGradient * PythonGradient::clone() const
 /* Copy constructor */
 PythonGradient::PythonGradient(const PythonGradient & other)
   : GradientImplementation(other)
-  , pyObj_(other.pyObj_)
+  , pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonHessian.cxx
+++ b/python/src/PythonHessian.cxx
@@ -67,8 +67,10 @@ PythonHessian * PythonHessian::clone() const
 /* Copy constructor */
 PythonHessian::PythonHessian(const PythonHessian & other)
   : HessianImplementation(other)
-  , pyObj_(other.pyObj_)
+  , pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonPointToFieldFunction.cxx
+++ b/python/src/PythonPointToFieldFunction.cxx
@@ -109,8 +109,10 @@ PythonPointToFieldFunction * PythonPointToFieldFunction::clone() const
 /* Copy constructor */
 PythonPointToFieldFunction::PythonPointToFieldFunction(const PythonPointToFieldFunction & other)
   : PointToFieldFunctionImplementation(other)
-  , pyObj_(other.pyObj_)
+  , pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
 }
 

--- a/python/src/PythonRandomVectorImplementation.cxx
+++ b/python/src/PythonRandomVectorImplementation.cxx
@@ -85,8 +85,10 @@ PythonRandomVectorImplementation * PythonRandomVectorImplementation::clone() con
 /* Copy constructor */
 PythonRandomVectorImplementation::PythonRandomVectorImplementation(const PythonRandomVectorImplementation & other)
   : RandomVectorImplementation(other),
-    pyObj_(other.pyObj_)
+    pyObj_()
 {
+  ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
+  pyObj_ = pyObjClone.get();
   Py_XINCREF( pyObj_ );
 }
 

--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -1752,7 +1752,7 @@ inline PySliceObject* SliceCast(PyObject* pyObj)
 
 
 inline
-void pickleSave(Advocate & adv, PyObject * pyObj)
+void pickleSave(Advocate & adv, PyObject * pyObj, const String attributName = "pyInstance_")
 {
   ScopedPyObjectPointer pickleModule(PyImport_ImportModule("pickle")); // new reference
   assert(pickleModule.get());
@@ -1787,15 +1787,15 @@ void pickleSave(Advocate & adv, PyObject * pyObj)
   assert(base64Dump.get());
 
   String pyInstanceSt(convert< _PyBytes_, String >(base64Dump.get()));
-  adv.saveAttribute("pyInstance_", pyInstanceSt);
+  adv.saveAttribute(attributName, pyInstanceSt);
 }
 
 
 inline
-void pickleLoad(Advocate & adv, PyObject * & pyObj)
+void pickleLoad(Advocate & adv, PyObject * & pyObj, const String attributName = "pyInstance_")
 {
   String pyInstanceSt;
-  adv.loadAttribute("pyInstance_", pyInstanceSt);
+  adv.loadAttribute(attributName, pyInstanceSt);
 
   ScopedPyObjectPointer base64Dump(convert< String, _PyBytes_ >(pyInstanceSt)); // new reference
   assert(base64Dump.get());

--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -1833,6 +1833,27 @@ void pickleLoad(Advocate & adv, PyObject * & pyObj)
 }
 
 
+
+inline
+ScopedPyObjectPointer deepCopy(PyObject * pyObj)
+{
+  ScopedPyObjectPointer copyModule(PyImport_ImportModule("copy"));
+  assert(copyModule.get());
+
+  PyObject * copyDict = PyModule_GetDict(copyModule.get());
+  assert(copyDict);
+
+  PyObject * deepCopyMethod = PyDict_GetItemString(copyDict, "deepcopy");
+  assert(deepCopyMethod );
+
+  if (!PyCallable_Check(deepCopyMethod))
+    throw InternalException(HERE) << "Python 'copy' module has no 'deepcopy' method";
+
+  ScopedPyObjectPointer pyObjDeepCopy(PyObject_CallFunctionObjArgs(deepCopyMethod, pyObj, NULL));
+  handleException();
+  return pyObjDeepCopy;
+}
+
 END_NAMESPACE_OPENTURNS
 
 #endif /* OPENTURNS_PYTHONWRAPPINGFUNCTIONS_HXX */

--- a/python/test/t_Distribution_python.expout
+++ b/python/test/t_Distribution_python.expout
@@ -26,6 +26,9 @@ quantile= [0.5]
 parameter= [0.5,1]
 parameter= [0.4,1]
 parameterDesc= [a_0,b_0]
+Cloning distribution
+dist parameter= [0.4,1]
+copy dist parameter= [0.5,1]
 pyDist= PythonDistribution -> #2
 myDist= class=PythonDistribution name=UniformNdPy description=[X0,X1]
 dimension= 2
@@ -54,6 +57,11 @@ quantile= [0.5,0.5]
 parameter= [0.5,0.5,1,1]
 parameter= [0.4,0.5,1,1]
 parameterDesc= [a_0,a_1,b_0,b_1]
+Cloning distribution
+dist parameter= [0.4,0.5,1,1]
+copy dist parameter= [0.5,0.5,1,1]
 ComposedDistribution(Normal(mu = 0, sigma = 1), Normal(mu = 0, sigma = 1), class=PythonDistribution name=UniformNdPy)
 try with another Python distribution
 The construction failed on purpose as class=PythonDistribution name=UniformNdPy is not a copula
+saved dist= class=PythonDistribution name=UniformNdPy
+loaded dist= class=PythonDistribution name=UniformNdPy

--- a/python/test/t_Distribution_python.py
+++ b/python/test/t_Distribution_python.py
@@ -228,6 +228,13 @@ for pyDist in [UniformNdPy(), UniformNdPy([0.] * 2, [1.] * 2)]:
     print('parameter=', myDist.getParameter())
     print('parameterDesc=', myDist.getParameterDescription())
 
+    print("Cloning distribution")
+    newDist = ot.Distribution(myDist)
+    param[0] = 0.5
+    newDist.setParameter(param)
+    print('dist parameter=', myDist.getParameter())
+    print('copy dist parameter=', newDist.getParameter())
+
 # Use the distribution as a copula
 myDist = ot.Distribution(UniformNdPy([0.0] * 2, [1.0] * 2))
 print(ot.ComposedDistribution([ot.Normal(), ot.Normal()], myDist))
@@ -244,3 +251,23 @@ copula = myDist.getCopula()
 
 # Test computePDF over a sample (ticket #899)
 res = copula.computePDF([[0.5] * 2] * 10)
+
+st = ot.Study()
+fileName = 'PyDIST.xml'
+st.setStorageManager(ot.XMLStorageManager(fileName))
+
+st.add("myDist", myDist)
+st.save()
+
+print('saved dist=', myDist)
+
+dist = ot.Distribution()
+
+st = ot.Study()
+st.setStorageManager(ot.XMLStorageManager(fileName))
+
+st.load()
+
+st.fillObject("myDist", dist)
+print('loaded dist=', dist)
+os.remove(fileName)


### PR DESCRIPTION
Fix openturns#1099 

 * Fix `PythonDistribution::setParameter` : need to compute the new range
 * Fix  `PythonDistribution::clone` : copy constructor PythonDistribution(other) should duplicate the internal attribut
 * Apply fix to `PythonEvaluation`, `PythonExperiment`, `PythonFieldToFunction`, `PythonGradient`, `PythonHessian`, `PythonRandomVectorImplementation` classes