### PR TITLE
CircleCI: Use real doc date on release branches

### DIFF
--- a/.circleci/run_docker_linux.sh
+++ b/.circleci/run_docker_linux.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # build with frozen date unless on release for reproducible builds
-if test -z "${CIRCLE_TAG}"
+if test "${CIRCLE_BRANCH}" = "master"
 then
   export SOURCE_DATE_EPOCH=1514764800
 fi

--- a/.circleci/upload_github_io.sh
+++ b/.circleci/upload_github_io.sh
@@ -9,7 +9,7 @@ then
   exit 0
 fi
 
-git clone https://${GH_TOKEN}@github.com/openturns/openturns.github.io.git
+git clone --depth 1 https://${GH_TOKEN}@github.com/openturns/openturns.github.io.git
 if test -n "${CIRCLE_TAG}"
 then
   CIRCLE_BRANCH="${CIRCLE_TAG:1}"


### PR DESCRIPTION
The previous logic was not working as tagged jobs are filtered by default:
https://circleci.com/docs/2.0/workflows/#git-tag-job-execution

I did not include tag jobs neither as the date will be overwritten by the new commit
in the release branch, so only setting a fake date in master will do.