### PR TITLE
Fix ev3 exponent var node derivation

### DIFF
--- a/lib/src/Base/Diff/Ev3/expression.cxx
+++ b/lib/src/Base/Diff/Ev3/expression.cxx
@@ -4862,10 +4862,19 @@ Expression DiffNoSimplify(const Expression& ac, Int vi)
               // numeric exponent != 0,1,2
               ret = Diff(a->GetNode(0), vi); // f'
               tmp = a->GetCopyOfNode(0);     // f
+              const double coeff = tmp->GetCoeff();
               tmp = tmp ^ a->GetCopyOfNode(1);  // f^c
-              tmp->GetNode(1)->ConsolidateValue();
-              tmp->SetCoeff(tmp->GetCoeff() * tmp->GetNode(1)->GetValue());//cf^c
-              tmp->GetNode(1)->SetValue(tmp->GetNode(1)->GetValue() - 1); //cf^(c-1)
+              if (tmp->GetOpType() == VAR)
+              {
+                tmp->SetCoeff(tmp->GetExponent() * std::pow(coeff, tmp->GetExponent() - 1.0)); // cf^c
+                tmp->SetExponent(tmp->GetExponent() - 1); // cf^(c-1)
+              }
+              else
+              {
+                tmp->GetNode(1)->ConsolidateValue();
+                tmp->SetCoeff(tmp->GetCoeff() * tmp->GetNode(1)->GetValue());//cf^c
+                tmp->GetNode(1)->SetValue(tmp->GetNode(1)->GetValue() - 1); //cf^(c-1)
+              }
               // can dispense from using copy here - Diff returns copies anyway.
               // when temporary is deleted, its subnodes are not automatically
               // deleted unless their reference counter is zero - which won't be.

--- a/python/test/t_SymbolicFunction_std.expout
+++ b/python/test/t_SymbolicFunction_std.expout
@@ -194,3 +194,4 @@ OK
 [x,y]->[x ^ y] , f([2, 3])= [8]
 [x]->[sqrt(x)] , f([-1]) not defined
 [x]->[sqrt(x)] , f([-1]) is normal? False
+[[ -0.0833332 ]]

--- a/python/test/t_SymbolicFunction_std.py
+++ b/python/test/t_SymbolicFunction_std.py
@@ -185,3 +185,8 @@ except:
 ot.ResourceMap.SetAsBool("SymbolicParser-CheckResult", False)
 f = ot.SymbolicFunction("x", "sqrt(x)")
 print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(f([-1.0])[0]))
+
+# joe copula bug
+f = ot.SymbolicFunction(['t'] , ['(t*3)^(-1)'])
+t = [2.0]
+print(f.gradient(t))


### PR DESCRIPTION
Fixes the Joe copula formula derivation: "1-((0.5*(1-t))^(-1.0/0.5)+(0.5*t)^(-1.0/0.5))^(-0.5)"