### PR TITLE
Fixed Sobol' indices examples

### DIFF
--- a/python/src/FAST_doc.i.in
+++ b/python/src/FAST_doc.i.in
@@ -97,10 +97,10 @@ Examples
 --------
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formulaIshigami = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
->>> modelIshigami = ot.SymbolicFunction(['X1', 'X2', 'X3'], formulaIshigami)
->>> distributions = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
->>> sensitivityAnalysis = ot.FAST(modelIshigami, distributions, 101)
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
+>>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
+>>> sensitivityAnalysis = ot.FAST(model, distribution, 101)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
 [0.311097,0.441786,0.000396837]"
 

--- a/python/src/JansenSensitivityAlgorithm_doc.i.in
+++ b/python/src/JansenSensitivityAlgorithm_doc.i.in
@@ -67,14 +67,12 @@ Examples
 --------
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+' + \
-...    '0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
 >>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
->>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3, \
-...                                         ot.IndependentCopula(3))
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
 >>> # Define designs to pre-compute
 >>> size = 100
->>> inputDesign = ot.SobolIndicesExperiment(distribution, size, True).generate()
+>>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
 >>> sensitivityAnalysis = ot.JansenSensitivityAlgorithm(inputDesign, outputDesign, size)

--- a/python/src/MartinezSensitivityAlgorithm_doc.i.in
+++ b/python/src/MartinezSensitivityAlgorithm_doc.i.in
@@ -72,19 +72,43 @@ SobolIndicesAlgorithm
 
 Examples
 --------
+
+Estimate first and total order Sobol' indices:
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+' + \
-...    '0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
 >>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
->>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3, \
-...                                         ot.IndependentCopula(3))
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
 >>> # Define designs to pre-compute
 >>> size = 100
->>> inputDesign = ot.SobolIndicesExperiment(distribution, size, True).generate()
+>>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
 >>> sensitivityAnalysis = ot.MartinezSensitivityAlgorithm(inputDesign, outputDesign, size)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
-[0.30449,0.448506,-0.0711394]"
+[0.30449,0.448506,-0.0711394]
+>>> print(sensitivityAnalysis.getTotalOrderIndices())
+[0.543004,0.29501,0.304615]
+
+Estimate first, total and second order Sobol' indices:
+>>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
+>>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
+>>> # Define designs to pre-compute
+>>> size = 100
+>>> computeSecondOrderIndices = True
+>>> inputDesign = ot.SobolIndicesExperiment(distribution, size, computeSecondOrderIndices).generate()
+>>> outputDesign = model(inputDesign)
+>>> # sensitivity analysis algorithm
+>>> sensitivityAnalysis = ot.MartinezSensitivityAlgorithm(inputDesign, outputDesign, size)
+>>> print(sensitivityAnalysis.getFirstOrderIndices())
+[0.30449,0.448506,-0.0711394]
+>>> print(sensitivityAnalysis.getTotalOrderIndices())
+[0.543004,0.29501,0.304615]
+>>> print(sensitivityAnalysis.getSecondOrderIndices())
+[[  0        -0.18008   0.169767 ]
+ [ -0.18008   0        -0.198839 ]
+ [  0.169767 -0.198839  0        ]]"
 

--- a/python/src/MartinezSensitivityAlgorithm_doc.i.in
+++ b/python/src/MartinezSensitivityAlgorithm_doc.i.in
@@ -74,7 +74,6 @@ Examples
 --------
 
 Estimate first and total order Sobol' indices:
-
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
@@ -92,7 +91,6 @@ Estimate first and total order Sobol' indices:
 [0.543004,0.29501,0.304615]
 
 Estimate first, total and second order Sobol' indices:
-
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']

--- a/python/src/MartinezSensitivityAlgorithm_doc.i.in
+++ b/python/src/MartinezSensitivityAlgorithm_doc.i.in
@@ -74,6 +74,7 @@ Examples
 --------
 
 Estimate first and total order Sobol' indices:
+
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
@@ -91,6 +92,7 @@ Estimate first and total order Sobol' indices:
 [0.543004,0.29501,0.304615]
 
 Estimate first, total and second order Sobol' indices:
+
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']

--- a/python/src/MauntzKucherenkoSensitivityAlgorithm_doc.i.in
+++ b/python/src/MauntzKucherenkoSensitivityAlgorithm_doc.i.in
@@ -67,14 +67,12 @@ Examples
 --------
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+' + \
-...    '0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
 >>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
->>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3, \
-...                                         ot.IndependentCopula(3))
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
 >>> # Define designs to pre-compute
 >>> size = 100
->>> inputDesign = ot.SobolIndicesExperiment(distribution, size, True).generate()
+>>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
 >>> sensitivityAnalysis = ot.MauntzKucherenkoSensitivityAlgorithm(inputDesign, outputDesign, size)

--- a/python/src/MauntzKucherenkoSensitivityAlgorithm_doc.i.in
+++ b/python/src/MauntzKucherenkoSensitivityAlgorithm_doc.i.in
@@ -77,5 +77,5 @@ Examples
 >>> # sensitivity analysis algorithm
 >>> sensitivityAnalysis = ot.MauntzKucherenkoSensitivityAlgorithm(inputDesign, outputDesign, size)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
-[0.182219,0.357106,-0.129096]"
+[0.18185,0.357918,-0.129502]"
 

--- a/python/src/SaltelliSensitivityAlgorithm_doc.i.in
+++ b/python/src/SaltelliSensitivityAlgorithm_doc.i.in
@@ -75,7 +75,7 @@ Examples
 >>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
->>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign)
+>>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
 [0.249038,0.425106,-0.0623136]"
 

--- a/python/src/SaltelliSensitivityAlgorithm_doc.i.in
+++ b/python/src/SaltelliSensitivityAlgorithm_doc.i.in
@@ -67,17 +67,15 @@ Examples
 --------
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+' + \
-...    '0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
 >>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
->>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3, \
-...                                         ot.IndependentCopula(3))
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
 >>> # Define designs to pre-compute
 >>> size = 100
->>> inputDesign = ot.SobolIndicesExperiment(distribution, size, True).generate()
+>>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
->>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
+>>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
 [0.249402,0.42429,-0.0619125]"
 

--- a/python/src/SaltelliSensitivityAlgorithm_doc.i.in
+++ b/python/src/SaltelliSensitivityAlgorithm_doc.i.in
@@ -75,7 +75,7 @@ Examples
 >>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
->>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
+>>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
 [0.249038,0.425106,-0.0623136]"
 

--- a/python/src/SaltelliSensitivityAlgorithm_doc.i.in
+++ b/python/src/SaltelliSensitivityAlgorithm_doc.i.in
@@ -75,7 +75,7 @@ Examples
 >>> inputDesign = ot.SobolIndicesExperiment(distribution, size).generate()
 >>> outputDesign = model(inputDesign)
 >>> # sensitivity analysis algorithm
->>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign)
+>>> sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
 >>> print(sensitivityAnalysis.getFirstOrderIndices())
-[0.249402,0.42429,-0.0619125]"
+[0.249038,0.425106,-0.0623136]"
 

--- a/python/src/SobolIndicesExperiment_doc.i.in
+++ b/python/src/SobolIndicesExperiment_doc.i.in
@@ -53,7 +53,6 @@ Examples
 --------
 
 Create a sample suitable to estimate first and total order Sobol' indices:
-
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
@@ -64,7 +63,6 @@ Create a sample suitable to estimate first and total order Sobol' indices:
 >>> sample = experiment.generate()
 
 Create a sample suitable to estimate first, total order and second order Sobol' indices:
-
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']

--- a/python/src/SobolIndicesExperiment_doc.i.in
+++ b/python/src/SobolIndicesExperiment_doc.i.in
@@ -51,13 +51,25 @@ SobolIndicesAlgorithm
 
 Examples
 --------
+
+Create a sample suitable to estimate first and total order Sobol' indices
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
->>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)*sin(pi_*X2)+' + \
-...    '0.1*((pi_*X3)*(pi_*X3)*(pi_*X3)*(pi_*X3))*sin(pi_*X1)']
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
 >>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
->>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3, \
-...                                         ot.IndependentCopula(3))
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
 >>> size = 10
->>> experiment = ot.SobolIndicesExperiment(distribution, size, True)
+>>> experiment = ot.SobolIndicesExperiment(distribution, size)
+>>> sample = experiment.generate()
+
+Create a sample suitable to estimate first, total order and second order Sobol' indices
+>>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
+>>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
+>>> model = ot.SymbolicFunction(['X1', 'X2', 'X3'], formula)
+>>> distribution = ot.ComposedDistribution([ot.Uniform(-1.0, 1.0)] * 3)
+>>> size = 10
+>>> computeSecondOrder = True
+>>> experiment = ot.SobolIndicesExperiment(distribution, size, computeSecondOrder)
 >>> sample = experiment.generate()"
+

--- a/python/src/SobolIndicesExperiment_doc.i.in
+++ b/python/src/SobolIndicesExperiment_doc.i.in
@@ -52,7 +52,8 @@ SobolIndicesAlgorithm
 Examples
 --------
 
-Create a sample suitable to estimate first and total order Sobol' indices
+Create a sample suitable to estimate first and total order Sobol' indices:
+
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']
@@ -62,7 +63,8 @@ Create a sample suitable to estimate first and total order Sobol' indices
 >>> experiment = ot.SobolIndicesExperiment(distribution, size)
 >>> sample = experiment.generate()
 
-Create a sample suitable to estimate first, total order and second order Sobol' indices
+Create a sample suitable to estimate first, total order and second order Sobol' indices:
+
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> formula = ['sin(pi_*X1)+7*sin(pi_*X2)^2+0.1*(pi_*X3)^4*sin(pi_*X1)']


### PR DESCRIPTION
This PR considers the Sobol' sampling examples
* simplifies the Ishigami formula with the power operator
* removes the unnecessary independent copula (which is independent, by default)
* provides examples for the second order indices, removing the unnecessary computations when they are not required
