### PR TITLE
Kriging improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,7 @@
  * Deprecated WeibullFactory in favor of WeibullMinFactory, buildAsWeibull
  * Deprecated GumbelAB
  * Deprecated GaussianNonLinearCalibration,NonLinearLeastSquaresCalibration::set,getAlgorithm
+ * Added getConditionalMarginalCovariance method to KrigingResult
 
 === Python module ===
  * Add Domain.__contains__ operator

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@
  * Deprecated GumbelAB
  * Deprecated GaussianNonLinearCalibration,NonLinearLeastSquaresCalibration::set,getAlgorithm
  * Added getConditionalMarginalCovariance method to KrigingResult
+ * Added getConditionalMarginalVariance method to KrigingResult
 
 === Python module ===
  * Add Domain.__contains__ operator

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -446,6 +446,38 @@ CovarianceMatrix KrigingResult::getConditionalCovariance(const Point & xi) const
   return getConditionalCovariance(sample);
 }
 
+/** Compute covariance matrices conditionnaly to observations (1 cov / point)*/
+KrigingResult::CovarianceMatrixCollection KrigingResult::getConditionalMarginalCovariance(const Sample & xi) const
+{
+  // For a process of dimension p & xi's size=s,
+  // returned a s-collection of cov matrices (pxp) 
+  const UnsignedInteger inputDimension = xi.getDimension();
+  if (inputDimension != covarianceModel_.getInputDimension())
+    throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
+  const UnsignedInteger outputDimension = covarianceModel_.getOutputDimension();
+  const UnsignedInteger sampleSize = xi.getSize();
+  if (sampleSize == 0)
+    throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, expected a non empty sample";
+  
+  CovarianceMatrixCollection collection(sampleSize);
+  Sample data(1, inputDimension);
+  for (UnsignedInteger i = 0; i < sampleSize; ++i)
+  {
+    for (UnsignedInteger j = 0; j < inputDimension; ++j) data(0, j) = xi(i, j);
+    collection[i] = getConditionalCovariance(data);
+  }
+  return collection;
+}
+
+/** Compute covariance matrix conditionnaly to observations (1 cov of size outdimension)*/
+CovarianceMatrix KrigingResult::getConditionalMarginalCovariance(const Point & xi) const
+{
+  const UnsignedInteger inputDimension = xi.getDimension();
+  if (inputDimension != covarianceModel_.getInputDimension())
+    throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
+  return getConditionalCovariance(xi);
+}
+
 /* Compute joint normal distribution conditionnaly to observations*/
 Normal KrigingResult::operator()(const Sample & xi) const
 {

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -464,7 +464,6 @@ CovarianceMatrix KrigingResult::getConditionalCovariance(const Point & point) co
   const UnsignedInteger inputDimension = point.getDimension();
   if (inputDimension != covarianceModel_.getInputDimension())
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalCovariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
-  const UnsignedInteger outputDimension = covarianceModel_.getOutputDimension();
   // 0) Take into account transformation
   Point data;
   // Transform data if necessary
@@ -560,7 +559,6 @@ KrigingResult::CovarianceMatrixCollection KrigingResult::getConditionalMarginalC
   const UnsignedInteger inputDimension = xi.getDimension();
   if (inputDimension != covarianceModel_.getInputDimension())
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
-  const UnsignedInteger outputDimension = covarianceModel_.getOutputDimension();
   const UnsignedInteger sampleSize = xi.getSize();
   if (sampleSize == 0)
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, expected a non empty sample";
@@ -646,7 +644,6 @@ Point KrigingResult::getConditionalMarginalVariance(const Sample & xi,
                                                      const Indices &indices) const
  {
   const UnsignedInteger inputDimension = point.getDimension();
-  const UnsignedInteger outputDimension = covarianceModel_.getOutputDimension();
   if (inputDimension != covarianceModel_.getInputDimension())
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalVariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
   if (!indices.check(covarianceModel_.getOutputDimension()))
@@ -664,7 +661,6 @@ Point KrigingResult::getConditionalMarginalVariance(const Sample & xi,
  {
 
   const UnsignedInteger inputDimension = xi.getDimension();
-  const UnsignedInteger outputDimension = covarianceModel_.getOutputDimension();
   if (inputDimension != covarianceModel_.getInputDimension())
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalVariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
   if (!indices.check(covarianceModel_.getOutputDimension()))

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -566,10 +566,11 @@ KrigingResult::CovarianceMatrixCollection KrigingResult::getConditionalMarginalC
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalMarginalCovariance, expected a non empty sample";
   
   CovarianceMatrixCollection collection(sampleSize);
-  Sample data(1, inputDimension);
+  Point data(inputDimension);
   for (UnsignedInteger i = 0; i < sampleSize; ++i)
   {
-    for (UnsignedInteger j = 0; j < inputDimension; ++j) data(0, j) = xi(i, j);
+    for (UnsignedInteger j = 0; j < inputDimension; ++j) data[j] = xi(i, j);
+    // Rely on getConditionalCovariance(Point&)
     collection[i] = getConditionalCovariance(data);
   }
   return collection;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -56,7 +56,6 @@ KrigingResult::KrigingResult(const Sample & inputSample,
   , trendCoefficients_(trendCoefficients)
   , covarianceModel_(covarianceModel)
   , covarianceCoefficients_(covarianceCoefficients)
-  , hasCholeskyFactor_(false)
   , covarianceCholeskyFactor_()
   , covarianceHMatrix_()
   , F_()
@@ -91,7 +90,6 @@ KrigingResult::KrigingResult(const Sample & inputSample,
   , trendCoefficients_(trendCoefficients)
   , covarianceModel_(covarianceModel)
   , covarianceCoefficients_(covarianceCoefficients)
-  , hasCholeskyFactor_(true)
   , covarianceCholeskyFactor_(covarianceCholeskyFactor)
   , covarianceHMatrix_(covarianceHMatrix)
   , F_()
@@ -325,8 +323,6 @@ CovarianceMatrix KrigingResult::getConditionalCovariance(const Sample & xi) cons
 {
   // For a process of dimension p & xi's size=s,
   // returned matrix should have dimensions (p * s) x (p * s)
-  if (!hasCholeskyFactor_)
-    throw InvalidArgumentException(HERE) << "In KrigingResult::getConditionalCovariance, Cholesky factor was not provided. This last one is mandatory to compute the covariance";
   const UnsignedInteger inputDimension = xi.getDimension();
   if (inputDimension != covarianceModel_.getInputDimension())
     throw InvalidArgumentException(HERE) << " In KrigingResult::getConditionalCovariance, input data should have the same dimension as covariance model's input dimension. Here, (input dimension = " << inputDimension << ", covariance model spatial's dimension = " << covarianceModel_.getInputDimension() << ")";
@@ -481,7 +477,6 @@ void KrigingResult::save(Advocate & adv) const
   adv.saveAttribute( "trendCoefficients_", trendCoefficients_ );
   adv.saveAttribute( "covarianceModel_", covarianceModel_ );
   adv.saveAttribute( "covarianceCoefficients_", covarianceCoefficients_ );
-  adv.saveAttribute( "hasCholeskyFactor_", hasCholeskyFactor_);
   adv.saveAttribute( "covarianceCholeskyFactor_", covarianceCholeskyFactor_);
   adv.saveAttribute( "F_", F_);
   adv.saveAttribute( "phiT_", phiT_);
@@ -502,7 +497,6 @@ void KrigingResult::load(Advocate & adv)
   adv.loadAttribute( "trendCoefficients_", trendCoefficients_ );
   adv.loadAttribute( "covarianceModel_", covarianceModel_ );
   adv.loadAttribute( "covarianceCoefficients_", covarianceCoefficients_ );
-  adv.loadAttribute( "hasCholeskyFactor_", hasCholeskyFactor_);
   adv.loadAttribute( "covarianceCholeskyFactor_", covarianceCholeskyFactor_);
   adv.loadAttribute( "F_", F_);
   adv.loadAttribute( "phiT_", phiT_);

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -51,6 +51,7 @@ public:
   typedef PersistentCollection<Point> PointPersistentCollection;
   typedef Collection<Basis> BasisCollection;
   typedef PersistentCollection<Basis> BasisPersistentCollection;
+  typedef Collection<CovarianceMatrix> CovarianceMatrixCollection;
 
   /** Default constructor */
   KrigingResult();
@@ -117,6 +118,12 @@ public:
 
   /** Compute covariance matrix conditionnaly to observations*/
   virtual CovarianceMatrix getConditionalCovariance(const Point & xi) const;
+
+  /** Compute covariance matrices conditionnaly to observations (1 cov / point)*/
+  virtual CovarianceMatrixCollection getConditionalMarginalCovariance(const Sample & xi) const;
+
+  /** Compute covariance matrix conditionnaly to observations (1 cov of size outdimension)*/
+  virtual CovarianceMatrix getConditionalMarginalCovariance(const Point & xi) const;
 
   /** Compute joint normal distribution conditionnaly to observations*/
   virtual Normal operator()(const Sample & xi) const;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -168,9 +168,6 @@ private:
   /** The covariance coefficients */
   Sample covarianceCoefficients_;
 
-  /** Boolean for cholesky. The factor is not mandatory (see KrigingAlgorithm) */
-  Bool hasCholeskyFactor_;
-
   /** Cholesky factor  */
   mutable TriangularMatrix covarianceCholeskyFactor_;
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -142,6 +142,7 @@ protected:
 
   /** Compute cross matrix method ==> not necessary square matrix  */
   Matrix getCrossMatrix(const Sample & x) const;
+  Matrix getCrossMatrix(const Point & point) const;
   void computeF() const;
   void computePhi() const;
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -136,6 +136,7 @@ protected:
   /** Compute cross matrix method ==> not necessary square matrix  */
   Matrix getCrossMatrix(const Sample & x) const;
   void computeF() const;
+  void computePhi() const;
 
 private:
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -125,6 +125,20 @@ public:
   /** Compute covariance matrix conditionnaly to observations (1 cov of size outdimension)*/
   virtual CovarianceMatrix getConditionalMarginalCovariance(const Point & xi) const;
 
+  /** Compute marginal variance conditionnaly to observations (1 cov of size outdimension)*/
+  virtual Scalar getConditionalMarginalVariance(const Point & point,
+                                                const UnsignedInteger marginalIndex = 0) const;
+
+  /** Compute marginal variance conditionnaly to observations (1 cov / point)*/
+  virtual Point getConditionalMarginalVariance(const Sample & xi,
+                                               const UnsignedInteger marginalIndex = 0) const;
+
+  virtual Point getConditionalMarginalVariance(const Point & point,
+                                               const Indices & indices) const;
+
+  virtual Point getConditionalMarginalVariance(const Sample & xi,
+                                               const Indices & indices) const;
+
   /** Compute joint normal distribution conditionnaly to observations*/
   virtual Normal operator()(const Sample & xi) const;
 

--- a/lib/src/Uncertainty/Algorithm/Optimization/EfficientGlobalOptimization.cxx
+++ b/lib/src/Uncertainty/Algorithm/Optimization/EfficientGlobalOptimization.cxx
@@ -88,7 +88,7 @@ public:
   {
     const Scalar mx = metaModelResult_.getConditionalMean(x)[0];
     const Scalar fmMk = optimalValue_ - mx;
-    const Scalar sk2 = metaModelResult_.getConditionalCovariance(x)(0, 0);
+    const Scalar sk2 = metaModelResult_.getConditionalMarginalVariance(x);
     const Scalar sk = sqrt(sk2);
     if (!SpecFunc::IsNormal(sk)) return Point(1, -SpecFunc::MaxScalar);
     const Scalar ratio = fmMk / sk;
@@ -183,7 +183,7 @@ void EfficientGlobalOptimization::run()
         optimalValuePrev = optimalValue;
 
         optimizer = inputSample[index];
-        optimalValue = outputSample[index][0];
+        optimalValue = outputSample(index, 0);
       }
   }
 
@@ -254,7 +254,7 @@ void EfficientGlobalOptimization::run()
       for (UnsignedInteger i = 0; i < size; ++ i)
       {
         const Point x(inputSample[i]);
-        const Scalar sk2 = metaModelResult.getConditionalCovariance(x)(0, 0);
+        const Scalar sk2 = metaModelResult.getConditionalMarginalVariance(x);
         const Scalar u = mx[i] + aeiTradeoff_ * sqrt(sk2);
         if ((problem.isMinimization() && (u < optimalValueSubstitute))
             || (!problem.isMinimization() && (u > optimalValueSubstitute)))

--- a/lib/test/t_KrigingAlgorithm_std.cxx
+++ b/lib/test/t_KrigingAlgorithm_std.cxx
@@ -85,6 +85,12 @@ int main(int, char *[])
       // Validation of the covariance ==> should be null on the learning set
       assert_almost_equal(Point(*covMatrix.getImplementation()), Point(sampleSize * sampleSize), 8.95e-7, 8.95e-7);
 
+      // Covariance per marginal & extract variance component
+      Collection<CovarianceMatrix> coll(result.getConditionalMarginalCovariance(X));
+
+      for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
+        assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-14, 1e-14);
+
     }
 
     {
@@ -156,6 +162,13 @@ int main(int, char *[])
       std::cout << "d^f(X0) & d^f(X0) FD similar ?" <<  std::endl;
       assert_almost_equal(Point(*gradientKriging.getImplementation()), Point(*gradientKrigingFD.getImplementation()), 1e-3, 1e-3);
       std::cout << "d^f(X0) & d^f(X0) FD are similar." <<  std::endl;
+
+      // Covariance per marginal & extract variance component
+      Collection<CovarianceMatrix> coll(result.getConditionalMarginalCovariance(X));
+
+      for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
+        assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-13, 1e-13);
+
 
     }
 

--- a/lib/test/t_KrigingAlgorithm_std.cxx
+++ b/lib/test/t_KrigingAlgorithm_std.cxx
@@ -91,6 +91,9 @@ int main(int, char *[])
       for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
         assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-14, 1e-14);
 
+      // Validation of marginal variance
+      const Point marginalVariance(result.getConditionalMarginalVariance(X));
+      assert_almost_equal(marginalVariance, Point(sampleSize), 1e-14, 1e-14);
     }
 
     {
@@ -169,6 +172,9 @@ int main(int, char *[])
       for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
         assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-13, 1e-13);
 
+      // Validation of marginal variance
+      const Point marginalVariance(result.getConditionalMarginalVariance(X));
+      assert_almost_equal(marginalVariance, Point(sampleSize), 1e-14, 1e-14);
 
     }
 

--- a/lib/test/t_KrigingAlgorithm_std_hmat.cxx
+++ b/lib/test/t_KrigingAlgorithm_std_hmat.cxx
@@ -95,6 +95,9 @@ int main(int, char *[])
       for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
         assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-14, 1e-14);
 
+      // Validation of marginal variance
+      const Point marginalVariance(result.getConditionalMarginalVariance(X));
+      assert_almost_equal(marginalVariance, Point(sampleSize), 1e-14, 1e-14);
     }
 
     {
@@ -173,6 +176,10 @@ int main(int, char *[])
 
       for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
         assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-13, 1e-13);
+
+      // Validation of marginal variance
+      const Point marginalVariance(result.getConditionalMarginalVariance(X));
+      assert_almost_equal(marginalVariance, Point(sampleSize), 1e-14, 1e-14);
 
     }
 

--- a/lib/test/t_KrigingAlgorithm_std_hmat.cxx
+++ b/lib/test/t_KrigingAlgorithm_std_hmat.cxx
@@ -89,6 +89,12 @@ int main(int, char *[])
       // Validation of the covariance ==> should be null on the learning set
       assert_almost_equal(Point(*covMatrix.getImplementation()), Point(sampleSize * sampleSize), 8.95e-7, 8.95e-7);
 
+      // Covariance per marginal & extract variance component
+      Collection<CovarianceMatrix> coll(result.getConditionalMarginalCovariance(X));
+
+      for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
+        assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-14, 1e-14);
+
     }
 
     {
@@ -161,6 +167,12 @@ int main(int, char *[])
       std::cout << "d^f(X0) & d^f(X0) FD similar ?" <<  std::endl;
       assert_almost_equal(Point(*gradientKriging.getImplementation()), Point(*gradientKrigingFD.getImplementation()), 1e-3, 1e-3);
       std::cout << "d^f(X0) & d^f(X0) FD are similar." <<  std::endl;
+
+      // Covariance per marginal & extract variance component
+      Collection<CovarianceMatrix> coll(result.getConditionalMarginalCovariance(X));
+
+      for(UnsignedInteger k = 0; k < coll.getSize(); ++k)
+        assert_almost_equal(Point(*coll[k].getImplementation()), Point(1, 0.0), 1e-13, 1e-13);
 
     }
 

--- a/python/src/KrigingResult_doc.i.in
+++ b/python/src/KrigingResult_doc.i.in
@@ -250,6 +250,48 @@ In case input parameter is a of type :class:`~openturns.Sample`, each element of
 covariance with respect to the input learning set (pointwise evaluation of the getConditionalCovariance)."
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::KrigingResult::getConditionalMarginalVariance
+"Compute the expected variance of the Gaussian process on a point (or several points).
+
+
+Available usages:
+    getConditionalMarginalVariance(x, marginalIndex)
+
+    getConditionalMarginalVariance(sampleX, marginalIndex)
+
+    getConditionalMarginalVariance(x, marginalIndices)
+
+    getConditionalMarginalVariance(sampleX, marginalIndices)
+
+Parameters
+----------
+x : sequence of float
+    The point :math:`\vect{x}` where the conditional mean of the output has to be evaluated.
+sampleX : 2-d sequence of float
+     The sample :math:`(\vect{\xi}_1, \dots, \vect{\xi}_M)` where the conditional mean of the output has to be evaluated (*M* can be equal to 1).
+marginalIndex : int
+    Marginal of interest (for multiple outputs).
+    Default value is 0
+marginalIndices : sequence of int
+    Marginals of interest (for multiple outputs).
+
+Returns
+-------
+var : float
+      Variance of interest.
+      float if one point (x) and one marginal of interest (x, marginalIndex)
+
+varPoint : sequence of float
+    The marginal variances
+
+
+Notes
+-----
+In case of fourth usage, the sequence of float is given as the concatenation of marginal variances 
+for each point in sampleX."
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::KrigingResult::getMetaModel
 "Accessor to the metamodel.
 

--- a/python/src/KrigingResult_doc.i.in
+++ b/python/src/KrigingResult_doc.i.in
@@ -219,6 +219,37 @@ condCov : :class:`~openturns.CovarianceMatrix`
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::KrigingResult::getConditionalMarginalCovariance
+"Compute the expected covariance of the Gaussian process on a point (or several points).
+
+
+Available usages:
+    getConditionalMarginalCovariance(x)
+
+    getConditionalMarginalCovariance(sampleX)
+
+Parameters
+----------
+x : sequence of float
+    The point :math:`\vect{x}` where the conditional mean of the output has to be evaluated.
+sampleX : 2-d sequence of float
+     The sample :math:`(\vect{\xi}_1, \dots, \vect{\xi}_M)` where the conditional mean of the output has to be evaluated (*M* can be equal to 1).
+
+Returns
+-------
+condCov : :class:`~openturns.CovarianceMatrix`
+    The conditional covariance :math:`\Cov{\vect{Y}(\omega, \vect{x})\, | \,  \cC}` at point :math:`\vect{x}`.
+
+condCov : :class:`~openturns.CovarianceMatrixCollection`
+    The collection of conditional covariance matrices :math:`\Cov{\vect{Y}(\omega, \vect{\xi})\, | \,  \cC}` at
+    each point of the sample :math:`(\vect{\xi}_1, \dots, \vect{\xi}_M)`:
+
+Notes
+-----
+In case input parameter is a of type :class:`~openturns.Sample`, each element of the collection corresponds to the conditional
+covariance with respect to the input learning set (pointwise evaluation of the getConditionalCovariance)."
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::KrigingResult::getMetaModel
 "Accessor to the metamodel.
 

--- a/python/test/t_KrigingAlgorithm_std.py
+++ b/python/test/t_KrigingAlgorithm_std.py
@@ -57,6 +57,10 @@ covarianceColl = Point(var)
 theoricalVariance = Point(sampleSize)
 assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
 
+# Variance per marginal
+var = result.getConditionalMarginalVariance(X)
+assert_almost_equal(var, Point(sampleSize), 1e-14, 1e-14)
+
 # Test 2
 
 # Kriging use case
@@ -119,6 +123,9 @@ covarianceColl = Point(var)
 theoricalVariance = Point(len(var))
 assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
 
+# Variance per marginal
+var = result.getConditionalMarginalVariance(inputSample)
+assert_almost_equal(var, Point(len(inputSample)), 1e-14, 1e-14)
 
 # Estimation
 assert_almost_equal(outputValidSample,  metaModel(

--- a/python/test/t_KrigingAlgorithm_std.py
+++ b/python/test/t_KrigingAlgorithm_std.py
@@ -42,13 +42,20 @@ assert_almost_equal(result.getResiduals(), [1.32804e-07], 1e-3, 1e-3)
 assert_almost_equal(result.getRelativeErrors(), [5.20873e-21])
 
 # Kriging variance is 0 on learning points
-var = result.getConditionalCovariance(X)
+covariance = result.getConditionalCovariance(X)
 
 # assert_almost_equal could not be applied to matrices
 # application to Point
-covariancePoint = Point(var.getImplementation())
+covariancePoint = Point(covariance.getImplementation())
 theoricalVariance = Point(sampleSize * sampleSize)
 assert_almost_equal(covariancePoint, theoricalVariance, 8.95e-7, 8.95e-7)
+
+# Covariance per marginal & extract variance component
+coll = result.getConditionalMarginalCovariance(X)
+var = [mat[0,0] for mat in coll]
+covarianceColl = Point(var)
+theoricalVariance = Point(sampleSize)
+assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
 
 # Test 2
 
@@ -97,13 +104,21 @@ assert_almost_equal(outputSample,  metaModel(inputSample), 3.0e-5, 3.0e-5)
 
 
 # 5) Kriging variance is 0 on learning points
-var = result.getConditionalCovariance(inputSample)
+covariance = result.getConditionalCovariance(inputSample)
 
 # assert_almost_equal could not be applied to matrices
 # application to Point
-covariancePoint = Point(var.getImplementation())
+covariancePoint = Point(covariance.getImplementation())
 theoricalVariance = Point(covariancePoint.getSize(), 0.0)
 assert_almost_equal(covariancePoint, theoricalVariance, 7e-7, 7e-7)
+
+# Covariance per marginal & extract variance component
+coll = result.getConditionalMarginalCovariance(inputSample)
+var = [mat[0,0] for mat in coll]
+covarianceColl = Point(var)
+theoricalVariance = Point(len(var))
+assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
+
 
 # Estimation
 assert_almost_equal(outputValidSample,  metaModel(

--- a/python/test/t_KrigingAlgorithm_std_hmat.py
+++ b/python/test/t_KrigingAlgorithm_std_hmat.py
@@ -54,6 +54,13 @@ covariancePoint = Point(var.getImplementation())
 theoricalVariance = Point(sampleSize * sampleSize)
 assert_almost_equal(covariancePoint, theoricalVariance, 8.95e-7, 8.95e-7)
 
+# Covariance per marginal & extract variance component
+coll = result.getConditionalMarginalCovariance(X)
+var = [mat[0,0] for mat in coll]
+covarianceColl = Point(var)
+theoricalVariance = Point(sampleSize)
+assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
+
 # Test 2
 
 # Kriging use case
@@ -108,6 +115,13 @@ var = result.getConditionalCovariance(inputSample)
 covariancePoint = Point(var.getImplementation())
 theoricalVariance = Point(covariancePoint.getSize(), 0.0)
 assert_almost_equal(covariancePoint, theoricalVariance, 7e-7, 7e-7)
+
+# Covariance per marginal & extract variance component
+coll = result.getConditionalMarginalCovariance(inputSample)
+var = [mat[0,0] for mat in coll]
+covarianceColl = Point(var)
+theoricalVariance = Point(len(var))
+assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
 
 # Estimation
 # rtol & a tol fixed to 1e-1

--- a/python/test/t_KrigingAlgorithm_std_hmat.py
+++ b/python/test/t_KrigingAlgorithm_std_hmat.py
@@ -61,6 +61,10 @@ covarianceColl = Point(var)
 theoricalVariance = Point(sampleSize)
 assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
 
+# Variance per marginal
+var = result.getConditionalMarginalVariance(X)
+assert_almost_equal(var, Point(sampleSize), 1e-14, 1e-14)
+
 # Test 2
 
 # Kriging use case
@@ -122,6 +126,10 @@ var = [mat[0,0] for mat in coll]
 covarianceColl = Point(var)
 theoricalVariance = Point(len(var))
 assert_almost_equal(covarianceColl, theoricalVariance, 1e-14, 1e-14)
+
+# Variance per marginal
+var = result.getConditionalMarginalVariance(inputSample)
+assert_almost_equal(var, Point(len(inputSample)), 1e-14, 1e-14)
 
 # Estimation
 # rtol & a tol fixed to 1e-1


### PR DESCRIPTION
The main objective is to provide new methods for kriging post-processing.
Here 2 methods are implemented :

 - `getConditionalMarginalCovariance` : which acts on a `n-Sample` and provide a n-`CovarianceMatrixCollection`. Each element of the collection corresponds to the conditional covariance evaluated on the `ith` element of sample conditionally to all observations
- `getConditionalMarginalVariance` : which acts on a `n-Sample` and provide a `n-Point` (if marginal of interest is 1D) or `(n*d)-Sample`, `d` being the size of marginal interests.
The method might be seen as the restriction of the previous one on specific marginal of interests.

This fixes #1184 
We also made benefit of this PR to update the API ( coding rules ).
