### PR TITLE
Bugfix in ProductCovarianceModel

### DIFF
--- a/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
@@ -24,6 +24,7 @@
 #include "openturns/CovarianceModel.hxx"
 #include "openturns/PersistentCollection.hxx"
 #include "openturns/Collection.hxx"
+#include "openturns/Indices.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -88,17 +89,21 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv);
 
-protected:
-  void setCollection(const CovarianceModelCollection & collection);
-
   /** Parameter accessor */
   virtual void setFullParameter(const Point & parameter);
   virtual Point getFullParameter() const;
   virtual Description getFullParameterDescription() const;
+  virtual void setActiveParameter(const Indices & active);
+
+protected:
+  void setCollection(const CovarianceModelCollection & collection);
 
 private:
   /** The collection of marginal models */
   CovarianceModelPersistentCollection collection_;
+
+  /** Handle extra parameters of the marginal models */
+  Indices extraParameterNumber_;
 
 } ; /* class ProductCovarianceModel */
 

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -233,6 +233,8 @@ ot_pyinstallcheck_test (UserDefinedCovarianceModel_std)
 ot_pyinstallcheck_test (UserDefinedStationaryCovarianceModel_std)
 ot_pyinstallcheck_test (StationaryCovarianceModelFactory_std)
 ot_pyinstallcheck_test (NonStationaryCovarianceModelFactory_std)
+ot_pyinstallcheck_test (ProductCovarianceModel_std)
+
 if (HMAT_FOUND)
 ot_pyinstallcheck_test (HMatrix_std)
 endif ()

--- a/python/test/t_ProductCovarianceModel_std.expout
+++ b/python/test/t_ProductCovarianceModel_std.expout
@@ -1,0 +1,22 @@
+1D Full parameter :  [0.5,1,2.5]
+1D active cov. param.:  ['scale_0', 'amplitude_0']
+Activate nu parameter
+active cov. param.:  ['scale_0', 'amplitude_0', 'nu']
+Matern d-dimensional covariance as product
+Full parameter :  [0.5,0.5,0.5,1,2.5,2.5,2.5]
+active cov. param.:  ['scale_0', 'scale_1', 'scale_2', 'amplitude_0', 'nu_0', 'nu_1', 'nu_2']
+Disable nu for marginals 0 & 1 parameter :  [0.5,0.5,0.5,1,2.5,2.5,2.5]
+active cov. param.:  ['scale_0', 'scale_1', 'scale_2', 'amplitude_0', 'nu_2']
+Check that active parameter is correctly propagated
+Model  0  : active cov. param.:  ['scale_0', 'amplitude_0']
+Model  1  : active cov. param.:  ['scale_0', 'amplitude_0']
+Model  2  : active cov. param.:  ['scale_0', 'amplitude_0', 'nu']
+Model 1 :  [scale_0,amplitude_0,nu]
+Activate nu parameter and disable sigma2
+model1 active parameter:  ['scale_0', 'nu']
+Model 2 :  [scale_0,amplitude_0,frequency]
+Activate freq parameter
+model2 active parameter:  ['scale_0', 'amplitude_0', 'frequency']
+Product covariance model
+Full parameter :  [1,1,1,2.5,1]
+active cov. param.:  ['scale_0', 'scale_1', 'amplitude_0', 'nu_0', 'frequency_1']

--- a/python/test/t_ProductCovarianceModel_std.py
+++ b/python/test/t_ProductCovarianceModel_std.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+import openturns as ot
+
+ot.TESTPREAMBLE()
+
+def test_active_parameter():
+	# Define product of matern 1d
+	cov_model_1d = ot.MaternModel([0.5], 2.5)
+	print("1D Full parameter : ", cov_model_1d.getFullParameter())
+	print("1D active cov. param.: ", [cov_model_1d.getFullParameterDescription()[i] for i in cov_model_1d.getActiveParameter()])
+	print("Activate nu parameter")
+	cov_model_1d.setActiveParameter([0,1,2])
+	print("active cov. param.: ", [cov_model_1d.getFullParameterDescription()[i] for i in cov_model_1d.getActiveParameter()])
+
+	print("Matern d-dimensional covariance as product")
+	d = 3
+	cov_model = ot.ProductCovarianceModel([cov_model_1d]*d)
+	print("Full parameter : ", cov_model.getFullParameter())
+	print("active cov. param.: ", [cov_model.getFullParameterDescription()[i] for i in cov_model.getActiveParameter()])
+	print("Disable nu for marginals 0 & 1 parameter : ", cov_model.getFullParameter())
+	cov_model.setActiveParameter([0,1,2,3,6])
+	print("active cov. param.: ", [cov_model.getFullParameterDescription()[i] for i in cov_model.getActiveParameter()])
+	print("Check that active parameter is correctly propagated")
+
+	for k in range(3):
+	    print("Model ", k, " : active cov. param.: ", [cov_model.getCollection()[k].getFullParameterDescription()[i] for i in cov_model.getCollection()[k].getActiveParameter()])
+
+
+def test_active_amplitude_parameter():
+	# Define product of matern 1d
+	model1 = ot.MaternModel([1.0], 2.5)
+	print("Model 1 : ", model1.getFullParameterDescription())
+	print("Activate nu parameter and disable sigma2")
+	model1.setActiveParameter([0,2])
+	print("model1 active parameter: ", [model1.getFullParameterDescription()[i] for i in model1.getActiveParameter()])
+
+	model2 = ot.ExponentiallyDampedCosineModel()
+	print("Model 2 : ", model2.getFullParameterDescription())
+	print("Activate freq parameter")
+	model2.setActiveParameter([0,1,2])
+	print("model2 active parameter: ", [model2.getFullParameterDescription()[i] for i in model2.getActiveParameter()])
+
+	print("Product covariance model")
+	d = 3
+	cov_model = ot.ProductCovarianceModel([model1, model2])
+	print("Full parameter : ", cov_model.getFullParameter())
+	print("active cov. param.: ", [cov_model.getFullParameterDescription()[i] for i in cov_model.getActiveParameter()])
+
+
+test_active_parameter()
+test_active_amplitude_parameter()


### PR DESCRIPTION
We fix It fixes openturns#1264

 * Now the parameter attribut take into account potential external parameters : `getFullParameter`, `getFullParameterDescription` and `setFullParameter` have the expected behaviour
 * `getActiveParameter`and `setActiveParameter` are fixed
 * A specific test is added
