### PR TITLE
Improve Kolmogorov-Smirnov test

### DIFF
--- a/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
@@ -52,8 +52,8 @@ FisherSnedecor FisherSnedecorFactory::buildMethodOfMoments(const Sample & sample
   if (mu <= 1.0) throw InvalidArgumentException(HERE) << "Error: cannot estimate a FisherSnedecor distribution based on a sample with sample mean less than 1 using the method of moments.";
   const Scalar sigma2 = sample.computeCovariance()(0,0);
   if (sigma2 == 0.0) throw InvalidArgumentException(HERE) << "Error: cannot estimate a FisherSnedecor distribution based on a constant sample using the method of moments.";
-  const Scalar d2 = 2*mu/(mu-1);
-  const Scalar d1 = 2*std::pow(d2,2)*(d2-2)/(std::pow(d2-2,2)*(d2-4)*sigma2-2*std::pow(d2,2));
+  const Scalar d2 = 2 * mu / (mu - 1);
+  const Scalar d1 = 2 * std::pow(d2,2.0) * (d2 - 2)/(std::pow(d2 - 2.0,2.0) * (d2 - 4) * sigma2 - 2 * std::pow(d2,2.0));
   FisherSnedecor result(d1, d2);
   result.setDescription(sample.getDescription());
   return result;
@@ -82,7 +82,7 @@ DistributionFactoryResult FisherSnedecorFactory::buildEstimator(const Sample & s
 FisherSnedecor FisherSnedecorFactory::buildAsFisherSnedecor(const Sample & sample) const
 {
   // Use method of moments as starting point
-  FisherSnedecor estimatedMomentsDistribution = buildMethodOfMoments(sample);
+  const FisherSnedecor estimatedMomentsDistribution = buildMethodOfMoments(sample);
   Point parametersFromMoments = estimatedMomentsDistribution.getParameter();
 
   const UnsignedInteger dimension = build().getParameterDimension();

--- a/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
@@ -45,6 +45,20 @@ FisherSnedecorFactory * FisherSnedecorFactory::clone() const
 
 /* Here is the interface that all derived class must implement */
 
+/* Algorithm associated with the method of moments */
+FisherSnedecor FisherSnedecorFactory::buildMethodOfMoments(const Sample & sample) const
+{
+  const Scalar mu = sample.computeMean()[0];
+  if (mu <= 1.0) throw InvalidArgumentException(HERE) << "Error: cannot estimate a FisherSnedecor distribution based on a sample with sample mean less than 1 using the method of moments.";
+  const Scalar sigma2 = sample.computeCovariance()(0,0);
+  if (sigma2 == 0.0) throw InvalidArgumentException(HERE) << "Error: cannot estimate a FisherSnedecor distribution based on a constant sample using the method of moments.";
+  const Scalar d2 = 2*mu/(mu-1);
+  const Scalar d1 = 2*std::pow(d2,2)*(d2-2)/(std::pow(d2-2,2)*(d2-4)*sigma2-2*std::pow(d2,2));
+  FisherSnedecor result(d1, d2);
+  result.setDescription(sample.getDescription());
+  return result;
+}
+
 Distribution FisherSnedecorFactory::build(const Sample & sample) const
 {
   return buildAsFisherSnedecor(sample).clone();

--- a/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecorFactory.cxx
@@ -81,6 +81,10 @@ DistributionFactoryResult FisherSnedecorFactory::buildEstimator(const Sample & s
 
 FisherSnedecor FisherSnedecorFactory::buildAsFisherSnedecor(const Sample & sample) const
 {
+  // Use method of moments as starting point
+  FisherSnedecor estimatedMomentsDistribution = buildMethodOfMoments(sample);
+  Point parametersFromMoments = estimatedMomentsDistribution.getParameter();
+
   const UnsignedInteger dimension = build().getParameterDimension();
   MaximumLikelihoodFactory factory(buildAsFisherSnedecor());
 
@@ -90,7 +94,7 @@ FisherSnedecor FisherSnedecorFactory::buildAsFisherSnedecor(const Sample & sampl
 
   // override starting point
   OptimizationAlgorithm solver(factory.getOptimizationAlgorithm());
-  solver.setStartingPoint(parametersLowerBound);
+  solver.setStartingPoint(parametersFromMoments);
   factory.setOptimizationAlgorithm(solver);
 
   // override bounds

--- a/lib/src/Uncertainty/Distribution/openturns/FisherSnedecorFactory.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FisherSnedecorFactory.hxx
@@ -50,6 +50,9 @@ public:
   Distribution build(const Point & parameters) const;
   Distribution build() const;
 
+  /** Algorithm associated with the method of moments */
+  FisherSnedecor buildMethodOfMoments(const Sample & sample) const;
+
   using DistributionFactoryImplementation::buildEstimator;
   DistributionFactoryResult buildEstimator(const Sample & sample) const;
 

--- a/lib/test/t_FisherSnedecorFactory_std.cxx
+++ b/lib/test/t_FisherSnedecorFactory_std.cxx
@@ -54,6 +54,15 @@ int main(int, char *[])
     fullprint << "Default fisherSnedecor=" << estimatedFisherSnedecor << std::endl;
     estimatedFisherSnedecor = factory.buildAsFisherSnedecor(distribution.getParameter());
     fullprint << "FisherSnedecor from parameters=" << estimatedFisherSnedecor << std::endl;
+    // buildMethodOfMoments
+    estimatedFisherSnedecor = factory.buildMethodOfMoments(sample);
+    fullprint << "Estimated from moments=" << estimatedFisherSnedecor << std::endl;
+    const Scalar sample_mu = sample.computeMean()[0];
+    const Scalar sample_sigma2 = sample.computeCovariance()(0,0);
+    const Scalar distribution_mu = estimatedFisherSnedecor.computeMean()[0];
+    const Scalar distribution_sigma2 = estimatedFisherSnedecor.computeCovariance()(0,0);
+    assert_almost_equal(sample_mu, distribution_mu, 1e-15, 1e-15);
+    assert_almost_equal(sample_sigma2, distribution_sigma2, 1e-15, 1e-15);
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_FisherSnedecorFactory_std.cxx
+++ b/lib/test/t_FisherSnedecorFactory_std.cxx
@@ -59,8 +59,8 @@ int main(int, char *[])
     fullprint << "Estimated from moments=" << estimatedFisherSnedecor << std::endl;
     const Scalar sample_mu = sample.computeMean()[0];
     const Scalar sample_sigma2 = sample.computeCovariance()(0,0);
-    const Scalar distribution_mu = estimatedFisherSnedecor.computeMean()[0];
-    const Scalar distribution_sigma2 = estimatedFisherSnedecor.computeCovariance()(0,0);
+    const Scalar distribution_mu = estimatedFisherSnedecor.getMean()[0];
+    const Scalar distribution_sigma2 = estimatedFisherSnedecor.getCovariance()(0,0);
     assert_almost_equal(sample_mu, distribution_mu, 1e-15, 1e-15);
     assert_almost_equal(sample_sigma2, distribution_sigma2, 1e-15, 1e-15);
   }

--- a/lib/test/t_FisherSnedecorFactory_std.expout
+++ b/lib/test/t_FisherSnedecorFactory_std.expout
@@ -6,3 +6,4 @@ FisherSnedecor          =class=FisherSnedecor name=FisherSnedecor dimension=1 d1
 Estimated fisherSnedecor=class=FisherSnedecor name=FisherSnedecor dimension=1 d1=4.5705 d2=8.2066
 Default fisherSnedecor=class=FisherSnedecor name=FisherSnedecor dimension=1 d1=1 d2=5
 FisherSnedecor from parameters=class=FisherSnedecor name=FisherSnedecor dimension=1 d1=4.5 d2=8.4
+Estimated from moments=class=FisherSnedecor name=FisherSnedecor dimension=1 d1=5.082 d2=8.2315

--- a/python/src/FisherSnedecorFactory_doc.i.in
+++ b/python/src/FisherSnedecorFactory_doc.i.in
@@ -4,7 +4,40 @@
 Available constructor:
     FisherSnedecorFactory()
 
+Notes
+-----
+Several estimators to build a FisherSnedecor distribution from a scalar sample
+are proposed.
+
+**Maximum likelihood estimator:**
+
 The parameters are estimated by numerical maximum likelihood estimation.
+
+**Moment based estimator:**
+
+Lets denote:
+
+- :math:`\displaystyle \overline{x}_n = \frac{1}{n} \sum_{i=1}^n x_i` the empirical
+  mean of the sample, 
+- :math:`\displaystyle s_n^2 = \frac{1}{n-1} \sum_{i=1}^n (x_i - \overline{x}_n)^2`
+  its empirical variance,
+
+We first compute :math:`d_2`:
+
+.. math::
+
+    d_2 = \frac{2 \overline{x}_n}{\overline{x}_n-1}
+
+if :math:`\overline{x}_n>1` (otherwise, the moment based estimator fails). 
+
+Then we compute :math:`d_1`:
+
+.. math::
+
+    d_1 = \frac{2 d_2^2 (d_2-2)}{(d_2-2)^2 (d_2-4)s_n^2 - 2d_2^2}
+
+if :math:`s_n^2>0` (otherwise, the moment based estimator fails). 
+
 
 See also
 --------

--- a/python/src/FisherSnedecorFactory_doc.i.in
+++ b/python/src/FisherSnedecorFactory_doc.i.in
@@ -11,7 +11,14 @@ are proposed.
 
 **Maximum likelihood estimator:**
 
-The parameters are estimated by numerical maximum likelihood estimation.
+The parameters are estimated by numerical maximum likelihood estimation. 
+The starting point of the optimization algorithm is based on the moment based 
+estimator. 
+
+The optimization sets lower bounds for the :math:`d_1` and :math:`d_2` parameters 
+in order to ensure that :math:`d_1>0` and :math:`d_2>0`. 
+The default values for these lower bounds are from the :class:`~openturns.ResourceMap` 
+keys `FisherSnedecorFactory-D1LowerBound` and `FisherSnedecorFactory-D2LowerBound`. 
 
 **Moment based estimator:**
 

--- a/python/src/FisherSnedecor_doc.i.in
+++ b/python/src/FisherSnedecor_doc.i.in
@@ -31,8 +31,8 @@ Its first moments are:
     :nowrap:
 
     \begin{eqnarray*}
-        \Expect{X} & = & \frac{d_2}{d_2 - 2} \\
-        \Var{X} & = & \frac{d_1 - 2}{d_1}\,\frac{d_2}{d_2 + 2}
+        \Expect{X} & = & \frac{d_2}{d_2 - 2} \textrm{ if } d_2>2\\
+        \Var{X} & = & \frac{2d_2^2(d_1+d_2-2)}{d_1(d_2-2)^2(d_2-4)} \textrm{ if } d_2>4
     \end{eqnarray*}
 
 Examples

--- a/python/src/LogNormalFactory_doc.i.in
+++ b/python/src/LogNormalFactory_doc.i.in
@@ -158,9 +158,10 @@ sample : 2-d sequence of float, of dimension 1
     The sample from which the distribution parameters are estimated.
 method : integer
     An integer ranges from 0 to 2 corresponding to a specific estimator method:
-    - 0 : Local likelihood maximum estimator
+    - 0 : Local likelihood maximum estimator (default)
     - 1 : Modified moment estimator
     - 2 : method of moment estimator.
+    The default value is from the :class:`~openturns.ResourceMap` key `LogNormalFactory-EstimationMethod`. 
 param : Collection of :class:`~openturns.PointWithDescription`
     A vector of parameters of the distribution.
 


### PR DESCRIPTION
The goal of this proposal is to increase the speed of the Kolmogorov-Smirnov test when the parameters of the distribution are estimated from a sample. Although the ultimate goal is to fix #1061, it only partially solves it and more work would be required. 

Since the FisherSnedecor was shown to have the least performance, this proposal creates a new FisherSnedecorFactory::buildMethodOfMoments method. 
* This method is used as a starting point for the likelihood maximization. This is, in general, better than using the parametersLowerBound in the current implementation. As a result, when the buildMethodOfMoments fails, the default "build" method fails: I consider that this is a reasonable behavior, but this might be discussed. 
* In the KS test experiments that I did, this increases the performance because the sample made the buildMethodOfMoments method to fail. This speeds up the benchmark by rejecting the FisherSnedecor distribution.

Aside from this, the PR improves the doc of the LogNormalFactory. 

This PR is related to #1275 and #1061. 
