### PR TITLE
Hypergeometric: Fix computeScalarQtle when dirac

### DIFF
--- a/lib/src/Uncertainty/Distribution/Hypergeometric.cxx
+++ b/lib/src/Uncertainty/Distribution/Hypergeometric.cxx
@@ -371,6 +371,8 @@ Scalar Hypergeometric::computeScalarQuantile(const Scalar prob,
   LOGDEBUG(OSS() << "in Hypergeometric::computeScalarQuantile, prob=" << prob << ", tail=" << tail);
   const Scalar a = getRange().getLowerBound()[0];
   const Scalar b = getRange().getUpperBound()[0];
+  if (a == b)
+    return a;
   if (prob <= 0.0) return (tail ? b : a);
   if (prob >= 1.0) return (tail ? a : b);
   Scalar quantile = (a + b) / 2;

--- a/python/src/Distribution.i
+++ b/python/src/Distribution.i
@@ -60,7 +60,7 @@ class SciPyDistribution(PythonDistribution):
     Examples
     --------
     >>> import openturns as ot
-    >>> import scipy.stats as st
+    >>> import scipy.stats as st  # doctest: +SKIP
     >>> scipy_dist = st.johnsonsu(2.55, 2.25)  # doctest: +SKIP
     >>> distribution = ot.Distribution(ot.SciPyDistribution(scipy_dist))  # doctest: +SKIP
     >>> distribution.getRealization()  # doctest: +SKIP

--- a/python/src/SystemFORM_doc.i.in
+++ b/python/src/SystemFORM_doc.i.in
@@ -22,11 +22,11 @@ For an intersection (parallel system) the probability writes:
 In practice the event has to be defined under its disjonctive normal form
 (union of intersections).
 Each probability of intersection region is computed using the previous formula,
-then the Poincarre formula is used to combine each union:
+then the Poincare formula is used to combine each union:
 
 .. math::
 
-    P(E_{sys}) = P(\bigcup_{i=1}^N E_i) = \sum_{i=1}^n P(E_i) - \sum_{j=2}^n \sum_{i=1}^j P(E_i \cap E_j) + \dots + (-1)^n P(E_1 \cap E_2 \cap \dots \cap E_n)
+    P(E_{sys}) = P(\bigcup_{i=1}^N E_i) = \sum_{i=1}^N P(E_i) - \sum_{i < j} P(E_i \cap E_j) + \dots + (-1)^N P(E_1 \cap E_2 \cap \dots \cap E_N)
 
 More details can be found in [lemaire2009]_, at the chapter *Reliability of systems*.
 

--- a/python/test/t_Hypergeometric_std.py
+++ b/python/test/t_Hypergeometric_std.py
@@ -82,3 +82,6 @@ for i in range(6):
     print("standard moment n=", i, ", value=",
           distribution.getStandardMoment(i))
 print("Standard representative=", distribution.getStandardRepresentative())
+
+# should not hang when the range is [0] (dirac)
+ot.Hypergeometric(25, 0, 0).computeScalarQuantile(0.6)


### PR DESCRIPTION
There are several combinations of parameters {n,k,m} where the distribution
is equivalent to a dirac (k=0, m=0).
In these configurations computeScalarQuantile can exit early to avoid
freezes.