### PR TITLE
Improve bernstein copula

### DIFF
--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -25,6 +25,7 @@
 #include "openturns/Exception.hxx"
 #include "openturns/SpecFunc.hxx"
 #include "openturns/DistFunc.hxx"
+#include "openturns/Uniform.hxx"
 #include "openturns/Distribution.hxx"
 #include "openturns/RandomGenerator.hxx"
 
@@ -332,6 +333,15 @@ Scalar EmpiricalBernsteinCopula::computeProbability(const Interval & interval) c
   return probabilityValue / size;
 }
 
+
+/* Get the distribution of the marginal distribution corresponding to the index */
+Distribution EmpiricalBernsteinCopula::getMarginal(const UnsignedInteger i) const
+{
+  if (i >= dimension_) throw InvalidArgumentException(HERE) << "The index of a marginal distribution must be in the range [0, dim-1]";
+  if (isCopula()) return Uniform(0.0, 1.0);
+  return getMarginal(Indices(1, i));
+}
+
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
 Distribution EmpiricalBernsteinCopula::getMarginal(const Indices & indices) const
 {
@@ -386,6 +396,12 @@ Bool EmpiricalBernsteinCopula::hasEllipticalCopula() const
 Bool EmpiricalBernsteinCopula::hasIndependentCopula() const
 {
   return (getDimension() == 1);
+}
+
+/* Compute the numerical range of the distribution given the parameters values */
+void EmpiricalBernsteinCopula::computeRange()
+{
+  range_ = Interval(dimension_);
 }
 
 /* Compute the normalization factors */

--- a/lib/src/Uncertainty/Distribution/Uniform.cxx
+++ b/lib/src/Uncertainty/Distribution/Uniform.cxx
@@ -334,9 +334,14 @@ Description Uniform::getParameterDescription() const
 /* Check if the distribution is elliptical */
 Bool Uniform::isElliptical() const
 {
-  return getDimension() == 1;
+  return true;
 }
 
+/* Check if the distribution is a copula */
+Bool Uniform::isCopula() const
+{
+  return (a_ == 0.0) && (b_ == 1.0);
+}
 
 
 /* A accessor */

--- a/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/EmpiricalBernsteinCopula.hxx
@@ -93,6 +93,7 @@ public:
 
   /** Get the distribution of the marginal distribution corresponding to indices dimensions */
   using ContinuousDistribution::getMarginal;
+  Distribution getMarginal(const UnsignedInteger i) const;
   Distribution getMarginal(const Indices & indices) const;
 
   /** Get the Spearman correlation of the distribution */
@@ -125,6 +126,9 @@ private:
 
   /** Compute the normalization factors */
   void update();
+
+  /** Compute the numerical range of the distribution given the parameters values */
+  void computeRange();
 
   /** The underlying sample */
   Sample copulaSample_;

--- a/lib/src/Uncertainty/Distribution/openturns/Uniform.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Uniform.hxx
@@ -134,6 +134,9 @@ public:
   /** Check if the distribution is elliptical */
   Bool isElliptical() const;
 
+  /** Check if the distribution is a copula */
+  Bool isCopula() const;
+
   /* Interface specific to Uniform */
 
   /** A accessor */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2671,6 +2671,12 @@ void DistributionImplementation::setRange(const Interval & range)
 /* Compute the numerical range of the distribution given the parameters values */
 void DistributionImplementation::computeRange()
 {
+  // Quick return for copulas
+  if (isCopula())
+    {
+      range_ = Interval(dimension_);
+      return;
+    }
   const Interval::BoolCollection finiteLowerBound(dimension_, false);
   const Interval::BoolCollection finiteUpperBound(dimension_, false);
   // Initialize the range with inverted bounds in order to inform the generic implementation of the
@@ -3351,6 +3357,8 @@ Scalar DistributionImplementation::computeDensityGeneratorSecondDerivative(const
 /* Get the i-th marginal distribution */
 Distribution DistributionImplementation::getMarginal(const UnsignedInteger i) const
 {
+  if (isCopula())
+    return Uniform(0.0, 1.0);
   return getMarginal(Indices(1, i));
 }
 

--- a/lib/test/t_EmpiricalBernsteinCopula_std.expout
+++ b/lib/test/t_EmpiricalBernsteinCopula_std.expout
@@ -79,20 +79,20 @@ covariance=class=CovarianceMatrix dimension=2 implementation=class=MatrixImpleme
 correlation=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.125,0.125,1]
 spearman=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.125,0.125,1]
 kendall=class=CorrelationMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,0.2712,0.2712,1]
-margin=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X0] data=[[0.833333],[0.583333],[0.166667],[0.666667],[0.916667],[0.5],[0.0833333],[0.25],[1],[0.416667],[0.75],[0.333333]] binNumber=3
+margin=class=Uniform name=Uniform dimension=1 a=0 b=1
 margin PDF=1
 margin CDF=0.25
 margin quantile=class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization=class=Point name=Unnamed dimension=1 values=[0.716177]
-margin=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X1] data=[[0.166667],[0.916667],[0.583333],[1],[0.833333],[0.5],[0.0833333],[0.416667],[0.333333],[0.666667],[0.75],[0.25]] binNumber=3
+margin realization=class=Point name=Unnamed dimension=1 values=[0.967116]
+margin=class=Uniform name=Uniform dimension=1 a=0 b=1
 margin PDF=1
 margin CDF=0.25
 margin quantile=class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization=class=Point name=Unnamed dimension=1 values=[0.875912]
+margin realization=class=Point name=Unnamed dimension=1 values=[0.367334]
 indices=[1,0]
 margins=class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=2 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=2 description=[X1,X0] data=[[0.166667,0.833333],[0.916667,0.583333],[0.583333,0.166667],[1,0.666667],[0.833333,0.916667],[0.5,0.5],[0.0833333,0.0833333],[0.416667,0.25],[0.333333,1],[0.666667,0.416667],[0.75,0.75],[0.25,0.333333]] binNumber=3
 margins PDF=1.0957
 margins CDF=0.0767822
 margins quantile=class=Point name=Unnamed dimension=2 values=[0.974525,0.974525]
 margins CDF(quantile)=0.95
-margins realization=class=Point name=Unnamed dimension=2 values=[0.00985624,0.0968128]
+margins realization=class=Point name=Unnamed dimension=2 values=[0.875912,0.449469]

--- a/python/test/t_EmpiricalBernsteinCopula_std.expout
+++ b/python/test/t_EmpiricalBernsteinCopula_std.expout
@@ -56,20 +56,20 @@ Unilateral confidence interval (upper tail)= [0.0254747, 1]
 [0.0254747, 1]
 beta= [0.974525]
 parameters= [0.833333,0.166667,0.583333,0.916667,0.166667,0.583333,0.666667,1,0.916667,0.833333,0.5,0.5,0.0833333,0.0833333,0.25,0.416667,1,0.333333,0.416667,0.666667,0.75,0.75,0.333333,0.25]#24
-margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X0] data=[[0.833333],[0.583333],[0.166667],[0.666667],[0.916667],[0.5],[0.0833333],[0.25],[1],[0.416667],[0.75],[0.333333]] binNumber=3
+margin= class=Uniform name=Uniform dimension=1 a=0 b=1
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.28876]
-margin= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=1 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=1 description=[X1] data=[[0.166667],[0.916667],[0.583333],[1],[0.833333],[0.5],[0.0833333],[0.416667],[0.333333],[0.666667],[0.75],[0.25]] binNumber=3
+margin realization= class=Point name=Unnamed dimension=1 values=[0.167019]
+margin= class=Uniform name=Uniform dimension=1 a=0 b=1
 margin PDF=1.000000
 margin CDF=0.250000
 margin quantile= class=Point name=Unnamed dimension=1 values=[0.95]
-margin realization= class=Point name=Unnamed dimension=1 values=[0.986902]
+margin realization= class=Point name=Unnamed dimension=1 values=[0.35979]
 indices= [1,0]
 margins= class=EmpiricalBernsteinCopula name=EmpiricalBernsteinCopula dimension=2 copulaSample=class=Sample name=Unnamed implementation=class=SampleImplementation name=Unnamed size=12 dimension=2 description=[X1,X0] data=[[0.166667,0.833333],[0.916667,0.583333],[0.583333,0.166667],[1,0.666667],[0.833333,0.916667],[0.5,0.5],[0.0833333,0.0833333],[0.416667,0.25],[0.333333,1],[0.666667,0.416667],[0.75,0.75],[0.25,0.333333]] binNumber=3
 margins PDF=1.095703
 margins CDF=0.076782
 margins quantile= class=Point name=Unnamed dimension=2 values=[0.974525,0.974525]
 margins CDF(qantile)=0.950000
-margins realization= class=Point name=Unnamed dimension=2 values=[0.411452,0.531198]
+margins realization= class=Point name=Unnamed dimension=2 values=[0.986902,0.756785]


### PR DESCRIPTION
Now the range is set using a unit interval instead of relying on the default algorithm (computation of many quantiles). On the following benchmark, typical from what append in graphical models:
```
import openturns as ot

dim = 6
size = 10000
binNumber = 5

sample = ot.IndependentCopula(dim).getSample(size)
copula = ot.EmpiricalBernsteinCopula(sample, binNumber)

from time import time

t0 = time()
for k in range(1, dim + 1):
    permutations = ot.KPermutations(k, dim).generate()
    for indices in permutations:
        d = copula.getMarginal(indices)
t1 = time()
print("t=", t1 - t0, "s")
```
the speed-up is more than 12x