### PR TITLE
KernelSmoothing: Handle n-d degenerate case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@
  * #1349 (Problem in the graph of Histogram)
  * #1351 (Text has a zero size)
  * #1354 (The doc of GeneralizedParetoFactory does not reflect the implementation)
+ * #1377 (The `setKnownParameter` method is not compatible with `buildEstimator`)
  * #1378 (Kriging-related covariance model weirdness)
 
 == 1.14 release (2019-11-13) == #release-1.14

--- a/python/test/t_KernelSmoothing_std.expout
+++ b/python/test/t_KernelSmoothing_std.expout
@@ -164,3 +164,4 @@ with automatic boundaries correction, pdf(left)=0.521461 , pdf(right)=0.505805
 with user defined lower/automatic upper boundaries correction, pdf(left)=0.506608 , pdf(right)=0.505805
 with automatic lower/user defined upper boundaries correction, pdf(left)=0.521461 , pdf(right)=0.504241
 with user defined boundaries correction, pdf(left)=0.506608 , pdf(right)=0.504241
+['KernelMixture', 'Dirac']

--- a/python/test/t_KernelSmoothing_std.py
+++ b/python/test/t_KernelSmoothing_std.py
@@ -162,6 +162,10 @@ try:
     print("with user defined boundaries correction, pdf(left)=%.6g" %
           ks9.computePDF(left), ", pdf(right)=%.6g" % ks9.computePDF(right))
 
+    # n-d degenerate case
+    sample = ComposedDistribution([Arcsine(2.0, 3.0), Dirac(8.0)]).getSample(50)
+    smoothed = KernelSmoothing().build(sample)
+    print([smoothed.getMarginal(j).getName() for j in range(smoothed.getDimension())])
 except:
     import sys
     print("t_KernelSmoothing_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
When at least one component is degenerate (xmin_j==xmax_j) set Diracs and perform univariate KS on the other marginals, marginal by marginal, I dont know if its better to do the KS by blocks of contiguous marginals (we'd need a composed that allows mutivariate blocks or something)

Closes #1377

Wait, maybe this is wrong if we have correlation...