### PR TITLE
Fixed Distribution arithmetic

### DIFF
--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -160,7 +160,7 @@ Distribution DistributionImplementation::operator + (const DistributionImplement
     coll[1] = other.clone();
     RandomMixture res(coll);
     // Check if a simplification has occured
-    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0))
+    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0) && (res.getConstant()[0] == 0.0))
       return res.getDistributionCollection()[0];
     // No simplification
     return res.clone();
@@ -187,7 +187,7 @@ Distribution DistributionImplementation::operator + (const Scalar value) const
     coll[1] = Dirac(Point(1, value));
     RandomMixture res(coll);
     // Check if a simplification has occured
-    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0))
+    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0) && (res.getConstant()[0] == 0.0))
       return res.getDistributionCollection()[0];
     // No simplification
     return res.clone();
@@ -222,7 +222,7 @@ Distribution DistributionImplementation::operator - (const DistributionImplement
     coll[1] = other.clone();
     RandomMixture res(coll, weights);
     // Check if a simplification has occured
-    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0))
+    if ((res.getDistributionCollection().getSize() == 1) && (res.getWeights()(0, 0) == 1.0) && (res.getConstant()[0] == 0.0))
       return res.getDistributionCollection()[0];
     // No simplification
     return res.clone();
@@ -296,8 +296,8 @@ Distribution DistributionImplementation::operator * (const Scalar value) const
   const Collection< Distribution > coll(1, *this);
   const Point weight(1, value);
   RandomMixture res(coll, weight);
-  // If the weight has been integrated into the unique atom
-  if (res.getWeights()(0, 0) == 1.0)
+  // If the weight has been integrated into the unique atom and there is no constant
+  if ((res.getWeights()(0, 0) == 1.0) && (res.getConstant()[0] == 0.0))
     return res.getDistributionCollection()[0];
   return res.clone();
 }

--- a/lib/test/t_Distribution_arithmetic.cxx
+++ b/lib/test/t_Distribution_arithmetic.cxx
@@ -231,6 +231,12 @@ int main(int, char *[])
       fullprint << "result=" << result << std::endl;
       fullprint << "cdf(-1.0)=" << result.computeCDF(-1.0) << std::endl;
     }
+    // Bug when there is a single atom after simplification:
+    // the nonzero constants were not taken into account
+    {
+      result = Poisson(5.0) + 1.0;
+      fullprint << "result=" << result << std::endl;
+    }
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_Distribution_arithmetic.expout
+++ b/lib/test/t_Distribution_arithmetic.expout
@@ -41,3 +41,4 @@ result=class=RandomMixture name=RandomMixture distribution collection=[class=Wei
 cdf(1.0)=0.81606
 result=class=RandomMixture name=RandomMixture distribution collection=[class=WeibullMin name=WeibullMin dimension=1 beta=1 alpha=1 gamma=0,class=Exponential name=Exponential dimension=1 lambda=1 gamma=0] weights =class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=1 columns=2 values=[-1,-1] constant=class=Point name=Unnamed dimension=1 values=[0]
 cdf(-1.0)=0.735759
+result=class=RandomMixture name=RandomMixture distribution collection=[class=Poisson name=Poisson dimension=1 lambda=5] weights =class=Matrix implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[1] constant=class=Point name=Unnamed dimension=1 values=[1]

--- a/python/test/t_Distribution_arithmetic.expout
+++ b/python/test/t_Distribution_arithmetic.expout
@@ -50,3 +50,6 @@ ComposedDistribution(Normal(mu = -3, sigma = 1), Normal(mu = -3, sigma = 1), Nor
  [ 0 1 ]]))
 Normal(mu = -7, sigma = 2)
 RandomMixture(-Gamma(k = 2, lambda = 1, gamma = 0))
+RandomMixture(-Gamma(k = 2, lambda = 0.5, gamma = 0))
+RandomMixture(1 - Gamma(k = 2, lambda = 0.5, gamma = 0))
+RandomMixture(1 + Poisson(lambda = 5))

--- a/python/test/t_Distribution_arithmetic.py
+++ b/python/test/t_Distribution_arithmetic.py
@@ -181,3 +181,11 @@ print(-x)
 # simplification of sum
 x = -ot.Exponential() - ot.Exponential()
 print(x)
+
+# take into account the weight and the constant in simplification
+x = 2*(-ot.Exponential() - ot.Exponential())
+print(x)
+x = 2*(-ot.Exponential() - ot.Exponential()) + 1.0
+print(x)
+x = ot.Poisson(5.0) + 1.0
+print(x)


### PR DESCRIPTION
The simplification mechanism was wrong when the RandomMixture generated by the distribution arithmetic was reduced to a unique atom and a non-zero constant: the constant was not taken into account. As a result, eg Poisson(5.0)+1 was aqual to Poisson(5.0).