### PR TITLE
GeneralLinearModelAlgorithm: Normalize scale with inputSample

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelAlgorithm.cxx
@@ -320,10 +320,12 @@ void GeneralLinearModelAlgorithm::setCovarianceModel(const CovarianceModel & cov
   // All the computation will be done on the reduced covariance model. We keep the initial covariance model (ie the one we just built) in order to reinitialize the reduced covariance model if some flags are changed after the creation of the algorithm.
   reducedCovarianceModel_ = covarianceModel_;
   // Now, adapt the model parameters.
-  // First, check if the parameters have to be optimized. If not, remove all the active parameters.
+  // First, check if the inputSample was normalized. If so, then the scale parameter should also be normalized.
+  if(normalize_) reducedCovarianceModel_.setScale(getInputTransformation()(covarianceModel_.getScale()) + inputSample_.computeMean());
+  // Second, check if the parameters have to be optimized. If not, remove all the active parameters.
   analyticalAmplitude_ = false;
   if (!optimizeParameters_) reducedCovarianceModel_.setActiveParameter(Indices());
-  // Second, check if the amplitude parameter is unique and active
+  // Third, check if the amplitude parameter is unique and active
   else if (ResourceMap::GetAsBool("GeneralLinearModelAlgorithm-UseAnalyticalAmplitudeEstimate") && (!noise_.getSize()))
   {
     // The model has to be of dimension 1

--- a/python/src/GeneralLinearModelAlgorithm_doc.i.in
+++ b/python/src/GeneralLinearModelAlgorithm_doc.i.in
@@ -222,8 +222,7 @@ Parameters
 ----------
 transformation : :class:`~openturns.Function`
     Function that normalizes the input.
-    The input dimension should be the same as input's sample dimension, output dimension
-    should be output sample's dimension"
+    The input and output dimensions should be the same as the input sample dimension."
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1407.
Corrects the docstring of `GeneralLinearModelAlgorithm::setInputTransformation`