### PR TITLE
HMat: Save state during factorization

### DIFF
--- a/lib/src/Base/Stat/openturns/HMatrixImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/HMatrixImplementation.hxx
@@ -121,6 +121,9 @@ public:
   /** Virtual copy constructor */
   virtual HMatrixImplementation * clone() const;
 
+  /** Copy assignment operator */
+  HMatrixImplementation& operator=(const HMatrixImplementation& rhs);
+
   // Destructor
   virtual ~HMatrixImplementation();
 

--- a/python/src/HMatrixImplementation.i
+++ b/python/src/HMatrixImplementation.i
@@ -4,6 +4,8 @@
 #include "openturns/HMatrixImplementation.hxx"
 %}
 
+%ignore OT::HMatrixImplementation::operator=(const HMatrixImplementation &);
+
 %include HMatrixImplementation_doc.i
 
 %include openturns/HMatrixImplementation.hxx


### PR DESCRIPTION
We have to create a copy as the factorization can leave the matrix in a broken state and should not be reused
Introduces a 30% performance penalty on Regis testcase.

Closes #1404