### PR TITLE
Improving KrigingResult post processing methods

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingEvaluation.cxx
@@ -229,20 +229,19 @@ struct KrigingEvaluationSampleFunctor
 
   inline void operator()( const TBB::BlockedRange<UnsignedInteger> & r ) const
   {
-    const UnsignedInteger start = r.begin();
     const UnsignedInteger dimension = evaluation_.getOutputDimension();
-    const UnsignedInteger size = r.end() - start;
     Matrix R(dimension, trainingSize_ * dimension);
-    for (UnsignedInteger i = 0; i != size; ++i)
+    for (UnsignedInteger i = 0; r.begin() != r.end(); ++i)
     {
       for (UnsignedInteger j = 0; j < trainingSize_; ++j)
       {
-        const CovarianceMatrix localCovariance(evaluation_.covarianceModel_(input_[start + i], evaluation_.inputSample_[j]));
+        const CovarianceMatrix localCovariance(evaluation_.covarianceModel_(input_[i], evaluation_.inputSample_[j]));
         for (UnsignedInteger columnIndex = 0; columnIndex < dimension; ++ columnIndex)
           for (UnsignedInteger rowIndex = 0; rowIndex < dimension; ++ rowIndex)
             R(rowIndex, columnIndex + j * dimension) = localCovariance(rowIndex, columnIndex);
       }
-      output_[start + i] = R * evaluation_.gamma_.getImplementation()->getData();
+      const Point RGamma(R * evaluation_.gamma_.getImplementation()->getData());
+      for (UnsignedInteger j = 0; j < dimension; ++j)  output_(i, j) = RGamma[j];
     }
   } // operator()
 }; // struct KrigingEvaluationSampleFunctor

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -162,8 +162,11 @@ protected:
 
 private:
 
-  // Structure for evaluation of crossCovariance
+  // Structures for evaluation of crossCovariance
   friend struct KrigingResultCrossCovarianceFunctor;
+  friend struct KrigingResultCrossCovarianceFunctor1D;
+  friend struct KrigingResultCrossCovariancePointFunctor;
+  friend struct KrigingResultCrossCovariancePointFunctor1D;
 
   /** inputData should be keeped*/
   Sample inputSample_;


### PR DESCRIPTION
This PR improves significantly the `KrigingResult::getMarginalVariance`method

With this basic benchmark : 
```
from __future__ import print_function
import openturns as ot
from time import time

model = ot.SymbolicFunction(["E", "F", "L", "I"], ["F*L^3/(3*E*I)"])
# Young's modulus E
E = ot.Beta(0.9, 3.5, 2.5e7, 5.0e7)  # in N/m^2
# Load F
F = ot.LogNormal()  # in N
F.setParameter(ot.LogNormalMuSigma()([30.e3, 9e3, 15.e3]))
# Length L
L = ot.Uniform(250., 260.)  # in cm
# Moment of inertia I
I = ot.Beta(2.5, 4, 310, 450)  # in cm^4
dist = ot.ComposedDistribution([E, F, L, I])

sampleSize_train = 2000
X_train = dist.getSample(sampleSize_train)
Y_train = model(X_train)

dimension = dist.getDimension()
basis = ot.ConstantBasisFactory(dimension).build()
covarianceModel = ot.SquaredExponential([1.]*dimension, [1.0])
tic = time()
algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
algo.run()
toc = time()
result = algo.getResult()
#print("Learning time : ", (toc - tic))

ot.RandomGenerator.SetSeed(1)
X = dist.getSample(10000)

size = len(X)
tic = time()
var = result.getConditionalMarginalVariance(X)
toc = time()
print("Time for conditional variance : ", toc - tic)
print("Unit cost : ", (toc - tic)/size)
print("Global cost : ", size / (toc - tic), "evals/s")
```

The outputs are the following : 

**master**
```
Time for conditional variance :  65.2275090218
Unit cost :  0.00652275090218
Global cost :  153.309549145 evals/s
```

**This branch**
```
Time for conditional variance :  1.03553390503
Unit cost :  0.000103553390503
Global cost :  9656.85425792 evals/s
```
