### PR TITLE
KernelSmoothing: fixed solve the equation rule

### DIFF
--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -146,7 +146,7 @@ struct PluginConstraint
         if (std::abs(x) < cutOffPlugin) phi += 2.0 * hermitePolynomial_(x) * std::exp(-0.5 * x * x);
       }
     }
-    const Scalar res = phi / ((N_ * (N_ - 1.0)) * std::pow(h, order_ + 1.0) * std::sqrt(2.0 * M_PI));
+    const Scalar res = phi / ((N_ * N_) * std::pow(h, order_ + 1.0) * std::sqrt(2.0 * M_PI));
     return res;
   }
 

--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -155,8 +155,12 @@ struct PluginConstraint
   {
     const Scalar h = x[0];
     const Scalar gammaH = K_ * std::pow(h, 5.0 / 7.0);
-    const Scalar phiGammaH = computePhi(gammaH);
-    const Scalar res = h - std::pow(2.0 * std::sqrt(M_PI) * phiGammaH * N_, -1.0 / 5.0);
+    Scalar phiGammaH = computePhi(gammaH);
+    if (phiGammaH < 0.0)
+    {
+      phiGammaH = - phiGammaH;
+    }
+    Scalar res = h - std::pow(2.0 * std::sqrt(M_PI) * phiGammaH * N_, -1.0 / 5.0);
     return Point(1, res);
   }
 

--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -155,12 +155,19 @@ struct PluginConstraint
   {
     const Scalar h = x[0];
     const Scalar gammaH = K_ * std::pow(h, 5.0 / 7.0);
-    Scalar phiGammaH = computePhi(gammaH);
+    const Scalar phiGammaH = computePhi(gammaH);
+    //std::cout<<"phiGammaH="<<phiGammaH<<std::endl;
+    Scalar deltaH;
     if (phiGammaH < 0.0)
     {
-      phiGammaH = - phiGammaH;
+      deltaH = - std::pow(- 2.0 * std::sqrt(M_PI) * phiGammaH * N_, -1.0 / 5.0);
     }
-    Scalar res = h - std::pow(2.0 * std::sqrt(M_PI) * phiGammaH * N_, -1.0 / 5.0);
+    else
+    {
+      deltaH = std::pow(2.0 * std::sqrt(M_PI) * phiGammaH * N_, -1.0 / 5.0);
+    }
+    //std::cout<<"deltaH="<<deltaH<<std::endl;
+    Scalar res = h - deltaH;
     return Point(1, res);
   }
 

--- a/python/src/KernelSmoothing_doc.i.in
+++ b/python/src/KernelSmoothing_doc.i.in
@@ -314,7 +314,15 @@ bandwidth : :class:`~openturns.Point`
 Notes
 -----
 Warning! It can take a lot of time for large samples, as the cost is  quadratic with the sample size.
-"
+The `"KernelSmoothing-CutOffPlugin"` key of the `ResourceMap` controls 
+the accuracy of the approximation used to estimate the rugosity of the 
+second derivative of the distribution. 
+The default value ensures that terms in the sum which weight are lower than 
+4.e-6 are ignored, which can reduce the calculation in some situations. 
+The properties of the standard gaussian density are so that, 
+in order to make the computation exact, the value of the 
+`"KernelSmoothing-CutOffPlugin"` must be set to 39, but this may increase the 
+computation time."
 
 // ---------------------------------------------------------------------
 %feature("docstring") OT::KernelSmoothing::computeMixedBandwidth

--- a/python/src/KernelSmoothing_doc.i.in
+++ b/python/src/KernelSmoothing_doc.i.in
@@ -314,14 +314,14 @@ bandwidth : :class:`~openturns.Point`
 Notes
 -----
 Warning! It can take a lot of time for large samples, as the cost is  quadratic with the sample size.
-The `"KernelSmoothing-CutOffPlugin"` key of the `ResourceMap` controls 
+The `KernelSmoothing-CutOffPlugin` key of the :class:`~openturns.ResourceMap` controls 
 the accuracy of the approximation used to estimate the rugosity of the 
 second derivative of the distribution. 
 The default value ensures that terms in the sum which weight are lower than 
 4.e-6 are ignored, which can reduce the calculation in some situations. 
 The properties of the standard gaussian density are so that, 
 in order to make the computation exact, the value of the 
-`"KernelSmoothing-CutOffPlugin"` must be set to 39, but this may increase the 
+`KernelSmoothing-CutOffPlugin` must be set to 39, but this may increase the 
 computation time."
 
 // ---------------------------------------------------------------------

--- a/python/test/t_KernelSmoothing_std.expout
+++ b/python/test/t_KernelSmoothing_std.expout
@@ -63,104 +63,104 @@ Point=  class=Point name=Unnamed dimension=2 values=[0,0]
  cdf(exact)=0.305529
 kernel= Normal
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302853  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206603  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302612  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206809  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302853  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206603  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302613  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206809  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.340009  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0879563  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.339485  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0881108  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.538128  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0535578  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.537734  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0535113  cdf(exact)= 0.0852122
 kernel= Epanechnikov
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.31681  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0889725  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.316358  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0891311  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.521834  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0517197  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.521348  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0516684  cdf(exact)= 0.0852122
 kernel= Uniform
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302201  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208887  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.300471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.209151  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302201  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208887  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.300471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.209151  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.294133  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0899223  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.292858  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0900743  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.482377  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0508262  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.492002  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0507868  cdf(exact)= 0.0852122
 kernel= Triangular
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302701  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208091  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208301  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302701  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208091  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208301  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.334462  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0885624  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.334082  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0887189  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.53165  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0527501  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.53136  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0527026  cdf(exact)= 0.0852122
 kernel= Logistic
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.30399  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20557  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.303756  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.205753  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.305565  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206621  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.305332  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206806  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.356202  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0870209  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.35561  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.087165  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.566465  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0567284  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.566139  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0566865  cdf(exact)= 0.0852122
 kernel= Beta
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.31681  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0889725  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.316358  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0891311  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.521834  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0517197  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.521348  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0516684  cdf(exact)= 0.0852122
 kernel= Beta
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302282  pdf(exact)= 0.266085
- cdf(smoothed)=  0.207751  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302041  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.207977  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302282  pdf(exact)= 0.266085
- cdf(smoothed)=  0.207751  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302041  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.207977  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.324639  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0886618  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.324188  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0888213  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.527875  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0522554  cdf(exact)= 0.0852122
-with low  bin count, pdf=0.364924
-with high bin count, pdf=0.365144
-without   binning,   pdf=0.365145
-with no boundary correction, pdf(left)=0.37857 , pdf(right)=0.358673
-with automatic lower boundary correction, pdf(left)=0.521461 , pdf(right)=0.358673
-with user defined lower boundary correction, pdf(left)=0.506608 , pdf(right)=0.358673
-with automatic upper boundary correction, pdf(left)=0.37857 , pdf(right)=0.505805
-with user defined upper boundary correction, pdf(left)=0.37857 , pdf(right)=0.504241
-with automatic boundaries correction, pdf(left)=0.521461 , pdf(right)=0.505805
-with user defined lower/automatic upper boundaries correction, pdf(left)=0.506608 , pdf(right)=0.505805
-with automatic lower/user defined upper boundaries correction, pdf(left)=0.521461 , pdf(right)=0.504241
-with user defined boundaries correction, pdf(left)=0.506608 , pdf(right)=0.504241
+ pdf(smoothed)=  0.527484  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0522069  cdf(exact)= 0.0852122
+with low  bin count, pdf=0.364917
+with high bin count, pdf=0.365136
+without   binning,   pdf=0.365137
+with no boundary correction, pdf(left)=0.378366 , pdf(right)=0.358454
+with automatic lower boundary correction, pdf(left)=0.521446 , pdf(right)=0.358454
+with user defined lower boundary correction, pdf(left)=0.506611 , pdf(right)=0.358454
+with automatic upper boundary correction, pdf(left)=0.378366 , pdf(right)=0.50572
+with user defined upper boundary correction, pdf(left)=0.378366 , pdf(right)=0.504159
+with automatic boundaries correction, pdf(left)=0.521446 , pdf(right)=0.50572
+with user defined lower/automatic upper boundaries correction, pdf(left)=0.506611 , pdf(right)=0.50572
+with automatic lower/user defined upper boundaries correction, pdf(left)=0.521446 , pdf(right)=0.504159
+with user defined boundaries correction, pdf(left)=0.506611 , pdf(right)=0.504159

--- a/python/test/t_KernelSmoothing_std.expout
+++ b/python/test/t_KernelSmoothing_std.expout
@@ -164,3 +164,4 @@ with automatic boundaries correction, pdf(left)=0.521446 , pdf(right)=0.50572
 with user defined lower/automatic upper boundaries correction, pdf(left)=0.506611 , pdf(right)=0.50572
 with automatic lower/user defined upper boundaries correction, pdf(left)=0.521446 , pdf(right)=0.504159
 with user defined boundaries correction, pdf(left)=0.506611 , pdf(right)=0.504159
+With reduced cutoff. h=0.769339

--- a/python/test/t_KernelSmoothing_std.py
+++ b/python/test/t_KernelSmoothing_std.py
@@ -161,6 +161,16 @@ try:
     ks9 = algo9.build(sample)
     print("with user defined boundaries correction, pdf(left)=%.6g" %
           ks9.computePDF(left), ", pdf(right)=%.6g" % ks9.computePDF(right))
+    
+    # Test with reduced Cutoff - generates non positive phiGammaH
+    distribution = Normal()
+    kernel = Normal()
+    factory = KernelSmoothing(kernel)
+    ResourceMap_SetAsScalar("KernelSmoothing-CutOffPlugin", 3.0)
+    RandomGenerator.SetSeed(8457)
+    sample = distribution.getSample(30)
+    h = factory.computePluginBandwidth(sample)[0]    
+    print("With reduced cutoff. h=%.6g" % (h))
 
 except:
     import sys


### PR DESCRIPTION
* Fix the calculation of psi: the N-1 expression is wrong, because the KS estimator is an average, not a variance.
* Clarified the doc of the KernelSmoothing-CutOffPlugin parameter
* KernelSmoothing: fixed failure when phiGammaH<0. This fixes the exception which is sometimes raised when the cutoff parameter is set too low (see the unit test for reference). This bug was *not* #1515 initially, but the discussion raised this issue afterwards. The pow function can be used, but with a negated argument, which produces a negative output, as expected.

Work in progress.