### PR TITLE
Fix KernelSmoothing::computeMixedBandwidth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,9 +30,9 @@
  * #1474 (optimization defaults)
  * #1507 (Leak in Collection typemaps)
  * #1510 (ot.Ceres('LEVENBERG_MARQUARDT') and ot.Ceres('DOGLEG') do not handle bound constraints)
+ * #1515 (KernelSmoothing build failure)
  * #1520 (The NLopt test is dubious)
  * #1521 (Basis of MonomialFunction)
-
 
 == 1.15 release (2020-05-25) == #release-1.15
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -973,7 +973,7 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("KernelMixture-SmallSize", 50);
 
   // KernelSmoothing parameters //
-  addAsScalar("KernelSmoothing-AbsolutePrecision", 0.0);
+  addAsScalar("KernelSmoothing-AbsolutePrecision", 1.0e-5);
   addAsScalar("KernelSmoothing-CutOffPlugin", 5.0);
   addAsScalar("KernelSmoothing-RelativePrecision", 1.0e-5);
   addAsScalar("KernelSmoothing-ResidualPrecision", 1.0e-10);

--- a/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
+++ b/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
@@ -1135,6 +1135,33 @@ UnsignedInteger SpecFunc::NextPowerOfTwo(const UnsignedInteger n)
   return powerOfTwo;
 }
 
+// Integer power
+Scalar SpecFunc::IPow(const Scalar x, const SignedInteger n)
+{
+  if (n == 0) return 1.0;
+  if (x == 0) return 0.0;
+  if (x < 0.0)
+    {
+      if (n % 2) return -std::pow(-x, 1.0 * n);
+      return std::pow(-x, 1.0 * n);
+    }
+  return std::pow(x, 1.0 * n);
+}
+  
+// Integer root
+Scalar SpecFunc::IRoot(const Scalar x, const SignedInteger n)
+{
+  if (n == 0) throw InvalidArgumentException(HERE) << "Cannot take the zeroth root of anything!";
+  if (x == 0) return 0.0;
+  if (x < 0.0)
+    {
+      if (n % 2 == 0) throw InvalidArgumentException(HERE) << "Cannot take an even root of a negative number";
+      return -std::pow(-x, 1.0 / n);
+    }
+  return std::pow(x, 1.0 / n);
+}
+  
+
 // Compute the number of bits sets to 1 in n
 // Best known algorithm for 64 bits n and fast multiply
 UnsignedInteger SpecFunc::BitCount(const Unsigned64BitsInteger n)

--- a/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
+++ b/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
@@ -272,6 +272,12 @@ public:
   // Next power of two
   static UnsignedInteger NextPowerOfTwo(const UnsignedInteger n);
 
+  // Integer power
+  static Scalar IPow(const Scalar x, const SignedInteger n);
+  
+  // Integer root
+  static Scalar IRoot(const Scalar x, const SignedInteger n);
+  
   // Integer log2
   static UnsignedInteger Log2(const Unsigned64BitsInteger n);
 

--- a/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/KPermutationsDistribution.cxx
@@ -116,7 +116,7 @@ Point KPermutationsDistribution::getRealization() const
   buffer.fill();
   for (UnsignedInteger i = 0; i < k_; ++i)
   {
-    UnsignedInteger index = i + RandomGenerator::IntegerGenerate(n_ - i);
+    const UnsignedInteger index = i + RandomGenerator::IntegerGenerate(n_ - i);
     realization[i] = buffer[index];
     buffer[index] = buffer[i];
   }

--- a/lib/test/t_KernelSmoothing_std.expout
+++ b/lib/test/t_KernelSmoothing_std.expout
@@ -48,119 +48,119 @@ Point= class=Point name=Unnamed dimension=2 values=[0,0]
  pdf(smoothed)= 0.0259139 pdf(exact)=0.0280502
  cdf(smoothed)= 0.27195 cdf(exact)=0.305529
 kernel=Normal
-Silverman's bandwidth=0.304667 plugin bandwidth=0.301536 mixed bandwidth=0.296607
+Silverman's bandwidth=0.304667 plugin bandwidth=0.301909 mixed bandwidth=0.309347
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.271227 pdf(exact)=0.266085
- cdf(smoothed)= 0.208052 cdf(exact)=0.18406
+ pdf(smoothed)= 0.27117 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208764 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.271227 pdf(exact)=0.266085
- cdf(smoothed)= 0.208052 cdf(exact)=0.18406
-Silverman's bandwidth=0.390286 plugin bandwidth=0.14183 mixed bandwidth=0.146186
+ pdf(smoothed)= 0.27117 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208764 cdf(exact)=0.18406
+Silverman's bandwidth=0.390286 plugin bandwidth=0.142064 mixed bandwidth=0.134005
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.458803 pdf(exact)=0.597681
- cdf(smoothed)= 0.0829312 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.476984 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0815684 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.640951 pdf(exact)=0.597681
- cdf(smoothed)= 0.0662669 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.649528 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0674756 cdf(exact)=0.0852122
 kernel=Epanechnikov
-Silverman's bandwidth=0.681257 plugin bandwidth=0.674254 mixed bandwidth=0.663233
+Silverman's bandwidth=0.681257 plugin bandwidth=0.675088 mixed bandwidth=0.69172
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.27125 pdf(exact)=0.266085
- cdf(smoothed)= 0.208384 cdf(exact)=0.18406
+ pdf(smoothed)= 0.269316 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209072 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.27125 pdf(exact)=0.266085
- cdf(smoothed)= 0.208384 cdf(exact)=0.18406
-Silverman's bandwidth=0.872707 plugin bandwidth=0.317142 mixed bandwidth=0.326883
+ pdf(smoothed)= 0.269316 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209072 cdf(exact)=0.18406
+Silverman's bandwidth=0.872707 plugin bandwidth=0.317664 mixed bandwidth=0.299644
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.437164 pdf(exact)=0.597681
- cdf(smoothed)= 0.0831747 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.453932 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0815102 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.640392 pdf(exact)=0.597681
- cdf(smoothed)= 0.0651184 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.650015 pdf(exact)=0.597681
+ cdf(smoothed)= 0.06633 cdf(exact)=0.0852122
 kernel=Uniform
-Silverman's bandwidth=0.527699 plugin bandwidth=0.522275 mixed bandwidth=0.513738
+Silverman's bandwidth=0.527699 plugin bandwidth=0.522921 mixed bandwidth=0.535804
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.282245 pdf(exact)=0.266085
- cdf(smoothed)= 0.208734 cdf(exact)=0.18406
+ pdf(smoothed)= 0.279953 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209476 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.282245 pdf(exact)=0.266085
- cdf(smoothed)= 0.208734 cdf(exact)=0.18406
-Silverman's bandwidth=0.675996 plugin bandwidth=0.245657 mixed bandwidth=0.253202
+ pdf(smoothed)= 0.279953 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209476 cdf(exact)=0.18406
+Silverman's bandwidth=0.675996 plugin bandwidth=0.246062 mixed bandwidth=0.232103
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.414688 pdf(exact)=0.597681
- cdf(smoothed)= 0.0829579 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.430843 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0812628 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.645071 pdf(exact)=0.597681
- cdf(smoothed)= 0.0642517 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.639084 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0655462 cdf(exact)=0.0852122
 kernel=Triangular
-Silverman's bandwidth=0.746279 plugin bandwidth=0.738609 mixed bandwidth=0.726535
+Silverman's bandwidth=0.746279 plugin bandwidth=0.739522 mixed bandwidth=0.757741
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.267673 pdf(exact)=0.266085
- cdf(smoothed)= 0.208251 cdf(exact)=0.18406
+ pdf(smoothed)= 0.267499 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208906 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.267673 pdf(exact)=0.266085
- cdf(smoothed)= 0.208251 cdf(exact)=0.18406
-Silverman's bandwidth=0.956002 plugin bandwidth=0.347412 mixed bandwidth=0.358082
+ pdf(smoothed)= 0.267499 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208906 cdf(exact)=0.18406
+Silverman's bandwidth=0.956002 plugin bandwidth=0.347984 mixed bandwidth=0.328243
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.447781 pdf(exact)=0.597681
- cdf(smoothed)= 0.0833693 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.465231 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0818188 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.637093 pdf(exact)=0.597681
- cdf(smoothed)= 0.0657848 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.646259 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0669392 cdf(exact)=0.0852122
 kernel=Logistic
-Silverman's bandwidth=0.167972 plugin bandwidth=0.166245 mixed bandwidth=0.163528
+Silverman's bandwidth=0.167972 plugin bandwidth=0.166451 mixed bandwidth=0.170552
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.270018 pdf(exact)=0.266085
- cdf(smoothed)= 0.207968 cdf(exact)=0.18406
+ pdf(smoothed)= 0.270181 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208669 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.270025 pdf(exact)=0.266085
- cdf(smoothed)= 0.207973 cdf(exact)=0.18406
-Silverman's bandwidth=0.215176 plugin bandwidth=0.0781951 mixed bandwidth=0.0805968
+ pdf(smoothed)= 0.27019 pdf(exact)=0.266085
+ cdf(smoothed)= 0.208676 cdf(exact)=0.18406
+Silverman's bandwidth=0.215176 plugin bandwidth=0.0783239 mixed bandwidth=0.0738807
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.476832 pdf(exact)=0.597681
- cdf(smoothed)= 0.0826949 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.494151 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0814931 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.643347 pdf(exact)=0.597681
- cdf(smoothed)= 0.0671709 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.650281 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0683098 cdf(exact)=0.0852122
 kernel=Beta
-Silverman's bandwidth=0.681257 plugin bandwidth=0.674254 mixed bandwidth=0.663233
+Silverman's bandwidth=0.681257 plugin bandwidth=0.675088 mixed bandwidth=0.69172
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.27125 pdf(exact)=0.266085
- cdf(smoothed)= 0.208384 cdf(exact)=0.18406
+ pdf(smoothed)= 0.269316 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209072 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.27125 pdf(exact)=0.266085
- cdf(smoothed)= 0.208384 cdf(exact)=0.18406
-Silverman's bandwidth=0.872707 plugin bandwidth=0.317142 mixed bandwidth=0.326883
+ pdf(smoothed)= 0.269316 pdf(exact)=0.266085
+ cdf(smoothed)= 0.209072 cdf(exact)=0.18406
+Silverman's bandwidth=0.872707 plugin bandwidth=0.317664 mixed bandwidth=0.299644
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.437164 pdf(exact)=0.597681
- cdf(smoothed)= 0.0831747 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.453932 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0815102 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.640392 pdf(exact)=0.597681
- cdf(smoothed)= 0.0651184 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.650015 pdf(exact)=0.597681
+ cdf(smoothed)= 0.06633 cdf(exact)=0.0852122
 kernel=Beta
-Silverman's bandwidth=0.806074 plugin bandwidth=0.797789 mixed bandwidth=0.784747
+Silverman's bandwidth=0.806074 plugin bandwidth=0.798775 mixed bandwidth=0.818454
 Bounded underlying distribution? False bounded reconstruction? False
- pdf(smoothed)= 0.270706 pdf(exact)=0.266085
- cdf(smoothed)= 0.208212 cdf(exact)=0.18406
+ pdf(smoothed)= 0.270208 pdf(exact)=0.266085
+ cdf(smoothed)= 0.2089 cdf(exact)=0.18406
 Bounded underlying distribution? False bounded reconstruction? True
- pdf(smoothed)= 0.270706 pdf(exact)=0.266085
- cdf(smoothed)= 0.208212 cdf(exact)=0.18406
-Silverman's bandwidth=1.0326 plugin bandwidth=0.375247 mixed bandwidth=0.386773
+ pdf(smoothed)= 0.270208 pdf(exact)=0.266085
+ cdf(smoothed)= 0.2089 cdf(exact)=0.18406
+Silverman's bandwidth=1.0326 plugin bandwidth=0.375865 mixed bandwidth=0.354543
 Bounded underlying distribution? True bounded reconstruction? False
- pdf(smoothed)= 0.443128 pdf(exact)=0.597681
- cdf(smoothed)= 0.0831543 cdf(exact)=0.0852122
+ pdf(smoothed)= 0.461496 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0815888 cdf(exact)=0.0852122
 Bounded underlying distribution? True bounded reconstruction? True
- pdf(smoothed)= 0.6398 pdf(exact)=0.597681
- cdf(smoothed)= 0.0654913 cdf(exact)=0.0852122
-with low  bin count, pdf=0.36692
-with high bin count, pdf=0.367185
-without   binning,   pdf=0.367185
-with no boundary correction, pdf(left)=0.417639, pdf(right)=0.379506
-with automatic lower boundary correction, pdf(left)=0.543167, pdf(right)=0.379506
-with user defined lower boundary correction, pdf(left)=0.534492, pdf(right)=0.379506
-with automatic upper boundary correction, pdf(left)=0.417639, pdf(right)=0.496837
-with user defined upper boundary correction, pdf(left)=0.417639, pdf(right)=0.496327
-with automatic boundaries correction, pdf(left)=0.543167, pdf(right)=0.496837
-with user defined lower/automatic upper boundaries correction, pdf(left)=0.534492, pdf(right)=0.496837
-with automatic lower/user defined upper boundaries correction, pdf(left)=0.543167, pdf(right)=0.496327
-with user defined boundaries correction, pdf(left)=0.534492, pdf(right)=0.496327
+ pdf(smoothed)= 0.649516 pdf(exact)=0.597681
+ cdf(smoothed)= 0.0667001 cdf(exact)=0.0852122
+with low  bin count, pdf=0.367047
+with high bin count, pdf=0.367323
+without   binning,   pdf=0.367323
+with no boundary correction, pdf(left)=0.412509, pdf(right)=0.374884
+with automatic lower boundary correction, pdf(left)=0.542562, pdf(right)=0.374884
+with user defined lower boundary correction, pdf(left)=0.534048, pdf(right)=0.374884
+with automatic upper boundary correction, pdf(left)=0.412509, pdf(right)=0.496313
+with user defined upper boundary correction, pdf(left)=0.412509, pdf(right)=0.495816
+with automatic boundaries correction, pdf(left)=0.542562, pdf(right)=0.496313
+with user defined lower/automatic upper boundaries correction, pdf(left)=0.534048, pdf(right)=0.496313
+with automatic lower/user defined upper boundaries correction, pdf(left)=0.542562, pdf(right)=0.495816
+with user defined boundaries correction, pdf(left)=0.534048, pdf(right)=0.495816

--- a/lib/test/t_NLopt_std.cxx
+++ b/lib/test/t_NLopt_std.cxx
@@ -41,7 +41,7 @@ int main(int, char *[])
     Description formula(1, "1+100*(x2-x1^2)^2+(1-x1)^2");
 
     SymbolicFunction f(inVars, formula);
-
+    Function g(SymbolicFunction(inVars, Description(1, "-1.0")) * f);
     UnsignedInteger dim = f.getInputDimension();
     Point startingPoint(dim, 1e-3);
 
@@ -63,7 +63,7 @@ int main(int, char *[])
           || (algoNames[i] == "AUGLAG_EQ"))
       {
         fullprint << "-- Skipped: algo=" << algoNames[i] << std::endl;
-        continue;
+        //        continue;
       }
 
       NLopt algo(algoNames[i]);
@@ -75,6 +75,8 @@ int main(int, char *[])
               if (!minimization && !bound)
                   continue;
               OptimizationProblem problem(f);
+              if (!inequality && !bound)
+                problem = OptimizationProblem(g);
               problem.setMinimization(minimization == 1);
               if (inequality)
                 // x1^2+x2^2 <= 1

--- a/python/src/SpecFunc_doc.i.in
+++ b/python/src/SpecFunc_doc.i.in
@@ -958,6 +958,54 @@ result : float"
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::SpecFunc::IPow
+"Raise the given :math:`x` to the integral power :math:`n`.
+
+.. math::
+
+    IPow(x, n) = x^n
+
+Parameters
+----------
+n : int
+x : float
+
+Returns
+-------
+result : foat
+
+Examples
+--------
+>>> import openturns as ot
+>>> ot.SpecFunc.IPow(-2.5, 3)
+-15.625"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::SpecFunc::IRoot
+"Extract the :math:`n` integral root of the given :math:`x`.
+
+.. math::
+
+    IRoot(x, n) = \sqrt[n]{x}
+
+Parameters
+----------
+n : int
+x : float
+
+Returns
+-------
+result : foat
+
+Examples
+--------
+>>> import openturns as ot
+>>> ot.SpecFunc.IRoot(-15.625, 3)
+-2.5"
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::SpecFunc::NextPowerOfTwo
 "Smallest power of two greater or equal to the given :math:`n`.
 

--- a/python/test/t_KernelSmoothing_std.expout
+++ b/python/test/t_KernelSmoothing_std.expout
@@ -63,107 +63,107 @@ Point=  class=Point name=Unnamed dimension=2 values=[0,0]
  cdf(exact)=0.305529
 kernel= Normal
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302853  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206603  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302612  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206809  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302853  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206603  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302613  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206809  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.340009  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0879563  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.339485  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0881108  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.538128  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0535578  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.537734  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0535113  cdf(exact)= 0.0852122
 kernel= Epanechnikov
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.31681  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0889725  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.316358  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0891311  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.521834  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0517197  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.521348  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0516684  cdf(exact)= 0.0852122
 kernel= Uniform
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302201  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208887  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.300471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.209151  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302201  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208887  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.300471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.209151  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.294133  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0899223  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.292858  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0900743  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.482377  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0508262  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.492002  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0507868  cdf(exact)= 0.0852122
 kernel= Triangular
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302701  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208091  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208301  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302701  pdf(exact)= 0.266085
- cdf(smoothed)=  0.208091  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302471  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208301  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.334462  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0885624  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.334082  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0887189  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.53165  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0527501  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.53136  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0527026  cdf(exact)= 0.0852122
 kernel= Logistic
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.30399  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20557  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.303756  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.205753  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.305565  pdf(exact)= 0.266085
- cdf(smoothed)=  0.206621  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.305332  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.206806  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.356202  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0870209  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.35561  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.087165  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.566465  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0567284  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.566139  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0566865  cdf(exact)= 0.0852122
 kernel= Beta
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302584  pdf(exact)= 0.266085
- cdf(smoothed)=  0.20833  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302157  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.208576  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.31681  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0889725  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.316358  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0891311  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.521834  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0517197  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.521348  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0516684  cdf(exact)= 0.0852122
 kernel= Beta
 Bounded underlying distribution?  False  bounded reconstruction?  False
- pdf(smoothed)=  0.302282  pdf(exact)= 0.266085
- cdf(smoothed)=  0.207751  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302041  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.207977  cdf(exact)= 0.18406
 Bounded underlying distribution?  False  bounded reconstruction?  True
- pdf(smoothed)=  0.302282  pdf(exact)= 0.266085
- cdf(smoothed)=  0.207751  cdf(exact)= 0.18406
+ pdf(smoothed)=  0.302041  pdf(exact)= 0.266085
+ cdf(smoothed)=  0.207977  cdf(exact)= 0.18406
 Bounded underlying distribution?  True  bounded reconstruction?  False
- pdf(smoothed)=  0.324639  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0886618  cdf(exact)= 0.0852122
+ pdf(smoothed)=  0.324188  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0888213  cdf(exact)= 0.0852122
 Bounded underlying distribution?  True  bounded reconstruction?  True
- pdf(smoothed)=  0.527875  pdf(exact)= 0.597681
- cdf(smoothed)=  0.0522554  cdf(exact)= 0.0852122
-with low  bin count, pdf=0.364924
-with high bin count, pdf=0.365144
-without   binning,   pdf=0.365145
-with no boundary correction, pdf(left)=0.37857 , pdf(right)=0.358673
-with automatic lower boundary correction, pdf(left)=0.521461 , pdf(right)=0.358673
-with user defined lower boundary correction, pdf(left)=0.506608 , pdf(right)=0.358673
-with automatic upper boundary correction, pdf(left)=0.37857 , pdf(right)=0.505805
-with user defined upper boundary correction, pdf(left)=0.37857 , pdf(right)=0.504241
-with automatic boundaries correction, pdf(left)=0.521461 , pdf(right)=0.505805
-with user defined lower/automatic upper boundaries correction, pdf(left)=0.506608 , pdf(right)=0.505805
-with automatic lower/user defined upper boundaries correction, pdf(left)=0.521461 , pdf(right)=0.504241
-with user defined boundaries correction, pdf(left)=0.506608 , pdf(right)=0.504241
+ pdf(smoothed)=  0.527484  pdf(exact)= 0.597681
+ cdf(smoothed)=  0.0522069  cdf(exact)= 0.0852122
+with low  bin count, pdf=0.365181
+with high bin count, pdf=0.365423
+without   binning,   pdf=0.365424
+with no boundary correction, pdf(left)=0.38087 , pdf(right)=0.361147
+with automatic lower boundary correction, pdf(left)=0.521626 , pdf(right)=0.361147
+with user defined lower boundary correction, pdf(left)=0.506571 , pdf(right)=0.361147
+with automatic upper boundary correction, pdf(left)=0.38087 , pdf(right)=0.506744
+with user defined upper boundary correction, pdf(left)=0.38087 , pdf(right)=0.505152
+with automatic boundaries correction, pdf(left)=0.521626 , pdf(right)=0.506744
+with user defined lower/automatic upper boundaries correction, pdf(left)=0.506571 , pdf(right)=0.506744
+with automatic lower/user defined upper boundaries correction, pdf(left)=0.521626 , pdf(right)=0.505152
+with user defined boundaries correction, pdf(left)=0.506571 , pdf(right)=0.505152
 0 : [ -7  0  8 ]
 1 : [ -7  0  8 ]
 2 : [ -7  0  8 ]


### PR DESCRIPTION
This PR provides the following improvements:
+ the SpecFunc::IPow() and SpecFunc::IRoot() methods to compute the nth power or nth root of a scalar of arbitrary sign (n being a signed integer)
+ a better selection of a subsample to compute the mixed bandwidth in KernelSmoothing, based on a quasi-random selection of the sub-sample
+ the correct extraction of nth root for negative intermediate values
+ a better default choice for the precision at which the plugin constraint is solved (the comment says "loosely solved" in the C++ code, but the default value was 0 for the absolute precision)
Feel free to cherry-pick things in this PR to improve PR #1509 or PR #1517.