### PR TITLE
Fix loglikelihood bug in RandomWalkMetropolisHastings

### DIFF
--- a/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
+++ b/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
@@ -85,6 +85,7 @@ const Scalar SpecFunc::MinScalar    = std::numeric_limits<Scalar>::min();
 const Scalar SpecFunc::LogMinScalar = log(MinScalar);
 const Scalar SpecFunc::MaxScalar    = std::numeric_limits<Scalar>::max();
 const Scalar SpecFunc::LogMaxScalar = log(MaxScalar);
+const Scalar SpecFunc::Infinity     = std::numeric_limits<Scalar>::infinity();
 const Scalar SpecFunc::ScalarEpsilon = std::numeric_limits<Scalar>::epsilon();
 // Maximum number of iterations for the algorithms
 const UnsignedInteger SpecFunc::MaximumIteration = ResourceMap::GetAsUnsignedInteger("SpecFunc-MaximumIteration");

--- a/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
+++ b/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
@@ -104,6 +104,8 @@ public:
   // Maximum positive real number
   static const Scalar MaxScalar;
   static const Scalar LogMaxScalar;
+  // Infinity
+  static const Scalar Infinity;
   // Real number accuracy
   static const Scalar ScalarEpsilon;
 

--- a/lib/src/Uncertainty/Bayesian/MCMC.cxx
+++ b/lib/src/Uncertainty/Bayesian/MCMC.cxx
@@ -128,11 +128,13 @@ UnsignedInteger MCMC::getDimension() const
 }
 
 
-/* Compute the likelihood w.r.t. observations */
+/* Compute the product of the prior and of the likelihood w.r.t. observations */
 Scalar MCMC::computeLogLikelihood(const Point & xi) const
 {
   Scalar value = prior_.computeLogPDF(xi);
-  if (value == SpecFunc::LogMinScalar) return SpecFunc::LogMinScalar;
+  /* If the logarithm of the prior density takes the minimal admissible value,
+  then set the  logarithm of the posterior density to - infinity. */
+  if (value == SpecFunc::LogMinScalar) return - SpecFunc::Infinity;
 
   const UnsignedInteger size = observations_.getSize();
   for (UnsignedInteger i = 0; i < size; ++ i)
@@ -144,7 +146,11 @@ Scalar MCMC::computeLogLikelihood(const Point & xi) const
     Distribution pI(conditional_);
     pI.setParameter(zi);
     Scalar logPdf = pI.computeLogPDF(observations_[i]);
-    if (logPdf == SpecFunc::LogMinScalar) return SpecFunc::LogMinScalar;
+
+  /* If the logPDF takes the minimal admissible value,
+  then set the  logarithm of the posterior density to - infinity. */
+    if (logPdf == SpecFunc::LogMinScalar) return - SpecFunc::Infinity;
+
     value += logPdf;
   }
   return value;

--- a/lib/src/Uncertainty/Bayesian/RandomWalkMetropolisHastings.cxx
+++ b/lib/src/Uncertainty/Bayesian/RandomWalkMetropolisHastings.cxx
@@ -117,8 +117,6 @@ Point RandomWalkMetropolisHastings::getRealization() const
   if (samplesNumber_ == 0)
   {
     currentLogLikelihood_ = computeLogLikelihood(currentState_);
-    if (currentLogLikelihood_ <= SpecFunc::LogMinScalar)
-      throw InvalidArgumentException(HERE) << "The likelihood of the initial state should be positive";
   }
 
   // for each new sample
@@ -158,10 +156,6 @@ Point RandomWalkMetropolisHastings::getRealization() const
       const Scalar uLog = log(RandomGenerator::Generate());
       if (nonRejectedComponent || (uLog < alphaLog))
       {
-        // the likelihood can be 0 wrt the observations because of a non-rejected component (always ok wrt prior)
-        if (nextLogLikelihood == SpecFunc::LogMinScalar)
-          throw InternalException(HERE) << "Cannot update the (non-accepted) component #" << j << " with null likelihood wrt observations";
-
         logLikelihoodCandidate = nextLogLikelihood;
         ++ acceptedNumber_[j];
         ++ accepted[j];

--- a/lib/src/Uncertainty/Bayesian/openturns/MCMC.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/MCMC.hxx
@@ -68,7 +68,7 @@ public:
   /** String converter */
   virtual String __repr__() const;
 
-  /** Compute the likelihood w.r.t. observartions */
+  /** Compute the product of the prior and of the likelihood w.r.t. observations */
   Scalar computeLogLikelihood(const Point & currentState) const;
 
   /** Prior accessor */


### PR DESCRIPTION
This PR addresses a bug reported on [Gitter by Merlin Keller](https://gitter.im/openturns/community?at=5ef0b8adfa0c9221fc5330f1) that concerns [RandomWalkMetropolisHastings::getRealization()](https://github.com/openturns/openturns/blob/f637c8b169f3dab8e1e20ca1c99540d570b29f4f/lib/src/Uncertainty/Bayesian/RandomWalkMetropolisHastings.cxx#L103).

It is due to an arbitrary lower bound on the log-likelihood that is enforced by the ``getRealization()`` method: [SpecFunc::LogMinScalar](https://github.com/openturns/openturns/blob/f637c8b169f3dab8e1e20ca1c99540d570b29f4f/lib/src/Base/Func/SpecFunc/SpecFunc.cxx#L85)

As the likelihood (which is the product of the PDF at all observation points) decreases with the number of observation points, it does not make sense to set an arbitrary lower bound on the log-likelihood.
 
The first commit in this PR implements the fix [proposed by Merlin Keller](https://gitter.im/openturns/community?at=5ef5be37ec4a341beeeda92e) to answer @jschueller who remarks that some lower bound on the likelihood must be enforced in order to prevent zeros propagating. The lower bound is already enforced in [MCMC::computeLogLikelihood()](https://github.com/openturns/openturns/blob/f637c8b169f3dab8e1e20ca1c99540d570b29f4f/lib/src/Uncertainty/Bayesian/MCMC.cxx#L132) at the individual observation level, so there is no need to enforce it again in ``RandomWalkMetropolisHastings::getRealization()``. The single commit in the PR removes this redundancy and thus the implicit constraint on the number of observations. 

The following script produces an error with the master branch but runs just fine with the fix. Note that [MCMC::computeLogLikelihood()](https://github.com/openturns/openturns/blob/f637c8b169f3dab8e1e20ca1c99540d570b29f4f/lib/src/Uncertainty/Bayesian/MCMC.cxx#L132) does not actually compute the log-likelihood, but the log-likelihood  plus the logarithm of the prior density (penalized log-likelihood)

```
import openturns as ot

fullModel = ot.SymbolicFunction(['x', 'theta'], ['theta', '1.0'])
model = ot.ParametricFunction(fullModel, [0], [1.0])

prior = ot.Normal(0.0, 1.0)
prior.setDescription(['theta'])
proposal = [ot.Normal(0.0, 1.0)]

thetaTrue = [2.0]

# We choose the most favorable initial state: the true parameter value.
initialState = thetaTrue

conditional = ot.Normal() # the log-likelihood is Gaussian

# 503 observations: OK
obsSize = 503
ot.RandomGenerator.SetSeed(0)
y_obs = ot.Normal(thetaTrue[0], 1.0).getSample(obsSize)

RWMHsampler = ot.RandomWalkMetropolisHastings(prior, conditional, model, y_obs, y_obs, initialState, proposal)
print("Penalized log-likelihood of thetaTrue = {!r}".format(RWMHsampler.computeLogLikelihood(thetaTrue)))
real_503 = RWMHsampler.getRealization()
print("With 503 observations, getRealization() produces {!r}".format(real_503[0]))

#504 observations: not OK
obsSize = 504
ot.RandomGenerator.SetSeed(0)
y_obs = ot.Normal(thetaTrue[0], 1.0).getSample(obsSize)

RWMHsampler = ot.RandomWalkMetropolisHastings(prior, conditional, model, y_obs, y_obs, initialState, proposal)
print("Penalized log-likelihood of thetaTrue = {!r}".format(RWMHsampler.computeLogLikelihood(thetaTrue)))
real_504 = RWMHsampler.getRealization() #produces an error with current master branch
print("With 504 observations, getRealization() produces {!r}".format(real_504[0]))
```
With the current master, the output is:
```
Penalized log-likelihood of thetaTrue = -708.2968891987429
With 503 observations, getRealization() produces 2.0
Penalized log-likelihood of thetaTrue = -709.26477360595

############################################
########## Some irrelevant stuff ###########
############################################

  File "/home/osboxes/GIT/openturns/build-spherical/install/lib/python3.7/site-packages/openturns/bayesian.py", line 2897, in getRealization
    return _bayesian.RandomWalkMetropolisHastings_getRealization(self)

TypeError: InvalidArgumentException : The likelihood of the initial state should be positive
```
Regarding the error message: recall that the initial state is actually the true value of the parameter! With 504 observations, the true value of the parameter yields a penalized log-likelihood lower than ``SpecFunc::LogMinScalar``, which is ``-708.3964185322641``.

With the fix, the output is:
```
Penalized log-likelihood of thetaTrue = -708.2968891987429
With 503 observations, getRealization() produces 2.0
Penalized log-likelihood of thetaTrue = -709.26477360595
With 504 observations, getRealization() produces 2.0
```