### PR TITLE
Fix numpy broadcasting error in example

### DIFF
--- a/python/doc/examples/meta_modeling/kriging_advanced.ipynb
+++ b/python/doc/examples/meta_modeling/kriging_advanced.ipynb
@@ -268,8 +268,8 @@
    "source": [
     "level = 0.95\n",
     "quantile = ot.Normal().computeQuantile((1-level)/2)[0]\n",
-    "borne_sup = np.hstack(krigingMeta(x_plot)) + quantile * np.sqrt(variance)\n",
-    "borne_inf = np.hstack(krigingMeta(x_plot)) - quantile * np.sqrt(variance)\n",
+    "borne_sup = krigingMeta(x_plot) + quantile * np.sqrt(variance)\n",
+    "borne_inf = krigingMeta(x_plot) - quantile * np.sqrt(variance)\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(8, 8))\n",
     "ax.plot(x, y, ('ro'))\n",


### PR DESCRIPTION
In the [Advanced Kriging](https://github.com/josephmure/openturns/blob/master/python/doc/examples/meta_modeling/kriging_advanced.ipynb) example (cell 8), in order to draw confidence intervals, Samples are converted to numpy arrays of shape (1000,) with the `np.hstack` command and then added to a numpy array with shape (1,1000). The resulting array has shape (1000,1000). This is not the desired behavior.
It turns out that this conversion is useless, because the sum of a Sample with size 1000 and dimension 1 and of a numpy array with shape (1,1000) is a Sample with size 1000 and dimension 1 which can be drawn by matplotlib.