### PR TITLE
Correct UserDefinedStationaryCovarianceModel doc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,7 @@
  * #1259 (The diagonal of a scatter plot matrix should have the histograms)
  * #1267 (Some CSV files cannot be imported)
  * #1377 (The `setKnownParameter` method is not compatible with `buildEstimator`)
+ * #1421 (UserDefinedStationaryCovarianceModel doc suggests input dimension can be >1)
  * #1447 (Highly inaccurate result in reliability model when using subset of RandomVector)
  * #1465 (The Sample constructor based on a list and an integer should not exist)
  * #1474 (optimization defaults)

--- a/python/doc/examples/probabilistic_modeling/user_stationary_covmodel.ipynb
+++ b/python/doc/examples/probabilistic_modeling/user_stationary_covmodel.ipynb
@@ -13,14 +13,14 @@
    "source": [
     "This use case illustrates how the user can define his own stationary covariance model thanks to the object *UserDefinedStationaryCovarianceModel* defined from:\n",
     "\n",
-    "- a mesh $\\mathcal{M}$ of dimension $n$ defined by the vertices $(\\underline{\\tau}_0,\\dots, \\underline{\\tau}_{N-1})$ and the associated simplices,\n",
-    "- a collection of covariance matrices stored in the object *CovarianceMatrixCollection* noted $\\underline{\\underline{C}}_0, \\dots, \\underline{\\underline{C}}_{N-1}$ where $\\underline{\\underline{C}}_k$ $\\in \\mathcal{M}_{d \\times d}(\\mathbb{R})$ for $0 \\leq k \\leq N-1$\n",
+    "- a time series $\\mathcal{M} = \\{\\tau_0,\\dots, \\tau_{N-1}\\}$ represented by a *RegularGrid*,\n",
+    "- a collection of covariance matrices stored in the object *CovarianceMatrixCollection* noted $\\underline{\\underline{C}}_0, \\dots, \\underline{\\underline{C}}_{N-1}$ where $\\underline{\\underline{C}}_k$ $\\in \\mathcal{M}_{d \\times d}(\\mathbb{R})$ for $0 \\leq k \\leq N-1$.\n",
     "\n",
     "Then we build a stationary covariance function which is a piecewise constant function on $\\mathcal{D}$ defined by:\n",
     "\n",
-    "$$\\forall \\underline{\\tau} \\in \\mathcal{D}, \\, C^{stat}(\\underline{\\tau}) =  \\underline{\\underline{C}}_k$$\n",
+    "$$\\forall t \\in \\mathcal{D}, \\, C^{stat}(t) =  \\underline{\\underline{C}}_k$$\n",
     "\n",
-    "where $k$  is such that $\\underline{\\tau}_k$ is the  vertex of $\\mathcal{M}$ the nearest to $\\underline{t}.$"
+    "where $k$ is such that $\\tau_k$ is the nearest point of $\\mathcal{M}$ to $t$."
    ]
   },
   {

--- a/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
+++ b/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
@@ -12,7 +12,7 @@ Notes
 -----
 The covariance model is built as follows.
 
-We consider a process :math:`X: \Omega \times\cD \mapsto \Rset^d` with :math:`\cD \in \Rset^n`. 
+We consider a process :math:`X: \Omega \times\cD \mapsto \Rset^d` with :math:`\cD \in \Rset`. 
 
 We note :math:`(\vect{t}_0,\dots, \vect{t}_{N-1})` the vertices of :math:`\cM \in \cD` and :math:`(\mat{C}_{k})_{0 \leq  k \leq N-1}` where :math:`\mat{C}_{k} \in \cS_d^+(\Rset)` the collection of covariance matrices fixed by the User.
 


### PR DESCRIPTION
UserDefinedStationaryCovarianceModel takes a RegularGrid as input, so the input space must be of dimension n=1.
Correct API doc and example notebook.
Closes #1421.