### PR TITLE
Document how to turn warnings off and other changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,8 +25,8 @@
  * Deprecated SORMResult::getEventProbabilityHohenBichler, use SORMResult::getEventProbabilityHohenbichler instead
  * Deprecated SORMResult::getGeneralisedReliabilityIndexHohenBichler, use SORMResult::getGeneralisedReliabilityIndexHohenbichler instead
  * Renamed SobolSequence::MaximumNumberOfDimension as SobolSequence::MaximumDimension
- * Deprecated VisualTest::DrawLinearModel(inputSample, outputSample, linearModelResult), use VisualTest::DrawLinearModel(linearModelResult) instead
- * Deprecated VisualTest::DrawLinearModelResidual(inputSample, outputSample, linearModelResult), use VisualTest::DrawLinearModelResidual(linearModelResult) instead
+ * Added VisualTest::DrawLinearModel(linearModelResult), useful if the test is performed on the training samples
+ * Added VisualTest::DrawLinearModelResidual(linearModelResult), useful if the test is performed on the training samples
  * Deprecated OptimizationResult::getLagrangeMultipliers
  * Moved OptimizationAlgorithm::computeLagrangeMultipliers to OptimizationResult
  * Added AIC & BestModelAIC static methods in FittingTest

--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@
 ==== API documentation ====
  * Clarified SobolIndicesExperiment page, notations now consistent with SobolIndicesAlgorithm page
  * Clarified SobolIndicesAlgorithm and (Saltellli|Martinez|MauntzKucherenko|Jansen)SensitivityAlgorithm pages, corrected formulas
+ * Documented how to turn warnings off or write them on a file
 
 === Python module ===
  * Renamed Viewer *_kwargs arguments to *_kw (matplotlib convention)

--- a/ChangeLog
+++ b/ChangeLog
@@ -74,6 +74,7 @@
  * #1567 (The API doc of SobolIndicesExperiment has a format issue)
  * #1573 (LinearModelAnalysis::drawQQPlot line is not the first bisector)
  * #1581 (LinearModelAlgorithm run() fails to parse Sample description)
+ * #1586 (Documentation: description error in the API for the FittingTest_BestModelKolmogorov and FittingTest_BestModelChiSquaredclasses)
  * #1592 (SubsetSampling returns an error if Pf=1)
  * #1594 (LinearLeastSquaresCalibration and CalibrationResult)
  * #1599 (FieldToPointConnection-BlockSize is missing)

--- a/TODO
+++ b/TODO
@@ -1,6 +1,4 @@
 Remove Pairs alias in 1.17
 Remove deprecated SORMResult::getEventProbabilityHohenBichler
 Remove deprecated SORMResult::getGeneralisedReliabilityIndexHohenBichler
-Remove alias VisualTest::DrawLinearModel(sample1, sample2, linearModelResult) in 1.17
-Remove alias VisualTest::DrawLinearModelResidual(sample1, sample2, linearModelResult) in 1.17
 Remove deprecated OptimizationResult::getLagrangeMultipliers, OptimizationAlgorithm::computeLagrangeMultipliers

--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -231,7 +231,7 @@ GridLayout VisualTest::DrawPairs(const Sample & sample)
 }
 
 
-/** Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
+/* Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
 GridLayout VisualTest::DrawPairsMarginals(const Sample & sample, const Distribution & distribution)
 {
   const UnsignedInteger dimension = sample.getDimension();
@@ -261,11 +261,9 @@ GridLayout VisualTest::DrawPairsMarginals(const Sample & sample, const Distribut
 }
 
 
-/* Draw the visual test for the LinearModel when its dimension is 1 */
-Graph VisualTest::DrawLinearModel(const LinearModelResult & linearModelResult)
+/* Draw the visual test for a 1D LinearModel */
+Graph VisualTest::DrawLinearModel(const Sample & sample1, const Sample & sample2, const LinearModelResult & linearModelResult)
 {
-  const Sample & sample1 = linearModelResult.getInputSample();
-  const Sample & sample2 = linearModelResult.getOutputSample();
   if (sample1.getDimension() != 1) throw InvalidDimensionException(HERE) << "Error: can draw a LinearModel residual visual test only if both input and output dimension equal 1, here input dimension=" << sample1.getDimension();
   if (sample2.getDimension() != 1) throw InvalidDimensionException(HERE) << "Error: can draw a LinearModel residual visual test only if both input and output dimension equal 1, here output dimension=" << sample2.getDimension();
   if (sample1.getSize() != sample2.getSize()) throw InvalidArgumentException(HERE) << "Error: can draw a LinearModel visual test only if sample 1 and sample 2 have the same size, here sample 1 size=" << sample1.getSize() << " and sample 2 size=" << sample2.getSize();
@@ -293,18 +291,17 @@ Graph VisualTest::DrawLinearModel(const LinearModelResult & linearModelResult)
   return graphLinearModelTest;
 }
 
-/* Deprecated alias for VisualTest::DrawLinearModel(const LinearModelResult &) */
-Graph VisualTest::DrawLinearModel(const Sample & /*sample1*/, const Sample & /*sample2*/, const LinearModelResult & linearModelResult)
+/* Draw the visual test for a 1D LinearModel using the training Samples **/
+Graph VisualTest::DrawLinearModel(const LinearModelResult & linearModelResult)
 {
-  LOGWARN("This way of using VisualTest::DrawLinearModel is deprecated. The two samples passed as arguments are ignored. Use VisualTest::DrawLinearModel(LinearModelResult) from now on.");
-  return VisualTest::DrawLinearModel(linearModelResult);
+  const Sample & sample1 = linearModelResult.getInputSample();
+  const Sample & sample2 = linearModelResult.getOutputSample();
+  return VisualTest::DrawLinearModel(sample1, sample2, linearModelResult);
 }
 
-/* Draw the visual test for the LinearModel residuals */
-Graph VisualTest::DrawLinearModelResidual(const LinearModelResult & linearModelResult)
+/* Draw the visual test for a 1D LinearModel's residuals */
+Graph VisualTest::DrawLinearModelResidual(const Sample & sample1, const Sample & sample2, const LinearModelResult & linearModelResult)
 {
-  const Sample sample1(linearModelResult.getInputSample());
-  const Sample sample2(linearModelResult.getOutputSample());
   if (sample1.getDimension() != 1) throw InvalidDimensionException(HERE) << "Error: can draw a LinearModel residual visual test only if both input and output dimension equal 1, here input dimension=" << sample1.getDimension();
   if (sample2.getDimension() != 1) throw InvalidDimensionException(HERE) << "Error: can draw a LinearModel residual visual test only if both input and output dimension equal 1, here output dimension=" << sample2.getDimension();
   if (sample1.getSize() != sample2.getSize()) throw InvalidArgumentException(HERE) << "Error: can draw a LinearModel residual visual test only if sample 1 and sample 2 have the same size, here sample 1 size=" << sample1.getSize() << " and sample 2 size=" << sample2.getSize();
@@ -330,11 +327,12 @@ Graph VisualTest::DrawLinearModelResidual(const LinearModelResult & linearModelR
   return graphLinearModelRTest;
 }
 
-/* Deprecated alias for VisualTest::DrawLinearModelResidual(const LinearModelResult &) */
-Graph VisualTest::DrawLinearModelResidual(const Sample & /*sample1*/, const Sample & /*sample2*/, const LinearModelResult & linearModelResult)
+/* Draw the visual test for a 1D LinearModel's residuals using the training Samples */
+Graph VisualTest::DrawLinearModelResidual(const LinearModelResult & linearModelResult)
 {
-  LOGWARN("This way of using VisualTest::DrawLinearModelResidual is deprecated. The two samples passed as arguments are ignored. Use VisualTest::DrawLinearModelResidual(LinearModelResult) from now on.");
-  return VisualTest::DrawLinearModel(linearModelResult);
+  const Sample sample1(linearModelResult.getInputSample());
+  const Sample sample2(linearModelResult.getOutputSample());
+  return VisualTest::DrawLinearModelResidual(sample1, sample2, linearModelResult);
 }
 
 /* Draw the CobWeb visual test */

--- a/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
@@ -71,21 +71,21 @@ public:
   /** Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
   static GridLayout DrawPairsMarginals(const Sample & sample, const Distribution & distribution);
 
-  /** Draw the visual test for the LinearModel when its dimension is 1 */
-  static Graph DrawLinearModel(const LinearModelResult & linearModelResult);
-
-  /** @deprecated alias for DrawLinearModel(const LinearModelResult &) */
+  /** Draw the visual test for a 1D LinearModel */
   static Graph DrawLinearModel(const Sample & sample1,
                                const Sample & sample2,
                                const LinearModelResult & linearModelResult);
 
-  /** Draw the visual test for the LinearModel residuals when its dimension is 1 */
-  static Graph DrawLinearModelResidual(const LinearModelResult & linearModelResult);
+  /** Draw the visual test for a 1D LinearModel using the training Samples **/
+  static Graph DrawLinearModel(const LinearModelResult & linearModelResult);
 
-  /** @deprecated alias for DrawLinearModelResidual(const LinearModelResult &) */
+  /** Draw the visual test for a 1D LinearModel's residuals */
   static Graph DrawLinearModelResidual(const Sample & sample1,
                                        const Sample & sample2,
                                        const LinearModelResult & linearModelResult);
+
+  /** Draw the visual test for a 1D LinearModel's residuals using the training Samples */
+  static Graph DrawLinearModelResidual(const LinearModelResult & linearModelResult);
 
   /** Draw the CobWeb visual test */
   static Graph DrawCobWeb(const Sample & inputSample,

--- a/python/src/FittingTest_doc.i.in
+++ b/python/src/FittingTest_doc.i.in
@@ -182,8 +182,7 @@ models : list of :class:`~openturns.Distribution` or :class:`~openturns.Distribu
 Returns
 -------
 best_model : :class:`~openturns.Distribution`
-    The best distribution for the sample according to Bayesian information
-    criterion.
+    The distribution that fits the sample best according to the criterion.
     This may raise a warning if the best model does not perform well.
 best_bic : float
     The Bayesian information criterion with the best model.
@@ -218,8 +217,7 @@ models : list of :class:`~openturns.Distribution` or :class:`~openturns.Distribu
 Returns
 -------
 best_model : :class:`~openturns.Distribution`
-    The best distribution for the sample according to Bayesian information
-    criterion.
+    The distribution that fits the sample best according to the test.
     This may raise a warning if the best model does not perform well.
 best_result : :class:`~openturns.TestResult`
     Best test result.
@@ -254,8 +252,7 @@ models : list of :class:`~openturns.Distribution` or :class:`~openturns.Distribu
 Returns
 -------
 best_model : :class:`~openturns.Distribution`
-    The best distribution for the sample according to Bayesian information
-    criterion.
+    The distribution that fits the sample best according to the test.
     This may raise a warning if the best model does not perform well.
 best_result : :class:`~openturns.TestResult`
     Best test result.
@@ -361,11 +358,6 @@ Raises
 ------
 TypeError : If the distribution is not discrete or if the sample is
     multivariate.
-
-Notes
------
-This is an interface to the `chisq.test function from the
-'stats' R package <http://stat.ethz.ch/R-manual/R-patched/library/stats/html/chisq.test.html>`_.
 
 Examples
 --------

--- a/python/src/Log_doc.i.in
+++ b/python/src/Log_doc.i.in
@@ -27,8 +27,10 @@ flags : int
 
 Examples
 --------
+Turn warnings off:
+
 >>> import openturns as ot
->>> ot.Log.Show(ot.Log.DEFAULT)"
+>>> ot.Log.Show(ot.Log.NONE)"
 
 // ---------------------------------------------------------------------
 
@@ -123,7 +125,14 @@ repeat : bool
 Parameters
 ----------
 file_name : str
-    Log file name"
+    Log file name
+
+Examples
+--------
+Write warnings in a file:
+
+>>> import openturns as ot
+>>> ot.Log.SetFile('Warnings.log')"
 
 // ---------------------------------------------------------------------
 

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -343,12 +343,14 @@ Examples
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::VisualTest::DrawLinearModel
-"Draw a linear model plot.
+"Plot a 1D linear model.
 
 Parameters
 ----------
-sample1, sample2 : 2-d sequence of float
-    Samples to draw.
+inputSample, outputSample : 2-d sequence of float (optional)
+    X and Y coordinates of the points the test is to be performed on.
+    If *inputSample* and *outputSample* were the training samples
+    of the linear model, there is no need to supply them (see example below).
 linearModelResult : :class:`~openturns.LinearModelResult`
     Linear model to plot.
 
@@ -366,26 +368,39 @@ Examples
 >>> R = ot.CorrelationMatrix(dimension)
 >>> R[0, 1] = 0.8
 >>> distribution = ot.Normal([3.0] * dimension, [2.0]* dimension, R)
->>> size = 100
+>>> size = 200
 >>> sample2D = distribution.getSample(size)
 >>> firstSample = ot.Sample(size, 1)
 >>> secondSample = ot.Sample(size, 1)
 >>> for i in range(size):
 ...     firstSample[i] = ot.Point(1, sample2D[i, 0])
 ...     secondSample[i] = ot.Point(1, sample2D[i, 1])
->>> lmtest = ot.LinearModelAlgorithm(firstSample, secondSample).getResult()
+>>> # Generate training Samples
+>>> inputTrainSample = firstSample[0:size//2]
+>>> outputTrainSample = secondSample[0:size//2]
+>>> # Generate test Samples
+>>> inputTestSample = firstSample[size//2:]
+>>> outputTestSample = secondSample[size//2:]
+>>> # Define and get the result of the linear model
+>>> lmtest = ot.LinearModelAlgorithm(inputTrainSample, outputTrainSample).getResult()
+>>> # Visual test on the training samples: no need to supply them again
 >>> drawLinearModelVTest = ot.VisualTest.DrawLinearModel(lmtest)
->>> View(drawLinearModelVTest).show()"
+>>> View(drawLinearModelVTest).show()
+>>> # Visual test on the test samples
+>>> drawLinearModelVTest2 = ot.VisualTest.DrawLinearModel(inputTestSample, outputTestSample, lmtest)
+>>> View(drawLinearModelVTest2).show()"
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::VisualTest::DrawLinearModelResidual
-"Draw a linear model residual plot.
+"Plot a 1D linear model's residuals.
 
 Parameters
 ----------
-sample1, sample2 : 2-d sequence of float
-    Samples to draw.
+inputSample, outputSample : 2-d sequence of float, optional
+    X and Y coordinates of the points the test is to be performed on.
+    If *inputSample* and *outputSample* were the training samples
+    of the linear model, there is no need to supply them (see example below).
 linearModelResult : :class:`~openturns.LinearModelResult`
     Linear model to plot.
 
@@ -403,16 +418,27 @@ Examples
 >>> R = ot.CorrelationMatrix(dimension)
 >>> R[0, 1] = 0.8
 >>> distribution = ot.Normal([3.0] * dimension, [2.0]* dimension, R)
->>> size = 100
+>>> size = 200
 >>> sample2D = distribution.getSample(size)
 >>> firstSample = ot.Sample(size, 1)
 >>> secondSample = ot.Sample(size, 1)
 >>> for i in range(size):
 ...     firstSample[i] = ot.Point(1, sample2D[i, 0])
 ...     secondSample[i] = ot.Point(1, sample2D[i, 1])
->>> lmtest = ot.LinearModelAlgorithm(firstSample, secondSample).getResult()
+>>> # Generate training Samples
+>>> inputTrainSample = firstSample[0:size//2]
+>>> outputTrainSample = secondSample[0:size//2]
+>>> # Generate test Samples
+>>> inputTestSample = firstSample[size//2:]
+>>> outputTestSample = secondSample[size//2:]
+>>> # Define and get the result of the linear model
+>>> lmtest = ot.LinearModelAlgorithm(inputTrainSample, outputTrainSample).getResult()
+>>> # Visual test on the training samples: no need to supply them again
 >>> drawLinearModelVTest = ot.VisualTest.DrawLinearModelResidual(lmtest)
->>> View(drawLinearModelVTest).show()"
+>>> View(drawLinearModelVTest).show()
+>>> # Visual test on the test samples
+>>> drawLinearModelVTest2 = ot.VisualTest.DrawLinearModelResidual(inputTestSample, outputTestSample, lmtest)
+>>> View(drawLinearModelVTest2).show()"
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
This question "How can I turn warnings off?" has now come up several times in discussions.
The first commit documents this and also wrote how to direct warnings to a log file. Closes #1578.

The second commit fixes #1586 and removes a leftover reference to R in the `FittingTest_BestModelChiSquared` doc.

The third commit undoes part of PR #1576: there are cases where the long version of `VisualTest_DrawLinearModel(Residual)` can be useful, which justifies undeprecating it (one could want to perform the test on a different sample than the training sample). However, the short version is useful for testing with the training sample, so it is kept as well. The doc is updated to reflect this.