### PR TITLE
New Sample::BuildFromSequence feature in python biding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -95,6 +95,7 @@
 === Python module ===
  * Renamed Viewer *_kwargs arguments to *_kw (matplotlib convention)
  * Add ProcessSample Field accessors
+ * Added Sample::BuildFromPoint
 
 === Miscellaneous ===
  * Do not compute Lagrange multipliers by default during an optimization

--- a/lib/src/Base/Stat/Sample.cxx
+++ b/lib/src/Base/Stat/Sample.cxx
@@ -45,13 +45,20 @@ Sample Sample::ImportFromTextFile(const FileName & fileName,
   return sample;
 }
 
+Sample Sample::BuildFromPoint(const Point &point)
+{
+    const UnsignedInteger size = point.getDimension();
+    Sample sample(size, 1);
+    sample.getImplementation()->setData(point);
+    return sample;
+}
+
 /* Save to CSV file */
 void Sample::exportToCSVFile(const FileName & filename,
                              const String & csvSeparator) const
 {
   getImplementation()->exportToCSVFile(filename, csvSeparator);
 }
-
 
 /* Store a sample in a temporary text file, one realization by line. Returns the file name. */
 String Sample::storeToTemporaryFile() const

--- a/lib/src/Base/Stat/openturns/Sample.hxx
+++ b/lib/src/Base/Stat/openturns/Sample.hxx
@@ -57,6 +57,7 @@ public:
                                    const UnsignedInteger skippedLines = 0,
                                    const String & numSeparator = ".");
 
+  static Sample BuildFromPoint(const Point & point);
 
   /** Export Sample into CSV file */
   void exportToCSVFile(const FileName & fileName,

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -81,6 +81,28 @@ experiments
 1 : [ 2 3 ]
 2 : [ 4 5 ]"
 
+
+%feature("docstring") OT::Sample::BuildFromPoint
+"Static method for building a sample from a sequence of float.
+
+Parameters
+----------
+data : 1d array-like
+    Data.
+
+Returns
+-------
+sample : :class:`~openturns.Sample`
+    Sample generated from sequence
+
+Examples
+--------
+>>> import openturns as ot
+>>> n = 20
+>>> x = ot.Sample_BuildFromPoint(range(n))
+>>> data = [2.0, 2.0, 1.0, 1.0, 2.0, 3.0, 1.0, 2.0, 2.0, 1.0]
+>>> sample = ot.Sample.BuildFromPoint(data)"
+
 %feature("docstring") OT::Sample::ImportFromCSVFile
 "Static method for building a sample from a CSV file.
 


### PR DESCRIPTION
In a previous [commit](https://github.com/openturns/openturns/pull/1467/commits/3dc8c299293ed256fd77da21510bb436ad0bf7a9), we dropped `Sample(seq, dim)` ctor. Even if this is a small feature with small impact, according to [that discussion](https://github.com/openturns/openturns/issues/1465#issuecomment-688673243), it might be considered as a regression.
Thus we propose here a small fix.
 