### PR TITLE
Remove top box with download link in doc pages

### DIFF
--- a/python/doc/_static/css/custom.css
+++ b/python/doc/_static/css/custom.css
@@ -14,3 +14,9 @@ li.show {
 div.sphx-glr-clear {
     clear: left;
 }
+
+/* hide the top link */
+div.sphx-glr-download-link-note {
+  height: 0px;
+  visibility: hidden;
+}


### PR DESCRIPTION
Append custom.css to disable the sphx-glr-download-link-note class. Fixes #1619.

I simply applied https://github.com/sphinx-gallery/sphinx-gallery/issues/757