### PR TITLE
Update Ev3 license

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,7 +640,6 @@ install (FILES COPYING
                 COPYING.LESSER
                 COPYING.cobyla
                 COPYING.dsfmt
-                COPYING.ev3
                 COPYING.exprtk
                 COPYING.faddeeva
                 COPYING.hmat

--- a/COPYING.ev3
+++ b/COPYING.ev3
@@ -1,7 +1,0 @@
-Extracted form the source files:
-** Author:    Leo Liberti
-...
-** Source:    GNU C++
-...
-** License:    (C) Leo Liberti, all rights reserved. Code published under the
-Common Public License.

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Up-to-date information can be found at http://www.openturns.org
 License
 =======
 OpenTURNS is distributed under the Lesser General Public License.
-Please see the LICENSE and the COPYING* files for details of the license of each components.
+Please see the LICENSE and the COPYING* files for details of the license of each component.
 
 Release Notes
 =============
@@ -47,7 +47,17 @@ for instructions on installing OpenTURNS on various platforms from binaries or s
 Documentation
 =============
 The http://openturns.github.io/openturns/latest/contents.html page contains
-the most recent set of updated documentation for this release. 
+the most recent set of updated documentation for this release.
+
+Acknowledgement
+===============
+The OpenTURNS team would like to thank Leo Liberti for his library Ev3:
+a modified version powers symbolic differentiation in OpenTURNS.
+
+The original version of Ev3, released under the LGPL,
+can be found at http://www.lix.polytechnique.fr/~liberti/Ev3-1.0.zip
+
+The OpenTURNS version of Ev3 can be found as a standalone library at https://github.com/openturns/ev3
 
 Contributing
 ============

--- a/lib/src/Base/Diff/Ev3/auxiliary.h
+++ b/lib/src/Base/Diff/Ev3/auxiliary.h
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        auxiliary.h                                            *
- * Source:      GNU C++                                                *
- * Purpose:     prototypes for auxiliary functions in expression.cxx   *
- * History:     030121 0.0 work started                                *
- * License:     (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief prototypes for auxiliary functions in expression.cxx 
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace Ev3
 {

--- a/lib/src/Base/Diff/Ev3/common.h
+++ b/lib/src/Base/Diff/Ev3/common.h
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        common.h                                               *
- * Source:      GNU C++                                                *
- * Purpose:     common stuff                                           *
- * History:     050909 0.0 work started                                *
- * License:    (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief common stuff
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3COMMONH__
 #define __EV3COMMONH__

--- a/lib/src/Base/Diff/Ev3/exceptions.h
+++ b/lib/src/Base/Diff/Ev3/exceptions.h
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        exceptions.h                                           *
- * Source:      GNU C++                                                *
- * Purpose:     Expression v3 exceptions                               *
- * History:     010622 0.0 work started                                *
- * License:     (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief Expression v3 exceptions
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3EXCEPTIONSH__
 #define __EV3EXCEPTIONSH__

--- a/lib/src/Base/Diff/Ev3/expression.cxx
+++ b/lib/src/Base/Diff/Ev3/expression.cxx
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        expression.cxx                                         *
- * Source:      GNU C++                                                *
- * Purpose:     symbolic expression (base classes and functionality)   *
- * History:     010517 0.0 work started                                *
- * License:    (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief symbolic expression (base classes and functionality)
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include <string>
 #include <sstream>

--- a/lib/src/Base/Diff/Ev3/expression.h
+++ b/lib/src/Base/Diff/Ev3/expression.h
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        expression.h                                           *
- * Source:      GNU C++                                                *
- * Purpose:     symbolic expression (base classes and functionality)   *
- * History:     010517 0.0 work started                                *
- * License:    (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief symbolic expression (base classes and functionality)
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3EXPRESSIONH__
 #define __EV3EXPRESSIONH__

--- a/lib/src/Base/Diff/Ev3/operand.cxx
+++ b/lib/src/Base/Diff/Ev3/operand.cxx
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        operand.cxx                                         *
- * Source:      GNU C++                                                *
- * Purpose:     symbolic expression (base classes and functionality)   *
- * History:     010517 0.0 work started                                *
- * License:    (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief symbolic expression (base classes and functionality)
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include <iomanip>
 #include <cmath>

--- a/lib/src/Base/Diff/Ev3/operand.h
+++ b/lib/src/Base/Diff/Ev3/operand.h
@@ -1,11 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        expression.h                                           *
- * Source:      GNU C++                                                *
- * Purpose:     symbolic expression (base classes and functionality)   *
- * History:     010517 0.0 work started                                *
- * License:    Code published under the Common Public License.         *
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief symbolic expression (base classes and functionality)
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3OPERANDH__
 #define __EV3OPERANDH__

--- a/lib/src/Base/Diff/Ev3/parser.cxx
+++ b/lib/src/Base/Diff/Ev3/parser.cxx
@@ -1,14 +1,23 @@
-/*
-** Name:      parser.cxx
-** Author:    Leo Liberti
-** Purpose:   C++ class that builds an Expression v3
-**            n-ary tree from a string containing a
-**            mathematical expression in n variables
-** Source:    GNU C++
-** History:   010624 derived from project Eval (class/EvalClass.cc)
-** License:    (C) Leo Liberti, all rights reserved. Code published under the
-Common Public License.
-*/
+//                                               -*- C++ -*-
+/**
+ *  @brief C++ class that builds an Expression v3 n-ary tree from a string containing a mathematical expression in n variables
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include "parser.h"
 #include "common.h"

--- a/lib/src/Base/Diff/Ev3/parser.h
+++ b/lib/src/Base/Diff/Ev3/parser.h
@@ -1,14 +1,23 @@
-/*
-** Name:      parser.h
-** Author:    Leo Liberti
-** Purpose:   C++ class that builds an Expression v3
-**            n-ary tree from a string containing a
-**            mathematical expression in n variables
-** Source:    GNU C++
-** History:   010624 derived from project Eval (class/EvalClass.cc)
-** License:    (C) Leo Liberti, all rights reserved. Code published under the
-Common Public License.
-*/
+//                                               -*- C++ -*-
+/**
+ *  @brief C++ class that builds an Expression v3 n-ary tree from a string containing a mathematical expression in n variables
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3PARSERH__
 #define __EV3PARSERH__

--- a/lib/src/Base/Diff/Ev3/tree.h
+++ b/lib/src/Base/Diff/Ev3/tree.h
@@ -1,12 +1,23 @@
-/**********************************************************************
- * Author:      Leo Liberti                                            *
- * Name:        tree.hxx                                               *
- * Source:      GNU C++                                                *
- * Purpose:     template for tree construction                         *
- * History:     010517 0.0 work started                                *
- * License:    (C) Leo Liberti, all rights reserved. Code published under the
-               Common Public License.
-***********************************************************************/
+//                                               -*- C++ -*-
+/**
+ *  @brief template for tree construction
+ *
+ *  Copyright (C) 2008-2010 Leo Liberti
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __EV3TREEH__
 #define __EV3TREEH__


### PR DESCRIPTION
Ev3 has been released under the LGPL by Leo Liberti, its original creator: http://www.lix.polytechnique.fr/~liberti/Ev3-1.0.zip



This PR updates the README with a proper acknowledgement and modifies the headers of all relevant files, like in our standalone Ev3 repo: https://github.com/openturns/ev3/pull/3.