### PR TITLE
Improve lilliefors model selection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -93,6 +93,7 @@
  * #1599 (FieldToPointConnection-BlockSize is missing)
  * #1603 (FieldToPointConnection generates an invalid exception)
  * #1605 (MaximumLikelihoodFactory cannot be used with FittingTest.Kolmogorov)
+ * #1624 (The graphs_loglikelihood_contour example has a bug)
 
 
 == 1.15 release (2020-05-25) == #release-1.15

--- a/python/doc/examples/py_graphs/plot_graphs_loglikelihood_contour.py
+++ b/python/doc/examples/py_graphs/plot_graphs_loglikelihood_contour.py
@@ -24,10 +24,10 @@ ot.Log.Show(ot.Log.NONE)
 
 # %%
 a = -1
-b=2.5
-mu = 2.
-sigma = 3.
-distribution = ot.TruncatedNormal(mu,sigma,a,b)
+b = 2.5
+mu = 2.0
+sigma = 3.0
+distribution = ot.TruncatedNormal(mu, sigma, a, b)
 sample = distribution.getSample(11)
 
 # %%
@@ -37,7 +37,7 @@ sample = distribution.getSample(11)
 graph = distribution.drawPDF()
 graph.setLegends(["TruncatedNormal"])
 graph.setColors(["red"])
-zeros = ot.Sample(sample.getSize(),1)
+zeros = ot.Sample(sample.getSize(), 1)
 cloud = ot.Cloud(sample,zeros)
 cloud.setLegend("Sample")
 graph.add(cloud)
@@ -60,14 +60,17 @@ def logLikelihood(X):
     '''
     Evaluate the log-likelihood of a TruncatedNormal on a sample. 
     '''
+    samplesize = sample.getSize()
     mu = X[0]
     sigma = X[1]
     a = sample.getMin()[0]
     b = sample.getMax()[0]
-    distribution = ot.TruncatedNormal(mu,sigma,a,b)
-    samplesize = sample.getSize()
+    delta = (b - a) / samplesize
+    a -= delta
+    b += delta
+    distribution = ot.TruncatedNormal(mu, sigma, a, b)
     samplelogpdf = distribution.computeLogPDF(sample)
-    loglikelihood = -samplelogpdf.computeMean()* samplesize
+    loglikelihood = samplelogpdf.computeMean() * samplesize
     return loglikelihood
 
 
@@ -96,7 +99,7 @@ view = viewer.View(graphBasic)
 # The level values are computed from the quantiles of the data, so that the contours are equally spaced. We can configure the number of levels by setting the `Contour-DefaultLevelsNumber` key in the `ResourceMap`. 
 
 # %%
-ot.ResourceMap_SetAsUnsignedInteger("Contour-DefaultLevelsNumber",5)
+ot.ResourceMap_SetAsUnsignedInteger("Contour-DefaultLevelsNumber", 5)
 logLikelihoodFunction = ot.PythonFunction(2, 1, logLikelihood)
 graphBasic = logLikelihoodFunction.draw([-3.0, 0.1], [5.0, 7.0], [50]*2)
 graphBasic.setXTitle(r"$\mu$")


### PR DESCRIPTION
* Improved FittingTest::BestModelLilliefors: now a first pass is done using the biased Kolmogorov p-value to sort the proposed factories. Then, as soon as a given factory leads to a distribution with an unbiased p-value greater than the biased p-value of another factory, this last one can be disgarded. It allows for massive savings in computation time while remaining exact.
* Fixed the loglikelihood function example: the loglikelihood function implemented in plot_graphs_loglikelihood_contour.py was wrong, leading to a theoretically infinite loglikelihood for any value of its input. It closes issue #1624.

The following script takes 167s to complete with this PR, while it is still running (>5h) with the current master:
```
import openturns as ot
from time import time

ot.Log.Show(ot.Log.INFO)
ot.ResourceMap.SetAsScalar("TrapezoidalFactory-RhoBeg", 0.1)
ot.ResourceMap.SetAsScalar("TrapezoidalFactory-RhoEnd", 1.0e-3)
ot.ResourceMap.SetAsUnsignedInteger("TrapezoidalFactory-MaximumIteration", 20)
allContinuousFactories = ot.DistributionFactory.GetContinuousUniVariateFactories()
print("allContinuousFactories=", allContinuousFactories)
size = 100
t0 = time()
print()
for factory in allContinuousFactories:
    print("Trying factory", factory)
    distribution, result = ot.FittingTest.BestModelLilliefors(factory.build().getSample(size), allContinuousFactories)
    print("distribution=", distribution, "result=", result, "\n")
print("t=", time() - t0, "s")
```

