### PR TITLE
Implement Frechet computeLogPDFGradient [1.16]

### DIFF
--- a/lib/src/Uncertainty/Distribution/Frechet.cxx
+++ b/lib/src/Uncertainty/Distribution/Frechet.cxx
@@ -211,6 +211,21 @@ Point Frechet::computePDFGradient(const Point & point) const
   return pdfGradient;
 }
 
+/* Get the LogPDFGradient of the distribution */
+Point Frechet::computeLogPDFGradient(const Point & point) const
+{
+  if (point.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=1, here dimension=" << point.getDimension();
+
+  const Scalar x = point[0] - gamma_;
+  Point logPdfGradient(3);
+  if (x <= 0.0) return logPdfGradient;
+  const Scalar logCdfplus1 = -std::expm1(-alpha_ * std::log(x / beta_));
+  logPdfGradient[0] = alpha_ / beta_ * logCdfplus1;
+  logPdfGradient[1] = 1.0 / alpha_ - std::log(x / beta_) * logCdfplus1;
+  logPdfGradient[2] = 1.0 / x * (1.0 + alpha_ * logCdfplus1);
+  return logPdfGradient;
+}
+
 /* Get the CDFGradient of the distribution */
 Point Frechet::computeCDFGradient(const Point & point) const
 {

--- a/lib/src/Uncertainty/Distribution/openturns/Frechet.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Frechet.hxx
@@ -84,6 +84,10 @@ public:
   using ContinuousDistribution::computePDFGradient;
   Point computePDFGradient(const Point & point) const override;
 
+  /** Get the gradient of the logPDF w.r.t the parameters of the distribution */
+  using ContinuousDistribution::computeLogPDFGradient;
+  Point computeLogPDFGradient(const Point & point) const override;
+
   /** Get the gradient of the CDF w.r.t the parameters of the distribution */
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;

--- a/lib/test/t_FrechetFactory_std.cxx
+++ b/lib/test/t_FrechetFactory_std.cxx
@@ -53,6 +53,20 @@ int main(int, char *[])
     fullprint << "Default frechet=" << estimatedFrechet << std::endl;
     estimatedFrechet = factory.buildAsFrechet(distribution.getParameter());
     fullprint << "Frechet from parameters=" << estimatedFrechet << std::endl;
+
+    // More involved test: the sample distribution does not fit the factory
+
+    // The distributions used :
+    Frechet myFrechet(1.0, 1.0, 0.0);
+    Gumbel myGumbel(1.0,3.0);
+    // We build our mixture sample of size 2*1000=2000.
+    Sample mixtureSample(myFrechet.getSample(1000));
+    Sample sampleGumbel(myGumbel.getSample(1000));
+    mixtureSample.add(sampleGumbel);
+    // Build on the mixture sample
+    estimatedFrechet = factory.buildAsFrechet(mixtureSample);
+    fullprint << "Estimated dist from mixture sample=" << estimatedFrechet << std::endl;
+
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_FrechetFactory_std.expout
+++ b/lib/test/t_FrechetFactory_std.expout
@@ -1,8 +1,9 @@
 Distribution          =class=Frechet name=Frechet dimension=1 beta=2.5 alpha=2 gamma=-1.5
-Estimated distribution=class=Frechet name=Frechet dimension=1 beta=2.48708 alpha=1.9596 gamma=-1.47832
+Estimated distribution=class=Frechet name=Frechet dimension=1 beta=2.48707 alpha=1.95959 gamma=-1.47831
 Default distribution=class=Frechet name=Frechet dimension=1 beta=1 alpha=1 gamma=0
 Distribution from parameters=class=Frechet name=Frechet dimension=1 beta=2.5 alpha=2 gamma=-1.5
 Frechet          =class=Frechet name=Frechet dimension=1 beta=2.5 alpha=2 gamma=-1.5
-Estimated frechet=class=Frechet name=Frechet dimension=1 beta=2.48708 alpha=1.9596 gamma=-1.47832
+Estimated frechet=class=Frechet name=Frechet dimension=1 beta=2.48707 alpha=1.95959 gamma=-1.47831
 Default frechet=class=Frechet name=Frechet dimension=1 beta=1 alpha=1 gamma=0
 Frechet from parameters=class=Frechet name=Frechet dimension=1 beta=2.5 alpha=2 gamma=-1.5
+Estimated dist from mixture sample=class=Frechet name=Frechet dimension=1 beta=2.57426 alpha=1.71402 gamma=-0.833636

--- a/python/test/t_FrechetFactory_std.expout
+++ b/python/test/t_FrechetFactory_std.expout
@@ -1,10 +1,11 @@
 Distribution                      = class=Frechet name=Frechet dimension=1 beta=2.5 alpha=2 gamma=-1.5
-Estimated distribution            = class=Frechet name=Frechet dimension=1 beta=2.48708 alpha=1.9596 gamma=-1.47832
-Parameter distribution            = Normal(mu = [2.48708,1.9596,-1.47832], sigma = [0.0530234,0.0393878,0.046005], R = [[  1         0.858608 -0.967707 ]
- [  0.858608  1        -0.918773 ]
+Estimated distribution            = class=Frechet name=Frechet dimension=1 beta=2.48707 alpha=1.95959 gamma=-1.47831
+Parameter distribution            = Normal(mu = [2.48707,1.95959,-1.47831], sigma = [0.0530232,0.0393876,0.0460048], R = [[  1         0.858607 -0.967707 ]
+ [  0.858607  1        -0.918773 ]
  [ -0.967707 -0.918773  1        ]])
 Default distribution              = Frechet(beta = 1, alpha = 1, gamma = 0)
 Distribution from parameters      = Frechet(beta = 2.5, alpha = 2, gamma = -1.5)
-Typed estimated distribution      = Frechet(beta = 2.48708, alpha = 1.9596, gamma = -1.47832)
+Typed estimated distribution      = Frechet(beta = 2.48707, alpha = 1.95959, gamma = -1.47831)
 Default typed distribution        = Frechet(beta = 1, alpha = 1, gamma = 0)
 Typed distribution from parameters= Frechet(beta = 2.5, alpha = 2, gamma = -1.5)
+Estimated dist from mixture sample= Frechet(beta = 2.57426, alpha = 1.71402, gamma = -0.833636)

--- a/python/test/t_FrechetFactory_std.py
+++ b/python/test/t_FrechetFactory_std.py
@@ -24,3 +24,18 @@ print('Default typed distribution        =', defaultTypedDistribution)
 typedFromParameterDistribution = factory.buildAsFrechet(
     distribution.getParameter())
 print('Typed distribution from parameters=', typedFromParameterDistribution)
+
+# More involved test: the sample distribution does not fit the factory
+
+# The distributions used :
+myFrechet = ot.Frechet(1.0, 1.0, 0.0)
+myGumbel = ot.Gumbel(1.0,3.0)
+# We build our mixture sample of size 2*1000=2000.
+mixtureSample = ot.Sample()
+sampleFrechet = myFrechet.getSample(1000)
+sampleGumbel = myGumbel.getSample(1000)
+mixtureSample.add(sampleFrechet)
+mixtureSample.add(sampleGumbel)
+# Build on the mixture sample
+typedEstimatedFromMixtureSample = factory.buildAsFrechet(mixtureSample)
+print('Estimated dist from mixture sample=', typedEstimatedFromMixtureSample)


### PR DESCRIPTION
This fixes a bug with `FrechetFactory::buildAsFrechet`.

Consider the following script. We try to fit a Frechet distribution on a sample obtained from a mixture of a Frechet and a Gumbel distribution. The optimization currently fails because the gradient of the logPDF is not implemented. Implementing it fixes the issue.

```
myFrechet = ot.Frechet(1.0, 1.0, 0.0)
myGumbel = ot.Gumbel(1.0,3.0)
# We build our mixture sample of size 2*1000=2000.
mixtureSample = ot.Sample()
sampleFrechet = myFrechet.getSample(1000)
sampleGumbel = myGumbel.getSample(1000)
mixtureSample.add(sampleFrechet)
mixtureSample.add(sampleGumbel)
# Build on the mixture sample
typedEstimatedFromMixtureSample = factory.buildAsFrechet(mixtureSample)
print('Estimated dist from mixture sample=', typedEstimatedFromMixtureSample)

print('Average logPDF of mixture sample=', typedEstimatedFromMixtureSample.computeLogPDF(mixtureSample).computeMean()[0])
```

Current output:
```
Estimated dist from mixture sample= Frechet(beta = 1.38232, alpha = 1.1757, gamma = 0.0926263)
Average logPDF of mixture sample= -93.89377428835414
```

Output after the fix:
```
Estimated dist from mixture sample= Frechet(beta = 2.57426, alpha = 1.71402, gamma = -0.833636)
Average logPDF of mixture sample= -2.283122349794321
```

