### PR TITLE
UserDefinedStationaryCovarianceModel easy 1d ctor

### DIFF
--- a/lib/src/Base/Stat/UserDefinedStationaryCovarianceModel.cxx
+++ b/lib/src/Base/Stat/UserDefinedStationaryCovarianceModel.cxx
@@ -53,8 +53,8 @@ UserDefinedStationaryCovarianceModel::UserDefinedStationaryCovarianceModel(const
 {
   const UnsignedInteger size = mesh.getVerticesNumber();
   if (size != covarianceFunction.getSize())
-    throw InvalidArgumentException(HERE) << "Error: for a non stationary covariance model, sizes are incoherents"
-                                         << " mesh size = " << size << "covariance function size = " << covarianceFunction.getSize();
+    throw InvalidArgumentException(HERE) << "Error: a covariance matrix should correspond to each distance specified in the regular grid. "
+                                         << "Regular grid size = " << size << " vs number of covariance matrices in the collection = " << covarianceFunction.getSize();
   inputDimension_ = mesh.getDimension();
   covarianceCollection_ = CovarianceMatrixCollection(size);
   // put the first element
@@ -66,6 +66,27 @@ UserDefinedStationaryCovarianceModel::UserDefinedStationaryCovarianceModel(const
     if (covarianceFunction[k].getDimension() != outputDimension_)
       throw InvalidArgumentException(HERE) << " Error with dimension; the covariance matrices should be of same dimension";
     covarianceCollection_[k] = covarianceFunction[k];
+  }
+}
+
+/* Easy constructor for 1D outputs*/
+UserDefinedStationaryCovarianceModel::UserDefinedStationaryCovarianceModel(const RegularGrid & mesh,
+    const Collection<Scalar> & covarianceValues)
+  : StationaryCovarianceModel()
+  , covarianceCollection_(0)
+  , mesh_(mesh)
+  , nearestNeighbour_(mesh)
+{
+  const UnsignedInteger size = mesh.getVerticesNumber();
+  if (size != covarianceValues.getSize())
+    throw InvalidArgumentException(HERE) << "Error: a covariance value should correspond to each distance specified in the regular grid. "
+                                         << "Regular grid size = " << size << " vs number of covariance values in the collection = " << covarianceValues.getSize();
+  covarianceCollection_ = CovarianceMatrixCollection(size, CovarianceMatrix(1));
+  for (UnsignedInteger k = 0; k < size; ++k)
+  {
+    if (covarianceValues[k] < 0)
+      throw InvalidArgumentException(HERE) << k << "-th covariance value is " << covarianceValues[k] << ", should be nonnegative.";
+    covarianceCollection_[k](0, 0) = covarianceValues[k];
   }
 }
 

--- a/lib/src/Base/Stat/openturns/UserDefinedStationaryCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/UserDefinedStationaryCovarianceModel.hxx
@@ -44,12 +44,16 @@ public:
   typedef PersistentCollection<CovarianceMatrix>          CovarianceMatrixPersistentCollection;
   typedef Collection<CovarianceMatrix>                    CovarianceMatrixCollection;
 
-  /** Default onstructor */
+  /** Default constructor */
   UserDefinedStationaryCovarianceModel();
 
-  /** Standard onstructor */
+  /** Standard constructor */
   UserDefinedStationaryCovarianceModel(const RegularGrid & mesh,
                                        const CovarianceMatrixCollection & covarianceCollection);
+
+  /** Easy constructor for 1D outputs*/
+  UserDefinedStationaryCovarianceModel(const RegularGrid & mesh,
+                                       const Collection<Scalar> & covarianceValues);
 
   /** Virtual copy constructor */
   UserDefinedStationaryCovarianceModel * clone() const override;

--- a/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
+++ b/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
@@ -5,8 +5,8 @@ Parameters
 ----------
 mesh : :class:`~openturns.RegularGrid`
     Time grid of size :math:`N` associated with the process.
-sample : :class:`~openturns.CovarianceMatrixCollection`
-    A collection of *N* covariance matrices.
+sample : :class:`~openturns.CovarianceMatrixCollection` or :class:`~openturns.ScalarCollection`
+    A collection of :math:`N` covariance matrices (any :math:`d`) or :math:`N` nonnegative scalars (:math:`d=1`).
 
 Notes
 -----
@@ -27,34 +27,30 @@ where *k* is such that :math:`\vect{t}_k` is the  vertex of :math:`\cM` the near
 
 Examples
 --------
-Create a mesh:
+Create a time grid:
 
 >>> import openturns as ot
->>> # Create the time grid
+>>> from numpy import array
 >>> t0 = 0.0
 >>> dt = 0.5
 >>> N = int((20.0 - t0)/ dt)
 >>> myShiftMesh =  ot.RegularGrid(t0, dt, N)
 
-Create the stationary covariance function:
+Create a stationary covariance function:
 
 >>> def gamma(tau):
 ...     return 1.0 / (1.0 + tau * tau)
 
-Create the collection of N covariance matrices:
+Create a collection of :math:`N` covariance values:
 
->>> myCovarianceCollection = ot.CovarianceMatrixCollection()
->>> for k in range(N):
-...     t = myShiftMesh.getValue(k)
-...     matrix = ot.CovarianceMatrix(1)
-...     matrix[0, 0] = gamma(t)
-...     myCovarianceCollection.add(matrix)
+>>> gridVertices = array(myShiftMesh.getVertices())
+>>> myCovarianceCollection = ot.Sample(gamma(gridVertices)).asPoint()
 
-Create the User defined stationary covariance model:
+Create the user defined stationary covariance model:
 
->>> myCovarianceModel = ot.UserDefinedStationaryCovarianceModel(myShiftMesh,myCovarianceCollection)
+>>> myCovarianceModel = ot.UserDefinedStationaryCovarianceModel(myShiftMesh, myCovarianceCollection)
 
-Compute the covariance function at the vertex tau:
+Compute the covariance function at a specific vertex tau:
 
 >>> tau = 1.5
 >>> myCovModelMatrix = myCovarianceModel(tau)

--- a/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
+++ b/python/src/UserDefinedStationaryCovarianceModel_doc.i.in
@@ -4,7 +4,7 @@
 Parameters
 ----------
 mesh : :class:`~openturns.RegularGrid`
-    Time grid of size :math:`N` associated with the process.
+    Time grid of size :math:`N` associated with the process. Negative vertices are ignored.
 sample : :class:`~openturns.CovarianceMatrixCollection` or :class:`~openturns.ScalarCollection`
     A collection of :math:`N` covariance matrices (any :math:`d`) or :math:`N` nonnegative scalars (:math:`d=1`).
 
@@ -12,18 +12,18 @@ Notes
 -----
 The covariance model is built as follows.
 
-We consider a process :math:`X: \Omega \times\cD \mapsto \Rset^d` with :math:`\cD \in \Rset`. 
+We consider a process :math:`X: \Omega \times \Rset \mapsto \Rset^d`.
 
-We note :math:`(\vect{t}_0,\dots, \vect{t}_{N-1})` the vertices of :math:`\cM \in \cD` and :math:`(\mat{C}_{k})_{0 \leq  k \leq N-1}` where :math:`\mat{C}_{k} \in \cS_d^+(\Rset)` the collection of covariance matrices fixed by the User.
+We note :math:`(t_0,\dots, t_{N-1})` the vertices of :math:`\cM \subset \Rset` and :math:`(\mat{C}_{k})_{0 \leq  k \leq N-1}` where :math:`\mat{C}_{k} \in \cS_d^+(\Rset)` the collection of covariance matrices provided by the user.
 
-Then we build a stationary covariance function :math:`C^{stat}` which is a  piecewise constant function defined on :math:`\cD \times \cD` by:
+Then we build a stationary covariance function :math:`C^{stat}` which is a piecewise constant function defined on :math:`\Rset` by:
 
 .. math::
 
-    \forall \vect{\tau} \in \cD, \, \quad C^{stat}(\vect{\tau}) =  \mat{C}_k
+    \forall \tau \in \Rset, \, \quad C^{stat}(\tau) =  \mat{C}_k
 
 
-where *k* is such that :math:`\vect{t}_k` is the  vertex of :math:`\cM` the nearest to :math:`\vect{\tau}`.
+where :math:`k` is such that :math:`t_k` is the vertex of :math:`\cM` closest to :math:`|\tau|`.
 
 Examples
 --------


### PR DESCRIPTION
I think most use cases of `UserDefinedStationaryCovarianceModel` are in settings with only one output dimension. In such cases, it seems a little heavy-handed to ask the user to create a collection of 1x1 covariance matrices.

This PR implements a new constructor for such cases: it takes a `ScalarCollection` instead of
a `CovarianceMatrixCollection` as input. As a result, the syntax of the example on the API doc page is simplified.