### PR TITLE
Correct the formula of MCMC::computeLogLikelihood [1.16]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -99,6 +99,7 @@
  * #1605 (MaximumLikelihoodFactory cannot be used with FittingTest.Kolmogorov)
  * #1624 (The graphs_loglikelihood_contour example has a bug)
  * #1643 (Problem in MaximumDistribution PDF)
+ * #1647 (MCMC::computeLogLikelihood does not compute the log-likelihood)
  * #1654 (StationaryFunctionalCovarianceModel::discretize segfaults)
  * #1660 (Cannot extract continuous modes from KLResult when dimension>1)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -98,6 +98,7 @@
  * #1603 (FieldToPointConnection generates an invalid exception)
  * #1605 (MaximumLikelihoodFactory cannot be used with FittingTest.Kolmogorov)
  * #1624 (The graphs_loglikelihood_contour example has a bug)
+ * #1642 (Big white space at the beginning of examples)
  * #1643 (Problem in MaximumDistribution PDF)
  * #1647 (MCMC::computeLogLikelihood does not compute the log-likelihood)
  * #1654 (StationaryFunctionalCovarianceModel::discretize segfaults)

--- a/TODO
+++ b/TODO
@@ -3,3 +3,4 @@ Remove deprecated SORMResult::getEventProbabilityHohenBichler
 Remove deprecated SORMResult::getGeneralisedReliabilityIndexHohenBichler
 Remove deprecated OptimizationResult::getLagrangeMultipliers, OptimizationAlgorithm::computeLagrangeMultipliers
 Remove deprecated FittingTest::Kolmogorov, FittingTestx::BestModelKolmogorov
+Remove deprecated RandomWalkMetropolisHastings::currentLogLikelihood_ attribute

--- a/lib/src/Uncertainty/Bayesian/MCMC.cxx
+++ b/lib/src/Uncertainty/Bayesian/MCMC.cxx
@@ -128,10 +128,10 @@ UnsignedInteger MCMC::getDimension() const
 }
 
 
-/* Compute the likelihood w.r.t. observations */
+/* Compute the log-likelihood */
 Scalar MCMC::computeLogLikelihood(const Point & xi) const
 {
-  Scalar value = prior_.computeLogPDF(xi);
+  Scalar value = 0.0;
 
   const UnsignedInteger size = observations_.getSize();
   for (UnsignedInteger i = 0; i < size; ++ i)

--- a/lib/src/Uncertainty/Bayesian/openturns/MCMC.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/MCMC.hxx
@@ -68,7 +68,7 @@ public:
   /** String converter */
   String __repr__() const override;
 
-  /** Compute the likelihood w.r.t. observartions */
+  /** Compute the log-likelihood */
   Scalar computeLogLikelihood(const Point & currentState) const;
 
   /** Prior accessor */

--- a/lib/src/Uncertainty/Bayesian/openturns/RandomWalkMetropolisHastings.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/RandomWalkMetropolisHastings.hxx
@@ -106,7 +106,8 @@ private:
   /// number of samples accepted
   mutable Indices acceptedNumber_;
 
-  mutable Scalar currentLogLikelihood_;
+  /// unnormalized log-posterior density of the current state
+  mutable Scalar currentPenalizedLogLikelihood_;
 }; /* class RandomWalkMetropolisHastings */
 
 

--- a/python/doc/_static/css/custom.css
+++ b/python/doc/_static/css/custom.css
@@ -20,3 +20,8 @@ div.sphx-glr-download-link-note {
   height: 0px;
   visibility: hidden;
 }
+
+/* Remove big whitespace to solve #1642 */
+pre, div[class*="highlight-"] {
+  clear: left;
+}

--- a/python/test/t_RandomWalkMetropolisHastings_std.expout
+++ b/python/test/t_RandomWalkMetropolisHastings_std.expout
@@ -10,7 +10,7 @@ prior variance= 1
   expected posterior ~N( 29.0771171389 ,  0.577350269189 )
   obtained posterior ~N( 29.4172027776 ,  0.468900115002 )
   acceptance rate= [0.420266,0]
-Penalized log-likelihood of thetaTrue = -708.2968891987429
+Log-likelihood of thetaTrue = -705.377950665538
 With 503 observations, getRealization() produces 2.0
-Penalized log-likelihood of thetaTrue = -709.26477360595
+Log-likelihood of thetaTrue = -706.3458350727452
 With 504 observations, getRealization() produces 2.0

--- a/python/test/t_RandomWalkMetropolisHastings_std.py
+++ b/python/test/t_RandomWalkMetropolisHastings_std.py
@@ -101,7 +101,7 @@ ot.RandomGenerator.SetSeed(0)
 y_obs = ot.Normal(thetaTrue[0], 1.0).getSample(obsSize)
 RWMHsampler = ot.RandomWalkMetropolisHastings(
     prior, conditional, model, y_obs, y_obs, initialState, proposal)
-print("Penalized log-likelihood of thetaTrue = {!r}".format(
+print("Log-likelihood of thetaTrue = {!r}".format(
     RWMHsampler.computeLogLikelihood(thetaTrue)))
 real_503 = RWMHsampler.getRealization()
 print("With 503 observations, getRealization() produces {!r}".format(
@@ -112,7 +112,7 @@ ot.RandomGenerator.SetSeed(0)
 y_obs = ot.Normal(thetaTrue[0], 1.0).getSample(obsSize)
 RWMHsampler = ot.RandomWalkMetropolisHastings(
     prior, conditional, model, y_obs, y_obs, initialState, proposal)
-print("Penalized log-likelihood of thetaTrue = {!r}".format(
+print("Log-likelihood of thetaTrue = {!r}".format(
     RWMHsampler.computeLogLikelihood(thetaTrue)))
 # produces an error with current master branch
 real_504 = RWMHsampler.getRealization()


### PR DESCRIPTION
- ~~Turn the old `computeLogLikelihood` public method
into a `computeLogLikelihoodPlusLogPrior` protected method.~~ Compute the sum of loglikelihood and logprior every time the class needs it.
- ~~Create a new~~ Make sure the public `computeLogLikelihood` method ~~that~~ actually
computes the log-likelihood. Fixes #1647.
- Deprecate `currentLogLikelihood_` attribute and replace it with
`currentLogLikelihoodPlusLogPrior_`.
- Update ChangeLog and TODO.

~~The method  `computeLogLikelihoodPlusLogPrior` is necessary, otherwise the class cannot work. Since 1.16rc1 is already out, however, I have chosen not to expose it. That way, if we decide to expose it in 1.17, we can change the name of the method without deprecating anything.~~

From the point of view of a user, nothing changes with this PR except that `computeLogLikelihood` now acts as advertised.

EDIT : added a commit to fix #1642 i.e. the big whitespace bug on doc pages.