### PR TITLE
Fixed LevelSetMesher

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -104,6 +104,7 @@
  * #1651 (Cobyla freezes in 0T1.16rc1)
  * #1654 (StationaryFunctionalCovarianceModel::discretize segfaults)
  * #1660 (Cannot extract continuous modes from KLResult when dimension>1)
+ * #1668 (LevelSetMesher does not take into account the comparison operator)
 
 
 == 1.15 release (2020-05-25) == #release-1.15

--- a/lib/src/Base/Geom/LevelSetMesher.cxx
+++ b/lib/src/Base/Geom/LevelSetMesher.cxx
@@ -134,6 +134,7 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
   const Function function(levelSet.getFunction());
   const Point values(function(boundingVertices).asPoint());
   const Scalar level = levelSet.getLevel();
+  const ComparisonOperator comparison(levelSet.getOperator());
   Indices goodSimplices(0);
   Sample goodVertices(0, dimension);
   // Flags for the vertices to keep
@@ -158,7 +159,7 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
     for (UnsignedInteger j = 0; j <= dimension; ++j)
     {
       const UnsignedInteger globalVertexIndex = boundingSimplices(i, j);
-      if (values[globalVertexIndex] <= level)
+      if (comparison(values[globalVertexIndex], level))
       {
         ++numGood;
         ++flagGoodVertices[globalVertexIndex];
@@ -184,7 +185,7 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
         Scalar centerValue = 0.0;
         // First pass: compute the center of the good points
         for (UnsignedInteger j = 0; j <= dimension; ++j)
-          if (localValues[j] <= level)
+          if (comparison(localValues[j], level))
           {
             center += localVertices[j];
             centerValue += localValues[j];
@@ -197,7 +198,7 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
         {
           const UnsignedInteger globalVertexIndex = boundingSimplices(i, j);
           // If the vertex has to be moved
-          if ((flagGoodVertices[globalVertexIndex] == 0) && (localValues[j] > level))
+          if ((flagGoodVertices[globalVertexIndex] == 0) && (!comparison(localValues[j], level)))
           {
             // C(v*) [inside], M(level) [on], B(v) [outside]
             // (M-C)/(B-C) = (level-v*)/(v-v*) = a

--- a/python/test/t_LevelSetMesher_std.py
+++ b/python/test/t_LevelSetMesher_std.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -56,6 +57,16 @@ try:
     mesh3D = mesher3D.build(levelSet3D, ot.Interval([-10.0] * 3, [10.0] * 3))
     print("mesh3D=", mesh3D)
 
+    # Issue #1668
+    f = ot.SymbolicFunction(["x", "y"], ["x^2+y^2"])
+    levelset = ot.LevelSet(f, ot.Less(), 1.0)
+    mesh = ot.LevelSetMesher([16]*2).build(levelset, ot.Interval([-1.5]*2, [1.5]*2))
+    gLess = mesh.draw()
+    f = ot.SymbolicFunction(["x", "y"], ["-(x^2+y^2)"])    
+    levelset = ot.LevelSet(f, ot.Greater(), -1.0)
+    mesh = ot.LevelSetMesher([16]*2).build(levelset, ot.Interval([-1.5]*2, [1.5]*2))
+    gGreater = mesh.draw()
+    ott.assert_almost_equal(gLess.getDrawable(0).getData(), gGreater.getDrawable(0).getData(), 1e-4, 1e-4)
 except:
     import sys
-    print("t_IntervalMesher_std.py", sys.exc_info()[0], sys.exc_info()[1])
+    print("t_LevelSetMesher_std.py", sys.exc_info()[0], sys.exc_info()[1])


### PR DESCRIPTION
Now, it takes into account the comparison operator of the underlying LevelSet. Fixes #1668.