### PR TITLE
Remove IsoProbabilisticTransform in Kriging examples

### DIFF
--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
@@ -18,7 +18,6 @@ Configuring the trend in Kriging
 # %%
 import openturns as ot
 ot.RandomGenerator.SetSeed(0)
-import openturns.viewer as viewer
 from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
@@ -37,10 +36,6 @@ dimension = cb.dim # number of inputs
 myDistribution = cb.distribution
 
 # %%
-# We use a transformation because data contain very large values.
-transformation = myDistribution.getIsoProbabilisticTransformation()
-
-# %%
 # Create the design of experiments
 # --------------------------------
 
@@ -48,7 +43,7 @@ transformation = myDistribution.getIsoProbabilisticTransformation()
 # We consider a simple Monte-Carlo sampling as a design of experiments. This is why we generate an input sample using the `getSample` method of the distribution. Then we evaluate the output using the `model` function.
 
 # %%
-sampleSize_train = 20
+sampleSize_train = 10
 X_train = myDistribution.getSample(sampleSize_train)
 Y_train = model(X_train)
 
@@ -57,14 +52,43 @@ Y_train = model(X_train)
 # --------------------
 
 # %%
-# In order to create the kriging metamodel, we first select a constant trend with the `ConstantBasisFactory` class. Then we use a squared exponential covariance model. Finally, we use the `KrigingAlgorithm` class to create the kriging metamodel, taking the training sample, the covariance model and the trend basis as input arguments. 
-
-# %%
-covarianceModel = ot.SquaredExponential([1.]*dimension, [1.0])
+# In order to create the Kriging metamodel, we first select a constant trend with the `ConstantBasisFactory` class. Then we use a squared exponential covariance kernel.
+# The `SquaredExponential` kernel has one amplitude coefficient and 4 scale coefficients. This is because this covariance kernel is anisotropic : each of the 4 input variables is associated with its own scale coefficient. 
 
 # %%
 basis = ot.ConstantBasisFactory(dimension).build()
-algo = ot.KrigingAlgorithm(transformation(X_train), Y_train, covarianceModel, basis)
+covarianceModel = ot.SquaredExponential(dimension)
+
+# %%
+# Typically, the optimization algorithm is quite good at setting sensible optimization bounds.
+# In this case, however, the range of the input domain is extreme.
+
+# %%
+print("Lower and upper bounds of X_train:")
+print(X_train.getMin(), X_train.getMax())
+
+# %%
+# We need to manually define sensible optimization bounds.
+# Note that since the amplitude parameter is computed analytically (this is possible when the output dimension is 1), we only need to set bounds on the scale parameter.
+
+# %%
+scaleOptimizationBounds = ot.Interval([1.0, 1.0, 1.0, 1.0e-10], [1.0e11, 1.0e3, 1.0e1, 1.0e-5])
+
+# %%
+# Finally, we use the `KrigingAlgorithm` class to create the Kriging metamodel.
+# It requires a training sample, a covariance kernel and a trend basis as input arguments. 
+# We need to set the initial scale parameter for the optimization. The upper bound of the input domain is a sensible choice here.
+# We must not forget to actually set the optimization bounds defined above.
+
+# %%
+covarianceModel.setScale(X_train.getMax())
+algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
+algo.setOptimizationBounds(scaleOptimizationBounds)
+
+# %%
+# Run the algorithm and get the result.
+
+# %%
 algo.run()
 result = algo.getResult()
 krigingWithConstantTrend = result.getMetaModel()
@@ -73,24 +97,23 @@ krigingWithConstantTrend = result.getMetaModel()
 # The `getTrendCoefficients` method returns the coefficients of the trend.
 
 # %%
-result.getTrendCoefficients()
+print(result.getTrendCoefficients())
 
 # %%
 # The constant trend always has only one coefficient (if there is one single output).
 
 # %%
-result.getCovarianceModel()
-
-# %%
-# The `SquaredExponential` model has one amplitude coefficient and 4 scale coefficients. This is because this covariance model is anisotropic : each of the 4 input variables is associated with its own scale coefficient. 
+print(result.getCovarianceModel())
 
 # %%
 # Setting the trend
 # -----------------
 
 # %%
+covarianceModel.setScale(X_train.getMax())
 basis = ot.LinearBasisFactory(dimension).build()
-algo = ot.KrigingAlgorithm(transformation(X_train), Y_train, covarianceModel, basis)
+algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
+algo.setOptimizationBounds(scaleOptimizationBounds)
 algo.run()
 result = algo.getResult()
 krigingWithLinearTrend = result.getMetaModel()
@@ -112,12 +135,16 @@ result.getTrendCoefficients()
 # * dim=4 coefficients for the linear part.
 
 # %%
+covarianceModel.setScale(X_train.getMax())
 basis = ot.QuadraticBasisFactory(dimension).build()
-algo = ot.KrigingAlgorithm(transformation(X_train), Y_train, covarianceModel, basis)
+algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
+algo.setOptimizationBounds(scaleOptimizationBounds)
 algo.run()
 result = algo.getResult()
 krigingWithQuadraticTrend = result.getMetaModel()
 result.getTrendCoefficients()
+print(algo.getOptimizationBounds())
+print(result.getCovarianceModel())
 
 # %%
 # This time, the trend has 15 coefficients:
@@ -139,7 +166,7 @@ result.getTrendCoefficients()
 # ----------------------
 
 # %%
-# We finally want to validate the kriging metamodel. This is why we generate a validation sample which size is equal to 100 and we evaluate the output of the model on this sample.
+# We finally want to validate the Kriging metamodel. This is why we generate a validation sample with size 100 and we evaluate the output of the model on this sample.
 
 # %%
 sampleSize_test = 100
@@ -165,24 +192,25 @@ from openturns.viewer import View
 # %%
 fig = pl.figure(figsize=(12, 4))
 ax1 = fig.add_subplot(1, 3, 1)
-graphConstant = drawMetaModelValidation(transformation(X_test), Y_test, krigingWithConstantTrend, "Constant")
+graphConstant = drawMetaModelValidation(X_test, Y_test, krigingWithConstantTrend, "Constant")
 _ = View(graphConstant, figure=fig, axes=[ax1])
 ax2 = fig.add_subplot(1, 3, 2)
-graphLinear = drawMetaModelValidation(transformation(X_test), Y_test, krigingWithLinearTrend, "Linear")
+graphLinear = drawMetaModelValidation(X_test, Y_test, krigingWithLinearTrend, "Linear")
 _ = View(graphLinear, figure=fig, axes=[ax2])
 ax3 = fig.add_subplot(1, 3, 3)
-graphQuadratic = drawMetaModelValidation(transformation(X_test), Y_test, krigingWithQuadraticTrend, "Quadratic")
+graphQuadratic = drawMetaModelValidation(X_test, Y_test, krigingWithQuadraticTrend, "Quadratic")
 _ = View(graphQuadratic, figure=fig, axes=[ax3])
 _ = fig.suptitle("Different trends")
 plt.show()
 
 # %%
-# We observe that the three trends perform very well in this case. The more the trend has coefficients, the more the kriging metamodel has flexibility to adjust to the training sample. This does not mean, however, that the trend coefficients will provide a good fit for the validation sample. 
+# We observe that the three trends perform very well in this case. With more coefficients, the Kriging metamodel is more flexibile and can adjust better to the training sample. This does not mean, however, that the trend coefficients will provide a good fit for the validation sample. 
 #
-# The number of parameters in each kriging metamodel is the following:
+# The number of parameters in each Kriging metamodel is the following:
 #
-# * the constant trend kriging has 6 coefficients to estimate: 5 coefficients for the covariance matrix and 1 coefficient for the trend,
-# * the linear trend kriging has 10 coefficients to estimate: 5 coefficients for the covariance matrix and 5 coefficients for the trend,
-# * the quadratic trend kriging has 20 coefficients to estimate: 5 coefficients for the covariance matrix and 15 coefficients for the trend.
+# * the constant trend Kriging has 6 coefficients to estimate: 5 coefficients for the covariance matrix and 1 coefficient for the trend,
+# * the linear trend Kriging has 10 coefficients to estimate: 5 coefficients for the covariance matrix and 5 coefficients for the trend,
+# * the quadratic trend Kriging has 20 coefficients to estimate: 5 coefficients for the covariance matrix and 15 coefficients for the trend.
 #
-# In the cantilever beam example, fitting the metamodel with a training sample which size is only equal to 20 is made much easier because the function to approximate is almost linear.
+# In the cantilever beam example, fitting the metamodel to a training sample with only 10 points is made much easier because the function to approximate is almost linear.
+# In this case, a quadratic trend is not advisable because it can interpolate all points in the training sample.

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam.py
@@ -3,7 +3,7 @@ Kriging the cantilever beam model
 =================================
 """
 # %%
-# In this example, we create a kriging metamodel of the :ref:`cantilever beam <use-case-cantilever-beam>`. We use a squared exponential covariance model for the kriging. In order to estimate the hyper-parameters, we use a design of experiments which size is 20.
+# In this example, we create a Kriging metamodel of the :ref:`cantilever beam <use-case-cantilever-beam>`. We use a squared exponential covariance kernel for the Gaussian process. In order to estimate the hyper-parameters, we use a design of experiments of size is 20.
 
 
 # %%
@@ -31,15 +31,11 @@ dim = cb.dim # number of inputs
 myDistribution = cb.distribution
 
 # %%
-# We use a transformation because data contain very large values.
-transformation = myDistribution.getIsoProbabilisticTransformation()
-
-# %%
 # Create the design of experiments
 # --------------------------------
 
 # %%
-# We consider a simple Monte-Carlo sampling as a design of experiments. This is why we generate an input sample using the `getSample` method of the distribution. Then we evaluate the output using the `model` function.
+# We consider a simple Monte-Carlo sample as a design of experiments. This is why we generate an input sample using the `getSample` method of the distribution. Then we evaluate the output using the `model` function.
 
 # %%
 sampleSize_train = 20
@@ -61,16 +57,39 @@ view = viewer.View(histo)
 # --------------------
 
 # %%
-# In order to create the kriging metamodel, we first select a constant trend with the `ConstantBasisFactory` class. Then we use a squared exponential covariance model. Finally, we use the `KrigingAlgorithm` class to create the kriging metamodel, taking the training sample, the covariance model and the trend basis as input arguments. 
+# In order to create the Kriging metamodel, we first select a constant trend with the `ConstantBasisFactory` class. Then we use a squared exponential covariance kernel.
+# The `SquaredExponential` kernel has one amplitude coefficient and 4 scale coefficients. This is because this covariance kernel is anisotropic : each of the 4 input variables is associated with its own scale coefficient. 
 
 # %%
-dimension = myDistribution.getDimension()
-basis = ot.ConstantBasisFactory(dimension).build()
-covarianceModel = ot.SquaredExponential([1.]*dimension, [1.0])
-algo = ot.KrigingAlgorithm(transformation(X_train), Y_train, covarianceModel, basis)
-algo.run()
-result = algo.getResult()
-krigingMetamodel = result.getMetaModel()
+basis = ot.ConstantBasisFactory(dim).build()
+covarianceModel = ot.SquaredExponential(dim)
+
+# %%
+# Typically, the optimization algorithm is quite good at setting sensible optimization bounds.
+# In this case, however, the range of the input domain is extreme.
+
+# %%
+print("Lower and upper bounds of X_train:")
+print(X_train.getMin(), X_train.getMax())
+
+# %%
+# We need to manually define sensible optimization bounds.
+# Note that since the amplitude parameter is computed analytically (this is possible when the output dimension is 1), we only need to set bounds on the scale parameter.
+
+# %%
+scaleOptimizationBounds = ot.Interval([1.0, 1.0, 1.0, 1.0e-10], [1.0e11, 1.0e3, 1.0e1, 1.0e-5])
+
+# %%
+# Finally, we use the `KrigingAlgorithm` class to create the Kriging metamodel.
+# It requires a training sample, a covariance kernel and a trend basis as input arguments. 
+# We need to set the initial scale parameter for the optimization. The upper bound of the input domain is a sensible choice here.
+# We must not forget to actually set the optimization bounds defined above.
+
+# %%
+covarianceModel.setScale(X_train.getMax())
+algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
+algo.setOptimizationBounds(scaleOptimizationBounds)
+
 
 # %%
 # The `run` method has optimized the hyperparameters of the metamodel. 
@@ -78,7 +97,15 @@ krigingMetamodel = result.getMetaModel()
 # We can then print the constant trend of the metamodel, which have been estimated using the least squares method.
 
 # %%
-result.getTrendCoefficients()
+algo.run()
+result = algo.getResult()
+krigingMetamodel = result.getMetaModel()
+
+# %%
+# The `getTrendCoefficients` method returns the coefficients of the trend.
+
+# %%
+print(result.getTrendCoefficients())
 
 # %%
 # We can also print the hyperparameters of the covariance model, which have been estimated by maximizing the likelihood. 
@@ -91,7 +118,7 @@ result.getCovarianceModel()
 # ----------------------
 
 # %%
-# We finally want to validate the kriging metamodel. This is why we generate a validation sample which size is equal to 100 and we evaluate the output of the model on this sample.
+# We finally want to validate the Kriging metamodel. This is why we generate a validation sample with size 100 and we evaluate the output of the model on this sample.
 
 # %%
 sampleSize_test = 100
@@ -102,17 +129,14 @@ Y_test = model(X_test)
 # The `MetaModelValidation` classe makes the validation easy. To create it, we use the validation samples and the metamodel. 
 
 # %%
-val = ot.MetaModelValidation(transformation(X_test), Y_test, krigingMetamodel)
+val = ot.MetaModelValidation(X_test, Y_test, krigingMetamodel)
 
 # %%
 # The `computePredictivityFactor` computes the Q2 factor. 
 
 # %%
 Q2 = val.computePredictivityFactor()[0]
-Q2
-
-# %%
-# Since the Q2 is larger than 95%, we can say that the quality is acceptable. 
+print(Q2)
 
 # %%
 # The residuals are the difference between the model and the metamodel. 
@@ -120,10 +144,13 @@ Q2
 # %%
 r = val.getResidualSample()
 graph = ot.HistogramFactory().build(r).drawPDF()
+graph.setXTitle("Residuals (cm)")
+graph.setTitle("Distribution of the residuals")
+graph.setLegends([""])
 view = viewer.View(graph)
 
 # %%
-# We observe that the negative residuals occur with nearly the same frequency of the positive residuals: this is a first   sign of good quality. Furthermore, the residuals are most of the times contained in the [-1,1] interval, which is a sign of quality given the amplitude of the output (approximately from 5 to 25 cm).
+# We observe that the negative residuals occur with nearly the same frequency of the positive residuals: this is a first sign of good quality.
 
 # %%
 # The `drawValidation` method allows to compare the observed outputs and the metamodel outputs.
@@ -134,7 +161,3 @@ graph.setTitle("Q2 = %.2f%%" % (100*Q2))
 view = viewer.View(graph)
 
 plt.show()
-# %%
-# We observe that the metamodel predictions are close to the model outputs, since most red points are close to the diagonal. However, when we consider extreme deviations (i.e. less than 10 or larger than 20), then the quality is less obvious.
-#
-# Given that the kriging metamodel quality is sensitive to the design of experiments, it might be interesting to consider a Latin Hypercube Sampling (LHS) design to further improve the predictions quality.

--- a/python/doc/examples/reliability_sensitivity/reliability/plot_subsetSampling.py
+++ b/python/doc/examples/reliability_sensitivity/reliability/plot_subsetSampling.py
@@ -32,7 +32,8 @@ Subset Sampling
 # First, import the python modules: 
 
 # %%
-from  openturns import *
+import openturns as ot
+from openturns.viewer import View
 
 # %%
 # Create the probabilistic model :math:`Y = g(X)`
@@ -42,40 +43,40 @@ from  openturns import *
 # Create the input random vector :math:`X`:
 
 # %%
-X = RandomVector(Normal([0.25]*2, [1]*2, IdentityMatrix(2)))
+X = ot.RandomVector(ot.Normal([0.25]*2, [1]*2, ot.IdentityMatrix(2)))
 
 # %%
 # Create the function :math:`g`:
 
 # %%
-g=SymbolicFunction(['x1', 'x2'], ['20-(x1-x2)^2-8*(x1+x2-4)^3'])
+g=ot.SymbolicFunction(['x1', 'x2'], ['20-(x1-x2)^2-8*(x1+x2-4)^3'])
 print('function g: ', g)
 
 # %%
 # In order to be able to get the subset samples used in the algorithm, it is necessary to transform the *SymbolicFunction* into a *MemoizeFunction*:
 
 # %%
-g = MemoizeFunction(g)
+g = ot.MemoizeFunction(g)
 
 # %%
 # Create the output random vector :math:`Y = g(X)`:
 
 # %%
-Y = CompositeRandomVector(g,X)
+Y = ot.CompositeRandomVector(g,X)
 
 # %%
 # Create the event :math:`\{ Y = g(X) \leq 0 \}`
 # ----------------------------------------------
 
 # %%
-myEvent = ThresholdEvent(Y, LessOrEqual(), 0.0) 
+myEvent = ot.ThresholdEvent(Y, ot.LessOrEqual(), 0.0) 
 
 # %%
 # Evaluate the probability with the subset sampling technique
 # -----------------------------------------------------------
 
 # %%
-algo = SubsetSampling(myEvent)
+algo = ot.SubsetSampling(myEvent)
 
 # %%
 # In order to get all the inputs and outputs that realize the event, you have to mention it now:
@@ -160,7 +161,7 @@ for i in range(Ns):
 # The following graph draws each subset sample and the frontier :math:`g(x_1, x_2) = l_i` where :math:`l_i` is the threshold at the step :math:`i`:
 
 # %%
-graph = Graph()
+graph = ot.Graph()
 graph.setAxes(True)
 graph.setGrid(True)
 graph.setTitle('Subset sampling: samples')
@@ -173,10 +174,10 @@ graph.setLegendPosition('bottomleft')
 
 # %%
 for i in range(Ns):
-    cloud = Cloud(list_subSamples[i])
+    cloud = ot.Cloud(list_subSamples[i])
     #cloud.setPointStyle("dot")
     graph.add(cloud)
-col = Drawable().BuildDefaultPalette(Ns)
+col = ot.Drawable().BuildDefaultPalette(Ns)
 graph.setColors(col)
 
 # %%
@@ -194,7 +195,7 @@ for i in range(levels.getSize()):
     graph.add(dr)
 
 # %%
-Show(graph)
+View(graph)
 
 # %%
 # Draw the frontiers only
@@ -203,7 +204,7 @@ Show(graph)
 # The following graph enables to understand the progresison of the algorithm:
 
 # %%
-graph=Graph()
+graph=ot.Graph()
 graph.setAxes(True)
 graph.setGrid(True)
 dr = gIsoLines.getDrawable(0)
@@ -220,7 +221,7 @@ graph.setTitle('Subset sampling: thresholds')
 graph.setXTitle(r'$x_1$')
 graph.setYTitle(r'$x_2$')
 
-Show(graph)
+View(graph)
 
 # %%
 # Get all the input and output points that realized the event
@@ -236,7 +237,7 @@ print('Number of event realizations = ', inputEventSample.getSize())
 # Here we have to avoid a bug of the version 1.15 because *getEventInputSample()* gives the sample in the stadrad space: we have to push it backward to the physical space.
 
 # %%
-dist = Normal([0.25]*2, [1]*2, IdentityMatrix(2))
+dist = ot.Normal([0.25]*2, [1]*2, ot.IdentityMatrix(2))
 transformFunc = dist.getInverseIsoProbabilisticTransformation()
 inputEventSample = transformFunc(inputEventSample)
 
@@ -244,10 +245,10 @@ inputEventSample = transformFunc(inputEventSample)
 # Draw them! They are all in the event space.
 
 # %%
-graph=Graph()
+graph=ot.Graph()
 graph.setAxes(True)
 graph.setGrid(True)
-cloud = Cloud(inputEventSample)
+cloud = ot.Cloud(inputEventSample)
 cloud.setPointStyle('dot')
 graph.add(cloud)
 gIsoLines =  g.draw([-3]*2, [5]*2, [1000]*2)
@@ -255,4 +256,4 @@ dr = gIsoLines.getDrawable(0)
 dr.setLevels([0.0])
 dr.setColor('red')
 graph.add(dr)
-Show(graph)
+View(graph)


### PR DESCRIPTION
It is possible to play with the bounds of the optimization algorithm instead.
This is more elementary in my opinion.