### PR TITLE
StationaryFunctionalCovarianceModel thread safety

### DIFF
--- a/lib/src/Base/Algo/ClassifierImplementation.cxx
+++ b/lib/src/Base/Algo/ClassifierImplementation.cxx
@@ -92,29 +92,13 @@ struct ClassifyPolicy
 }; /* end struct ClassifyPolicy */
 
 
-Indices ClassifierImplementation::classifyParallel(const Sample & inS) const
+Indices ClassifierImplementation::classify(const Sample & inS) const
 {
   const UnsignedInteger size = inS.getSize();
   Indices result(size);
   const ClassifyPolicy policy(inS, result, this);
-  TBB::ParallelFor(0, size, policy);
+  TBB::ParallelForCondition(isParallel_, 0, size, policy);
   return result;
-}
-
-Indices ClassifierImplementation::classifySequential(const Sample & inS) const
-{
-  const UnsignedInteger size = inS.getSize();
-  Indices prediction(size);
-  for (UnsignedInteger i = 0; i < size; ++ i)
-    prediction[i] = classify(inS[i]);
-  return prediction;
-}
-
-Indices ClassifierImplementation::classify(const Sample & inS) const
-{
-  if (isParallel_)
-    return classifyParallel(inS);
-  return classifySequential(inS);
 }
 
 /* Grade a point */

--- a/lib/src/Base/Algo/openturns/ClassifierImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/ClassifierImplementation.hxx
@@ -53,11 +53,6 @@ public:
   virtual UnsignedInteger classify(const Point & inP) const;
   virtual Indices classify(const Sample & inS) const;
 
-protected:
-  virtual Indices classifyParallel(const Sample & inS) const;
-  virtual Indices classifySequential(const Sample & inS) const;
-public:
-
   /** Grade a point as if it were associated to a class */
   virtual Scalar grade(const Point & inP,
                        const UnsignedInteger outC) const;

--- a/lib/src/Base/Common/openturns/TBB.hxx
+++ b/lib/src/Base/Common/openturns/TBB.hxx
@@ -162,6 +162,16 @@ public:
 
   template <typename BODY>
   static inline
+  void ParallelForCondition(const Bool condition, UnsignedInteger from, UnsignedInteger to, const BODY & body, std::size_t gs = 1)
+  {
+    if (condition)
+      ParallelFor(from, to, body, gs);
+    else
+      body(tbb::blocked_range<UnsignedInteger>(from, to, gs));
+  }
+
+  template <typename BODY>
+  static inline
   void ParallelReduce( UnsignedInteger from, UnsignedInteger to, BODY & body, std::size_t gs = 1)
   {
     TBBContext context;

--- a/lib/src/Base/Func/AggregatedEvaluation.cxx
+++ b/lib/src/Base/Func/AggregatedEvaluation.cxx
@@ -289,6 +289,16 @@ Bool AggregatedEvaluation::isLinearlyDependent(const UnsignedInteger index) cons
   return true;
 }
 
+/* Is it safe to call in parallel? */
+Bool AggregatedEvaluation::isParallel() const
+{
+  for (UnsignedInteger i = 0; i < functionsCollection_.getSize(); ++i)
+    if (!functionsCollection_[i].getImplementation()->isParallel())
+      return false;
+
+  return true;
+}
+
 /* Method save() stores the object through the StorageManager */
 void AggregatedEvaluation::save(Advocate & adv) const
 {

--- a/lib/src/Base/Func/ComposedEvaluation.cxx
+++ b/lib/src/Base/Func/ComposedEvaluation.cxx
@@ -204,4 +204,11 @@ Bool ComposedEvaluation::isLinearlyDependent(const UnsignedInteger index) const
   return leftFunction_.isLinearlyDependent(index) && rightFunction_.isLinearlyDependent(index);
 }
 
+/* Is it safe to call in parallel? */
+Bool ComposedEvaluation::isParallel() const
+{
+  return leftFunction_.getImplementation()->isParallel() && rightFunction_.getImplementation()->isParallel();
+}
+
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/DualLinearCombinationEvaluation.cxx
+++ b/lib/src/Base/Func/DualLinearCombinationEvaluation.cxx
@@ -394,6 +394,16 @@ Bool DualLinearCombinationEvaluation::isLinearlyDependent(const UnsignedInteger 
   return true;
 }
 
+/* Is it safe to call in parallel? */
+Bool DualLinearCombinationEvaluation::isParallel() const
+{
+  for (UnsignedInteger i = 0; i < functionsCollection_.getSize(); ++i)
+    if (!functionsCollection_[i].getImplementation()->isParallel())
+      return false;
+
+  return true;
+}
+
 /* Method save() stores the object through the StorageManager */
 void DualLinearCombinationEvaluation::save(Advocate & adv) const
 {

--- a/lib/src/Base/Func/EvaluationImplementation.cxx
+++ b/lib/src/Base/Func/EvaluationImplementation.cxx
@@ -278,6 +278,12 @@ Bool EvaluationImplementation::isLinearlyDependent(const UnsignedInteger index) 
   return false;
 }
 
+/* Is it safe to call in parallel? */
+Bool EvaluationImplementation::isParallel() const
+{
+  return true;
+}
+
 /* Invalid values check accessor */
 void EvaluationImplementation::setCheckOutput(const Bool checkOutput)
 {

--- a/lib/src/Base/Func/EvaluationProxy.cxx
+++ b/lib/src/Base/Func/EvaluationProxy.cxx
@@ -207,6 +207,12 @@ Bool EvaluationProxy::isLinearlyDependent(const UnsignedInteger index) const
   return evaluation_.isLinearlyDependent(index);
 }
 
+/* Is it safe to call in parallel? */
+Bool EvaluationProxy::isParallel() const
+{
+  return evaluation_.getImplementation()->isParallel();
+}
+
 /* Invalid values check accessor */
 void EvaluationProxy::setCheckOutput(const Bool checkOutput)
 {

--- a/lib/src/Base/Func/FunctionImplementation.cxx
+++ b/lib/src/Base/Func/FunctionImplementation.cxx
@@ -382,6 +382,12 @@ Bool FunctionImplementation::isLinearlyDependent(const UnsignedInteger index) co
   return evaluation_.isLinearlyDependent(index);
 }
 
+/* Is it safe to call in parallel? */
+Bool FunctionImplementation::isParallel() const
+{
+  return evaluation_.getImplementation()->isParallel();
+}
+
 /* Draw the given 1D marginal output as a function of the given 1D marginal input around the given central point */
 Graph FunctionImplementation::draw(const UnsignedInteger inputMarginal,
                                    const UnsignedInteger outputMarginal,

--- a/lib/src/Base/Func/LinearCombinationEvaluation.cxx
+++ b/lib/src/Base/Func/LinearCombinationEvaluation.cxx
@@ -338,6 +338,16 @@ Bool LinearCombinationEvaluation::isLinearlyDependent(const UnsignedInteger inde
   return true;
 }
 
+/* Is it safe to call in parallel? */
+Bool LinearCombinationEvaluation::isParallel() const
+{
+  for (UnsignedInteger i = 0; i < functionsCollection_.getSize(); ++i)
+    if (!functionsCollection_[i].getImplementation()->isParallel())
+      return false;
+
+  return true;
+}
+
 
 /* Method save() stores the object through the StorageManager */
 void LinearCombinationEvaluation::save(Advocate & adv) const

--- a/lib/src/Base/Func/MemoizeEvaluation.cxx
+++ b/lib/src/Base/Func/MemoizeEvaluation.cxx
@@ -329,6 +329,12 @@ String MemoizeEvaluation::__str__(const String & offset) const
   return OSS(false) << evaluation_.getImplementation()->__str__(offset);
 }
 
+/* Is it safe to call in parallel? */
+Bool MemoizeEvaluation::isParallel() const
+{
+  return false;
+}
+
 /* Method save() stores the object through the StorageManager */
 void MemoizeEvaluation::save(Advocate & adv) const
 {

--- a/lib/src/Base/Func/ParametricEvaluation.cxx
+++ b/lib/src/Base/Func/ParametricEvaluation.cxx
@@ -209,6 +209,10 @@ Bool ParametricEvaluation::isLinearlyDependent(const UnsignedInteger index) cons
   return function_.isLinearlyDependent(inputPositions_[index]);
 }
 
+Bool ParametricEvaluation::isParallel() const
+{
+  return function_.getImplementation()->isParallel();
+}
 
 /* String converter */
 String ParametricEvaluation::__repr__() const

--- a/lib/src/Base/Func/SymbolicEvaluation.cxx
+++ b/lib/src/Base/Func/SymbolicEvaluation.cxx
@@ -268,6 +268,13 @@ Bool SymbolicEvaluation::isLinearlyDependent(const UnsignedInteger index) const
   return true;
 }
 
+/* Is it safe to call in parallel? */
+Bool SymbolicEvaluation::isParallel() const
+{
+  // neither Exprtk nor muParser are thread-safe
+  return false;
+}
+
 /* Invalid values check accessor */
 void SymbolicEvaluation::setCheckOutput(const Bool checkOutput)
 {

--- a/lib/src/Base/Func/openturns/AggregatedEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/AggregatedEvaluation.hxx
@@ -90,6 +90,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Base/Func/openturns/ComposedEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/ComposedEvaluation.hxx
@@ -93,6 +93,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
 protected:
 
   ComposedEvaluation() {};

--- a/lib/src/Base/Func/openturns/DualLinearCombinationEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/DualLinearCombinationEvaluation.hxx
@@ -102,6 +102,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Base/Func/openturns/EvaluationImplementation.hxx
+++ b/lib/src/Base/Func/openturns/EvaluationImplementation.hxx
@@ -126,6 +126,9 @@ public:
   virtual Bool isLinear() const;
   virtual Bool isLinearlyDependent(const UnsignedInteger index) const;
 
+  /** Is it safe to call in parallel? */
+  virtual Bool isParallel() const;
+
   /** Invalid values check accessor */
   virtual void setCheckOutput(const Bool checkOutput);
   virtual Bool getCheckOutput() const;

--- a/lib/src/Base/Func/openturns/EvaluationProxy.hxx
+++ b/lib/src/Base/Func/openturns/EvaluationProxy.hxx
@@ -116,6 +116,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Invalid values check accessor */
   void setCheckOutput(const Bool checkOutput) override;
   Bool getCheckOutput() const override;

--- a/lib/src/Base/Func/openturns/FunctionImplementation.hxx
+++ b/lib/src/Base/Func/openturns/FunctionImplementation.hxx
@@ -168,9 +168,11 @@ public:
   virtual UnsignedInteger getHessianCallsNumber() const;
 
   /** Linearity accessors */
-  Bool isLinear() const;
-  Bool isLinearlyDependent(const UnsignedInteger index) const;
+  virtual Bool isLinear() const;
+  virtual Bool isLinearlyDependent(const UnsignedInteger index) const;
 
+  /** Is it safe to call in parallel? */
+  virtual Bool isParallel() const;
 
   /** Draw the given 1D marginal output as a function of the given 1D marginal input around the given central point */
   virtual Graph draw(const UnsignedInteger inputMarginal,

--- a/lib/src/Base/Func/openturns/LinearCombinationEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/LinearCombinationEvaluation.hxx
@@ -96,6 +96,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Base/Func/openturns/MemoizeEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/MemoizeEvaluation.hxx
@@ -124,6 +124,9 @@ public:
   /** Retrieve the history of the output values */
   Sample getOutputHistory() const;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Base/Func/openturns/MethodBoundEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/MethodBoundEvaluation.hxx
@@ -24,7 +24,6 @@
 
 #include "openturns/EvaluationImplementation.hxx"
 #include "openturns/FunctionImplementation.hxx"
-#include "openturns/Point.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -127,7 +126,7 @@ public:
 
 
   /** Virtual constructor */
-  virtual MethodBoundEvaluation * clone() const
+  MethodBoundEvaluation * clone() const override
   {
     return new MethodBoundEvaluation(*this);
   }
@@ -141,7 +140,7 @@ public:
 
 
   /** String converter */
-  virtual String __repr__() const
+  String __repr__() const override
   {
     OSS oss;
     oss << "class=MethodBoundEvaluation name=" << getName();
@@ -152,23 +151,28 @@ public:
   /* Here is the interface that all derived class must implement */
 
   /** Operator () */
-  virtual Point operator() (const Point & inP) const
+  Point operator() (const Point & inP) const override
   {
-    Point result(ReturnTypeAdapter<ReturnType_>::toPoint( ( obj_.*method_ ) ( ArgumentTypeAdapter<ArgumentType_>::fromPoint( inP ) ) ));
+    Point result(ReturnTypeAdapter<ReturnType_>::toPoint( ( obj_.*method_ ) (ArgumentTypeAdapter<ArgumentType_>::fromPoint(inP))));
     callsNumber_.increment();
     return result;
   }
 
   /** Accessor for input point dimension */
-  virtual UnsignedInteger getInputDimension() const
+  UnsignedInteger getInputDimension() const override
   {
     return inputDimension_;
   }
 
   /** Accessor for output point dimension */
-  virtual UnsignedInteger getOutputDimension() const
+  UnsignedInteger getOutputDimension() const override
   {
     return outputDimension_;
+  }
+
+  Bool isParallel() const override
+  {
+    return false;
   }
 
 
@@ -203,9 +207,9 @@ FunctionImplementation
 bindMethod (const EvaluableObject & obj,
             typename MethodBoundEvaluation<EvaluableObject, ReturnType_, ArgumentType_>::EvaluationMethod method,
             const UnsignedInteger inputDimension,
-            const UnsignedInteger outputDimension )
+            const UnsignedInteger outputDimension)
 {
-  return FunctionImplementation( new MethodBoundEvaluation<EvaluableObject, ReturnType_, ArgumentType_>( obj, method, inputDimension, outputDimension ) );
+  return FunctionImplementation(new MethodBoundEvaluation<EvaluableObject, ReturnType_, ArgumentType_>(obj, method, inputDimension, outputDimension));
 }
 
 

--- a/lib/src/Base/Func/openturns/ParametricEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/ParametricEvaluation.hxx
@@ -81,6 +81,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** String converter */
   String __repr__() const override;
   String __str__(const String & offset = "") const override;

--- a/lib/src/Base/Func/openturns/SymbolicEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/SymbolicEvaluation.hxx
@@ -93,6 +93,9 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
+
   /** Invalid values check accessor */
   void setCheckOutput(const Bool checkOutput) override;
 

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -402,7 +402,7 @@ CovarianceMatrix CovarianceModelImplementation::discretize(const Sample & vertic
     CovarianceMatrix rhoMatrix(size);
     const CovarianceModelDiscretizeKroneckerPolicy policy( vertices, rhoMatrix, *this );
     // The loop is over the lower block-triangular part
-    TBB::ParallelFor( 0, size * (size + 1) / 2, policy );
+    TBB::ParallelForCondition(isParallel(), 0, size * (size + 1) / 2, policy);
     rhoMatrix.checkSymmetry();
     outputCovariance_.checkSymmetry();
     // Compute the Kronecker product of rhoMatrix by outputCovariance_
@@ -414,7 +414,7 @@ CovarianceMatrix CovarianceModelImplementation::discretize(const Sample & vertic
     CovarianceMatrix covarianceMatrix(fullSize);
     const CovarianceModelDiscretizePolicy policy( vertices, covarianceMatrix, *this );
     // The loop is over the lower block-triangular part
-    TBB::ParallelFor( 0, size * (size + 1) / 2, policy );
+    TBB::ParallelForCondition(isParallel(), 0, size * (size + 1) / 2, policy);
     return covarianceMatrix;
   }
 }
@@ -444,7 +444,7 @@ TriangularMatrix CovarianceModelImplementation::discretizeAndFactorize(const Sam
     CovarianceMatrix rhoMatrix(size);
     const CovarianceModelDiscretizeKroneckerPolicy policy( vertices, rhoMatrix, *this );
     // The loop is over the lower block-triangular part
-    TBB::ParallelFor( 0, size * (size + 1) / 2, policy );
+    TBB::ParallelForCondition(isParallel(), 0, size * (size + 1) / 2, policy);
     // Compute the Cholesky factor of outputCovariance_
     if (outputCovarianceCholeskyFactor_.getDimension() == 0)
       outputCovarianceCholeskyFactor_ = outputCovariance_.computeCholesky();
@@ -526,12 +526,12 @@ Sample CovarianceModelImplementation::discretizeRow(const Sample & vertices,
   if (outputDimension_ == 1)
   {
     const CovarianceModelScalarDiscretizeRowPolicy policy( vertices, p, result, *this );
-    TBB::ParallelFor( 0, size, policy );
+    TBB::ParallelForCondition(isParallel(), 0, size, policy);
   }
   else
   {
     const CovarianceModelDiscretizeRowPolicy policy( vertices, p, result, *this );
-    TBB::ParallelFor( 0, size, policy );
+    TBB::ParallelForCondition(isParallel(), 0, size, policy);
   }
   return result;
 }
@@ -815,6 +815,12 @@ Bool CovarianceModelImplementation::isStationary() const
 Bool CovarianceModelImplementation::isDiagonal() const
 {
   return isDiagonal_;
+}
+
+/* Is it safe to compute discretize etc in parallel? */
+Bool CovarianceModelImplementation::isParallel() const
+{
+  return true;
 }
 
 /* Marginal accessor */

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -367,6 +367,14 @@ Bool ProductCovarianceModel::isStationary() const
   return true;
 }
 
+/* Is it safe to compute discretize etc in parallel? */
+Bool ProductCovarianceModel::isParallel() const
+{
+  for (UnsignedInteger i = 0; i < collection_.getSize(); ++i)
+    if (!collection_[i].getImplementation()->isParallel()) return false;
+  return true;
+}
+
 /* String converter */
 String ProductCovarianceModel::__repr__() const
 {

--- a/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
+++ b/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
@@ -136,6 +136,12 @@ Description StationaryFunctionalCovarianceModel::getFullParameterDescription() c
   return description;
 }
 
+/* Is it safe to compute discretize etc in parallel? */
+Bool StationaryFunctionalCovarianceModel::isParallel() const
+{
+  return rho_.getImplementation()->isParallel();
+}
+
 /* String converter */
 String StationaryFunctionalCovarianceModel::__repr__() const
 {

--- a/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
+++ b/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
@@ -261,6 +261,14 @@ Bool TensorizedCovarianceModel::isDiagonal() const
   return true;
 }
 
+/* Is it safe to compute discretize etc in parallel? */
+Bool TensorizedCovarianceModel::isParallel() const
+{
+  for (UnsignedInteger i = 0; i < collection_.getSize(); ++i)
+    if (!collection_[i].getImplementation()->isParallel()) return false;
+  return true;
+}
+
 /* String converter */
 String TensorizedCovarianceModel::__repr__() const
 {

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -140,6 +140,9 @@ public:
   /** Is it a diagonal covariance model ? */
   virtual Bool isDiagonal() const;
 
+  /** Is it safe to compute discretize etc in parallel? */
+  virtual Bool isParallel() const;
+
   /** Amplitude accessors */
   virtual Point getAmplitude() const;
   virtual void setAmplitude(const Point & amplitude);

--- a/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
@@ -77,6 +77,9 @@ public:
   /** Is it a stationary covariance model ? */
   Bool isStationary() const override;
 
+  /** Is it safe to compute discretize etc in parallel? */
+  Bool isParallel() const override;
+
   /** String converter */
   String __repr__() const override;
 

--- a/lib/src/Base/Stat/openturns/StationaryFunctionalCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/StationaryFunctionalCovarianceModel.hxx
@@ -62,6 +62,9 @@ public:
   Function getRho() const;
   void setRho(const Function & rho);
 
+  /** Is it safe to compute discretize etc in parallel? */
+  Bool isParallel() const override;
+
   /** String converter */
   String __repr__() const override;
 

--- a/lib/src/Base/Stat/openturns/TensorizedCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/TensorizedCovarianceModel.hxx
@@ -80,6 +80,9 @@ public:
   /** Is it a diagonal covariance model ? */
   Bool isDiagonal() const override;
 
+  /** Is it safe to compute discretize etc in parallel? */
+  Bool isParallel() const override;
+
   /** String converter */
   String __repr__() const override;
 

--- a/lib/src/Uncertainty/Algorithm/Classification/MixtureClassifier.cxx
+++ b/lib/src/Uncertainty/Algorithm/Classification/MixtureClassifier.cxx
@@ -84,7 +84,7 @@ UnsignedInteger MixtureClassifier::classify(const Point& inP) const
   return bestClass;
 }
 
-Indices MixtureClassifier::classifySequential(const Sample & inS) const
+Indices MixtureClassifier::classify(const Sample & inS) const
 {
   const UnsignedInteger mixtureSize = mixture_.getDistributionCollection().getSize();
   const UnsignedInteger size = inS.getSize();

--- a/lib/src/Uncertainty/Algorithm/Classification/openturns/MixtureClassifier.hxx
+++ b/lib/src/Uncertainty/Algorithm/Classification/openturns/MixtureClassifier.hxx
@@ -54,9 +54,7 @@ public:
   /** Associate a point to a class */
   using ClassifierImplementation::classify;
   UnsignedInteger classify(const Point & inP) const override;
-
-private:
-  Indices classifySequential(const Sample & inS) const override;
+  Indices classify(const Sample & inS) const override;
 public:
 
   /** Grade a point as if it were associated to a class */

--- a/python/src/CovarianceModelImplementation.i
+++ b/python/src/CovarianceModelImplementation.i
@@ -6,5 +6,7 @@
 
 %include CovarianceModelImplementation_doc.i
 
+%ignore OT::CovarianceModelImplementation::isParallel;
+
 %include openturns/CovarianceModelImplementation.hxx
 namespace OT{ %extend CovarianceModelImplementation { CovarianceModelImplementation(const CovarianceModelImplementation & other) { return new OT::CovarianceModelImplementation(other); } } }

--- a/python/src/EvaluationImplementation.i
+++ b/python/src/EvaluationImplementation.i
@@ -6,5 +6,7 @@
 
 %include EvaluationImplementation_doc.i
 
+%ignore OT::EvaluationImplementation::isParallel;
+
 %include openturns/EvaluationImplementation.hxx
 namespace OT { %extend EvaluationImplementation { EvaluationImplementation(const EvaluationImplementation & other) { return new OT::EvaluationImplementation(other); } } }

--- a/python/src/FunctionImplementation.i
+++ b/python/src/FunctionImplementation.i
@@ -15,5 +15,7 @@
 %ignore OT::FunctionImplementation::getUseDefaultHessianImplementation;
 %ignore OT::FunctionImplementation::setUseDefaultHessianImplementation;
 
+%ignore OT::FunctionImplementation::isParallel;
+
 %include openturns/FunctionImplementation.hxx
 namespace OT { %extend FunctionImplementation { FunctionImplementation(const FunctionImplementation & other) { return new OT::FunctionImplementation(other); } } }

--- a/python/src/PythonEvaluation.cxx
+++ b/python/src/PythonEvaluation.cxx
@@ -467,6 +467,12 @@ Bool PythonEvaluation::isLinearlyDependent(const UnsignedInteger index) const
     return false;
 }
 
+/* Is it safe to call in parallel? */
+Bool PythonEvaluation::isParallel() const
+{
+  return false;
+}
+
 /* Method save() stores the object through the StorageManager */
 void PythonEvaluation::save(Advocate & adv) const
 {

--- a/python/src/openturns/PythonEvaluation.hxx
+++ b/python/src/openturns/PythonEvaluation.hxx
@@ -78,6 +78,8 @@ public:
   Bool isLinear() const override;
   Bool isLinearlyDependent(const UnsignedInteger index) const override;
 
+  /** Is it safe to call in parallel? */
+  Bool isParallel() const override;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/python/test/t_StationaryFunctionalCovarianceModel_std.py
+++ b/python/test/t_StationaryFunctionalCovarianceModel_std.py
@@ -40,3 +40,41 @@ assert c != c_ref, "inactive parameter"
 X = ot.Uniform(1, 2).getSample(10)
 C = cov.discretize(X)
 assert C.getNbRows() == 10, "wrong size"
+
+# thread-safety test
+for i in range(1000):
+
+    def fun_mixte(X):
+        xx, z = X
+        if z == 0:
+            y = m.sin(7.0*xx)
+        else:
+            y = 2.0*m.sin(7.0*xx)
+        return y
+
+    XX_input = ot.Sample([[0.1,0], [0.32,0], [0.6,0], [0.9,0], [0.07,1], [0.1,1], [0.4,1], [0.5,1], [0.85,1]])
+    y_output = ot.Sample(len(XX_input),1)
+    for i in range(len(XX_input)):
+        y_output[i, 0] = fun_mixte(XX_input[i])
+
+    def C(s, t):
+        return m.exp( -4.0 * abs(s - t) / (1 + (s * s + t * t)))
+
+    N = 32
+    a = 4.0
+    myMesh = ot.IntervalMesher([N]).build(ot.Interval(-a, a))
+
+    myCovariance = ot.CovarianceMatrix(myMesh.getVerticesNumber())
+    for k in range(myMesh.getVerticesNumber()):
+        t = myMesh.getVertices()[k]
+        for l in range(k + 1):
+            s = myMesh.getVertices()[l]
+            myCovariance[k, l] = C(s[0], t[0])
+
+    covModel_discrete = ot.UserDefinedCovarianceModel(myMesh, myCovariance)
+    f_ = ot.SymbolicFunction(["tau", "theta", "sigma"], ["(tau!=0) * exp(-1/theta) * sigma * sigma +  (tau==0) * exp(0) * sigma * sigma"])
+    rho = ot.ParametricFunction(f_, [1, 2], [0.2, 0.3])
+    covModel_discrete = ot.StationaryFunctionalCovarianceModel([1.0], [1.0], rho)
+    covModel_continuous = ot.SquaredExponential([1.0],[1.0])
+    covarianceModel = ot.ProductCovarianceModel([covModel_continuous, covModel_discrete])
+    covarianceModel.discretize(XX_input)


### PR DESCRIPTION
Here the goal is to fix StationaryFunctionalCovarianceModel thread safety in CovarianceModel::discretize, so we need:
- Function::isParallel 
- CovarianceModel::isParallel
- Add TBB::ParallelForCondition to reuse the parallel path, but to disable the actual parallelization according to a boolean (eg the value of CovarianceModel::isParallel)