### PR TITLE
Improved example for Kolmogorov statistics: take sort into account.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@
  * Removed StationaryCovarianceModel
 
 === Documentation ===
+ * Fixed example and plot of Kolmogorov statistics.
 
 === Python module ===
  * Serialize Python wrapper objects using dill (PythonDistribution, PythonFunction ...)

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_distribution.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_distribution.py
@@ -5,18 +5,18 @@ Kolmogorov-Smirnov : get the statistics distribution
 # %% 
 
 # %%
-# In this example, we draw the Kolmogorov-Smirnov distribution for a sample size 10. We want to test the hypothesis that this sample has the `Uniform(0,1)` distribution. The K.S. distribution is first plot in the case where the parameters of the Uniform distribution are known. Then we plot the distribution when the parameters of the Uniform distribution are estimated from the sample.
+# In this example, we draw the Kolmogorov-Smirnov distribution for a sample size 10. 
+# We want to test the hypothesis that this sample has the `Uniform(0, 1)` 
+# distribution. 
+# The K.S. distribution is first plot in the case where the 
+# parameters of the Uniform distribution are known. 
+# Then we plot the distribution when the parameters of the `Uniform` 
+# distribution are estimated from the sample.
 #
 # *Reference* : Hovhannes Keutelian, "The Kolmogorov-Smirnov test when parameters are estimated from data", 30 April 1991, Fermilab
 #
-# There is a sign error in the paper; the equation:
-# ```
-# D[i]=max(abs(S+step),D[i]) 
-# ```
-# must be replaced with 
-# ```
-# D[i]=max(abs(S-step),D[i]) 
-# ```
+# Note: There is a sign error in the paper; the equation:
+# `D[i]=max(abs(S+step),D[i])` must be replaced with `D[i]=max(abs(S-step),D[i])`.
 
 # %%
 import openturns as ot

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_distribution.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_distribution.py
@@ -8,9 +8,9 @@ Kolmogorov-Smirnov : get the statistics distribution
 # In this example, we draw the Kolmogorov-Smirnov distribution for a sample size 10. 
 # We want to test the hypothesis that this sample has the `Uniform(0, 1)` 
 # distribution. 
-# The K.S. distribution is first plot in the case where the 
-# parameters of the Uniform distribution are known. 
-# Then we plot the distribution when the parameters of the `Uniform` 
+# The K.S. distribution is first plotted in the case where the 
+# parameters of the uniform distribution are known.
+# Then we plot the distribution when the parameters of the uniform
 # distribution are estimated from the sample.
 #
 # *Reference* : Hovhannes Keutelian, "The Kolmogorov-Smirnov test when parameters are estimated from data", 30 April 1991, Fermilab

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -95,9 +95,9 @@ sample = N.getSample(n)
 # Compute the index which achieves the maximum Kolmogorov-Smirnov distance.
 
 # %%
-# We then create a uiform distribution whose parameters are estimated  
+# We then create a uniform distribution whose parameters are estimated  
 # from the sample.  
-# This way, the K.S. distance is large enough to being graphically significant.
+# This way, the K.S. distance is large enough to be graphically significant.
 
 # %%
 distFactory = ot.UniformFactory()
@@ -117,6 +117,6 @@ view = viewer.View(graph)
 plt.show()
 
 # %%
-# We see that the K.S. statistics is acheived where the distance  
+# We see that the K.S. statistics is achieved at the observation where the distance  
 # between the empirical distribution function of the sample and the  
 # candidate distribution is largest.

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -9,7 +9,7 @@ Kolmogorov-Smirnov : understand the statistics
 #
 # * We generate a sample from a gaussian distribution.
 # * We create a Uniform distribution which parameters are estimated from the sample.
-# * The Kolmogorov-Smirnov statistics is computed and plot on the empirical cumulated distribution function.
+# * Compute the Kolmogorov-Smirnov statistic and plot it on top of the empirical cumulated distribution function.
 
 # %%
 import openturns as ot
@@ -19,7 +19,12 @@ from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# The computeKSStatisticsIndex function computes the Kolmogorov-Smirnov distance between the sample and the distribution. Furthermore, it returns the index which achieves the maximum distance in the sorted sample. The following function is for teaching purposes only: use `FittingTest` for real applications.
+# The computeKSStatisticsIndex function computes the Kolmogorov-Smirnov 
+# distance between the sample and the distribution. 
+# Furthermore, it returns the index which achieves the maximum distance 
+# in the sorted sample. 
+# The following function is for teaching purposes only: use 
+# `FittingTest` for real applications.
 
 # %%
 def computeKSStatisticsIndex(sample, distribution):
@@ -48,7 +53,15 @@ def computeKSStatisticsIndex(sample, distribution):
 
 
 # %%
-# The drawKSDistance function plots the empirical distribution function of the sample and the Kolmogorov-Smirnov distance at point x. The empirical CDF is a staircase function and is discontinuous at each observation. The computeEmpiricalCDF() method computes the probability P(X <= x), but this only takes into account for half the extreme values of the CDF. The other half is P(X < x) which is approximated by P(X <= x - delta) where delta is close to zero.
+# The `drawKSDistance()` function plots the empirical distribution 
+# function of the sample and the Kolmogorov-Smirnov distance at point x. 
+# The empirical CDF is a staircase function and is discontinuous at  
+# each observation. The computeEmpiricalCDF() method computes  
+# the probability :math:`\mathbb{P}(X \leq x)`, but this only  
+# takes into account for half the extreme values of the CDF.  
+# The other half is :math:`\mathbb{P}(X < x)` which is approximated  
+# by :math:`\mathbb{P}(X \leq x - \delta)` where :math:`\delta`  
+# is close to zero.
 
 # %%
 def drawKSDistance(
@@ -82,7 +95,7 @@ def drawKSDistance(
 
 
 # %%
-# We generate a sample from a standard gaussian distribution.
+# We generate a sample from a standard normal distribution.
 
 # %%
 N = ot.Normal()
@@ -93,7 +106,9 @@ sample = N.getSample(n)
 # Compute the index which achieves the maximum Kolmogorov-Smirnov distance.
 
 # %%
-# We then create a Uniform distribution which parameters are estimated from the sample. This way, the K.S. distance is large enough to being graphically significant.
+# We then create a uiform distribution whose parameters are estimated  
+# from the sample.  
+# This way, the K.S. distance is large enough to being graphically significant.
 
 # %%
 distFactory = ot.UniformFactory()
@@ -113,4 +128,6 @@ view = viewer.View(graph)
 plt.show()
 
 # %%
-# We see that the K.S. statistics is acheived where the distance between the empirical distribution function of the sample and the candidate distribution is largest.
+# We see that the K.S. statistics is acheived where the distance  
+# between the empirical distribution function of the sample and the  
+# candidate distribution is largest.

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -5,7 +5,7 @@ Kolmogorov-Smirnov : understand the statistics
 # %%
 
 # %%
-# In this example, we illustrate how the Kolmogorov-Smirnov statistics is computed.
+# In this example, we illustrate how the Kolmogorov-Smirnov statistic is computed.
 #
 # * We generate a sample from a normal distribution.
 # * We create a uniform distribution and estimate its parameters from the sample.

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -7,8 +7,8 @@ Kolmogorov-Smirnov : understand the statistics
 # %%
 # In this example, we illustrate how the Kolmogorov-Smirnov statistics is computed.
 #
-# * We generate a sample from a gaussian distribution.
-# * We create a Uniform distribution which parameters are estimated from the sample.
+# * We generate a sample from a normal distribution.
+# * We create a uniform distribution and estimate its parameters from the sample.
 # * Compute the Kolmogorov-Smirnov statistic and plot it on top of the empirical cumulated distribution function.
 
 # %%

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -53,36 +53,24 @@ def computeKSStatisticsIndex(sample, distribution):
 
 
 # %%
-# The `drawKSDistance()` function plots the empirical distribution 
-# function of the sample and the Kolmogorov-Smirnov distance at point x. 
-# The empirical CDF is a staircase function and is discontinuous at  
-# each observation. The computeEmpiricalCDF() method computes  
-# the probability :math:`\mathbb{P}(X \leq x)`, but this only  
-# takes into account for half the extreme values of the CDF.  
-# The other half is :math:`\mathbb{P}(X < x)` which is approximated  
-# by :math:`\mathbb{P}(X \leq x - \delta)` where :math:`\delta`  
-# is close to zero.
+# The `drawKSDistance()` function plots the empirical distribution function of the sample and the Kolmogorov-Smirnov distance at point x. The empirical CDF is a staircase function and is discontinuous at each observation. Denote by :math:`\hat{F}` the empirical CDF. For a given observation :math:`x` which achieves the maximum distance to the candidate distribution CDF, let us denote :math:`\hat{F}^- = \lim_{x \rightarrow x^-} \hat{F}(x)` and :math:`\hat{F}^+ = \lim_{x\rightarrow x^+} \hat{F}(x)`. The maximum distance can be achieved either by :math:`\hat{F}^-` or :math:`\hat{F}^+`. The `computeEmpiricalCDF(x)` method computes :math:`\hat{F}^+=\mathbb{P}(X \leq x)`. We compute :math:`\hat{F}^-` with the equation :math:`\hat{F}^- = \hat{F}^+ - 1/n` where :math:`n` is the sample size.
 
 # %%
-def drawKSDistance(
-    sample, distribution, observation, D, distFactory, delta_x=ot.Point([1.0e-6])
-):
+def drawKSDistance(sample, distribution, observation, D, distFactory):
     graph = ot.Graph("KS Distance = %.4f" % (D), "X", "CDF", True, "topleft")
-    # Vertical line at point x
-    ECDF_index = sample.computeEmpiricalCDF(observation)
-    ECDF_index_shifted = sample.computeEmpiricalCDF(observation - delta_x)
+    # Thick vertical line at point x
+    ECDF_x_plus = sample.computeEmpiricalCDF(observation)
+    ECDF_x_minus = ECDF_x_plus - 1.0 / sample.getSize()
     CDF_index = distribution.computeCDF(observation)
     curve = ot.Curve(
         [observation[0], observation[0], observation[0]],
-        [ECDF_index, ECDF_index_shifted, CDF_index],
+        [ECDF_x_plus, ECDF_x_minus, CDF_index],
     )
-    curve.setColor("green")
     curve.setLegend("KS Statistics")
     curve.setLineWidth(4.0 * curve.getLineWidth())
     graph.add(curve)
     # Empirical CDF
     empiricalCDF = ot.UserDefined(sample).drawCDF()
-    empiricalCDF.setColors(["blue"])
     empiricalCDF.setLegends(["Empirical DF"])
     graph.add(empiricalCDF)
     #
@@ -91,6 +79,7 @@ def drawKSDistance(
     cdf = distribution.drawCDF()
     cdf.setLegends([distname])
     graph.add(cdf)
+    graph.setColors(ot.Drawable_BuildDefaultPalette(3))
     return graph
 
 

--- a/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
+++ b/python/doc/examples/data_analysis/statistical_tests/plot_kolmogorov_statistics.py
@@ -19,7 +19,7 @@ from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# The computeKSStatisticsIndex function computes the Kolmogorov-Smirnov 
+# The `computeKSStatisticsIndex()` function computes the Kolmogorov-Smirnov 
 # distance between the sample and the distribution. 
 # Furthermore, it returns the index which achieves the maximum distance 
 # in the sorted sample. 


### PR DESCRIPTION
This fixes a bug in:
openturns.github.io/openturns/master/auto_data_analysis/statistical_hypothesis_testing/plot_kolmogorov_statistics.html

The wrong figure is:
![image](https://user-images.githubusercontent.com/31351465/102379002-b05ea800-3fc6-11eb-8361-a204fc9118f0.png)

The figure is obviously wrong, because the location where the maximum distance occurs cannot be where the green line is represented. Actually, the code for the index of the observation which achieves the maximum distance is wrong, because it does not take into account for the sorted sample (the value of the statistics is correct).

A correct figure is:
![image](https://user-images.githubusercontent.com/31351465/102379065-c53b3b80-3fc6-11eb-82c1-4626d827857a.png)
