### PR TITLE
Non-regression StationaryFunctionalCovarianceModel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,7 @@
  * #1729 (LinearModelAnalysis sometimes fail)
  * #1737 (Low rank tensor doc issues)
  * #1742 (The example which shows how to set the figure size is wrong.)
+ * #1752 (Error while estimating the reduced log-likelihood when using a StationaryFunctionalCovarianceModel)
  * #1759 (Kriging model with StationaryFunctionalCovarianceModel might provide bad results)
 
 

--- a/lib/test/t_KrigingAlgorithm_std.cxx
+++ b/lib/test/t_KrigingAlgorithm_std.cxx
@@ -64,6 +64,9 @@ int main(int, char *[])
       Basis basis(ConstantBasisFactory(dimension).build());
       SquaredExponential covarianceModel(Point(1, 1e-02), Point(1, 4.50736));
       KrigingAlgorithm algo(X, Y, covarianceModel, basis);
+
+      // set sensible optimization bounds and estimate hyperparameters
+      algo.setOptimizationBounds(Interval(X.getMin(), X.getMax()));
       algo.run();
 
       // perform an evaluation
@@ -81,7 +84,7 @@ int main(int, char *[])
       CovarianceMatrix covMatrix(result.getConditionalCovariance(X));
 
       // Validation of the covariance ==> should be null on the learning set
-      assert_almost_equal(covMatrix, SquareMatrix(sampleSize), 8.95e-7, 8.95e-7);
+      assert_almost_equal(covMatrix, SquareMatrix(sampleSize), 0.0, 1e-14);
 
       // Covariance per marginal & extract variance component
       Collection<CovarianceMatrix> coll(result.getConditionalMarginalCovariance(X));
@@ -92,6 +95,9 @@ int main(int, char *[])
       // Validation of marginal variance
       const Point marginalVariance(result.getConditionalMarginalVariance(X));
       assert_almost_equal(marginalVariance, Point(sampleSize), 1e-14, 1e-14);
+
+      // Prediction accuracy
+      assert_almost_equal(Y2, result.getMetaModel()(X2), 0.3, 0.0);
     }
 
     {

--- a/python/test/t_KrigingAlgorithm_funcmodel.py
+++ b/python/test/t_KrigingAlgorithm_funcmodel.py
@@ -25,6 +25,7 @@ outputValidSample = model(inputValidSample)
 # Basis definition
 basis = ot.LinearBasisFactory(inputDimension).build()
 
+# Reimplement the squared exponential covariance model
 rho = ot.SymbolicFunction(
     ['x', 'y'], ['exp(-0.5* (x * x + y * y))'])
 covarianceModel = ot.StationaryFunctionalCovarianceModel([5, 2], [1], rho)
@@ -32,8 +33,25 @@ covarianceModel.setParameter([6.72648, 3.49326, 4.90341])
 
 # Kriging algorithm
 algo = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
+loglikelihood = algo.getReducedLogLikelihoodFunction()([50.0] * inputDimension)
 algo.setOptimizeParameters(False)
 algo.run()
 result = algo.getResult()
 metaModel = result.getMetaModel()
-ott.assert_almost_equal(outputValidSample,  metaModel(inputValidSample), 5.0e-3, 5.0e-3)
+
+# Consistency check: does the reimplementation fit the SquaredExponential class?
+squaredExponential = ot.SquaredExponential(inputDimension)
+squaredExponential.setParameter([6.72648, 3.49326, 4.90341])
+algoSE = ot.KrigingAlgorithm(inputSample, outputSample, squaredExponential, basis)
+loglikelihoodSE = algoSE.getReducedLogLikelihoodFunction()([50.0] * inputDimension)
+ott.assert_almost_equal(loglikelihood, loglikelihoodSE, 0.0, 0.0)
+
+# High level consistency check: does the prediction fit too?
+algoSE.setOptimizeParameters(False)
+algoSE.run()
+resultSE = algoSE.getResult()
+metaModelSE = resultSE.getMetaModel()
+ott.assert_almost_equal(metaModel(inputValidSample), metaModelSE(inputValidSample), 0.0, 0.0)
+
+# Validate the metamodel
+ott.assert_almost_equal(outputValidSample, metaModel(inputValidSample), 5.0e-3, 5.0e-3)


### PR DESCRIPTION
New unit test: make sure the Kriging log-likelihood of a squared exponential kernel created as a StationaryFunctionalCovarianceModel is the same as that of the actual SquaredExponential kernel.

Closes #1752.