### PR TITLE
New specific method to CovarianceModel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@
  * Moved Sample::computeStandardDeviationPerComponent, to computeStandardDeviation
  * Deprecated KarhunenLoeveResult::getEigenValues, use getEigenvalues
  * Removed StationaryCovarianceModel
+ * CovarianceModel.computeAsScalar allows scalars
 
 === Documentation ===
 

--- a/lib/src/Base/Stat/AbsoluteExponential.cxx
+++ b/lib/src/Base/Stat/AbsoluteExponential.cxx
@@ -82,6 +82,17 @@ Scalar AbsoluteExponential::computeAsScalar(const Collection<Scalar>::const_iter
   return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-tauOverThetaNorm);
 }
 
+Scalar AbsoluteExponential::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar tauOverThetaNorm = std::abs(tau / scale_[0]);
+  return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-tauOverThetaNorm);
+}
+
 /* Gradient */
 Matrix AbsoluteExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/CovarianceModel.cxx
+++ b/lib/src/Base/Stat/CovarianceModel.cxx
@@ -93,6 +93,17 @@ Scalar CovarianceModel::computeAsScalar(const Point &tau) const
   return getImplementation()->computeAsScalar(tau);
 }
 
+Scalar CovarianceModel::computeAsScalar(const Scalar s,
+                                        const Scalar t) const
+{
+  return getImplementation()->computeAsScalar(s, t);
+}
+
+Scalar CovarianceModel::computeAsScalar(const Scalar tau) const
+{
+  return getImplementation()->computeAsScalar(tau);
+}
+
 SquareMatrix CovarianceModel::operator() (const Scalar tau) const
 {
   return getImplementation()->operator() (tau);

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -183,6 +183,8 @@ Scalar CovarianceModelImplementation::computeAsScalar (const Point & s,
   if (t.getDimension() != inputDimension_)
     throw InvalidArgumentException(HERE) << "Error: the point t has dimension=" << t.getDimension() << ", expected dimension=" << inputDimension_;
   // Return the scalar value
+  // Even if model is stationary we do not create a new Point tau
+  // We prefer relying on the iterator method
   return computeAsScalar(s.begin(), t.begin());
 }
 
@@ -191,11 +193,33 @@ Scalar CovarianceModelImplementation::computeAsScalar(const Collection<Scalar>::
 {
   throw NotYetImplementedException(HERE) << "In CovarianceModelImplementation::computeAsScalar(const Collection<Scalar>::const_iterator & s_begin, const Collection<Scalar>::const_iterator & t_begin) const";
 }
+
 Scalar CovarianceModelImplementation::computeAsScalar(const Point &) const
 {
   if (outputDimension_ != 1)
     throw NotDefinedException(HERE) << "Error: the covariance model is of dimension=" << outputDimension_ << ", expected dimension=1.";
   throw NotYetImplementedException(HERE) << "In CovarianceModelImplementation::computeAsScalar (const Point & tau) const";
+}
+
+Scalar CovarianceModelImplementation::computeAsScalar(const Scalar s,
+                                                      const Scalar t) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  if (isStationary())
+    return computeAsScalar(s - t);
+  throw NotYetImplementedException(HERE) << "In CovarianceModelImplementation::computeAsScalar(const Scalar s, const Scalar t) const";
+}
+
+Scalar CovarianceModelImplementation::computeAsScalar(const Scalar) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  throw NotYetImplementedException(HERE) << "In CovarianceModelImplementation::computeAsScalar(const Scalar tau) const";
 }
 
 /* Computation of the covariance function */

--- a/lib/src/Base/Stat/DiracCovarianceModel.cxx
+++ b/lib/src/Base/Stat/DiracCovarianceModel.cxx
@@ -21,6 +21,7 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Exception.hxx"
 #include "openturns/Log.hxx"
+#include "openturns/SpecFunc.hxx"
 #include "openturns/HMatrix.hxx"
 #include "openturns/HMatrixFactory.hxx"
 #include "openturns/TBB.hxx"
@@ -125,7 +126,7 @@ DiracCovarianceModel::DiracCovarianceModel(const UnsignedInteger inputDimension,
 
 void DiracCovarianceModel::computeCovariance()
 {
-  // Method that helps to compute outputCovariance_ attribut (for tau=0)
+  // Method that helps to compute outputCovariance_ (for tau=0)
   // after setAmplitude, setOutputCorrelation
   outputCovariance_ = CovarianceMatrix(outputDimension_);
   for(UnsignedInteger j = 0; j < outputDimension_; ++j) outputCovariance_(j, j) = amplitude_[j] * amplitude_[j] * (1.0 + nuggetFactor_);
@@ -185,6 +186,18 @@ Scalar DiracCovarianceModel::computeAsScalar(const Collection<Scalar>::const_ite
   }
   tauNorm = sqrt(tauNorm);
   if (tauNorm == 0)
+    return outputCovariance_(0, 0);
+  else
+    return 0.0;
+}
+
+Scalar DiracCovarianceModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  if (std::abs(tau) <= SpecFunc::ScalarEpsilon)
     return outputCovariance_(0, 0);
   else
     return 0.0;

--- a/lib/src/Base/Stat/ExponentialModel.cxx
+++ b/lib/src/Base/Stat/ExponentialModel.cxx
@@ -137,6 +137,18 @@ Scalar ExponentialModel::computeAsScalar(const Collection<Scalar>::const_iterato
   return (tauOverThetaNorm == 0.0 ? amplitude_[0] * amplitude_[0] * (1.0 + nuggetFactor_) : amplitude_[0] * amplitude_[0] * exp(-tauOverThetaNorm));
 }
 
+Scalar ExponentialModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar tauOverThetaNorm = std::abs(tau / scale_[0]);
+  // Return value
+  return (tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-tauOverThetaNorm));
+}
+
 /** Gradient */
 Matrix ExponentialModel::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
+++ b/lib/src/Base/Stat/ExponentiallyDampedCosineModel.cxx
@@ -101,6 +101,19 @@ Scalar ExponentiallyDampedCosineModel::computeAsScalar(const Collection<Scalar>:
   return amplitude_[0] * amplitude_[0] * exp(-absTau) * cos(2.0 * M_PI * absTau);
 }
 
+Scalar ExponentiallyDampedCosineModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar absTau = std::abs(tau / scale_[0]);
+  if (absTau <= SpecFunc::ScalarEpsilon)
+    return amplitude_[0] * amplitude_[0] * (1.0 + nuggetFactor_);
+  return amplitude_[0] * amplitude_[0] * exp(-absTau) * cos(2.0 * M_PI * frequency_ * absTau);
+}
+
 /* Discretize the covariance function on a given TimeGrid */
 CovarianceMatrix ExponentiallyDampedCosineModel::discretize(const RegularGrid & timeGrid) const
 {
@@ -120,7 +133,6 @@ CovarianceMatrix ExponentiallyDampedCosineModel::discretize(const RegularGrid & 
     const Scalar covTau = computeAsScalar(Point(1, diag * timeStep));
     for (UnsignedInteger i = 0; i < size - diag; ++i) cov(i, i + diag) = covTau;
   }
-
   return cov;
 }
 

--- a/lib/src/Base/Stat/GeneralizedExponential.cxx
+++ b/lib/src/Base/Stat/GeneralizedExponential.cxx
@@ -92,6 +92,17 @@ Scalar GeneralizedExponential::computeAsScalar(const Collection<Scalar>::const_i
   return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-pow(tauOverThetaNorm, p_));
 }
 
+Scalar GeneralizedExponential::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar tauOverThetaNorm = std::abs(tau / scale_[0]);
+  return tauOverThetaNorm <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-pow(tauOverThetaNorm, p_));
+}
+
 /* Gradient wrt s */
 Matrix GeneralizedExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/MaternModel.cxx
+++ b/lib/src/Base/Stat/MaternModel.cxx
@@ -116,6 +116,19 @@ Scalar MaternModel::computeAsScalar(const Collection<Scalar>::const_iterator & s
     return outputCovariance_(0, 0) * exp(logNormalizationFactor_ + nu_ * std::log(scaledPoint) + SpecFunc::LogBesselK(nu_, scaledPoint));
 }
 
+Scalar MaternModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  const Scalar scaledPoint = std::abs(tau * sqrt2nuOverTheta_[0]);
+  if (scaledPoint <= SpecFunc::ScalarEpsilon)
+    return outputCovariance_(0, 0) * (1.0 + nuggetFactor_);
+  else
+    return outputCovariance_(0, 0) * exp(logNormalizationFactor_ + nu_ * std::log(scaledPoint) + SpecFunc::LogBesselK(nu_, scaledPoint));
+}
+
 /* Gradient */
 Matrix MaternModel::partialGradient(const Point & s,
                                     const Point & t) const

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -194,6 +194,15 @@ Scalar ProductCovarianceModel::computeAsScalar(const Collection<Scalar>::const_i
   return rho;
 }
 
+Scalar ProductCovarianceModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  return collection_[0].getImplementation()->computeAsScalar(tau);
+}
+
 /* Gradient */
 Matrix ProductCovarianceModel::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/SphericalModel.cxx
+++ b/lib/src/Base/Stat/SphericalModel.cxx
@@ -95,6 +95,21 @@ Scalar SphericalModel::computeAsScalar(const Collection<Scalar>::const_iterator 
   return amplitude_[0] * (1.0 - 0.5 * normTauOverScaleA * (3.0 - normTauOverScaleA * normTauOverScaleA));
 }
 
+Scalar SphericalModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar normTauOverScaleA = std::abs(tau / scale_[0]) / radius_;
+  if (normTauOverScaleA <= SpecFunc::ScalarEpsilon)
+    return amplitude_[0] * amplitude_[0] * (1.0 + nuggetFactor_);
+  if (normTauOverScaleA >= 1.0)
+    return 0.0;
+  return amplitude_[0] * amplitude_[0] * (1.0 - 0.5 * normTauOverScaleA * (3.0 - normTauOverScaleA * normTauOverScaleA));
+}
+
 /* Discretize the covariance function on a given TimeGrid */
 CovarianceMatrix SphericalModel::discretize(const RegularGrid & timeGrid) const
 {

--- a/lib/src/Base/Stat/SquaredExponential.cxx
+++ b/lib/src/Base/Stat/SquaredExponential.cxx
@@ -87,6 +87,17 @@ Scalar SquaredExponential::computeAsScalar(const Collection<Scalar>::const_itera
   return tauOverTheta2 <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-0.5 * tauOverTheta2);
 }
 
+Scalar SquaredExponential::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar tauOverTheta2 = tau * tau / (scale_[0]  * scale_[0]);
+  return tauOverTheta2 <= SpecFunc::ScalarEpsilon ? outputCovariance_(0, 0) * (1.0 + nuggetFactor_) : outputCovariance_(0, 0) * exp(-0.5 * tauOverTheta2);
+}
+
 /* Gradient */
 Matrix SquaredExponential::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
+++ b/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
@@ -87,6 +87,20 @@ Scalar StationaryFunctionalCovarianceModel::computeAsScalar(const Collection<Sca
   return outputCovariance_(0, 0) * rho_(tauOverTheta)[0];
 }
 
+Scalar StationaryFunctionalCovarianceModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+
+  const Scalar tauOverThetaNorm = std::abs(tau / scale_[0]);
+  if (tauOverThetaNorm <= SpecFunc::ScalarEpsilon)
+    return outputCovariance_(0, 0) * (1.0 + nuggetFactor_);
+  const Point tauOverTheta(1, tau / scale_[0]); 
+  return outputCovariance_(0, 0) * rho_(tauOverTheta)[0];
+}
+
 /* Gradient */
 Matrix StationaryFunctionalCovarianceModel::partialGradient(const Point & s,
     const Point & t) const

--- a/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
+++ b/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
@@ -134,6 +134,14 @@ Scalar TensorizedCovarianceModel::computeAsScalar(const Collection<Scalar>::cons
                                          << "Here, output dimension = " << outputDimension_;
   return collection_[0].getImplementation()->computeAsScalar(s_begin, t_begin);
 }
+Scalar TensorizedCovarianceModel::computeAsScalar(const Scalar tau) const
+{
+  if (inputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
+  if (outputDimension_ != 1)
+    throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
+  return collection_[0].getImplementation()->computeAsScalar(tau);
+}
 
 /* Computation of the covariance density function */
 SquareMatrix TensorizedCovarianceModel::operator() (const Point & s,

--- a/lib/src/Base/Stat/openturns/AbsoluteExponential.hxx
+++ b/lib/src/Base/Stat/openturns/AbsoluteExponential.hxx
@@ -56,6 +56,9 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
                          const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+
+  Scalar computeAsScalar(const Scalar tau) const override;
+
   /** Gradient */
   Matrix partialGradient(const Point & s, const Point & t) const override;
 

--- a/lib/src/Base/Stat/openturns/CovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModel.hxx
@@ -70,6 +70,11 @@ public:
 
   virtual Scalar computeAsScalar(const Point &tau) const;
 
+  virtual Scalar computeAsScalar(const Scalar s,
+                                 const Scalar t) const;
+
+  virtual Scalar computeAsScalar(const Scalar tau) const;
+
   virtual SquareMatrix operator()(const Scalar tau) const;
 
   virtual SquareMatrix operator() (const Point & tau) const;

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -80,6 +80,11 @@ public:
                                   const Point & t) const;
   virtual Scalar computeAsScalar(const Point &tau) const;
 
+  // Special case for 1D input /output  model
+  virtual Scalar computeAsScalar(const Scalar s,
+                                 const Scalar t) const;
+  virtual Scalar computeAsScalar(const Scalar tau) const;
+
 #ifndef SWIG
   // Special case for 1D model
   virtual Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,

--- a/lib/src/Base/Stat/openturns/DiracCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/DiracCovarianceModel.hxx
@@ -67,6 +67,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator &s_begin,
                          const Collection<Scalar>::const_iterator &t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Discretize the covariance function */
   using CovarianceModelImplementation::discretize;

--- a/lib/src/Base/Stat/openturns/ExponentialModel.hxx
+++ b/lib/src/Base/Stat/openturns/ExponentialModel.hxx
@@ -76,6 +76,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator &s_begin,
                          const Collection<Scalar>::const_iterator &t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Gradient */
   using CovarianceModelImplementation::partialGradient;

--- a/lib/src/Base/Stat/openturns/ExponentiallyDampedCosineModel.hxx
+++ b/lib/src/Base/Stat/openturns/ExponentiallyDampedCosineModel.hxx
@@ -1,7 +1,7 @@
 //                                               -*- C++ -*-
 /**
- *  @brief This class is enables to build an exponential covariance
- *  model, a second order model's implementation
+ *  @brief This class is enables to build an exponentially damped cosine
+ * covariance model.
  *
  *  Copyright 2005-2021 Airbus-EDF-IMACS-ONERA-Phimeca
  *
@@ -63,6 +63,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
                          const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   using CovarianceModelImplementation::operator();
   SquareMatrix operator() (const Point & tau) const override;

--- a/lib/src/Base/Stat/openturns/GeneralizedExponential.hxx
+++ b/lib/src/Base/Stat/openturns/GeneralizedExponential.hxx
@@ -55,12 +55,14 @@ public:
   Scalar computeAsScalar(const Point & tau) const override;
 #ifndef SWIG
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
-                                       const Collection<Scalar>::const_iterator & t_begin) const override;
+                         const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
 
+  Scalar computeAsScalar(const Scalar tau) const override;
+
   /** Gradient */
-  virtual Matrix partialGradient(const Point & s,
-                                 const Point & t) const override;
+  Matrix partialGradient(const Point & s,
+                         const Point & t) const override;
 
   /** P accessor */
   Scalar getP() const;

--- a/lib/src/Base/Stat/openturns/MaternModel.hxx
+++ b/lib/src/Base/Stat/openturns/MaternModel.hxx
@@ -55,8 +55,10 @@ public:
   Scalar computeAsScalar(const Point & tau) const override;
 #ifndef SWIG
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
-                                       const Collection<Scalar>::const_iterator & t_begin) const override;
+                         const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Gradient */
   Matrix partialGradient(const Point & s, const Point & t) const override;

--- a/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/ProductCovarianceModel.hxx
@@ -58,6 +58,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
                          const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Gradient */
   Matrix partialGradient(const Point & s,

--- a/lib/src/Base/Stat/openturns/SphericalModel.hxx
+++ b/lib/src/Base/Stat/openturns/SphericalModel.hxx
@@ -1,7 +1,6 @@
 //                                               -*- C++ -*-
 /**
- *  @brief This class is enables to build an exponential covariance
- *  model, a second order model's implementation
+ *  @brief This class is enables to build a spherical covariance model
  *
  *  Copyright 2005-2021 Airbus-EDF-IMACS-ONERA-Phimeca
  *
@@ -63,6 +62,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
                          const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Discretize the covariance function on a given TimeGrid */
   using CovarianceModelImplementation::discretize;

--- a/lib/src/Base/Stat/openturns/SquaredExponential.hxx
+++ b/lib/src/Base/Stat/openturns/SquaredExponential.hxx
@@ -54,8 +54,9 @@ public:
   Scalar computeAsScalar(const Point & tau) const override;
 #ifndef SWIG
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
-                                       const Collection<Scalar>::const_iterator & t_begin) const override;
+                         const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Gradient */
   Matrix partialGradient(const Point & s,

--- a/lib/src/Base/Stat/openturns/StationaryFunctionalCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/StationaryFunctionalCovarianceModel.hxx
@@ -55,6 +55,8 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
                                        const Collection<Scalar>::const_iterator & t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
+
   /** Gradient */
   Matrix partialGradient(const Point & s, const Point & t) const override;
 

--- a/lib/src/Base/Stat/openturns/TensorizedCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/TensorizedCovarianceModel.hxx
@@ -67,6 +67,7 @@ public:
   Scalar computeAsScalar(const Collection<Scalar>::const_iterator &s_begin,
                          const Collection<Scalar>::const_iterator &t_begin) const override;
 #endif
+  Scalar computeAsScalar(const Scalar tau) const override;
 
   /** Gradient */
   Matrix partialGradient(const Point & s, const Point & t) const override;

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -19,9 +19,9 @@ Available usages:
 
 Parameters
 ----------
-s, t : sequences of float
+s, t : floats (if :math:`n=1`) or sequences of floats (any :math:`n`)
     Multivariate index :math:`(\vect{s}, \vect{t}) \in \cD \times \cD`
-tau : sequence of float
+tau : float (if :math:`n=1`) or sequence of floats (any :math:`n`)
     Multivariate index :math:`\vect{\tau} \in \cD`
 
 Returns
@@ -67,9 +67,9 @@ covariance matrix:
 
     \mat{C}_{1,\dots,k} = \left(
         \begin{array}{cccc}
-        C(\vect{t}_1, \vect{t}_1) &C(\vect{t}_1, \vect{t}_2) & \dots & 
+        C(\vect{t}_1, \vect{t}_1) &C(\vect{t}_1, \vect{t}_2) & \dots &
         C(\vect{t}_1, \vect{t}_{k}) \\
-        \dots & C(\vect{t}_2, \vect{t}_2)  & \dots & 
+        \dots & C(\vect{t}_2, \vect{t}_2)  & \dots &
         C(\vect{t}_2, \vect{t}_{k}) \\
         \dots & \dots & \dots & \dots \\
         \dots & \dots & \dots & C(\vect{t}_{k}, \vect{t}_{k})
@@ -123,10 +123,10 @@ HMatrix : :class:`~openturns.HMatrix`
 
 Notes
 -----
-This method si similar to the *discretize* method. This method requires that 
+This method is similar to the :meth:`discretize` method. This method requires that
 OpenTURNS has been compiled with the hmat library.
-The method is helpfull for very large parameters (Mesh, grid, Sample) 
-as its compress data.
+The method is helpful for very large parameters (Mesh, grid, Sample)
+because it compresses data.
 "
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::discretizeHMatrix
@@ -154,10 +154,10 @@ HMatrix : :class:`~openturns.HMatrix`
 
 Notes
 -----
-This method si similar to the *discretizeAndFactorize* method. This method 
+This method is similar to the :meth:`discretizeAndFactorize` method. This method requires that
 requires that OpenTURNS has been compiled with the hmat library.
-The method is helpfull for very large parameters (Mesh, grid, Sample) 
-as its compress data.
+The method is helpful for very large parameters (Mesh, grid, Sample)
+because it compresses data.
 "
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::discretizeAndFactorizeHMatrix
@@ -180,7 +180,7 @@ OT_CovarianceModel_discretizeRow_doc
 Returns
 -------
 amplitude : :class:`~openturns.Point`
-    The amplitude parameter :math:`\vect{\sigma} \in \Rset^d` of the covariance 
+    The amplitude parameter :math:`\vect{\sigma} \in \Rset^d` of the covariance
     function."
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::getAmplitude
@@ -269,7 +269,7 @@ OT_CovarianceModel_getParameterDescription_doc
 Returns
 -------
 scale : :class:`~openturns.Point`
-    The scale parameter :math:`\vect{\theta} \in \Rset^n` used in the 
+    The scale parameter :math:`\vect{\theta} \in \Rset^n` used in the
     covariance function."
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::getScale
@@ -386,7 +386,7 @@ Parameters
 ----------
 amplitude : :class:`~openturns.Point`
     The amplitude parameter :math:`\vect{\sigma} \in \Rset^d` to be used in the
-    covariance function. 
+    covariance function.
     Its size must be equal to the dimension of the covariance function."
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::setAmplitude
@@ -585,4 +585,3 @@ description : :class:`~openturns.Description`
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::getFullParameterDescription
 OT_CovarianceModel_getFullParameterDescription_doc
-

--- a/python/test/t_CovarianceModel_std.py
+++ b/python/test/t_CovarianceModel_std.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -58,6 +59,25 @@ def test_model(myModel, test_grad=True, x1=None, x2=None):
         print('dCov/dP=', pGrad)
         ot.PlatformInfo.SetNumericalPrecision(precision)
 
+
+def test_scalar_model(myModel, test_grad=True):
+
+    inputDimension = 1
+    dimension = 1
+    active = myModel.getActiveParameter()
+    
+    x1 = 2.0
+    x2 = -3.0
+    ott.assert_almost_equal(myModel.computeAsScalar([x1], [x2]), myModel.computeAsScalar(x1, x2), 1.0e-14, 1.0e-14)
+
+    eps = 1e-5
+ 
+    grad = myModel.partialGradient([x1], [x2])[0, 0]
+
+    x1_g = x1 + eps
+    x1_d = x1 - eps
+    gradfd = (myModel.computeAsScalar(x1_g, x2) - myModel.computeAsScalar(x1_d, x2)) / (2.0 * eps)
+    ott.assert_almost_equal(gradfd, grad, 1e-5, 1e-5)
 
 inputDimension = 2
 
@@ -156,3 +176,9 @@ test_model(myModel, test_grad=False)
 scale = [2.5, 1.5]
 myModel.setScale(scale)
 test_model(myModel, test_grad=False)
+
+# Test scalar input models
+coll = [ot.AbsoluteExponential(), ot.SquaredExponential(), ot.GeneralizedExponential()]
+coll += [ot.MaternModel(), ot.SphericalModel(), ot.ExponentiallyDampedCosineModel()]
+for model in coll:
+    test_scalar_model(model)


### PR DESCRIPTION
Purpose is to introduce `CovarianceModelImplementation.computeAsScalar(Scalar tau)` in case input/output dimension are 1!

It will be helpful for the new `isotropic` feature!
