### PR TITLE
CircleCI saves doc pages as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build and test
+          name: Build
           command: ./.circleci/run_docker_linux.sh
+      - store_artifacts:
+          path: ~/.local/share/openturns/doc/html
+          destination: html
+      - run:
+          name: Test
+          command: ./.circleci/run_docker_linux_test.sh
       - run:
           name: Publish documentation
           command: ./.circleci/upload_github_io.sh

--- a/.circleci/run_docker_linux.sh
+++ b/.circleci/run_docker_linux.sh
@@ -2,9 +2,6 @@
 
 set -xe
 
-uid=$1
-gid=$2
-
 env
 
 # build with frozen date unless on release for reproducible builds
@@ -28,11 +25,4 @@ cmake -DCMAKE_INSTALL_PREFIX=~/.local \
       -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -D_GLIBCXX_ASSERTIONS" -DSWIG_COMPILE_FLAGS="-O1 -Wno-unused-parameter -Wno-missing-field-initializers" \
       ${source_dir}
 make install
-if test -n "${uid}" -a -n "${gid}"
-then
-  zip -r openturns-doc.zip ~/.local/share/openturns/doc/html/*
-  sudo chown ${uid}:${gid} openturns-doc.zip && sudo cp openturns-doc.zip ${source_dir}
-fi
-ctest -R pyinstallcheck --output-on-failure --timeout 100 ${MAKEFLAGS} --repeat after-timeout:2 --schedule-random
-make tests
-ctest -R cppcheck --output-on-failure --timeout 100 ${MAKEFLAGS} --repeat after-timeout:2 --schedule-random
+

--- a/.circleci/run_docker_linux_test.sh
+++ b/.circleci/run_docker_linux_test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -xe
+
+uid=$1
+gid=$2
+
+env
+
+## copy build variables
+# build with frozen date unless on release for reproducible builds
+if test "${CIRCLE_BRANCH}" = "master"
+then
+  export SOURCE_DATE_EPOCH=1514764800
+fi
+
+if test -d "/io"
+then
+  source_dir=/io  # local
+  cd /tmp
+else
+  source_dir=`pwd`  # circleci
+fi
+## end copy build variables
+
+cd build
+
+if test -n "${uid}" -a -n "${gid}"
+then
+  zip -r openturns-doc.zip ~/.local/share/openturns/doc/html/*
+  sudo chown ${uid}:${gid} openturns-doc.zip && sudo cp openturns-doc.zip ${source_dir}
+fi
+ctest -R pyinstallcheck --output-on-failure --timeout 100 ${MAKEFLAGS} --repeat after-timeout:2 --schedule-random
+make tests
+ctest -R cppcheck --output-on-failure --timeout 100 ${MAKEFLAGS} --repeat after-timeout:2 --schedule-random

--- a/utils/build_locally.sh
+++ b/utils/build_locally.sh
@@ -6,6 +6,7 @@ case $choice in
   1)
     docker pull openturns/archlinux-python
     docker run -e MAKEFLAGS='-j8' -v `pwd`:/io openturns/archlinux-python /io/.circleci/run_docker_linux.sh `id -u` `id -g`
+    docker run -e MAKEFLAGS='-j8' -v `pwd`:/io openturns/archlinux-python /io/.circleci/run_docker_linux_test.sh `id -u` `id -g`
     ;;
   2)
     docker pull openturns/archlinux-mingw


### PR DESCRIPTION
As suggested by @tupui on [Discourse](https://openturns.discourse.group/t/build-doc-without-code/93/3?u=josephmure), I have modified the `.circleci/config.yml` file in order to make CircleCI `build_linux` save all doc pages as artifacts. This way the doc will be temporarily saved (for a duration of 30 days) every time new commits are pushed. This should make doc reviews easier.

EDIT: Since @jschueller has pushed updates to the CircleCI config, I have rebased the branch and updated my proposal. The change w.r.t. the master is that artifacts are uploaded between build and test. This prevents issues affecting tests making the compiled doc unavailable. I have also tried to fix the issue reported by @jschueller concerning the `utils/build_locally.sh` script, but since I do not know how to use docker, I cannot check if it works.