### PR TITLE
Improve VisualTest::DrawKendallPlot

### DIFF
--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -482,24 +482,50 @@ Sample VisualTest::ComputeKendallPlotEmpiricalStatistics(const Sample & sample)
 {
   const UnsignedInteger size = sample.getSize();
   Sample result(size, 1);
+  const Scalar scalarSize = static_cast<Scalar>(size - 1);
+  /* To ease reading and implementation, we have a full double
+     loop for i & j variables from 0 to size
+     It is also possible to reduce costs by a factor 2 by completing
+     sequentially (not practice for maintenance and similar performance as current
+     implementation)
+
+     for (UnsignedInteger i = 0; i < size; ++i)
+     {
+       const Scalar uI = sample(i, 0);
+        const Scalar vI = sample(i, 1);
+       UnsignedInteger cardinalIJ = 0;
+       for (UnsignedInteger j = 0; j < i; ++j)
+       {
+         const Scalar uJ = sample(j, 0);
+         const Scalar vJ = sample(j, 1);
+         cardinalIJ = (uJ <= uI) && (vJ <= vI);
+         result(i, 0) += cardinalIJ;
+         cardinalIJ = (uI <= uJ) && (vI <= vJ);
+         result(j, 0) += cardinalIJ;
+       }
+     }
+     for (UnsignedInteger i = 0; i < size; ++i) result(i, 0) /= scalarSize;
+  */
   for (UnsignedInteger i = 0; i < size; ++i)
   {
-    const Point pointI(sample[i]);
-    const Scalar uI = pointI[0];
-    const Scalar vI = pointI[1];
+    const Scalar uI = sample(i, 0);
+    const Scalar vI = sample(i, 1);
     UnsignedInteger cardinal = 0;
     for (UnsignedInteger j = 0; j < i; ++j)
     {
-      const Point pointJ(sample[j]);
-      cardinal += (pointJ[0] <= uI) && (pointJ[1] <= vI);
+      const Scalar uJ = sample(j, 0);
+      const Scalar vJ = sample(j, 1);
+      cardinal += (uJ <= uI) && (vJ <= vI);
     }
     for (UnsignedInteger j = i + 1; j < size; ++j)
     {
-      const Point pointJ(sample[j]);
-      cardinal += (pointJ[0] <= uI) && (pointJ[1] <= vI);
+      const Scalar uJ = sample(j, 0);
+      const Scalar vJ = sample(j, 1);
+      cardinal += (uJ <= uI) && (vJ <= vI);
     }
-    result[i] = Point(1, cardinal / static_cast<Scalar>(size - 1));
+    result(i, 0) = cardinal / scalarSize;
   }
+
   return result.sort(0);
 }
 
@@ -513,7 +539,7 @@ Sample VisualTest::ComputeKendallPlotTheoreticalStatistics(const Distribution & 
   for (UnsignedInteger i = 0; i < maximumIteration; ++i)
   {
     const Sample empiricalStatistics(ComputeKendallPlotEmpiricalStatistics(copula.getSample(size)));
-    for (UnsignedInteger j = 0; j < size; ++j) result[j] = (result[j] * i + empiricalStatistics[j]) / (i + 1);
+    for (UnsignedInteger j = 0; j < size; ++j) result(j, 0) = (result(j, 0) * i + empiricalStatistics(j, 0)) / (i + 1);
   }
   return result;
 }


### PR DESCRIPTION
It is useless to generate Point when not necessarly, especially inside
for loop/nested for loops

Performances are significantly improved. As an example, with the following test:
```
import openturns as ot
import time
ot.RandomGenerator.SetSeed(0)
copula1 = ot.FrankCopula(1.5)
copula2 = ot.GumbelCopula(4.5)

for size in [100, 200, 1000, 2000]:

    sample1 = copula1.getSample(size)
    sample1.setName('data 1')
    sample2 = copula2.getSample(size)
    sample2.setName('data 2')
    tic = time.time()
    kendallPlot1 = ot.VisualTest.DrawKendallPlot(sample1, copula2)
    toc = time.time()
    print("size=%d, dt=%1.3g"%(size,toc - tic))
```

Outputs are the following:
```
# master
size=100, dt=0.271
size=200, dt=0.753
size=1000, dt=18.4
size=2000, dt=73.4

# current branch
size=100, dt=0.00919
size=200, dt=0.0201
size=1000, dt=0.37
size=2000, dt=1.36
```