### PR TITLE
Small doc fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,6 +63,7 @@
  * #1790 (LinearModelResult.getFormula() method is not updated by Stepwise regression)
  * #1794 (Some doc examples seem to behave with new infrastructure)
  * #1796 (VonMisesFactory is missing)
+ * #1803 (The API example of Experiment has a format issue)
 
 
 == 1.16 release (2020-11-16) == #release-1.16

--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,7 @@
  * #1774 (ExponentialModel::partialGradient is wrong)
  * #1775 (ExponentialModel does not account correlation with Covariance ctor)
  * #1776 (Typo in the Branin use case implementation)
+ * #1781 (The link_to_an_external_code example has small bugs)
  * #1784 (The drawPDF method of Histogram sometimes fail)
  * #1787 (CovarianceMatrix from SymmetricMatrix raises InvalidArgumentException)
  * #1790 (LinearModelResult.getFormula() method is not updated by Stepwise regression)

--- a/python/doc/examples/functional_modeling/link_to_an_external_code/plot_link_computer_code_coupling_tools.py
+++ b/python/doc/examples/functional_modeling/link_to_an_external_code/plot_link_computer_code_coupling_tools.py
@@ -42,10 +42,9 @@ Link to a computer code with coupling tools
 # * evaluates the output,
 # * writes the `"output.txt"` file.
 #
-# The command line to evaluate the code is: 
-# ```
-# python external_program.py input.py
-# ```
+# The command line to evaluate the code is:
+#
+# `python external_program.py input.py`
 
 # %%
 import openturns as ot
@@ -56,7 +55,7 @@ from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# The following is the content `external_program.py` script.
+# The following is the content of the `external_program.py` script.
 
 # %%
 code = '''
@@ -113,7 +112,7 @@ f.write(content)
 f.close()
 
 # %%
-# The `input_template.py` file is a template which will be used to generate the actual file `"input.txt"`. 
+# The `input_template.py` file is a template which will be used to generate the actual file `input.txt`.
 
 # %%
 content = '''
@@ -163,7 +162,7 @@ myWrapper = ot.PythonFunction (3 ,2 , mySimulator )
 # %%
 X = [1.2 , 45, 91.8]
 Y = myWrapper(X)
-Y
+print(Y)
 
 # %%
 # Write the input file with the replace function
@@ -171,16 +170,14 @@ Y
 #
 # The simplest calling sequence is:
 #
-# ```
-# replace (infile , outfile , tokens , values )
-# ```
+# `replace(infile, outfile, tokens, values)`
 #
 # where
 #
-# * `infile`: a string, the (template) file to read, 
-# * `outfile`: a string, the file to write.
-# * `tokens` a list of N items, the regular expressions to find, 
-# * `values` a list of N items (strings, floats, etc...), the values to replace.
+# * `infile` is a string, the (template) file to read,
+# * `outfile` is a string, the file to write,
+# * `tokens` is a list of N items, the regular expressions to find,
+# * `values` is a list of N items (strings, floats, etc...), the values to replace.
 
 # %%
 X = [1.2 , 45, 91.8]
@@ -200,25 +197,22 @@ print(f.read())
 # Read the output with the get function
 # -------------------------------------
 #
-# The simplest calling sequence is:
+# The simplest calling sequence to get a list of values is:
 #
-# ```
-# Get a list of values
-# Y= get ( filename , tokens = None , skip_tokens = None , \
-# skip_lines = None , skip_cols = None )
-# Get a single value
-# Y= get_value ( filename , token = None , skip_token = 0, \
-# skip_line = 0, skip_col = 0)
-# ```
+# `Y = get(filename, tokens=None, skip_tokens=None, skip_lines=None, skip_cols=None)`
 #
 # where
 #
-# * `filename`: string, the file to read,  
-# * `tokens`: list of N items, the regular expression to search, 
-# * `skip_tokens`: list of N items, the number of tokens to ignore before reading the value, 
-# * `skip_lines`: list of N items, the number of rows to ignore before reading the value, 
-# * `skip_cols`: list of N items, the number of columns to ignore before reading the value, 
-# * `Y`: list of N floats (for `get`) or a float (for `get_value`).
+# * `filename` is a string (the file to read),
+# * `tokens` is a list of N items (regular expressions to search),
+# * `skip_tokens` is a list of N items (number of tokens to ignore before reading the value),
+# * `skip_lines` is a list of N items (number of rows to ignore before reading the value),
+# * `skip_cols` is a list of N items (number of columns to ignore before reading the value),
+# * `Y` is a list of N floats.
+#
+# And to get a single value:
+#
+# `Y = get_value(filename, token=None, skip_token=0, skip_line=0, skip_col=0)`
 
 # %%
 # Consider for example the following file.

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_1D.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_1D.py
@@ -241,6 +241,7 @@ mycolors = [[120, 1.0, 1.0], [120, 1.0, 0.75], [120, 1.0, 0.5]]
 # We are ready to display all the previous information and the three confidence intervals we want.
 
 # %%
+# sphinx_gallery_thumbnail_number = 4
 graph = ot.Graph('','','',True,'')
 graph.add(plot_data_test(x_test,y_test))
 graph.add(plot_data_train(x_train,y_train))

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_advanced.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_advanced.py
@@ -148,6 +148,7 @@ fig.suptitle("Kriging result");
 # -------------------------------
 
 # %%
+# sphinx_gallery_thumbnail_number = 3
 level = 0.95
 quantile = ot.Normal().computeQuantile((1-level)/2)[0]
 borne_sup = krigingMeta(x_plot) + quantile * np.sqrt(variance)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam.py
@@ -156,6 +156,7 @@ view = viewer.View(graph)
 # The `drawValidation` method allows to compare the observed outputs and the metamodel outputs.
 
 # %%
+# sphinx_gallery_thumbnail_number = 3
 graph = val.drawValidation()
 graph.setTitle("Q2 = %.2f%%" % (100*Q2))
 view = viewer.View(graph)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam_hmat.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_cantilever_beam_hmat.py
@@ -165,6 +165,7 @@ view = viewer.View(graph)
 # The `drawValidation` method allows to compare the observed outputs and the metamodel outputs.
 
 # %%
+# sphinx_gallery_thumbnail_number = 3
 graph = val.drawValidation()
 graph.setTitle("Q2 = %.2f%%" % (100*Q2))
 view = viewer.View(graph)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
@@ -351,6 +351,7 @@ _ = axes[0].set_ylim(-2.5, 4.0)
 
 
 # %%
+# sphinx_gallery_thumbnail_number = 10
 # The same graphic with the 68% confidence interval.
 boundsPoly = plot_ICBounds(x_test, y_test, nTest, sigma)
 graph.add(boundsPoly)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_sequential.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_sequential.py
@@ -210,6 +210,7 @@ Y.add(yNew)
 # We now plot the updated kriging.
 
 # %%
+# sphinx_gallery_thumbnail_number = 3
 krigResult = createMyBasicKriging(X,Y)
 krigingStep += 1
 myTitle = "Krigeage #%d" % (krigingStep+1)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_simulate.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_simulate.py
@@ -207,6 +207,7 @@ type(trajectories)
 # The `getSample` method returns a `ProcessSample`. By comparison, the `getSample` method of a `KrigingRandomVector` would return a `Sample`. 
 
 # %%
+# sphinx_gallery_thumbnail_number = 3
 graph = trajectories.drawMarginal()
 graph.add(plot_data_test(x_test,y_test))
 graph.add(plot_data_train(x_train,y_train))

--- a/python/doc/examples/probabilistic_modeling/stochastic_processes/plot_kronecker_covmodel.py
+++ b/python/doc/examples/probabilistic_modeling/stochastic_processes/plot_kronecker_covmodel.py
@@ -1,70 +1,156 @@
 """
-Create a Kronecker covariance model
-===================================
+Sample trajectories from a Gaussian Process with correlated outputs
+===================================================================
+
+A :class:`~openturns.KroneckerCovarianceModel` takes a covariance function
+with 1-d output and makes its output multidimensional.
+
+In this example, we use one to define a Gaussian Process with 2 correlated scalar outputs.
+
+For that purpose, a covariance matrix for the outputs is needed
+in addition to a scalar correlation function :math:`\\rho`.
+
 """
-# %%
-# This example illustrates how the User can create a Kronecker covariance function, which allows defining a multivariate covariance function with a specific covariance structure.
-#
-# For that purpose, a spatial covariance matrix :math:`\mat{C}^{stat}` is needed in addition to a scalar correlation function :math:`\rho`.
-#
-#  We recall that the Kronecker covariance model is defined by
-#
-# .. math::
-#
-#    C(\vect{s}, \vect{t}) = \rho\left(\dfrac{\vect{s}}{\theta}, \dfrac{\vect{t}}{\theta}\right) C^{stat}
-#
-# where the output covariance matrix :math:`C^{stat}` is given by
-#
-# .. math::
-#    C^{stat} = \mbox{Diag}(\vect{\sigma}) \, \mat{R} \,  \mbox{Diag}(\vect{\sigma}).
-#
-#
-# :math:`\vect{\sigma}` and :math:`\vect{\theta}` are respectively the amplitude and scale vectors.
-#
-# The library implements this multivariate model thanks to the *KroneckerCovarianceModel* class which can be instanciated from:
-#
-#
-# - the correlation function and amplitude vectors :math:`(\rho, \vect{\sigma})`: in that case, by default :math:`\mat{R} = \mat{I}`;
-# - the correlation function, the amplitude vector and the spatial correlation matrix :math:`(\rho, \vect{\sigma}, \mat{R})`;
-# - the correlation function, the amplitude vector and the spatial covariance matrix :math:`(\rho, \vect{\sigma}, \mat{C})`;
-#
 
 # %%
-from __future__ import print_function
 import openturns as ot
 import openturns.viewer as viewer
-from matplotlib import pylab as plt
-import math as m
+from numpy import square
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# Scale vector (input dimension 1)
-theta = [4.0]
+# Create a Kronecker covariance function
+# --------------------------------------
+#
+# First, define the scalar correlation function :math:`\rho`.
 
-# Create the rho function
+# %%
+theta = [2.0]
 rho = ot.MaternModel(theta, 1.5)
 
-# Create the amplitude vector (output dimension 2)
-sigma = [1.0, 2.0]
+# %%
+# Second, define the covariance matrix of the outputs.
 
-# output correlation
-R = ot.CorrelationMatrix(2)
-R[1, 0] = 0.01
-
-# output covariance
+# %%
 C = ot.CovarianceMatrix(2)
-C[0, 0] = 4.0
-C[1, 1] = 5.0
-C[1, 0] = 0.5
+C[0, 0] = 1.0
+C[1, 1] = 1.5
+C[1, 0] = 0.9
+print(C)
 
 # %%
-# Create the covariance model from the amplitude and correlation, no spatial correlation
-ot.KroneckerCovarianceModel(rho, sigma)
+# Use these ingredients to build the :class:`~openturns.KroneckerCovarianceModel`.
 
 # %%
-# or from the correlation function, amplitude, and spatialCovariance
-ot.KroneckerCovarianceModel(rho, sigma, R)
+kronecker = ot.KroneckerCovarianceModel(rho, C)
 
 # %%
-# or from the correlation model and spatialCovariance
-ot.KroneckerCovarianceModel(rho, C)
+# Build a Gaussian Process with Kronecker covariance function
+# -----------------------------------------------------------
+#
+# Define a :class:`~openturns.GaussianProcess` with null trend using this covariance function.
+
+# %%
+gp = ot.GaussianProcess(kronecker, ot.RegularGrid(0.0, 0.1, 100))
+
+# %%
+# Sample and draw a realization of the Gaussian process.
+
+# %%
+ot.RandomGenerator.SetSeed(5)
+realization = gp.getRealization()
+graph = realization.drawMarginal(0)
+graph.add(realization.drawMarginal(1))
+graph.setYTitle("")
+graph.setTitle("")
+graph.setColors(ot.Drawable.BuildDefaultPalette(2))
+graph.setLegends(["Y1", "Y2"])
+graph.setLegendPosition("topleft")
+_ = viewer.View(graph)
+
+# %%
+# Draw the trajectory on the complex plane.
+
+# %%
+graph = realization.draw()
+graph.setXTitle("Real part")
+graph.setYTitle("Imaginary part")
+graph.setTitle("Trajectory on the complex plane")
+diagonal = ot.Curve([-1.5, 1.5], [-1.5, 1.5])
+diagonal.setLineStyle("dotdash")
+diagonal.setColor("grey")
+graph.add(diagonal)
+_ = viewer.View(graph, square_axes=True)
+
+# %%
+# Change the correlation between the outputs
+# ------------------------------------------
+#
+# By setting covariance matrix of the outputs, we have implicitely set the
+# amplitudes and the correlation matrix of the Kronecker covariance function.
+#
+# The amplitudes are the square roots of the diagonal elements
+# of the covariance matrix.
+
+# %%
+
+# Recall C
+print(C)
+
+# %%
+
+# Print squared amplitudes
+print(square(kronecker.getAmplitude()))
+
+# %%
+# The diagonal of the correlation matrix is by definition filled with ones.
+
+# %%
+output_correlation = kronecker.getOutputCorrelation()
+print(output_correlation)
+
+# %%
+# Since the correlation matrix is symmetric
+# and its diagonal necessarily contains ones,
+# we only need to change its upper right (or bottom left) element.
+
+# %%
+output_correlation[0, 1] = 0.9
+print(output_correlation)
+
+# %%
+# Changing the output correlation matrix does not change the amplitudes.
+
+# %%
+kronecker.setOutputCorrelation(output_correlation)
+print(square(kronecker.getAmplitude()))
+
+# %%
+# Let us resample a trajectory.
+#
+# To show the effect ot the output correlation change,
+# we use the same random seed in order to get a comparable trajectory.
+
+# %%
+gp = ot.GaussianProcess(kronecker, ot.RegularGrid(0.0, 0.1, 100))
+ot.RandomGenerator.SetSeed(5)
+realization = gp.getRealization()
+graph = realization.drawMarginal(0)
+graph.add(realization.drawMarginal(1))
+graph.setYTitle("")
+graph.setTitle("")
+graph.setColors(ot.Drawable.BuildDefaultPalette(2))
+graph.setLegends(["Y1", "Y2"])
+graph.setLegendPosition("topleft")
+_ = viewer.View(graph)
+
+# %%
+graph = realization.draw()
+graph.setXTitle("Real part")
+graph.setYTitle("Imaginary part")
+graph.setTitle("Trajectory on the complex plane")
+diagonal = ot.Curve([-1.5, 1.5], [-1.5, 1.5])
+diagonal.setLineStyle("dotdash")
+diagonal.setColor("grey")
+graph.add(diagonal)
+_ = viewer.View(graph, square_axes=True)

--- a/python/src/BootstrapExperiment_doc.i.in
+++ b/python/src/BootstrapExperiment_doc.i.in
@@ -13,9 +13,10 @@ sample : 2-d sequence of float
 Notes
 -----
 BootstrapExperiment is a random weighted design of experiments.
-To call the BootstrapExperiment constructor is equivalent to call the
+Calling the :class:`BootstrapExperiment` constructor is equivalent to calling the
 :class:`~openturns.WeightedExperiment` constructor as follows:
-*WeightedExperiment(UserDefined(sample), sample.getSize())*.
+
+``WeightedExperiment(UserDefined(sample), sample.getSize())``
 
 See also
 --------

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -48,18 +48,19 @@ OT_CovarianceModel_computeAsScalar_doc
 
 Parameters
 ----------
-meshOrGrid : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid`
-    Mesh or time grid of size :math:`N` associated with the process.
+where : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid` or :class:`~openturns.Sample`
+    Container of the discretization vertices
 
 Returns
 -------
 covarianceMatrix : :class:`~openturns.CovarianceMatrix`
     Covariance matrix :math:`\in \cS_{nd}^+(\Rset)` (if the process is of
-    dimension :math:`d`
+    dimension :math:`d`)
 
 Notes
 -----
-This method makes a discretization of the model on *meshOrGrid* composed of
+This method makes a discretization of the model on the given :class:`~openturns.Mesh`,
+:class:`~openturns.RegularGrid` or :class:`~openturns.Sample` composed of
 the vertices :math:`(\vect{t}_1, \dots, \vect{t}_{N-1})` and returns the
 covariance matrix:
 
@@ -85,20 +86,21 @@ OT_CovarianceModel_discretize_doc
 
 Parameters
 ----------
-meshOrGrid : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid`
-    Mesh or time grid of size :math:`N` associated with the process.
+where : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid` or :class:`~openturns.Sample`
+    Container of the discretization vertices
 
 Returns
 -------
 CholeskyMatrix : :class:`~openturns.TriangularMatrix`
     Cholesky factor of the covariance matrix :math:`\in \cM_{nd\times nd}(\Rset)`
-    (if the process is of dimension :math:`d`).
+    (if the process is of dimension :math:`d`)
 
 Notes
 -----
-This method makes a discretization of the model on *meshOrGrid* composed of
+This method makes a discretization of the model on the given :class:`~openturns.Mesh`,
+:class:`~openturns.RegularGrid` or :class:`~openturns.Sample` composed of
 the vertices :math:`(\vect{t}_1, \dots, \vect{t}_{N-1})` thanks to the
-`discretize` method and returns its Cholesky factor."
+:meth:`discretize` method and returns its Cholesky factor."
 %enddef
 %feature("docstring") OT::CovarianceModelImplementation::discretizeAndFactorize
 OT_CovarianceModel_discretizeAndFactorize_doc
@@ -110,8 +112,8 @@ OT_CovarianceModel_discretizeAndFactorize_doc
 
 Parameters
 ----------
-meshOrGrid : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid`
-    Mesh or time grid of size :math:`N` associated with the process.
+where : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid` or :class:`~openturns.Sample`
+    Container of the discretization vertices
 hmatParam : :class:`~openturns.HMatrixParameters`
     Parameter values for the HMatrix
 
@@ -141,8 +143,8 @@ This uses HMatrix.
 
 Parameters
 ----------
-meshOrGrid : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid`
-    Mesh or time grid of size :math:`N` associated with the process.
+where : :class:`~openturns.Mesh` or :class:`~openturns.RegularGrid` or :class:`~openturns.Sample`
+    Container of the discretization vertices
 hmatParam : :class:`~openturns.HMatrixParameters`
     Parameter values for the HMatrix
 

--- a/python/src/ExperimentImplementation_doc.i.in
+++ b/python/src/ExperimentImplementation_doc.i.in
@@ -10,12 +10,12 @@ Different types of design of experiments can be determined:
 - some stratified patterns: axial, composite, factorial or box patterns,
 
 - some weighted patterns that we can split into different categories:
-  the random patterns, the low discrepancy sequences and the deterministic
-  patterns.
+  random patterns, low discrepancy sequences and deterministic patterns.
 
 Examples
 --------
 Define a custom design of experiment:
+
 >>> import openturns as ot
 >>> ot.RandomGenerator.SetSeed(0)
 >>> class RandomExp(object):

--- a/python/src/Sample_doc.i.in
+++ b/python/src/Sample_doc.i.in
@@ -200,15 +200,17 @@ And load it back
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::Sample::add
-"Append a vector (in-place).
+"Append a sample (in-place).
 
 Parameters
 ----------
-point : sequence of float
-    The point to append.
+point or sample : sequence or 2-d sequence of float
+    The point(s) to append.
 
 Examples
 --------
+Append an existing sample with a single point.
+
 >>> import openturns as ot
 >>> sample = ot.Sample(3, 2)
 >>> sample.add([1.0, 2.0])
@@ -216,7 +218,18 @@ Examples
 0 : [ 0 0 ]
 1 : [ 0 0 ]
 2 : [ 0 0 ]
-3 : [ 1 2 ]"
+3 : [ 1 2 ]
+
+Append an existing sample with an other sample.
+
+>>> sample.add(ot.Sample(2, [2.0, 1.0]))
+>>> print(sample)
+0 : [ 0 0 ]
+1 : [ 0 0 ]
+2 : [ 0 0 ]
+3 : [ 1 2 ]
+4 : [ 2 1 ]
+5 : [ 2 1 ]"
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes a few issues:

- The [CovarianceModel.discretize docstring](https://openturns.github.io/openturns/1.16/user_manual/_generated/openturns.CovarianceModel.html#openturns.CovarianceModel.discretize) does not mention that this method can take a `Sample` as input.
- Formatting issues in the [Link to a computer code with coupling tools](https://openturns.github.io/openturns/1.16/auto_functional_modeling/link_to_an_external_code/plot_link_computer_code_coupling_tools.html) example: together with @jschueller's PR #1766, this closes #1781. 
- More appealing thumbnail pictures for Kriging examples.
- Correct the description of the `Sample::add` method, which can admit either a `Point` or a `Sample` as argument.
- Add trajectory sampling to @sofianehaddad's [KroneckerCovarianceModel example](https://openturns.github.io/openturns/master/auto_probabilistic_modeling/stochastic_processes/plot_kronecker_covmodel.html).
- Fix formatting issue regarding [Experiment](https://openturns.github.io/openturns/latest/user_manual/_generated/openturns.Experiment.html)'s API example. Closes #1803.