### PR TITLE
LinearModelAlgorithm: Allow null DOF

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
@@ -124,8 +124,8 @@ void LinearModelAlgorithm::run()
 
   const UnsignedInteger size = inputSample_.getSize();
   const UnsignedInteger basisSize = basis_.getSize();
-  if(!(size - basisSize > 0))
-    throw InvalidArgumentException(HERE) << "Number of basis elements is great or equals the sample size. Data size = " << outputSample_.getSize()
+  if (basisSize > size)
+    throw InvalidArgumentException(HERE) << "Number of basis elements is greater than sample size. Data size = " << outputSample_.getSize()
                                          << ", basis size = " << basisSize;
 
   // No particular strategy : using the full basis
@@ -164,9 +164,8 @@ void LinearModelAlgorithm::run()
   // Residual sample
   const Sample residualSample(outputSample_ - metaModel(inputSample_));
 
-  // Sigma2
-
-  const Scalar sigma2 = size * residualSample.computeRawMoment(2)[0] / (size - basisSize);
+  // noise variance
+  const Scalar sigma2 = (basisSize >= size) ? 0.0 : size * residualSample.computeRawMoment(2)[0] / (size - basisSize);
 
   Sample standardizedResiduals(size, 1);
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx
@@ -50,7 +50,9 @@ LinearModelAnalysis::LinearModelAnalysis(const LinearModelResult & linearModelRe
   : PersistentObject()
   , linearModelResult_(linearModelResult)
 {
-  // Nothing to do
+  const SignedInteger dof = linearModelResult_.getDegreesOfFreedom();
+  if (dof <= 0)
+    throw InvalidArgumentException(HERE) << "Cannot perform linear model analysis when DOF is null";
 }
 
 /* Virtual constructor */
@@ -78,7 +80,7 @@ String LinearModelAnalysis::__str__(const String & offset) const
   const Point pValues(getCoefficientsPValues());
   const Description names(linearModelResult_.getCoefficientsNames());
   const Scalar sigma2 = linearModelResult_.getSampleResiduals().computeRawMoment(2)[0];
-  const UnsignedInteger dof = linearModelResult_.getDegreesOfFreedom();
+  const SignedInteger dof = linearModelResult_.getDegreesOfFreedom();
   const UnsignedInteger n = linearModelResult_.getSampleResiduals().getSize();
   const String separator(" | ");
   const String separatorEndLine(" |");

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
@@ -94,7 +94,7 @@ public:
   virtual Sample getStandardizedResiduals() const;
 
   /** Number of degrees of freedom */
-  virtual UnsignedInteger getDegreesOfFreedom() const;
+  virtual SignedInteger getDegreesOfFreedom() const;
 
   /** Leverages accessor */
   virtual Point getLeverages() const;

--- a/lib/src/Uncertainty/StatTests/LinearModelTest.cxx
+++ b/lib/src/Uncertainty/StatTests/LinearModelTest.cxx
@@ -58,7 +58,9 @@ TestResult LinearModelTest::LinearModelFisher(const Sample & firstSample,
   if (size < 3) throw InvalidArgumentException(HERE) << "Error: sample too small. Sample should contains at least 3 elements";
   // As we rely on a linear model result, we should be very generic
   // Instead of using input dimension, one should use parameter size
-  const UnsignedInteger df = linearModelResult.getDegreesOfFreedom();
+  const SignedInteger dof = linearModelResult.getDegreesOfFreedom();
+  if (dof <= 0)
+    throw InvalidArgumentException(HERE) << "Cannot perform linear model test when DOF is null";
 
   // Regression coefficient
   const Function fHat(linearModelResult.getMetaModel());
@@ -76,12 +78,12 @@ TestResult LinearModelTest::LinearModelFisher(const Sample & firstSample,
   // H0 : Beta_i = 0
   // H1 : Beta_i < 0 or Beta_i > 0
   // The statistics follows a Fisher distribution
-  const Scalar numerator = sumSquaredExplained / (size - df - 1);
-  const Scalar denomerator = sumSquaredResiduals / df;
+  const Scalar numerator = sumSquaredExplained / (size - dof - 1);
+  const Scalar denomerator = sumSquaredResiduals / dof;
 
   const Scalar statistic = numerator / denomerator;
   Log::Debug(OSS() << "F-statistic = " << statistic);
-  const Scalar pValue =  FisherSnedecor(size - df - 1, df).computeComplementaryCDF(statistic);
+  const Scalar pValue =  FisherSnedecor(size - dof - 1, dof).computeComplementaryCDF(statistic);
   return TestResult("Fisher", pValue > level, pValue, level, statistic);
 }
 
@@ -117,7 +119,9 @@ TestResult LinearModelTest::LinearModelResidualMean(const Sample & firstSample,
   if (size < 3) throw InvalidArgumentException(HERE) << "Error: sample too small. Sample should contains at least 3 elements";
   // As we rely on a linear model result, we should be very generic
   // Instead of using input dimension, one should use parameter size
-  const UnsignedInteger df = linearModelResult.getDegreesOfFreedom();
+  const SignedInteger dof = linearModelResult.getDegreesOfFreedom();
+  if (dof <= 0)
+    throw InvalidArgumentException(HERE) << "Cannot perform linear model test when DOF is null";
   // Residuals
   const Sample residualSample(linearModelResult.getSampleResiduals());
   // Compute mean & standard deviation
@@ -130,7 +134,7 @@ TestResult LinearModelTest::LinearModelResidualMean(const Sample & firstSample,
   // The statistics follows a Student distribution
   const Scalar statistic = std::abs(mean) * std::sqrt(size * 1.0) / std;
   Log::Debug(OSS() << "t-statistic = " << statistic);
-  const Scalar pValue =  2.0 * DistFunc::pStudent(df, statistic, true);
+  const Scalar pValue = 2.0 * DistFunc::pStudent(dof, statistic, true);
   return TestResult("ResidualMean", pValue > level, pValue, level, statistic);
 }
 

--- a/python/src/LinearModelResult_doc.i.in
+++ b/python/src/LinearModelResult_doc.i.in
@@ -137,6 +137,7 @@ sampleResiduals : :class:`~openturns.Sample`
 Returns
 -------
 dof : int
+    Sample size minus basis size, a null value is allowed.
 "
 
 // ---------------------------------------------------------------------
@@ -147,6 +148,7 @@ dof : int
 Returns
 -------
 noiseDistribution : :class:`~openturns.Distribution`
+    Not defined when degrees of freedom is null.
 "
 
 // ---------------------------------------------------------------------
@@ -207,5 +209,6 @@ rSquared : float
 Returns
 -------
 adjustedRSquared : float
+    Not defined when degrees of freedom is null.
 "
 

--- a/python/test/t_LinearModelAlgorithm_std.expout
+++ b/python/test/t_LinearModelAlgorithm_std.expout
@@ -3,3 +3,4 @@ trend coefficients =  [3.01168,-2.00025]
 Fit y ~ 1 + 0.1 x + 10 x^2 model using 100 points
 trend coefficients =  [0.978992,0.110565,9.99924]
 class=LinearModelResult beta=class=Point name=Unnamed dimension=3 values=[0.978992,0.110565,9.99924] formula=Basis( [[X0,X1]->[1],[X0,X1]->[X0],[X0,X1]->[X1]] )
+[-2,4] 0 [0]

--- a/python/test/t_LinearModelAlgorithm_std.py
+++ b/python/test/t_LinearModelAlgorithm_std.py
@@ -59,3 +59,12 @@ ott.assert_almost_equal(leverages[0:6], leverages_reference, 1e-6, 0.0)
 X.setDescription(['X0', 'price (euros)'])
 result = ot.LinearModelAlgorithm(X, Y).getResult()
 print(result)
+
+# dof=0
+input_sample = ot.Sample([[1], [2]])
+output_sample = ot.Sample([[2], [6]])
+basis = ot.LinearBasisFactory(1).build()
+algo = ot.LinearModelAlgorithm(input_sample, basis, output_sample)
+algo.run()
+result = algo.getResult()
+print(result.getCoefficients(), result.getDegreesOfFreedom(), result.getResiduals())


### PR DESCRIPTION
Allows cases whese basis size == sample size, (not just sample size > basis size).
In that case, we throw when user asks for the noise distribution which is not defined, also for the R^2