### PR TITLE
Implement CovarianceModel::computeCrossCovariance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@
  * Removed deprecated KarhunenLoeveResult::getEigenValues
  * Removed deprecated coupling_tools.execute is_shell/workdir/shell_exe/check_exit_code arguments
  * RandomVector::get/setParameter and getParameterDescription available to PythonRandomVector
+ * Implemented CovarianceModel::computeCrossCovariance
 
 === Documentation ===
 

--- a/lib/src/Base/Stat/CovarianceModel.cxx
+++ b/lib/src/Base/Stat/CovarianceModel.cxx
@@ -150,6 +150,24 @@ Sample CovarianceModel::discretizeRow(const Sample & vertices,
   return getImplementation()->discretizeRow(vertices, p);
 }
 
+Matrix CovarianceModel::computeCrossCovariance(const Sample &firstSample,
+                                               const Sample &secondSample) const
+{
+  return getImplementation()->computeCrossCovariance(firstSample, secondSample);
+}
+
+Matrix CovarianceModel::computeCrossCovariance(const Sample &sample,
+                                               const Point &point) const
+{
+  return getImplementation()->computeCrossCovariance(sample, point);
+}
+
+Matrix CovarianceModel::computeCrossCovariance(const Point &point,
+                                               const Sample &sample) const
+{
+  return getImplementation()->computeCrossCovariance(point, sample);
+}
+
 /** Discretize and factorize the covariance function on a given TimeGrid/Mesh */
 TriangularMatrix CovarianceModel::discretizeAndFactorize(const RegularGrid & timeGrid) const
 {

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -475,6 +475,210 @@ CovarianceMatrix CovarianceModelImplementation::discretize(const Sample & vertic
   }
 }
 
+struct CrossCovarianceFunctor1D
+{
+  const SampleImplementation &firstSample_;
+  const SampleImplementation &secondSample_;
+  MatrixImplementation &output_;
+  const CovarianceModelImplementation &model_;
+
+  CrossCovarianceFunctor1D(const Sample &firstSample,
+                           const Sample &secondSample,
+                           Matrix &output,
+                           const CovarianceModelImplementation &model)
+      : firstSample_(*firstSample.getImplementation())
+      , secondSample_(*secondSample.getImplementation())
+      , output_(*output.getImplementation())
+      , model_(model)
+  {
+  }
+
+  inline void operator()(const TBB::BlockedRange<UnsignedInteger> &r) const
+  {
+
+    const UnsignedInteger inputDimension = firstSample_.getDimension();
+    for (UnsignedInteger index = r.begin(); index != r.end(); ++index)
+    {
+      // Fill by column
+      // Fill Matrix is firstSampleSize x secondSampleSize
+      // As we might have strong differences between sizes, the loop rely on final blocksize
+      const UnsignedInteger columnIndex = index / firstSample_.getSize();
+      const UnsignedInteger rowIndex = index - columnIndex * firstSample_.getSize();
+      output_(rowIndex, columnIndex) = model_.computeAsScalar(firstSample_.data_begin() + (rowIndex * inputDimension),
+                                                              secondSample_.data_begin() + (columnIndex * inputDimension));
+    }
+  } // operator()
+};
+/* end struct CrossCovarianceFunctor1D */
+
+struct CrossCovarianceFunctor
+{
+  const SampleImplementation &firstSample_;
+  const SampleImplementation &secondSample_;
+  MatrixImplementation &output_;
+  const CovarianceModelImplementation &model_;
+  const UnsignedInteger dimension_;
+
+  CrossCovarianceFunctor(const Sample &firstSample,
+                         const Sample &secondSample,
+                         Matrix &output,
+                         const CovarianceModelImplementation &model)
+      : firstSample_(*firstSample.getImplementation())
+      , secondSample_(*secondSample.getImplementation())
+      , output_(*output.getImplementation())
+      , model_(model)
+      , dimension_(model.getOutputDimension())
+  {
+  }
+
+  inline void operator()(const TBB::BlockedRange<UnsignedInteger> &r) const
+  {
+    for (UnsignedInteger i = r.begin(); i != r.end(); ++i)
+    {
+      // Fill by column
+      // jLocal ==> which column to fill
+      // jBase : use of block size to determine first element of matrix
+      // iLocal : for a fixed jLocal row, which iLocal-th element to fill
+      // iBase : same as jBase but for rows
+      const UnsignedInteger jLocal = i / firstSample_.getSize();
+      const UnsignedInteger jBase = jLocal * dimension_;
+      const UnsignedInteger iLocal = i - jLocal * firstSample_.getSize();
+      const UnsignedInteger iBase = iLocal * dimension_;
+      // Local covariance matrix
+      const SquareMatrix localCovariance(model_(firstSample_[iLocal], secondSample_[jLocal]));
+      for (UnsignedInteger jj = 0; jj < dimension_; ++jj)
+      {
+        for (UnsignedInteger ii = 0; ii < dimension_; ++ii)
+        {
+          output_(iBase + ii, jBase + jj) = localCovariance(ii, jj);
+        }
+      }
+    }
+  }
+};
+/* end struct CrossCovarianceFunctor */
+
+Matrix CovarianceModelImplementation::computeCrossCovariance(const Sample &firstSample,
+                                                             const Sample &secondSample) const
+{
+  if (firstSample.getDimension() != inputDimension_)
+    throw InvalidArgumentException(HERE) << "Error: the first sample has a dimension=" << firstSample.getDimension() << " different from the input dimension=" << inputDimension_;
+
+  if (secondSample.getDimension() != inputDimension_)
+    throw InvalidArgumentException(HERE) << "Error: the second sample has a dimension=" << secondSample.getDimension() << " different from the input dimension=" << inputDimension_;
+
+  const UnsignedInteger dimension = getOutputDimension();
+  if (dimension == 1)
+  {
+    const UnsignedInteger firstSampleSize = firstSample.getSize();
+    const UnsignedInteger secondSampleSize = secondSample.getSize();
+    Matrix result(firstSampleSize, secondSampleSize);
+    const CrossCovarianceFunctor1D policy(firstSample, secondSample, result, *this);
+    // The loop is over X & Y samples
+    TBB::ParallelForIf(isParallel(), 0, firstSampleSize * secondSampleSize, policy);
+    return result;
+  }
+  const UnsignedInteger firstSampleSize = firstSample.getSize();
+  const UnsignedInteger firstSampleFullSize = firstSampleSize * dimension;
+  const UnsignedInteger secondSampleSize = secondSample.getSize();
+  const UnsignedInteger secondSampleFullSize = secondSampleSize * dimension;
+  Matrix result(firstSampleFullSize, secondSampleFullSize);
+  const CrossCovarianceFunctor policy(firstSample, secondSample, result, *this);
+  // The loop is over the lower block-triangular part
+  TBB::ParallelForIf(isParallel(), 0, firstSampleSize * secondSampleSize, policy);
+  return result;
+}
+
+struct CrossCovariancePointFunctor1D
+{
+  const SampleImplementation &sample_;
+  const Point &point_;
+  MatrixImplementation &output_;
+  const CovarianceModelImplementation &model_;
+
+  CrossCovariancePointFunctor1D(const Sample &sample,
+                                const Point &point,
+                                Matrix &output,
+                                const CovarianceModelImplementation &model)
+      : sample_(*sample.getImplementation())
+      , point_(point)
+      , output_(*output.getImplementation())
+      , model_(model)
+  {
+  }
+
+  inline void operator()(const TBB::BlockedRange<UnsignedInteger> &r) const
+  {
+
+    const UnsignedInteger inputDimension = point_.getDimension();
+    for (UnsignedInteger i = r.begin(); i != r.end(); ++i)
+    {
+      output_(i, 0) = model_.computeAsScalar(sample_.data_begin() + (i * inputDimension),
+                                             point_.begin());
+    }
+  } // operator()
+};
+/* end struct CrossCovariancePointFunctor1D */
+
+struct CrossCovariancePointFunctor
+{
+  const SampleImplementation &sample_;
+  const Point &point_;
+  MatrixImplementation &output_;
+  const CovarianceModelImplementation &model_;
+
+  CrossCovariancePointFunctor(const Sample &sample,
+                              const Point &point,
+                              Matrix &output,
+                              const CovarianceModelImplementation &model)
+      : sample_(*sample.getImplementation())
+      , point_(point)
+      , output_(*output.getImplementation())
+      , model_(model)
+  {
+  }
+
+  inline void operator()(const TBB::BlockedRange<UnsignedInteger> &r) const
+  {
+    const UnsignedInteger dimension = model_.getOutputDimension();
+    for (UnsignedInteger i = r.begin(); i != r.end(); ++i)
+    {
+      SquareMatrix localCovariance(model_(sample_[i], point_));
+      for (UnsignedInteger columnIndex = 0; columnIndex < dimension; ++columnIndex)
+        for (UnsignedInteger rowIndex = 0; rowIndex < dimension; ++rowIndex)
+          output_(i * dimension + rowIndex, columnIndex) = localCovariance(rowIndex, columnIndex);
+    }
+  } // operator()
+};
+/* end struct CrossCovariancePointFunctor */
+
+Matrix CovarianceModelImplementation::computeCrossCovariance(const Sample &sample,
+                                                             const Point &point) const
+{
+  const UnsignedInteger size = sample.getSize();
+  const UnsignedInteger outputDimension = getOutputDimension();
+  if (outputDimension == 1)
+  {
+    Matrix result(size, 1);
+    const CrossCovariancePointFunctor1D policy(sample, point, result, *this);
+    // The loop is over the lower block-triangular part
+    TBB::ParallelForIf(isParallel(), 0, size, policy);
+    return result;
+  }
+  const UnsignedInteger fullSize = size * outputDimension;
+  Matrix result(fullSize, outputDimension);
+  const CrossCovariancePointFunctor policy(sample, point, result, *this);
+  TBB::ParallelForIf(isParallel(), 0, size, policy);
+  return result;
+}
+
+Matrix CovarianceModelImplementation::computeCrossCovariance(const Point &point,
+                                                             const Sample &sample) const
+{
+  // TODO : transposeInPlace
+  return computeCrossCovariance(sample, point).transpose();
+}
+
 CovarianceMatrix CovarianceModelImplementation::discretize(const Mesh & mesh) const
 {
   return discretize(mesh.getVertices());

--- a/lib/src/Base/Stat/openturns/CovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModel.hxx
@@ -91,8 +91,15 @@ public:
   virtual CovarianceMatrix discretize(const RegularGrid & timeGrid) const;
   virtual CovarianceMatrix discretize(const Mesh & mesh) const;
   virtual CovarianceMatrix discretize(const Sample & vertices) const;
-  virtual Sample discretizeRow(const Sample & vertices,
+  virtual Sample discretizeRow(const Sample &vertices,
                                const UnsignedInteger p) const;
+
+  virtual Matrix computeCrossCovariance(const Sample &firstSample,
+                                        const Sample &secondSample) const;
+  virtual Matrix computeCrossCovariance(const Sample &sample,
+                                        const Point &point) const;
+  virtual Matrix computeCrossCovariance(const Point &point,
+                                        const Sample &sample) const;
 
   /** Discretize and factorize the covariance function on a given TimeGrid/Mesh */
   virtual TriangularMatrix discretizeAndFactorize(const RegularGrid & timeGrid) const;

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -109,6 +109,13 @@ public:
   virtual CovarianceMatrix discretize(const Sample & vertices) const;
   virtual Sample discretizeRow(const Sample & vertices,
                                const UnsignedInteger p) const;
+  virtual Matrix computeCrossCovariance(const Sample &firstSample,
+                                        const Sample &secondSample) const;
+
+  virtual Matrix computeCrossCovariance(const Sample &sample,
+                                        const Point &point) const;
+  virtual Matrix computeCrossCovariance(const Point &point,
+                                        const Sample &sample) const;
 
   /** Discretize and factorize the covariance function on a given TimeGrid/Mesh */
   virtual TriangularMatrix discretizeAndFactorize(const RegularGrid & timeGrid) const;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/openturns/KrigingResult.hxx
@@ -151,18 +151,10 @@ public:
 protected:
 
   /** Compute cross matrix method ==> not necessary square matrix  */
-  Matrix getCrossMatrix(const Sample & x) const;
-  Matrix getCrossMatrix(const Point & point) const;
   void computeF() const;
   void computePhi() const;
 
 private:
-
-  // Structures for evaluation of crossCovariance
-  friend struct KrigingResultCrossCovarianceFunctor;
-  friend struct KrigingResultCrossCovarianceFunctor1D;
-  friend struct KrigingResultCrossCovariancePointFunctor;
-  friend struct KrigingResultCrossCovariancePointFunctor1D;
 
   /** input/output samples */
   Sample inputSample_;

--- a/lib/test/t_CovarianceModel_std.cxx
+++ b/lib/test/t_CovarianceModel_std.cxx
@@ -50,7 +50,7 @@ static void test_model(const CovarianceModel & myModel, const Bool test_grad = t
   // interval mesher
   Indices levels(inputDimension);
   for (UnsignedInteger k = 0; k < inputDimension; ++k)
-    levels[k] = 9;
+    levels[k] = 7;
   IntervalMesher intervalMesher(levels);
 
   // Building interval
@@ -90,47 +90,59 @@ static void test_model(const CovarianceModel & myModel, const Bool test_grad = t
     }
   }
 
+  // Now we suppose that discretize is ok
+  // we look at crossCovariance of (vertices, vertices) which should return the same values
+  cov.getImplementation()->symmetrize();
+  const Matrix crossCov(myModel.computeCrossCovariance(vertices, vertices));
+  assert_almost_equal(crossCov, cov, 1e-14, 1e-14, OSS() << "in " << myModel.getImplementation()->getClassName() << "::computeCrossCovariance" );
+
+  // Now crossCovariance(sample, sample) is ok
+  // Let us validate crossCovariance(Sample, point) with 1st column(s) of previous calculations
+  const Matrix crossCovSamplePoint(myModel.computeCrossCovariance(vertices, vertices[0]));
+  const Matrix crossCovCol(crossCov.reshape(crossCov.getNbRows(), dimension));
+  assert_almost_equal(crossCovSamplePoint, crossCovCol, 1e-14, 1e-14,  OSS() << "in " << myModel.getImplementation()->getClassName() << "::computeCrossCovarianceSamplePoint");
+
   // gradient testing
   if (test_grad)
-  {
-    // Testing partial gradient
-    Matrix grad(myModel.partialGradient(x1, x2));
+    {
+      // Testing partial gradient
+      Matrix grad(myModel.partialGradient(x1, x2));
 
-    Scalar eps = 1.0e-3;
-    if (dimension == 1)
-    {
-      Matrix gradfd(inputDimension, 1);
-      for (UnsignedInteger j = 0; j < inputDimension; ++j)
+      Scalar eps = 1.0e-3;
+      if (dimension == 1)
       {
-        Point x1_g(x1);
-        Point x1_d(x1);
-        x1_g[j] += eps;
-        x1_d[j] -= eps;
-        gradfd(j, 0) = (myModel(x1_g, x2)(0, 0) - myModel(x1_d, x2)(0, 0)) / (2.0 * eps);
+        Matrix gradfd(inputDimension, 1);
+        for (UnsignedInteger j = 0; j < inputDimension; ++j)
+        {
+          Point x1_g(x1);
+          Point x1_d(x1);
+          x1_g[j] += eps;
+          x1_d[j] -= eps;
+          gradfd(j, 0) = (myModel(x1_g, x2)(0, 0) - myModel(x1_d, x2)(0, 0)) / (2.0 * eps);
+        }
+        assert_almost_equal(grad, gradfd, 1e-6, 1e-6, OSS() << "in " << myModel.getImplementation()->getClassName() << " grad");
       }
-      assert_almost_equal(grad, gradfd, 1e-6, 1e-6, OSS() << "in " << myModel.getImplementation()->getClassName() << " grad");
-    }
-    else
-    {
-      Matrix gradfd(inputDimension, dimension * dimension);
-      SquareMatrix covarianceX1X2 = myModel(x1, x2);
-      // Convert result into MatrixImplementation to get the collection
-      MatrixImplementation covarianceX1X2Implementation(*covarianceX1X2.getImplementation());
-      const Point centralValue(covarianceX1X2Implementation);
-      // Loop over the shifted points
-      for (UnsignedInteger i = 0; i < inputDimension; ++i)
+      else
       {
-        Point currentPoint(x1);
-        currentPoint[i] += eps;
-        SquareMatrix localCovariance = myModel(currentPoint, x2);
-        MatrixImplementation localCovarianceImplementation(*localCovariance.getImplementation());
-        const Point currentValue(localCovarianceImplementation);
-        for (UnsignedInteger j = 0; j < centralValue.getDimension(); ++j)
-          gradfd(i, j) = (currentValue[j] - centralValue[j]) / eps;
+        Matrix gradfd(inputDimension, dimension * dimension);
+        SquareMatrix covarianceX1X2 = myModel(x1, x2);
+        // Convert result into MatrixImplementation to get the collection
+        MatrixImplementation covarianceX1X2Implementation(*covarianceX1X2.getImplementation());
+        const Point centralValue(covarianceX1X2Implementation);
+        // Loop over the shifted points
+        for (UnsignedInteger i = 0; i < inputDimension; ++i)
+        {
+          Point currentPoint(x1);
+          currentPoint[i] += eps;
+          SquareMatrix localCovariance = myModel(currentPoint, x2);
+          MatrixImplementation localCovarianceImplementation(*localCovariance.getImplementation());
+          const Point currentValue(localCovarianceImplementation);
+          for (UnsignedInteger j = 0; j < centralValue.getDimension(); ++j)
+            gradfd(i, j) = (currentValue[j] - centralValue[j]) / eps;
+        }
+        assert_almost_equal(grad, gradfd, 2e5, 2e-5, OSS() << "in " << myModel.__str__() << " grad");
       }
-      assert_almost_equal(grad, gradfd, 2e5, 2e-5, OSS() << "in " << myModel.__str__() << " grad");
     }
-  }
 }
 
 static void test_scalar_model(const CovarianceModel &myModel)

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -43,6 +43,45 @@ OT_CovarianceModel_computeAsScalar_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_CovarianceModel_computeCrossCovariance_doc
+"computeCrossCovariance the covariance function on a given mesh.
+
+Parameters
+----------
+firstVertices : :class:`~openturns.Sample` or :class:`~openturns.Point`
+    Container of the first discretization vertices
+
+secondVertices : :class:`~openturns.Sample` or :class:`~openturns.Point`
+    Container of the second discretization vertices
+
+Returns
+-------
+Matrix : :class:`~openturns.Matrix`
+    Container of the cross covariance
+
+Notes
+-----
+This method computes a cross-covariance matrix.
+The cross-covariance is the evaluation of the covariance model 
+on both `firstVertices` and `secondVertices`.
+
+If :math:`firstVertices` contains :math:`n_1` points and :math:`secondVertices` contains :math:`n_2` points,
+the method returns an :math:`n_1 d \times n_2 d` matrix (:math:`d` being the output dimension).
+
+To make things easier, let us focus on the :math:`d=1` case.
+Let :math:`\vect{x}_0, \dots, \vect{x}_{n_1-1}` be the points of `firstVertices`
+and let :math:`\vect{y}_0, \dots, \vect{y}_{n_2-1}` be the points of `secondVertices`.
+The result is the :math:`n_1 \times n_2` matrix :math:`\mat{M}`
+such that for any nonnegative integers :math:`i < n_1` and :math:`j < n_2`,
+:math:`\mat{M}_{i,j} = \mathcal{C}(\vect{x}_i, \vect{y}_j)`.
+
+"
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::computeCrossCovariance
+OT_CovarianceModel_computeCrossCovariance_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_CovarianceModel_discretize_doc
 "Discretize the covariance function on a given mesh.
 

--- a/python/src/CovarianceModel_doc.i.in
+++ b/python/src/CovarianceModel_doc.i.in
@@ -4,6 +4,8 @@
 OT_CovarianceModel_doc
 %feature("docstring") OT::CovarianceModel::computeAsScalar
 OT_CovarianceModel_computeAsScalar_doc
+%feature("docstring") OT::CovarianceModel::computeCrossCovariance
+OT_CovarianceModel_computeCrossCovariance_doc
 %feature("docstring") OT::CovarianceModel::discretize
 OT_CovarianceModel_discretize_doc
 %feature("docstring") OT::CovarianceModel::discretizeAndFactorize


### PR DESCRIPTION
This allows to compute the covariance interaction between X & Y samples.
or X/p where X is a `Sample`, p a `Point`
It was already implemented (but private) in `KrigingResult` for `Kriging`
variance purposes. Now we implement the method in the CovarianceModel
class as the service is mandatory for some applications such as `HSIC`

We also implement unit tests in `CovarianceModel_std` tests and made tests less time consuming for continuous integration purposes