### PR TITLE
VisualTest: Rename DrawCobWeb to DrawParallelCoordinates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@
  * Implemented CovarianceModel::computeCrossCovariance
  * Deprecated Hanning in favor of Hann
  * Deprecated AdaptiveDirectionalSampling in favor of AdaptiveDirectionalStratification
+ * Deprecated VisualTest::DrawCobWeb in favor of DrawParallelCoordinates
 
 === Documentation ===
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
 Remove Sample::computeStandardDeviationPerComponent
 Remove Hanning alias
 Remove ADS alias
+Remove deprecated VisualTest::DrawCobWeb method

--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -341,8 +341,19 @@ Graph VisualTest::DrawLinearModelResidual(const LinearModelResult & linearModelR
   return VisualTest::DrawLinearModelResidual(sample1, sample2, linearModelResult);
 }
 
-/* Draw the CobWeb visual test */
 Graph VisualTest::DrawCobWeb(const Sample & inputSample,
+                             const Sample & outputSample,
+                             const Scalar minValue,
+                             const Scalar maxValue,
+                             const String & color,
+                             const Bool quantileScale)
+{
+  LOGWARN(OSS() << "VisualTest.DrawCobWeb is deprecated, use DrawParallelCoordinates");
+  return DrawParallelCoordinates(inputSample, outputSample, minValue, maxValue, color, quantileScale);
+}
+
+/* Draw the parallel coordinates visual test */
+Graph VisualTest::DrawParallelCoordinates(const Sample & inputSample,
                              const Sample & outputSample,
                              const Scalar minValue,
                              const Scalar maxValue,

--- a/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
@@ -87,7 +87,15 @@ public:
   /** Draw the visual test for a 1D LinearModel's residuals using the training Samples */
   static Graph DrawLinearModelResidual(const LinearModelResult & linearModelResult);
 
-  /** Draw the CobWeb visual test */
+  /** Draw the parallel coordinates visual test */
+  static Graph DrawParallelCoordinates(const Sample & inputSample,
+                          const Sample & outputSample,
+                          const Scalar minValue,
+                          const Scalar maxValue,
+                          const String & color,
+                          const Bool quantileScale = true);
+
+  /** @deprecated */
   static Graph DrawCobWeb(const Sample & inputSample,
                           const Sample & outputSample,
                           const Scalar minValue,

--- a/lib/test/t_VisualTest_std.cxx
+++ b/lib/test/t_VisualTest_std.cxx
@@ -89,9 +89,9 @@ int main(int, char *[])
     formula[0] = oss;
     SymbolicFunction model(inputVar, formula);
     Sample outputSample(model(inputSample));
-    Graph cobwebValue(VisualTest::DrawCobWeb(inputSample, outputSample, 2.5, 3.0, "red", false));
+    Graph cobwebValue(VisualTest::DrawParallelCoordinates(inputSample, outputSample, 2.5, 3.0, "red", false));
     fullprint << "cobwebValue = " << cobwebValue << std::endl;
-    Graph cobwebQuantile(VisualTest::DrawCobWeb(inputSample, outputSample, 0.7, 0.9, "red", false));
+    Graph cobwebQuantile(VisualTest::DrawParallelCoordinates(inputSample, outputSample, 0.7, 0.9, "red", false));
     fullprint << "cobwebQuantile = " << cobwebQuantile << std::endl;
   }
 

--- a/python/doc/examples/data_analysis/graphics/plot_sensitivity_par_coo_ishigami.py
+++ b/python/doc/examples/data_analysis/graphics/plot_sensitivity_par_coo_ishigami.py
@@ -3,7 +3,7 @@ Visualize sensitivity
 =====================
 """
 # %%
-# The Cobweb graph enables to visualize all the combinations of the input
+# The parallel coordinates graph enables to visualize all the combinations of the input
 # variables which lead to a specific range of the output variable. It is a very simple and cheap tool to visualize sensitivity from the raw data.
 #
 # Let us consider a model :math:`f: \mathbb{R}^n \longrightarrow \mathbb{R}`, where :math:`f(\underline{X}) = Y`.
@@ -81,9 +81,9 @@ maxValue = Y.getMax()[0]
 
 # We deactivate the default quantile scale.
 quantileScale = False
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
-graphCobweb.setLegendPosition('bottomright')
-view = viewer.View(graphCobweb)
+graph = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
+graph.setLegendPosition('bottomright')
+view = viewer.View(graph)
 
 # %%
 # Here we would like to conclude that the highest values of `Y` are obtained from a specific input as the highlighted lines clearly follow one only path.
@@ -94,12 +94,12 @@ view = viewer.View(graphCobweb)
 minValue = 0.80 * Y.getMax()[0]
 maxValue = Y.getMax()[0]
 quantileScale = False
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
-graphCobweb.setLegendPosition('bottomright')
-view = viewer.View(graphCobweb)
+graph = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
+graph.setLegendPosition('bottomright')
+view = viewer.View(graph)
 
 # %%
-# A new path is then available ! That is the reason why we chose a quantile based ranking as the value based cobweb involves a bit of guessing.
+# A new path is then available ! That is the reason why we chose a quantile based ranking as the value based parallel plot involves a bit of guessing.
 
 
 # %%
@@ -114,12 +114,12 @@ minValue = 0.95
 maxValue = 1.0
 # a quantileScale is used, default behaviour
 quantileScale = True
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
-graphCobweb.setLegendPosition('bottomright')
-view = viewer.View(graphCobweb)
+graph = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
+graph.setLegendPosition('bottomright')
+view = viewer.View(graph)
 
 # %%
-# The cobweb obtained is helpful : we see peculiar values for each marginal.
+# The parallel coordinates plot obtained is helpful : we see peculiar values for each marginal.
 #
 #
 
@@ -138,8 +138,8 @@ view = viewer.View(graphCobweb)
 # - the :math:`7sin^2(X_2)` term around :math:`X_2 = -\pi / 2` and :math:`X_2 = \pi / 2` ;
 # - the :math:`X_3^4 sin(X_1)` term around :math:`X_1 = \pi / 2` and :math:`X_3 = \{ -\pi, \pi}`.
 #
-# These values can be seen on the cobweb as for each marginal there is a cluster around respectively 1, 2 and 2 values for :math`X_1`, :math`X_2` and :math`X_3`.
-# This amounts to 4 different values 'realizing' the maximum and we can observe 4 distinct paths on the cobweb as well.
+# These values can be seen on the parallel plot as for each marginal there is a cluster around respectively 1, 2 and 2 values for :math`X_1`, :math`X_2` and :math`X_3`.
+# This amounts to 4 different values 'realizing' the maximum and we can observe 4 distinct paths on the parallel plot as well.
 #
 
 # %%
@@ -149,23 +149,23 @@ view = viewer.View(graphCobweb)
 # A dependence between these two marginals would have presented unbalanced paths.
 
 # %%
-# When the cobweb brings nothing
-# ------------------------------
+# When the parallel plot brings nothing
+# -------------------------------------
 #
-# To conclude our tour on the cobweb graph we look at the 50% quantile : that is
+# To conclude our tour on the parallel plot we look at the 50% quantile : that is
 # values around the mean :
 
 # %%
 minValue = 0.48
 maxValue = 0.52
 quantileScale = True
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
-graphCobweb.setLegendPosition('topright')
-view = viewer.View(graphCobweb)
+graph = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
+graph.setLegendPosition('topright')
+view = viewer.View(graph)
 
 # %%
-# We cannot extract any useful information from this cobweb. In fact it is the expected behaviour as mean values should be attained from various combinations of# the input variables.
-# The cobweb graph is a cheap tool and highly useful to explore more extreme values !
+# We cannot extract any useful information from this parallel plot. In fact it is the expected behaviour as mean values should be attained from various combinations of# the input variables.
+# The parallel coordinates graph is a cheap tool and highly useful to explore more extreme values !
 
 # %%
 # Display figures

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_par_coo.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_par_coo.py
@@ -1,9 +1,9 @@
 """
-Cobweb graph as sensitivity tool
-================================
+Parallel coordinates graph as sensitivity tool
+==============================================
 """
 # %%
-# The Cobweb graph enables to visualize all the combinations of the input
+# The parallel coordinates graph enables to visualize all the combinations of the input
 # variables which lead to a specific range of the output variable.
 #
 # Let us consider a model :math:`f: \mathbb{R}^n \longrightarrow \mathbb{R}`, where :math:`f(\underline{X}) = Y`.
@@ -65,7 +65,7 @@ print(Y.getMin(), Y.getMax(), Y.computeQuantilePerComponent(0.9))
 minValue = 3.35
 maxValue = 20.0
 quantileScale = False
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
+graphCobweb = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
 graphCobweb.setLegendPosition('bottomright')
 view = viewer.View(graphCobweb)
 
@@ -74,7 +74,7 @@ view = viewer.View(graphCobweb)
 minValue = 0.9
 maxValue = 1.0
 quantileScale = True
-graphCobweb = ot.VisualTest.DrawCobWeb(X, Y, minValue, maxValue, 'red', quantileScale)
+graphCobweb = ot.VisualTest.DrawParallelCoordinates(X, Y, minValue, maxValue, 'red', quantileScale)
 graphCobweb.setLegendPosition('bottomright')
 view = viewer.View(graphCobweb)
 plt.show()

--- a/python/doc/pyplots/VisualTest_DrawParallelCoordinates.py
+++ b/python/doc/pyplots/VisualTest_DrawParallelCoordinates.py
@@ -16,7 +16,7 @@ for i in range(inputDimension):
 model = ot.SymbolicFunction(inputVar, [expression])
 outputSample = model(inputSample)
 
-cobweb = ot.VisualTest.DrawCobWeb(
+cobweb = ot.VisualTest.DrawParallelCoordinates(
     inputSample, outputSample, 2.5, 3.0, 'red', False)
 
 View(cobweb, figure_kw={'figsize': (10, 6)},

--- a/python/doc/user_manual/statistics_on_sample.rst
+++ b/python/doc/user_manual/statistics_on_sample.rst
@@ -206,7 +206,7 @@ Graphical tests
 
     VisualTest_DrawPairs
     VisualTest_DrawPairsMarginals
-    VisualTest_DrawCobWeb
+    VisualTest_DrawParallelCoordinates
     VisualTest_DrawHenryLine
     VisualTest_DrawKendallPlot
     VisualTest_DrawLinearModel

--- a/python/src/VisualTest.i
+++ b/python/src/VisualTest.i
@@ -10,3 +10,4 @@
 
 %include openturns/VisualTest.hxx
 
+

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -228,11 +228,8 @@ Draw a two-sample CDF-plot:
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::VisualTest::DrawCobWeb
-"Draw a Cobweb plot.
-
-Available usages:
-    VisualTest.DrawCobWeb(*inputSample, outputSample, min, max, color, quantileScale=True*)
+%feature("docstring") OT::VisualTest::DrawParallelCoordinates
+"Draw a parallel coordinates plot.
 
 Parameters
 ----------
@@ -296,10 +293,10 @@ Generate a random sample from a Normal distribution:
 >>> model = ot.SymbolicFunction(['X0', 'X1'], formula)
 >>> outputSample = model(inputSample)
 
-Draw a Cobweb plot:
+Draw a parallel plot:
 
->>> cobweb = ot.VisualTest.DrawCobWeb(inputSample, outputSample, 1.0, 2.0, 'red', False)
->>> View(cobweb).show()"
+>>> parplot = ot.VisualTest.DrawParallelCoordinates(inputSample, outputSample, 1.0, 2.0, 'red', False)
+>>> View(parplot).show()"
 
 // ---------------------------------------------------------------------
 

--- a/python/test/t_Viewer.py
+++ b/python/test/t_Viewer.py
@@ -112,7 +112,7 @@ try:
         expression += 'cos(' + str(i + 1) + '*' + inputVar[i] + ')'
     model = ot.SymbolicFunction(inputVar, [expression])
     outputSample = model(inputSample)
-    graph = ot.VisualTest.DrawCobWeb(
+    graph = ot.VisualTest.DrawParallelCoordinates(
         inputSample, outputSample, 2.5, 3.0, 'red', False)
     # graph.draw('curve6.png')
     view = View(graph, legend_kw={'loc': 'lower center'})

--- a/python/test/t_VisualTest_std.py
+++ b/python/test/t_VisualTest_std.py
@@ -59,11 +59,11 @@ for i in range(inputDimension):
 formula[0] = expression
 model = ot.SymbolicFunction(inputVar, formula)
 outputSample = model(inputSample)
-cobwebValue = ot.VisualTest.DrawCobWeb(
+cobwebValue = ot.VisualTest.DrawParallelCoordinates(
     inputSample, outputSample, 2.5, 3.0, "red", False)
 print("cobwebValue = ", cobwebValue)
 
-cobwebQuantile = ot.VisualTest.DrawCobWeb(
+cobwebQuantile = ot.VisualTest.DrawParallelCoordinates(
     inputSample, outputSample, 0.7, 0.9, "red", False)
 print("cobwebQuantile = ", cobwebQuantile)
 


### PR DESCRIPTION
CobWeb plot is for iterated function plots: https://en.wikipedia.org/wiki/Cobweb_plot
We want https://en.wikipedia.org/wiki/Parallel_coordinates

cc @adutfoy @mbaudin47