### PR TITLE
thread-safe python bindings

### DIFF
--- a/.circleci/run_docker_linux.sh
+++ b/.circleci/run_docker_linux.sh
@@ -26,7 +26,7 @@ mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=~/.local \
       -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=32 \
       -DCMAKE_C_FLAGS="-Wall -Wextra -Werror" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -D_GLIBCXX_ASSERTIONS" \
-      -DSWIG_COMPILE_FLAGS="-O1 -Wno-unused-parameter -Wno-missing-field-initializers" \
+      -DSWIG_COMPILE_FLAGS="-O1 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations" \
       -DSPHINX_FLAGS="-W -T -j4" \
       ${source_dir}
 make install

--- a/.circleci/run_docker_mingw.sh
+++ b/.circleci/run_docker_mingw.sh
@@ -17,7 +17,7 @@ MINGW_PREFIX=/usr/${ARCH}-w64-mingw32
 PYMAJMIN=39
 PREFIX=${PWD}/install
 CXXFLAGS="-Wall -Wextra -Werror -D_GLIBCXX_ASSERTIONS" ${ARCH}-w64-mingw32-cmake \
-  -DSWIG_COMPILE_FLAGS="-O0 -Wno-unused-parameter -Wno-missing-field-initializers" \
+  -DSWIG_COMPILE_FLAGS="-O0 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations" \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=${PREFIX}/lib \
   -DPYTHON_INCLUDE_DIR=${MINGW_PREFIX}/include/python${PYMAJMIN} \
   -DPYTHON_LIBRARY=${MINGW_PREFIX}/lib/libpython${PYMAJMIN}.dll.a \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         -DBISON_EXECUTABLE=/usr/local/opt/bison/bin/bison \
         -DSPECTRA_INCLUDE_DIR=/Users/runner/include \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" \
-        -DSWIG_COMPILE_FLAGS="-O1 -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers" \
+        -DSWIG_COMPILE_FLAGS="-O1 -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers -Wno-deprecated-declarations" \
         -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=32 .
         make install -j3
         make tests -j3

--- a/python/src/Basis.i
+++ b/python/src/Basis.i
@@ -44,6 +44,7 @@ OTTypedInterfaceObjectHelper(Basis)
 
 OT::Collection<OT::Function> (PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   return OT::buildCollectionFromPySequence<OT::Function>(pyObj);
 }
 
@@ -71,6 +72,7 @@ UnsignedInteger __len__() const
 
 Basis(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   try
   {
     OT::Pointer<OT::Collection<OT::Function> > p_coll =  OT::buildCollectionFromPySequence<OT::Function>( pyObj );

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -2,14 +2,18 @@
 
 add_definitions (${OPENTURNS_SWIG_DEFINITIONS})
 
+set (CMAKE_SWIG_FLAGS "-threads" CACHE STRING "SWIG flags for generating wrapper code")
+
+# allows to pass compile flags like -O1 to reduce memory usage
+set (SWIG_COMPILE_FLAGS "" CACHE STRING "C++ compiler flags used for wrapper code")
+
 # generate SWIG runtime header
-set (SWIG_PYTHON_OPTIONS "-python")
 execute_process (COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/openturns)
-add_custom_command (OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/openturns/swig_runtime.hxx
+add_custom_command (OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/openturns/swigpyrun.h
                      COMMAND ${SWIG_EXECUTABLE}
-                     ARGS ${SWIG_PYTHON_OPTIONS} ${CMAKE_SWIG_FLAGS} ${OPENTURNS_SWIG_DEFINITIONS} -external-runtime ${CMAKE_CURRENT_BINARY_DIR}/openturns/swig_runtime.hxx
-                     COMMENT "Swig header")
-add_custom_target (generate_swig_runtime DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/openturns/swig_runtime.hxx)
+                     ARGS -python -external-runtime ${CMAKE_CURRENT_BINARY_DIR}/openturns/swigpyrun.h
+                     COMMENT "Swig runtime header")
+add_custom_target (generate_swig_runtime DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/openturns/swigpyrun.h)
 add_custom_target (generate_docstrings)
 add_custom_target (pylib)
 
@@ -71,8 +75,6 @@ macro (ot_add_python_module MODULENAME SOURCEFILE)
 
   target_link_libraries_with_dynamic_lookup (${module_target} ${PYTHON_LIBRARIES})
 
-  # allows to pass compile flags like -O1 to reduce memory usage
-  set (SWIG_COMPILE_FLAGS "" CACHE STRING "Additional flags used when compiling swig generated code")
   set_target_properties (${module_target} PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
 
   set_target_properties (${module_target} PROPERTIES UNITY_BUILD OFF)

--- a/python/src/Collection.i
+++ b/python/src/Collection.i
@@ -32,6 +32,7 @@ template <class T> Collection(const Collection<T> & other)
 %define OT_COLLECTION_GETITEM(collectionType, elementType)
 PyObject * __getitem__(PyObject * arg) const
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (PyInt_Check(arg))
   {
     long val2 = 0;
@@ -60,7 +61,7 @@ PyObject * __getitem__(PyObject * arg) const
     else
       for (Py_ssize_t i = 0; i < size; ++ i)
         result.at(i) = self->at(start + i * step);
-    return SWIG_NewPointerObj((new collectionType(static_cast< const collectionType& >(result))), SWIG_TypeQuery(#collectionType " *"), SWIG_POINTER_OWN |  0);
+    return SWIG_NewPointerObj(new collectionType(result), SWIG_TypeQuery(#collectionType " *"), SWIG_POINTER_OWN);
   }
   else if (PySequence_Check(arg))
   {
@@ -91,7 +92,7 @@ PyObject * __getitem__(PyObject * arg) const
       }
       result[i] = self->at(index);
     }
-    return SWIG_NewPointerObj((new collectionType(static_cast< const collectionType& >(result))), SWIG_TypeQuery(#collectionType " *"), SWIG_POINTER_OWN |  0);
+    return SWIG_NewPointerObj(new collectionType(result), SWIG_TypeQuery(#collectionType " *"), SWIG_POINTER_OWN);
   }
   else if (PyObject_HasAttrString(arg, "__int__"))
   {
@@ -107,6 +108,7 @@ PyObject * __getitem__(PyObject * arg) const
   }
   else
     SWIG_exception(SWIG_TypeError, "Collection.__getitem__ expects int, slice or sequence argument");
+  SWIG_PYTHON_THREAD_END_BLOCK;
 fail:
   return NULL;
 }
@@ -116,6 +118,7 @@ fail:
 %define OT_COLLECTION_SETITEM(collectionType, elementType)
 PyObject * __setitem__(PyObject * arg, PyObject * valObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (PyInt_Check(arg))
   {
     long val2 = 0;
@@ -206,6 +209,7 @@ PyObject * __setitem__(PyObject * arg, PyObject * valObj)
   else
     SWIG_exception(SWIG_TypeError, "Collection.__setitem__ expects int, slice or sequence argument");
   return SWIG_Py_Void();
+  SWIG_PYTHON_THREAD_END_BLOCK;
 fail:
   return NULL;
 }

--- a/python/src/ComplexMatrix.i
+++ b/python/src/ComplexMatrix.i
@@ -49,7 +49,11 @@ namespace OT {
 
   ComplexMatrix(const ComplexMatrix & other) { return new OT::ComplexMatrix(other); }
 
-  ComplexMatrix(PyObject * pyObj) { return new OT::ComplexMatrix( OT::convert<OT::_PySequence_,OT::ComplexMatrix>(pyObj) ); }
+  ComplexMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::ComplexMatrix(OT::convert<OT::_PySequence_, OT::ComplexMatrix>(pyObj));
+  }
 
   OTComplexMatrixGetAccessors()  
   

--- a/python/src/ComplexTensor.i
+++ b/python/src/ComplexTensor.i
@@ -41,7 +41,11 @@ namespace OT {
 
   ComplexTensor(const ComplexTensor & other) { return new OT::ComplexTensor(other); }
 
-  ComplexTensor(PyObject * pyObj) { return new OT::ComplexTensor( OT::convert<OT::_PySequence_,OT::ComplexTensor>(pyObj) ); }
+  ComplexTensor(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::ComplexTensor(OT::convert<OT::_PySequence_,OT::ComplexTensor>(pyObj));
+  }
 
   OTTensorAccessors(ComplexTensor, Complex, _PyComplex_)
 

--- a/python/src/CorrelationMatrix.i
+++ b/python/src/CorrelationMatrix.i
@@ -32,7 +32,11 @@ namespace OT {
 
   CorrelationMatrix(const CorrelationMatrix & other) { return new OT::CorrelationMatrix(other); }
 
-  CorrelationMatrix(PyObject * pyObj) { return new OT::CorrelationMatrix(OT::convert<OT::_PySequence_, OT::CorrelationMatrix>(pyObj)); }
+  CorrelationMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::CorrelationMatrix(OT::convert<OT::_PySequence_, OT::CorrelationMatrix>(pyObj));
+  }
 
   OTMatrixAccessors()
 

--- a/python/src/CovarianceMatrix.i
+++ b/python/src/CovarianceMatrix.i
@@ -56,7 +56,11 @@ namespace OT {
 
   CovarianceMatrix(const CovarianceMatrix & other) { return new OT::CovarianceMatrix(other); }
   
-  CovarianceMatrix(PyObject * pyObj) { return new OT::CovarianceMatrix( OT::convert<OT::_PySequence_,OT::CovarianceMatrix>(pyObj) ); }
+  CovarianceMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::CovarianceMatrix( OT::convert<OT::_PySequence_, OT::CovarianceMatrix>(pyObj));
+  }
   
   OTMatrixAccessors()
   

--- a/python/src/Distribution.i
+++ b/python/src/Distribution.i
@@ -29,6 +29,7 @@ Distribution(const Distribution & other)
 
 Distribution(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   return new OT::Distribution( new OT::PythonDistribution( pyObj ) );
 }
 

--- a/python/src/Drawable.i
+++ b/python/src/Drawable.i
@@ -44,6 +44,7 @@ Drawable(const Drawable & other) { return new OT::Drawable(other); }
 
 Drawable(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   return new OT::Drawable( OT::convert<OT::_PyObject_,OT::Drawable>(pyObj) );
 }
 

--- a/python/src/Field.i
+++ b/python/src/Field.i
@@ -60,8 +60,9 @@ UnsignedInteger __len__() const
   return self->getSize();
 }
 
-PyObject * __getitem__(PyObject * args) const {
-
+PyObject * __getitem__(PyObject * args) const
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (!PyTuple_Check(args))
   {
     if (PyObject_HasAttrString(args, "__int__"))
@@ -76,7 +77,7 @@ PyObject * __getitem__(PyObject * args) const {
       if (index < 0)
         throw OT::OutOfBoundException(HERE) << "index should be in [-" << self->getSize() << ", " << self->getSize() - 1 << "]." ;
       OT::Point result(self->at(index));
-      return SWIG_NewPointerObj((new OT::Point(static_cast< const OT::Point& >(result))), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Point(result), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN);
     }
   }
 
@@ -116,8 +117,9 @@ fail:
 }
 
 
-void __setitem__(PyObject * args, PyObject * valObj) {
-
+void __setitem__(PyObject * args, PyObject * valObj)
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (!PyTuple_Check(args))
   {
     if (PyObject_HasAttrString(args, "__int__"))

--- a/python/src/FieldFunction.i
+++ b/python/src/FieldFunction.i
@@ -63,6 +63,7 @@ namespace OT {
 
 FieldFunction(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   void * ptr = 0;
   if (SWIG_IsOK(SWIG_ConvertPtr(pyObj, &ptr, SWIGTYPE_p_OT__Object, 0)))
   {

--- a/python/src/FieldToPointFunction.i
+++ b/python/src/FieldToPointFunction.i
@@ -63,6 +63,7 @@ namespace OT {
 
 FieldToPointFunction(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   void * ptr = 0;
   if (SWIG_IsOK(SWIG_ConvertPtr(pyObj, &ptr, SWIGTYPE_p_OT__Object, 0)))
   {

--- a/python/src/Function.i
+++ b/python/src/Function.i
@@ -57,6 +57,7 @@ namespace OT {
 
 Function(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   void * ptr = 0;
   if (SWIG_IsOK(SWIG_ConvertPtr(pyObj, &ptr, SWIGTYPE_p_OT__Object, 0)))
   {

--- a/python/src/HMatrix.i
+++ b/python/src/HMatrix.i
@@ -10,6 +10,7 @@ public:
   PythonHMatrixRealAssemblyFunction(PyObject * pyObj)
   : pyObj_(pyObj)
   {
+    OT::InterpreterUnlocker iul;
     if (!PyCallable_Check(pyObj)) {
       throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
     }
@@ -17,6 +18,7 @@ public:
 
   virtual OT::Scalar operator() (OT::UnsignedInteger i, OT::UnsignedInteger j) const
   {
+    OT::InterpreterUnlocker iul;
     OT::ScopedPyObjectPointer index1(OT::convert< OT::UnsignedInteger, OT::_PyInt_ >(i));
     OT::ScopedPyObjectPointer index2(OT::convert< OT::UnsignedInteger, OT::_PyInt_ >(j));
     OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj_, index1.get(), index2.get(), NULL));
@@ -33,6 +35,7 @@ public:
   PythonHMatrixTensorRealAssemblyFunction(PyObject * pyObj, const OT::UnsignedInteger outputDimension)
   : HMatrixTensorRealAssemblyFunction(outputDimension), pyObj_(pyObj)
   {
+    OT::InterpreterUnlocker iul;
     if (!PyCallable_Check(pyObj)) {
       throw OT::InvalidArgumentException(HERE) << "Argument is not a callable object.";
     }
@@ -40,6 +43,7 @@ public:
 
   virtual void compute(OT::UnsignedInteger i, OT::UnsignedInteger j, OT::Matrix* localValues) const
   {
+    OT::InterpreterUnlocker iul;
     OT::ScopedPyObjectPointer index1(OT::convert< OT::UnsignedInteger, OT::_PyInt_ >(i));
     OT::ScopedPyObjectPointer index2(OT::convert< OT::UnsignedInteger, OT::_PyInt_ >(j));
     OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj_, index1.get(), index2.get(), NULL));

--- a/python/src/HermitianMatrix.i
+++ b/python/src/HermitianMatrix.i
@@ -22,7 +22,11 @@ namespace OT {
 %extend HermitianMatrix {
   HermitianMatrix(const HermitianMatrix & other) { return new  OT::HermitianMatrix(other); }
 
-  HermitianMatrix(PyObject * pyObj) { return new OT::HermitianMatrix( OT::convert<OT::_PySequence_,OT::HermitianMatrix>(pyObj) ); }
+  HermitianMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::HermitianMatrix(OT::convert<OT::_PySequence_, OT::HermitianMatrix>(pyObj));
+  }
 
   OTComplexMatrixGetAccessors()
 

--- a/python/src/Indices.i
+++ b/python/src/Indices.i
@@ -34,7 +34,11 @@ namespace OT {
 
   Indices(const Indices & other) { return new OT::Indices(other); }  
 
-  Indices(PyObject * pyObj) { return new OT::Indices( OT::convert<OT::_PySequence_,OT::Indices>(pyObj) ); }
+  Indices(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::Indices( OT::convert<OT::_PySequence_,OT::Indices>(pyObj) );
+  }
 
   OTCollectionOperatorsHelper(OT::Indices, OT::UnsignedInteger)
 

--- a/python/src/IndicesCollection.i
+++ b/python/src/IndicesCollection.i
@@ -71,7 +71,8 @@ IndicesCollection(const IndicesCollection & other)
 
 IndicesCollection(PyObject * pyObj)
 {
-  return new OT::IndicesCollection( OT::convert< OT::_PySequence_, OT::IndicesCollection >(pyObj) );
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  return new OT::IndicesCollection(OT::convert< OT::_PySequence_, OT::IndicesCollection >(pyObj));
 }
 
 }

--- a/python/src/Matrix.i
+++ b/python/src/Matrix.i
@@ -25,8 +25,9 @@
 %apply const ScalarCollection & { const OT::Matrix::ScalarCollection & };
 
 %define OTMatrixGetAccessor(baseType, elementType, pythonElementType)
-PyObject * __getitem__(PyObject * args) const {
-
+PyObject * __getitem__(PyObject * args) const
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   Py_ssize_t start1 = 0;
   Py_ssize_t stop1 = 0;
   Py_ssize_t step1 = 0;
@@ -37,14 +38,14 @@ PyObject * __getitem__(PyObject * args) const {
   { 
     PySlice_GetIndicesEx( OT::SliceCast( args ), self->getNbRows(), &start1, &stop1, &step1, &slicelength1 );
     OT::baseType result(slicelength1, self->getNbColumns());
-    for( OT::UnsignedInteger j = 0; j < self->getNbColumns(); ++ j )
+    for(OT::UnsignedInteger j = 0; j < self->getNbColumns(); ++ j)
     {
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
         result.operator()(i, j) = self->operator()( start1 + i*step1, j );
       }
     }
-    return SWIG_NewPointerObj((new OT::baseType(static_cast< const OT::baseType& >(result))), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN |  0 );
+    return SWIG_NewPointerObj(new OT::baseType(result), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN);
   }
 
   PyObject * obj1 = 0 ;
@@ -83,7 +84,7 @@ PyObject * __getitem__(PyObject * args) const {
   // convert second list argument
   if ( PySlice_Check( obj2 ) )
   {
-    PySlice_GetIndicesEx( OT::SliceCast( obj2 ), self->getNbColumns(), &start2, &stop2, &step2, &slicelength2 );
+    PySlice_GetIndicesEx(OT::SliceCast( obj2 ), self->getNbColumns(), &start2, &stop2, &step2, &slicelength2);
   }
   else
   {
@@ -100,45 +101,45 @@ PyObject * __getitem__(PyObject * args) const {
   }
 
   // handle arguments
-  if ( PySlice_Check( obj1 ) )
+  if (PySlice_Check(obj1))
   {
 
-    if ( PySlice_Check( obj2 ) )
+    if (PySlice_Check(obj2))
     {
       // case #1: [slice/slice] => baseType
       OT::baseType result( slicelength1, slicelength2 );
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
-        for ( Py_ssize_t j = 0; j < slicelength2; ++ j )
+        for (Py_ssize_t j = 0; j < slicelength2; ++ j)
         {
           result.operator()(i, j) = self->operator()( start1 + i*step1, start2 + j*step2 );
         }
       }
-      return SWIG_NewPointerObj((new OT::baseType(static_cast< const OT::baseType& >(result))), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN |  0 );
+      return SWIG_NewPointerObj(new OT::baseType(result), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN);
     }
     else
     {
       // case #2: [slice/index] => baseType
       OT::baseType result( slicelength1, 1 );
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
         result.operator()(i, 0) = self->operator()( start1 + i*step1, arg3 );
       }
-      return SWIG_NewPointerObj((new OT::baseType(static_cast< const OT::baseType& >(result))), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN |  0 );
+      return SWIG_NewPointerObj(new OT::baseType(result), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN);
     }
 
   }
   else
   {
-    if ( PySlice_Check( obj2 ) )
+    if (PySlice_Check(obj2))
     {
       // case #3: [index/slice] => baseType
-      OT::baseType result( 1, slicelength2 );
-      for ( Py_ssize_t j = 0; j < slicelength2; ++ j )
+      OT::baseType result(1, slicelength2);
+      for (Py_ssize_t j = 0; j < slicelength2; ++ j)
       {
         result.operator()(0, j) = self->operator()( arg2, start2 + j*step2 );
       }
-      return SWIG_NewPointerObj((new OT::baseType(static_cast< const OT::baseType& >(result))), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN |  0 );
+      return SWIG_NewPointerObj(new OT::baseType(result), SWIG_TypeQuery("OT::" #baseType " *"), SWIG_POINTER_OWN);
     }
     else
     {  
@@ -146,14 +147,16 @@ PyObject * __getitem__(PyObject * args) const {
       return OT::convert< OT::elementType, OT::pythonElementType>( self->operator()(arg2, arg3) );
     }
   }
+  SWIG_PYTHON_THREAD_END_BLOCK;
 fail:
   return NULL;
 }
 %enddef
 
 %define OTMatrixSetAccessor(baseType, elementType, pythonElementType)
-PyObject * __setitem__(PyObject * args, PyObject * valObj) {
-
+PyObject * __setitem__(PyObject * args, PyObject * valObj)
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   Py_ssize_t start1 = 0;
   Py_ssize_t stop1 = 0;
   Py_ssize_t step1 = 0;
@@ -170,9 +173,9 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
       val2 = &temp2;
     }
     assert( val2 );
-    for ( OT::UnsignedInteger j = 0; j < val2->getNbColumns(); ++ j)
+    for (OT::UnsignedInteger j = 0; j < val2->getNbColumns(); ++ j)
     {
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
         self->operator()( start1 + i*step1, j ) = val2->operator()(i, j);
       }
@@ -195,7 +198,7 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
   if (!PyArg_ParseTuple(args,(char *)"OO:" #baseType "___getitem__",&obj1,&obj2)) SWIG_fail;
 
   // convert first list argument 
-  if ( PySlice_Check( obj1 ) )
+  if (PySlice_Check(obj1))
   { 
     PySlice_GetIndicesEx(OT::SliceCast(obj1), self->getNbRows(), &start1, &stop1, &step1, &slicelength1);
   }
@@ -214,7 +217,7 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
   }
 
   // convert second list argument
-  if ( PySlice_Check( obj2 ) )
+  if (PySlice_Check(obj2))
   {
     PySlice_GetIndicesEx(OT::SliceCast(obj2), self->getNbColumns(), &start2, &stop2, &step2, &slicelength2);
   }
@@ -233,10 +236,10 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
   }
 
   // handle arguments
-  if ( PySlice_Check( obj1 ) )
+  if (PySlice_Check(obj1))
   {
 
-    if ( PySlice_Check( obj2 ) )
+    if (PySlice_Check(obj2))
     {
       // case #1: [slice/slice] <= baseType
       OT::baseType temp2 ;
@@ -245,9 +248,9 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
         temp2 = OT::convert<OT::_PySequence_,OT::baseType>( valObj );
         val2 = &temp2;
       }
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
-        for ( Py_ssize_t j = 0; j < slicelength2; ++ j )
+        for (Py_ssize_t j = 0; j < slicelength2; ++ j)
         {
           self->operator()( start1 + i*step1, start2 + j*step2 ) = val2->operator()(i, j);
         }
@@ -262,7 +265,7 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
         temp2 = OT::convert<OT::_PySequence_,OT::baseType>( valObj );
         val2 = &temp2;
       }
-      for ( Py_ssize_t i = 0; i < slicelength1; ++ i )
+      for (Py_ssize_t i = 0; i < slicelength1; ++ i)
       {
         self->operator()( start1 + i*step1, arg3 ) = val2->operator()(i, 0);
       }
@@ -271,7 +274,7 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
   }
   else
   {
-    if ( PySlice_Check( obj2 ) )
+    if (PySlice_Check(obj2))
     {
       // case #3: [index/slice] <= baseType
       OT::baseType temp2 ;
@@ -280,7 +283,7 @@ PyObject * __setitem__(PyObject * args, PyObject * valObj) {
         temp2 = OT::convert<OT::_PySequence_,OT::baseType>( valObj );
         val2 = &temp2;
       }
-      for ( Py_ssize_t j = 0; j < slicelength2; ++ j )
+      for (Py_ssize_t j = 0; j < slicelength2; ++ j)
       {
         self->operator()( arg2, start2 + j*step2 ) = val2->operator()(0, j);
       }
@@ -332,7 +335,11 @@ namespace OT {
 
   Matrix(const Matrix & other) { return new OT::Matrix(other); }
 
-  Matrix(PyObject * pyObj) { return new OT::Matrix( OT::convert<OT::_PySequence_,OT::Matrix>(pyObj) ); }
+  Matrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::Matrix(OT::convert<OT::_PySequence_, OT::Matrix>(pyObj));
+  }
 
   OTMatrixAccessors()
 

--- a/python/src/OptimizationAlgorithmImplementation.i
+++ b/python/src/OptimizationAlgorithmImplementation.i
@@ -5,6 +5,7 @@
 #include "openturns/PythonWrappingFunctions.hxx"
 
 static void OptimizationAlgorithmImplementation_ProgressCallback(OT::Scalar percent, void * data) {
+  OT::InterpreterUnlocker iul;
   PyObject * pyObj = reinterpret_cast<PyObject *>(data);
   OT::ScopedPyObjectPointer point(OT::convert< OT::Scalar, OT::_PyFloat_ >(percent));
   OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj, point.get(), NULL));
@@ -13,6 +14,7 @@ static void OptimizationAlgorithmImplementation_ProgressCallback(OT::Scalar perc
 }
 
 static OT::Bool OptimizationAlgorithmImplementation_StopCallback(void * data) {
+  OT::InterpreterUnlocker iul;
   PyObject * pyObj = reinterpret_cast<PyObject *>(data);
   OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj, NULL));
   if (result.isNull())

--- a/python/src/Point.i
+++ b/python/src/Point.i
@@ -68,6 +68,7 @@ namespace OT {
 
 Point(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   return new OT::Point(OT::convert<OT::_PySequence_,OT::Point>(pyObj));
 }
 

--- a/python/src/PointToFieldFunction.i
+++ b/python/src/PointToFieldFunction.i
@@ -63,6 +63,7 @@ namespace OT {
 
 PointToFieldFunction(PyObject * pyObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   void * ptr = 0;
   if (SWIG_IsOK(SWIG_ConvertPtr(pyObj, &ptr, SWIGTYPE_p_OT__Object, 0)))
   {

--- a/python/src/PythonDistribution.cxx
+++ b/python/src/PythonDistribution.cxx
@@ -19,7 +19,7 @@
  *
  */
 #include <Python.h>
-#include "openturns/swig_runtime.hxx"
+#include "openturns/swigpyrun.h"
 
 #include "openturns/PythonDistribution.hxx"
 #include "openturns/OSS.hxx"
@@ -51,6 +51,7 @@ PythonDistribution::PythonDistribution(PyObject * pyObject)
   : DistributionImplementation(),
     pyObj_(pyObject)
 {
+  InterpreterUnlocker iul;
   // Python memory management is not thread-safe
   setParallel(false);
 
@@ -90,6 +91,7 @@ PythonDistribution::PythonDistribution(const PythonDistribution & other)
   : DistributionImplementation(other),
     pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -100,6 +102,7 @@ PythonDistribution & PythonDistribution::operator=(const PythonDistribution & rh
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     DistributionImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -111,6 +114,7 @@ PythonDistribution & PythonDistribution::operator=(const PythonDistribution & rh
 /* Destructor */
 PythonDistribution::~PythonDistribution()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -144,6 +148,7 @@ String PythonDistribution::__str__(const String & ) const
 
 Point PythonDistribution::getRealization() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getRealization") ) )
   {
 
@@ -168,6 +173,7 @@ Point PythonDistribution::getRealization() const
 /* Numerical sample accessor */
 Sample PythonDistribution::getSample(const UnsignedInteger size) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getSample")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_ >("getSample"));
@@ -194,6 +200,7 @@ Sample PythonDistribution::getSample(const UnsignedInteger size) const
 /* Get the DDF of the distribution */
 Point PythonDistribution::computeDDF(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeDDF")))
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -221,6 +228,7 @@ Point PythonDistribution::computeDDF(const Point & inP) const
 /* Get the PDF of the distribution */
 Scalar PythonDistribution::computePDF(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computePDF")))
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -247,6 +255,7 @@ Scalar PythonDistribution::computePDF(const Point & inP) const
 /* Get the PDF of the distribution */
 Scalar PythonDistribution::computeLogPDF(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeLogPDF")))
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -273,6 +282,7 @@ Scalar PythonDistribution::computeLogPDF(const Point & inP) const
 /* Get the CDF of the distribution */
 Scalar PythonDistribution::computeCDF(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger dimension = inP.getDimension();
   if (dimension != getDimension())
     throw InvalidDimensionException(HERE) << "Input point has incorrect dimension. Got " << dimension << ". Expected " << getDimension();
@@ -293,6 +303,7 @@ Scalar PythonDistribution::computeCDF(const Point & inP) const
 /* Get the complementary CDF of the distribution */
 Scalar PythonDistribution::computeComplementaryCDF(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeComplementaryCDF") ) )
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -320,6 +331,7 @@ Scalar PythonDistribution::computeComplementaryCDF(const Point & inP) const
 /* Get the quantile of the distribution */
 Point PythonDistribution::computeQuantile(const Scalar prob, const Bool tail) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeQuantile")))
   {
     const UnsignedInteger dimension = getDimension();
@@ -347,6 +359,7 @@ Point PythonDistribution::computeQuantile(const Scalar prob, const Bool tail) co
 /* Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
 Complex PythonDistribution::computeCharacteristicFunction(const Scalar x) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeCharacteristicFunction")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_>("computeCharacteristicFunction"));
@@ -371,6 +384,7 @@ Complex PythonDistribution::computeCharacteristicFunction(const Scalar x) const
 /* Get the PDFGradient of the distribution */
 Point PythonDistribution::computePDFGradient(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computePDFGradient")))
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -398,6 +412,7 @@ Point PythonDistribution::computePDFGradient(const Point & inP) const
 /* Get the CDFGradient of the distribution */
 Point PythonDistribution::computeCDFGradient(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeCDFGradient")))
   {
     const UnsignedInteger dimension = inP.getDimension();
@@ -426,6 +441,7 @@ Point PythonDistribution::computeCDFGradient(const Point & inP) const
 Scalar PythonDistribution::computeScalarQuantile(const Scalar prob,
     const Bool tail) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("computeScalarQuantile") ) )
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_>("computeScalarQuantile"));
@@ -452,6 +468,7 @@ Scalar PythonDistribution::computeScalarQuantile(const Scalar prob,
 /* Get the roughness, i.e. the L2-norm of the PDF */
 Scalar PythonDistribution::getRoughness() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getRoughness")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -473,6 +490,7 @@ Scalar PythonDistribution::getRoughness() const
 /* Mean accessor */
 Point PythonDistribution::getMean() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getMean")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -495,6 +513,7 @@ Point PythonDistribution::getMean() const
 /* Standard deviation accessor */
 Point PythonDistribution::getStandardDeviation() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getStandardDeviation") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -517,6 +536,7 @@ Point PythonDistribution::getStandardDeviation() const
 /* Skewness accessor */
 Point PythonDistribution::getSkewness() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getSkewness") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -539,6 +559,7 @@ Point PythonDistribution::getSkewness() const
 /* Kurtosis accessor */
 Point PythonDistribution::getKurtosis() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getKurtosis") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -562,6 +583,7 @@ Point PythonDistribution::getKurtosis() const
 /* Get the raw moments of the distribution */
 Point PythonDistribution::getStandardMoment(const UnsignedInteger n) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getStandardMoment") ) )
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_>( "getStandardMoment" ));
@@ -587,6 +609,7 @@ Point PythonDistribution::getStandardMoment(const UnsignedInteger n) const
 /* Get the raw moments of the distribution */
 Point PythonDistribution::getMoment(const UnsignedInteger n) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getMoment") ) )
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_>( "getMoment" ));
@@ -611,6 +634,7 @@ Point PythonDistribution::getMoment(const UnsignedInteger n) const
 /* Get the centered moments of the distribution */
 Point PythonDistribution::getCenteredMoment(const UnsignedInteger n) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getCenteredMoment") ) )
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_>( "getCenteredMoment" ));
@@ -636,6 +660,7 @@ Point PythonDistribution::getCenteredMoment(const UnsignedInteger n) const
 /* Check if the distribution is a copula */
 Bool PythonDistribution::isCopula() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isCopula") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -658,6 +683,7 @@ Bool PythonDistribution::isCopula() const
 /* Check if the distribution is elliptical */
 Bool PythonDistribution::isElliptical() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isElliptical") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -680,6 +706,7 @@ Bool PythonDistribution::isElliptical() const
 /* Check if the distribution is continuous */
 Bool PythonDistribution::isContinuous() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isContinuous") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
@@ -701,6 +728,7 @@ Bool PythonDistribution::isContinuous() const
 
 Bool PythonDistribution::isDiscrete() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isDiscrete") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
@@ -723,6 +751,7 @@ Bool PythonDistribution::isDiscrete() const
 /* Check if the distribution is integral */
 Bool PythonDistribution::isIntegral() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isIntegral") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -745,6 +774,7 @@ Bool PythonDistribution::isIntegral() const
 /* Tell if the distribution has elliptical copula */
 Bool PythonDistribution::hasEllipticalCopula() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("hasEllipticalCopula") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -767,6 +797,7 @@ Bool PythonDistribution::hasEllipticalCopula() const
 /* Tell if the distribution has independent copula */
 Bool PythonDistribution::hasIndependentCopula() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("hasIndependentCopula") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
@@ -789,6 +820,7 @@ Bool PythonDistribution::hasIndependentCopula() const
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
 Distribution PythonDistribution::getMarginal(const Indices & indices) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getMarginal")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_ >("getMarginal"));
@@ -829,7 +861,7 @@ Distribution PythonDistribution::getMarginal(const UnsignedInteger i) const
 void PythonDistribution::save(Advocate & adv) const
 {
   DistributionImplementation::save(adv);
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -838,7 +870,7 @@ void PythonDistribution::save(Advocate & adv) const
 void PythonDistribution::load(Advocate & adv)
 {
   DistributionImplementation::load(adv);
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 
@@ -912,6 +944,7 @@ convert< _PyObject_, Interval >(PyObject * pyObj)
 /* Compute the numerical range of the distribution given the parameters values */
 void PythonDistribution::computeRange()
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getRange") ) )
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
@@ -933,6 +966,7 @@ void PythonDistribution::computeRange()
 /* Get the support of a discrete distribution that intersect a given interval */
 Sample PythonDistribution::getSupport(const Interval & interval) const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getSupport")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_ >("getSupport"));
@@ -954,6 +988,7 @@ Sample PythonDistribution::getSupport(const Interval & interval) const
 
 Point PythonDistribution::getParameter() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getParameter")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
@@ -976,6 +1011,7 @@ Point PythonDistribution::getParameter() const
 
 void PythonDistribution::setParameter(const Point & parameter)
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("setParameter")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_ >("setParameter"));
@@ -994,6 +1030,7 @@ void PythonDistribution::setParameter(const Point & parameter)
 
 Description PythonDistribution::getParameterDescription() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getParameterDescription")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,

--- a/python/src/PythonEvaluation.cxx
+++ b/python/src/PythonEvaluation.cxx
@@ -56,6 +56,7 @@ PythonEvaluation::PythonEvaluation(PyObject * pyCallable)
   , pyObj_discard_openturns_memoryview_(true)
   , pyBufferClass_(NULL)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   initializePythonState();
@@ -120,6 +121,7 @@ PythonEvaluation::PythonEvaluation(const PythonEvaluation & other)
   , pyObj_discard_openturns_memoryview_(other.pyObj_discard_openturns_memoryview_)
   , pyBufferClass_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
 
@@ -135,6 +137,7 @@ PythonEvaluation& PythonEvaluation::operator=(const PythonEvaluation & rhs)
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     EvaluationImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -154,6 +157,7 @@ PythonEvaluation& PythonEvaluation::operator=(const PythonEvaluation & rhs)
 /* Destructor */
 PythonEvaluation::~PythonEvaluation()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
   Py_XDECREF(pyBufferClass_);
 }
@@ -190,6 +194,7 @@ String PythonEvaluation::__str__(const String & ) const
 /* Operator () */
 Point PythonEvaluation::operator() (const Point & inP) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger dimension = inP.getDimension();
 
   if (dimension != getInputDimension())
@@ -285,6 +290,7 @@ Point PythonEvaluation::operator() (const Point & inP) const
 /* Operator () */
 Sample PythonEvaluation::operator() (const Sample & inS) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger inDim = inS.getDimension();
 
   if (inDim != getInputDimension())
@@ -412,6 +418,7 @@ void PythonEvaluation::initializePythonState()
 /* Accessor for input point dimension */
 UnsignedInteger PythonEvaluation::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -423,6 +430,7 @@ UnsignedInteger PythonEvaluation::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonEvaluation::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -433,6 +441,7 @@ UnsignedInteger PythonEvaluation::getOutputDimension() const
 /* Linearity accessors */
 Bool PythonEvaluation::isLinear() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, "isLinear"))
   {
     ScopedPyObjectPointer result( PyObject_CallMethod (pyObj_,
@@ -448,6 +457,7 @@ Bool PythonEvaluation::isLinear() const
 
 Bool PythonEvaluation::isLinearlyDependent(const UnsignedInteger index) const
 {
+  InterpreterUnlocker iul;
   // Check index consistency
   if (index > getInputDimension())
     throw InvalidDimensionException(HERE) << "index (" << index << ") exceeds function input dimension (" << getInputDimension() << ")";
@@ -477,6 +487,7 @@ Bool PythonEvaluation::isParallel() const
 void PythonEvaluation::save(Advocate & adv) const
 {
   EvaluationImplementation::save(adv);
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
   pickleSave(adv, pyBufferClass_, "pyBufferClass_");
   adv.saveAttribute("pyObj_has_exec_", pyObj_has_exec_);
@@ -489,6 +500,7 @@ void PythonEvaluation::save(Advocate & adv) const
 void PythonEvaluation::load(Advocate & adv)
 {
   EvaluationImplementation::load(adv);
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
   pickleLoad(adv, pyBufferClass_, "pyBufferClass_");
   adv.loadAttribute("pyObj_has_exec_", pyObj_has_exec_);

--- a/python/src/PythonExperiment.cxx
+++ b/python/src/PythonExperiment.cxx
@@ -49,7 +49,9 @@ PythonExperiment::PythonExperiment(PyObject * pyObject)
   : ExperimentImplementation(),
     pyObj_(pyObject)
 {
-  if ( !PyObject_HasAttrString( pyObj_, const_cast<char *>("generate") ) ) throw InvalidArgumentException(HERE) << "Error: the given object does not have a generate() method.";
+  InterpreterUnlocker iul;
+  if (!PyObject_HasAttrString( pyObj_, const_cast<char *>("generate")))
+    throw InvalidArgumentException(HERE) << "Error: the given object does not have a generate() method.";
 
   Py_XINCREF(pyObj_);
 
@@ -73,6 +75,7 @@ PythonExperiment::PythonExperiment(const PythonExperiment & other)
   : ExperimentImplementation(other),
     pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -83,6 +86,7 @@ PythonExperiment & PythonExperiment::operator=(const PythonExperiment & rhs)
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     ExperimentImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -94,6 +98,7 @@ PythonExperiment & PythonExperiment::operator=(const PythonExperiment & rhs)
 /* Destructor */
 PythonExperiment::~PythonExperiment()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -128,6 +133,7 @@ String PythonExperiment::__str__(const String & ) const
 
 Sample PythonExperiment::generate() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
                                const_cast<char *>( "generate" ),
                                const_cast<char *>( "()" ) ));
@@ -144,7 +150,7 @@ Sample PythonExperiment::generate() const
 void PythonExperiment::save(Advocate & adv) const
 {
   ExperimentImplementation::save( adv );
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -153,7 +159,7 @@ void PythonExperiment::save(Advocate & adv) const
 void PythonExperiment::load(Advocate & adv)
 {
   ExperimentImplementation::load( adv );
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonFieldFunction.cxx
+++ b/python/src/PythonFieldFunction.cxx
@@ -19,7 +19,7 @@
  *
  */
 #include <Python.h>
-#include "openturns/swig_runtime.hxx"
+#include "openturns/swigpyrun.h"
 
 #include "openturns/PythonFieldFunction.hxx"
 #include "openturns/OSS.hxx"
@@ -48,6 +48,7 @@ PythonFieldFunction::PythonFieldFunction(PyObject * pyCallable)
   : FieldFunctionImplementation()
   , pyObj_(pyCallable)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   // Set the name of the object as its Python classname
@@ -124,6 +125,7 @@ PythonFieldFunction::PythonFieldFunction(const PythonFieldFunction & other)
   : FieldFunctionImplementation(other)
   , pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -134,6 +136,7 @@ PythonFieldFunction & PythonFieldFunction::operator=(const PythonFieldFunction &
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     FieldFunctionImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -145,6 +148,7 @@ PythonFieldFunction & PythonFieldFunction::operator=(const PythonFieldFunction &
 /* Destructor */
 PythonFieldFunction::~PythonFieldFunction()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -181,6 +185,7 @@ String PythonFieldFunction::__str__(const String & ) const
 /* Operator () */
 Sample PythonFieldFunction::operator() (const Sample & inF) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger inputDimension = getInputDimension();
   if (inputDimension != inF.getDimension())
     throw InvalidDimensionException(HERE) << "Input field values have incorrect dimension. Got " << inF.getDimension() << ". Expected " << inputDimension;
@@ -234,6 +239,7 @@ Sample PythonFieldFunction::operator() (const Sample & inF) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonFieldFunction::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -245,6 +251,7 @@ UnsignedInteger PythonFieldFunction::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonFieldFunction::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -256,6 +263,7 @@ UnsignedInteger PythonFieldFunction::getOutputDimension() const
 /* Accessor for output point dimension */
 Bool PythonFieldFunction::isActingPointwise() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isActingPointwise")))
   {
     ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
@@ -271,7 +279,7 @@ Bool PythonFieldFunction::isActingPointwise() const
 void PythonFieldFunction::save(Advocate & adv) const
 {
   FieldFunctionImplementation::save( adv );
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -280,7 +288,7 @@ void PythonFieldFunction::save(Advocate & adv) const
 void PythonFieldFunction::load(Advocate & adv)
 {
   FieldFunctionImplementation::load( adv );
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonFieldToPointFunction.cxx
+++ b/python/src/PythonFieldToPointFunction.cxx
@@ -19,7 +19,7 @@
  *
  */
 #include <Python.h>
-#include "openturns/swig_runtime.hxx"
+#include "openturns/swigpyrun.h"
 
 #include "openturns/PythonFieldToPointFunction.hxx"
 #include "openturns/OSS.hxx"
@@ -48,6 +48,7 @@ PythonFieldToPointFunction::PythonFieldToPointFunction(PyObject * pyCallable)
   : FieldToPointFunctionImplementation()
   , pyObj_(pyCallable)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   // Set the name of the object as its Python classname
@@ -111,6 +112,7 @@ PythonFieldToPointFunction::PythonFieldToPointFunction(const PythonFieldToPointF
   : FieldToPointFunctionImplementation(other)
   , pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -121,6 +123,7 @@ PythonFieldToPointFunction & PythonFieldToPointFunction::operator=(const PythonF
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     FieldToPointFunctionImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -132,6 +135,7 @@ PythonFieldToPointFunction & PythonFieldToPointFunction::operator=(const PythonF
 /* Destructor */
 PythonFieldToPointFunction::~PythonFieldToPointFunction()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -168,6 +172,7 @@ String PythonFieldToPointFunction::__str__(const String & ) const
 /* Operator () */
 Point PythonFieldToPointFunction::operator() (const Sample & inF) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger inputDimension = getInputDimension();
   if (inputDimension != inF.getDimension())
     throw InvalidDimensionException(HERE) << "Input field values have incorrect dimension. Got " << inF.getDimension() << ". Expected " << inputDimension;
@@ -212,6 +217,7 @@ Point PythonFieldToPointFunction::operator() (const Sample & inF) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonFieldToPointFunction::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -223,6 +229,7 @@ UnsignedInteger PythonFieldToPointFunction::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonFieldToPointFunction::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -235,7 +242,7 @@ UnsignedInteger PythonFieldToPointFunction::getOutputDimension() const
 void PythonFieldToPointFunction::save(Advocate & adv) const
 {
   FieldToPointFunctionImplementation::save( adv );
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -244,7 +251,7 @@ void PythonFieldToPointFunction::save(Advocate & adv) const
 void PythonFieldToPointFunction::load(Advocate & adv)
 {
   FieldToPointFunctionImplementation::load( adv );
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonGradient.cxx
+++ b/python/src/PythonGradient.cxx
@@ -48,6 +48,7 @@ PythonGradient::PythonGradient(PyObject * pyCallable)
   : GradientImplementation()
   , pyObj_(pyCallable)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   // Set the name of the object as its Python classname
@@ -69,6 +70,7 @@ PythonGradient::PythonGradient(const PythonGradient & other)
   : GradientImplementation(other)
   , pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -79,6 +81,7 @@ PythonGradient & PythonGradient::operator=(const PythonGradient & rhs)
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     GradientImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -124,6 +127,7 @@ String PythonGradient::__str__(const String & ) const
 /* Operator () */
 Matrix PythonGradient::gradient(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger dimension = inP.getDimension();
 
   if (dimension != getInputDimension())
@@ -161,6 +165,7 @@ Matrix PythonGradient::gradient(const Point & inP) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonGradient::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -172,6 +177,7 @@ UnsignedInteger PythonGradient::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonGradient::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -184,7 +190,7 @@ UnsignedInteger PythonGradient::getOutputDimension() const
 void PythonGradient::save(Advocate & adv) const
 {
   GradientImplementation::save(adv);
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -193,7 +199,7 @@ void PythonGradient::save(Advocate & adv) const
 void PythonGradient::load(Advocate & adv)
 {
   GradientImplementation::load(adv);
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonHessian.cxx
+++ b/python/src/PythonHessian.cxx
@@ -48,6 +48,7 @@ PythonHessian::PythonHessian(PyObject * pyCallable)
   : HessianImplementation()
   , pyObj_(pyCallable)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   // Set the name of the object as its Python classname
@@ -69,6 +70,7 @@ PythonHessian::PythonHessian(const PythonHessian & other)
   : HessianImplementation(other)
   , pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -79,6 +81,7 @@ PythonHessian & PythonHessian::operator=(const PythonHessian & rhs)
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     HessianImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -90,6 +93,7 @@ PythonHessian & PythonHessian::operator=(const PythonHessian & rhs)
 /* Destructor */
 PythonHessian::~PythonHessian()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -124,6 +128,7 @@ String PythonHessian::__str__(const String & ) const
 /* Operator () */
 SymmetricTensor PythonHessian::hessian(const Point & inP) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger dimension = inP.getDimension();
 
   if (dimension != getInputDimension())
@@ -165,6 +170,7 @@ SymmetricTensor PythonHessian::hessian(const Point & inP) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonHessian::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -176,6 +182,7 @@ UnsignedInteger PythonHessian::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonHessian::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -188,7 +195,7 @@ UnsignedInteger PythonHessian::getOutputDimension() const
 void PythonHessian::save(Advocate & adv) const
 {
   HessianImplementation::save(adv);
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -197,7 +204,7 @@ void PythonHessian::save(Advocate & adv) const
 void PythonHessian::load(Advocate & adv)
 {
   HessianImplementation::load(adv);
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonPointToFieldFunction.cxx
+++ b/python/src/PythonPointToFieldFunction.cxx
@@ -19,7 +19,7 @@
  *
  */
 #include <Python.h>
-#include "openturns/swig_runtime.hxx"
+#include "openturns/swigpyrun.h"
 
 #include "openturns/PythonPointToFieldFunction.hxx"
 #include "openturns/OSS.hxx"
@@ -48,6 +48,7 @@ PythonPointToFieldFunction::PythonPointToFieldFunction(PyObject * pyCallable)
   : PointToFieldFunctionImplementation()
   , pyObj_(pyCallable)
 {
+  InterpreterUnlocker iul;
   Py_XINCREF(pyCallable);
 
   // Set the name of the object as its Python classname
@@ -111,6 +112,7 @@ PythonPointToFieldFunction::PythonPointToFieldFunction(const PythonPointToFieldF
   : PointToFieldFunctionImplementation(other)
   , pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -121,6 +123,7 @@ PythonPointToFieldFunction & PythonPointToFieldFunction::operator=(const PythonP
 {
   if (this != & rhs)
   {
+    InterpreterUnlocker iul;
     PointToFieldFunctionImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -132,6 +135,7 @@ PythonPointToFieldFunction & PythonPointToFieldFunction::operator=(const PythonP
 /* Destructor */
 PythonPointToFieldFunction::~PythonPointToFieldFunction()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -168,6 +172,7 @@ String PythonPointToFieldFunction::__str__(const String & ) const
 /* Operator () */
 Sample PythonPointToFieldFunction::operator() (const Point & inP) const
 {
+  InterpreterUnlocker iul;
   const UnsignedInteger inputDimension = getInputDimension();
   if (inputDimension != inP.getDimension())
     throw InvalidDimensionException(HERE) << "Input point has incorrect dimension. Got " << inP.getDimension() << ". Expected " << getInputDimension();
@@ -206,6 +211,7 @@ Sample PythonPointToFieldFunction::operator() (const Point & inP) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonPointToFieldFunction::getInputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
                                const_cast<char *>("getInputDimension"),
                                const_cast<char *>("()")));
@@ -217,6 +223,7 @@ UnsignedInteger PythonPointToFieldFunction::getInputDimension() const
 /* Accessor for output point dimension */
 UnsignedInteger PythonPointToFieldFunction::getOutputDimension() const
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
                                const_cast<char *>("getOutputDimension"),
                                const_cast<char *>("()")));
@@ -229,7 +236,7 @@ UnsignedInteger PythonPointToFieldFunction::getOutputDimension() const
 void PythonPointToFieldFunction::save(Advocate & adv) const
 {
   PointToFieldFunctionImplementation::save( adv );
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -238,7 +245,7 @@ void PythonPointToFieldFunction::save(Advocate & adv) const
 void PythonPointToFieldFunction::load(Advocate & adv)
 {
   PointToFieldFunctionImplementation::load( adv );
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/PythonRandomVector.cxx
+++ b/python/src/PythonRandomVector.cxx
@@ -49,30 +49,32 @@ PythonRandomVector::PythonRandomVector(PyObject * pyObject)
   : RandomVectorImplementation(),
     pyObj_(pyObject)
 {
-  if ( !PyObject_HasAttrString( pyObj_, const_cast<char *>("getRealization") ) ) throw InvalidArgumentException(HERE) << "Error: the given object does not have a getRealization() method.";
+  InterpreterUnlocker iul;
+  if (!PyObject_HasAttrString( pyObj_, const_cast<char *>("getRealization")))
+    throw InvalidArgumentException(HERE) << "Error: the given object does not have a getRealization() method.";
 
-  Py_XINCREF( pyObj_ );
+  Py_XINCREF(pyObj_);
 
   // Set the name of the object as its Python classname
   ScopedPyObjectPointer cls(PyObject_GetAttrString ( pyObj_,
-                            const_cast<char *>( "__class__" ) ));
+                            const_cast<char *>( "__class__" )));
   ScopedPyObjectPointer name(PyObject_GetAttrString( cls.get(),
-                             const_cast<char *>( "__name__" ) ));
+                             const_cast<char *>( "__name__" )));
 
-  setName( checkAndConvert< _PyString_, String >(name.get()) );
+  setName(checkAndConvert< _PyString_, String >(name.get()));
 
   const UnsignedInteger dimension  = getDimension();
   Description description(dimension);
   ScopedPyObjectPointer desc(PyObject_CallMethod ( pyObj_,
                              const_cast<char *>( "getDescription" ),
                              const_cast<char *>( "()" ) ));
-  if ( ( desc.get() != NULL )
-       && PySequence_Check( desc.get() )
-       && ( PySequence_Size( desc.get() ) == static_cast<SignedInteger>(dimension) ) )
+  if ((desc.get() != NULL)
+       && PySequence_Check(desc.get())
+       && (PySequence_Size(desc.get()) == static_cast<SignedInteger>(dimension) ) )
   {
     description = convert< _PySequence_, Description >( desc.get() );
   }
-  else for (UnsignedInteger i = 0; i < dimension; ++i) description[i] = (OSS() << "x" << i);
+  else for (UnsignedInteger i = 0; i < dimension; ++ i) description[i] = (OSS() << "x" << i);
   setDescription(description);
 }
 
@@ -87,6 +89,7 @@ PythonRandomVector::PythonRandomVector(const PythonRandomVector & other)
   : RandomVectorImplementation(other),
     pyObj_()
 {
+  InterpreterUnlocker iul;
   ScopedPyObjectPointer pyObjClone(deepCopy(other.pyObj_));
   pyObj_ = pyObjClone.get();
   Py_XINCREF(pyObj_);
@@ -97,6 +100,7 @@ PythonRandomVector & PythonRandomVector::operator=(const PythonRandomVector & rh
 {
   if (this != &rhs)
   {
+    InterpreterUnlocker iul;
     RandomVectorImplementation::operator=(rhs);
     ScopedPyObjectPointer pyObjClone(deepCopy(rhs.pyObj_));
     pyObj_ = pyObjClone.get();
@@ -108,6 +112,7 @@ PythonRandomVector & PythonRandomVector::operator=(const PythonRandomVector & rh
 /* Destructor */
 PythonRandomVector::~PythonRandomVector()
 {
+  InterpreterUnlocker iul;
   Py_XDECREF(pyObj_);
 }
 
@@ -143,9 +148,10 @@ String PythonRandomVector::__str__(const String & ) const
 /* Accessor for input point dimension */
 UnsignedInteger PythonRandomVector::getDimension() const
 {
-  ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
-                               const_cast<char *>( "getDimension" ),
-                               const_cast<char *>( "()" ) ));
+  InterpreterUnlocker iul;
+  ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
+                               const_cast<char *>("getDimension"),
+                               const_cast<char *>("()")));
   if ( result.isNull() )
   {
     handleException();
@@ -157,9 +163,10 @@ UnsignedInteger PythonRandomVector::getDimension() const
 
 Point PythonRandomVector::getRealization() const
 {
-  ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
-                               const_cast<char *>( "getRealization" ),
-                               const_cast<char *>( "()" ) ));
+  InterpreterUnlocker iul;
+  ScopedPyObjectPointer result(PyObject_CallMethod(pyObj_,
+                               const_cast<char *>("getRealization"),
+                               const_cast<char *>("()")));
   if ( result.isNull() )
   {
     handleException();
@@ -172,16 +179,17 @@ Point PythonRandomVector::getRealization() const
 /* Numerical sample accessor */
 Sample PythonRandomVector::getSample(const UnsignedInteger size) const
 {
+  InterpreterUnlocker iul;
   Sample sample;
 
-  if ( PyObject_HasAttrString( pyObj_, const_cast<char *>("getSample") ) )
+  if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getSample")))
   {
-    ScopedPyObjectPointer methodName(convert< String, _PyString_>( "getSample" ));
+    ScopedPyObjectPointer methodName(convert< String, _PyString_>("getSample"));
     ScopedPyObjectPointer sizeArg(convert< UnsignedInteger, _PyInt_ >(size));
-    ScopedPyObjectPointer result(PyObject_CallMethodObjArgs( pyObj_,
+    ScopedPyObjectPointer result(PyObject_CallMethodObjArgs(pyObj_,
                                  methodName.get(),
-                                 sizeArg.get(), NULL ));
-    if ( result.get() )
+                                 sizeArg.get(), NULL));
+    if (result.get())
     {
       sample = convert<_PySequence_, Sample>(result.get());
       if (sample.getSize() != size) throw InvalidDimensionException(HERE) << "Sample returned by PythonRandomVector has incorrect size. Got " << sample.getSize() << ". Expected" << size;
@@ -198,9 +206,10 @@ Sample PythonRandomVector::getSample(const UnsignedInteger size) const
 /* Mean accessor */
 Point PythonRandomVector::getMean() const
 {
-  ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
-                               const_cast<char *>( "getMean" ),
-                               const_cast<char *>( "()" ) ));
+  InterpreterUnlocker iul;
+  ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
+                               const_cast<char *>("getMean"),
+                               const_cast<char *>("()")));
   if ( result.isNull() )
   {
     handleException();
@@ -214,9 +223,10 @@ Point PythonRandomVector::getMean() const
 /* Covariance accessor */
 CovarianceMatrix PythonRandomVector::getCovariance() const
 {
-  ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
-                               const_cast<char *>( "getCovariance" ),
-                               const_cast<char *>( "()" ) ));
+  InterpreterUnlocker iul;
+  ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
+                               const_cast<char *>("getCovariance"),
+                               const_cast<char *>("()")));
   if ( result.isNull() )
   {
     handleException();
@@ -230,11 +240,12 @@ CovarianceMatrix PythonRandomVector::getCovariance() const
 
 Bool PythonRandomVector::isEvent() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isEvent")))
   {
-    ScopedPyObjectPointer result(PyObject_CallMethod ( pyObj_,
-                                 const_cast<char *>( "isEvent" ),
-                                 const_cast<char *>( "()" ) ));
+    ScopedPyObjectPointer result(PyObject_CallMethod (pyObj_,
+                                 const_cast<char *>("isEvent"),
+                                 const_cast<char *>("()")));
     if ( result.isNull() )
     {
       handleException();
@@ -252,11 +263,12 @@ Bool PythonRandomVector::isEvent() const
 /* Parameter accessor */
 Point PythonRandomVector::getParameter() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getParameter")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
-                                     const_cast<char *>( "getParameter" ),
-                                     const_cast<char *>( "()" ) ));
+                                     const_cast<char *>("getParameter"),
+                                     const_cast<char *>("()")));
     if (callResult.isNull())
     {
       handleException();
@@ -274,6 +286,7 @@ Point PythonRandomVector::getParameter() const
 /* Parameter accessor */
 void PythonRandomVector::setParameter(const Point & parameter)
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("setParameter")))
   {
     ScopedPyObjectPointer methodName(convert< String, _PyString_ >("setParameter"));
@@ -291,11 +304,12 @@ void PythonRandomVector::setParameter(const Point & parameter)
 /* Parameter description accessor */
 Description PythonRandomVector::getParameterDescription() const
 {
+  InterpreterUnlocker iul;
   if (PyObject_HasAttrString(pyObj_, const_cast<char *>("getParameterDescription")))
   {
     ScopedPyObjectPointer callResult(PyObject_CallMethod( pyObj_,
-                                     const_cast<char *>( "getParameterDescription" ),
-                                     const_cast<char *>( "()" ) ));
+                                     const_cast<char *>("getParameterDescription"),
+                                     const_cast<char *>("()")));
     if (callResult.isNull())
     {
       handleException();
@@ -314,7 +328,7 @@ Description PythonRandomVector::getParameterDescription() const
 void PythonRandomVector::save(Advocate & adv) const
 {
   RandomVectorImplementation::save( adv );
-
+  InterpreterUnlocker iul;
   pickleSave(adv, pyObj_);
 }
 
@@ -323,7 +337,7 @@ void PythonRandomVector::save(Advocate & adv) const
 void PythonRandomVector::load(Advocate & adv)
 {
   RandomVectorImplementation::load( adv );
-
+  InterpreterUnlocker iul;
   pickleLoad(adv, pyObj_);
 }
 

--- a/python/src/RandomVector.i
+++ b/python/src/RandomVector.i
@@ -176,11 +176,12 @@ namespace OT { %extend RandomVector {
 RandomVector(const RandomVector & other)
 {
   return new OT::RandomVector(other);
-} 
+}
 
 RandomVector(PyObject * pyObj)
 {
-  return new OT::RandomVector( new OT::PythonRandomVector(pyObj) );
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  return new OT::RandomVector(new OT::PythonRandomVector(pyObj));
 } 
 
 } // class RandomVector

--- a/python/src/Sample.i
+++ b/python/src/Sample.i
@@ -174,6 +174,7 @@ UnsignedInteger __len__() const
 
 PyObject * __getitem__(PyObject * args) const
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (!PyTuple_Check(args))
   {
     if (PySlice_Check(args))
@@ -188,7 +189,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t i = 0; i < size; ++ i)
         result.at(i) = self->at(start + i * step);
       result.setDescription(self->getDescription());
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PySequence_Check(args))
     {
@@ -218,7 +219,7 @@ PyObject * __getitem__(PyObject * args) const
         result.at(i) = self->at(index);
       }
       result.setDescription(self->getDescription());
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PyObject_HasAttrString(args, "__int__"))
     {
@@ -232,7 +233,7 @@ PyObject * __getitem__(PyObject * args) const
       if (index < 0)
         throw OT::OutOfBoundException(HERE) << "index should be in [-" << self->getSize() << ", " << self->getSize() - 1 << "]." ;
       OT::Point result(self->at(index));
-      return SWIG_NewPointerObj((new OT::Point(static_cast< const OT::Point& >(result))), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Point(result), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN);
     }
   }
 
@@ -279,7 +280,7 @@ PyObject * __getitem__(PyObject * args) const
       OT::Point result(size2);
       for (Py_ssize_t j = 0; j < size2; ++ j)
         result.at(j) = self->at(index1, start2 + j * step2);
-      return SWIG_NewPointerObj((new OT::Point(static_cast< const OT::Point& >(result))), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Point(result), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN);
     }
     else if (PySequence_Check(obj2))
     {
@@ -302,7 +303,7 @@ PyObject * __getitem__(PyObject * args) const
         else
           SWIG_exception(SWIG_TypeError, "Indexing list expects int type");
       }
-      return SWIG_NewPointerObj((new OT::Point(static_cast< const OT::Point& >(result))), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Point(result), SWIGTYPE_p_OT__Point, SWIG_POINTER_OWN);
     }
   }
   else if (PySlice_Check(obj1))
@@ -328,7 +329,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t i = 0; i < size1; ++ i)
         result.at(i, 0) = self->at(start1 + i * step1, index2);
       result.setDescription(OT::Description(1, self->getDescription()[index2]));
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PySlice_Check(obj2))
     {
@@ -347,7 +348,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t j = 0; j < size2; ++ j)
         description[j] = entireDescription[start2 + j*step2];
       result.setDescription(description);
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PySequence_Check(obj2))
     {
@@ -379,7 +380,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t j = 0; j < size2; ++ j)
         marginalDescription[j] = description[indices2[j]];
       result.setDescription(marginalDescription);
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
   }
   else if (PySequence_Check(obj1))
@@ -418,7 +419,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t i = 0; i < size1; ++ i)
         result.at(i, 0) = self->at(indices1[i], index2);
       result.setDescription(OT::Description(1, self->getDescription()[index2]));
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PySlice_Check(obj2))
     {
@@ -437,7 +438,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t j = 0; j < size2; ++ j)
         marginalDescription[j] = description[start2 + j*step2];
       result.setDescription(marginalDescription);
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
     else if (PySequence_Check(obj2))
     {
@@ -469,7 +470,7 @@ PyObject * __getitem__(PyObject * args) const
       for (Py_ssize_t j = 0; j < size2; ++ j)
         marginalDescription[j] = description[indices2[j]];
       result.setDescription(marginalDescription);
-      return SWIG_NewPointerObj((new OT::Sample(static_cast< const OT::Sample& >(result))), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN | 0);
+      return SWIG_NewPointerObj(new OT::Sample(result), SWIGTYPE_p_OT__Sample, SWIG_POINTER_OWN);
     }
   }
   else
@@ -482,6 +483,7 @@ fail:
 
 void __setitem__(PyObject * args, PyObject * valObj)
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   if (!PyTuple_Check(args))
   {
     if (PySlice_Check(args))
@@ -806,12 +808,13 @@ fail:
 
 Sample(const Sample & other)
 {
-  return new OT::Sample( other );
+  return new OT::Sample(other);
 }
 
 Sample(PyObject * pyObj)
 {
-  return new OT::Sample( OT::convert< OT::_PySequence_, OT::Sample>(pyObj) );  
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  return new OT::Sample(OT::convert< OT::_PySequence_, OT::Sample>(pyObj));
 }
 
 Bool __eq__(const Sample & other) { return (*self) == other; }

--- a/python/src/SimulationAlgorithm.i
+++ b/python/src/SimulationAlgorithm.i
@@ -5,6 +5,7 @@
 #include "openturns/PythonWrappingFunctions.hxx"
 
 static void SimulationAlgorithm_ProgressCallback(OT::Scalar percent, void * data) {
+  OT::InterpreterUnlocker iul;
   PyObject * pyObj = reinterpret_cast<PyObject *>(data);
   OT::ScopedPyObjectPointer point(OT::convert< OT::Scalar, OT::_PyFloat_ >(percent));
   OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj, point.get(), NULL));
@@ -13,6 +14,7 @@ static void SimulationAlgorithm_ProgressCallback(OT::Scalar percent, void * data
 }
 
 static OT::Bool SimulationAlgorithm_StopCallback(void * data) {
+  OT::InterpreterUnlocker iul;
   PyObject * pyObj = reinterpret_cast<PyObject *>(data);
   OT::ScopedPyObjectPointer result(PyObject_CallFunctionObjArgs(pyObj, NULL));
   if (result.isNull())

--- a/python/src/SplitterImplementation.i
+++ b/python/src/SplitterImplementation.i
@@ -24,6 +24,7 @@ SplitterImplementation * __iter__()
 
 PyObject* __next__()
 {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   OT::Indices indices1;
   OT::Indices indices2;
   try {

--- a/python/src/SquareComplexMatrix.i
+++ b/python/src/SquareComplexMatrix.i
@@ -16,7 +16,11 @@ namespace OT {
 
   SquareComplexMatrix(const SquareComplexMatrix & other) { return new OT::SquareComplexMatrix(other); }
 
-  SquareComplexMatrix(PyObject * pyObj) { return new OT::SquareComplexMatrix( OT::convert<OT::_PySequence_,OT::SquareComplexMatrix>(pyObj) ); }
+  SquareComplexMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::SquareComplexMatrix(OT::convert<OT::_PySequence_, OT::SquareComplexMatrix>(pyObj));
+  }
 
   OTComplexMatrixGetAccessors()
 

--- a/python/src/SquareMatrix.i
+++ b/python/src/SquareMatrix.i
@@ -20,7 +20,11 @@ namespace OT {
 
   SquareMatrix(const SquareMatrix & other) { return new OT::SquareMatrix(other); }
 
-  SquareMatrix(PyObject * pyObj) { return new OT::SquareMatrix( OT::convert<OT::_PySequence_,OT::SquareMatrix>(pyObj) ); }
+  SquareMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::SquareMatrix(OT::convert<OT::_PySequence_, OT::SquareMatrix>(pyObj));
+  }
 
   OTMatrixAccessors()
 

--- a/python/src/SymmetricMatrix.i
+++ b/python/src/SymmetricMatrix.i
@@ -28,7 +28,11 @@ namespace OT {
 %extend SymmetricMatrix {
   SymmetricMatrix(const SymmetricMatrix & other) { return new OT::SymmetricMatrix(other); }
 
-  SymmetricMatrix(PyObject * pyObj) { return new OT::SymmetricMatrix( OT::convert<OT::_PySequence_,OT::SymmetricMatrix>(pyObj) ); }
+  SymmetricMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::SymmetricMatrix( OT::convert<OT::_PySequence_, OT::SymmetricMatrix>(pyObj));
+  }
 
   OTMatrixAccessors()
 

--- a/python/src/SymmetricTensor.i
+++ b/python/src/SymmetricTensor.i
@@ -25,7 +25,11 @@ namespace OT {
 
   SymmetricTensor(const SymmetricTensor & other) { return new OT::SymmetricTensor(other); }
 
-  SymmetricTensor(PyObject * pyObj) { return new OT::SymmetricTensor( OT::convert<OT::_PySequence_,OT::SymmetricTensor>(pyObj) ); }
+  SymmetricTensor(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::SymmetricTensor(OT::convert<OT::_PySequence_, OT::SymmetricTensor>(pyObj));
+  }
 
   OTTensorAccessors(SymmetricTensor, Scalar, _PyFloat_)
 

--- a/python/src/Tensor.i
+++ b/python/src/Tensor.i
@@ -15,7 +15,9 @@
 
 %define OTTensorAccessors(baseType, elementType, pythonElementType)
 
-PyObject * __getitem__(PyObject * args) const {
+PyObject * __getitem__(PyObject * args) const
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   OT::UnsignedInteger arg2 = 0;
   OT::UnsignedInteger arg3 = 0;
   OT::UnsignedInteger arg4 = 0;
@@ -51,13 +53,14 @@ PyObject * __getitem__(PyObject * args) const {
   }
   arg4 = static_cast< OT::UnsignedInteger >(val4);
 
-  return OT::convert<OT::elementType, OT::pythonElementType>((*self)(arg2,arg3,arg4));
+  return OT::convert<OT::elementType, OT::pythonElementType>((*self)(arg2, arg3, arg4));
 fail:
   return NULL;
 }
 
-PyObject * __setitem__(PyObject * args, elementType val) {
-
+PyObject * __setitem__(PyObject * args, elementType val)
+{
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
   OT::UnsignedInteger arg2 = 0;
   OT::UnsignedInteger arg3 = 0;
   OT::UnsignedInteger arg4 = 0;
@@ -71,7 +74,7 @@ PyObject * __setitem__(PyObject * args, elementType val) {
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
 
-  if (!PyArg_ParseTuple(args,(char *)"OOO:" #baseType "___setitem__",&obj1,&obj2,&obj3)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOO:" #baseType "___setitem__", &obj1, &obj2, &obj3)) SWIG_fail;
 
   ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
@@ -130,7 +133,11 @@ namespace OT {
 
   Tensor(const Tensor & other) { return new OT::Tensor(other); }
 
-  Tensor(PyObject * pyObj) { return new OT::Tensor( OT::convert<OT::_PySequence_,OT::Tensor>(pyObj) ); }
+  Tensor(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::Tensor(OT::convert<OT::_PySequence_, OT::Tensor>(pyObj));
+  }
 
   OTTensorAccessors(Tensor, Scalar, _PyFloat_)
 

--- a/python/src/TestResult.i
+++ b/python/src/TestResult.i
@@ -53,7 +53,8 @@ TestResult(const TestResult & other) { return new OT::TestResult(other); }
 
 TestResult(PyObject * pyObj)
 {
- return new OT::TestResult( OT::convert<OT::_PySequence_,OT::TestResult>(pyObj) );
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  return new OT::TestResult(OT::convert<OT::_PySequence_, OT::TestResult>(pyObj));
 }
 
 }

--- a/python/src/TriangularComplexMatrix.i
+++ b/python/src/TriangularComplexMatrix.i
@@ -14,7 +14,11 @@ namespace OT {
 
   TriangularComplexMatrix(const TriangularComplexMatrix & other) { return new OT::TriangularComplexMatrix(other); }
 
-  TriangularComplexMatrix(PyObject * pyObj) { return new OT::TriangularComplexMatrix( OT::convert<OT::_PySequence_,OT::TriangularComplexMatrix>(pyObj) ); }
+  TriangularComplexMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::TriangularComplexMatrix(OT::convert<OT::_PySequence_, OT::TriangularComplexMatrix>(pyObj));
+  }
 
   OTComplexMatrixGetAccessors()
 

--- a/python/src/TriangularMatrix.i
+++ b/python/src/TriangularMatrix.i
@@ -14,7 +14,11 @@ namespace OT {
 
   TriangularMatrix(const TriangularMatrix & other) { return new OT::TriangularMatrix(other); }
 
-  TriangularMatrix(PyObject * pyObj) { return new OT::TriangularMatrix( OT::convert<OT::_PySequence_,OT::TriangularMatrix>(pyObj) ); }
+  TriangularMatrix(PyObject * pyObj)
+  {
+    SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+    return new OT::TriangularMatrix(OT::convert<OT::_PySequence_, OT::TriangularMatrix>(pyObj));
+  }
 
   OTMatrixAccessors()
 

--- a/python/src/UniVariatePolynomial.i
+++ b/python/src/UniVariatePolynomial.i
@@ -37,7 +37,8 @@ UniVariatePolynomial(const UniVariatePolynomial & other) { return new OT::UniVar
 
 UniVariatePolynomial(PyObject * pyObj)
 {
- return new OT::UniVariatePolynomial( OT::convert<OT::_PySequence_,OT::Point>(pyObj) );
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  return new OT::UniVariatePolynomial(OT::convert<OT::_PySequence_, OT::Point>(pyObj));
 }
 
 }

--- a/python/src/openturns/PythonWrappingFunctions.hxx
+++ b/python/src/openturns/PythonWrappingFunctions.hxx
@@ -69,6 +69,16 @@ private:
 };
 
 
+/** Aquire/release the GIL */
+class InterpreterUnlocker {
+public:
+  InterpreterUnlocker() : state_(PyGILState_Ensure()) {}
+  ~InterpreterUnlocker() { PyGILState_Release(state_); }
+private:
+  PyGILState_STATE state_;
+};
+
+
 /** These templates are just declared, not defined. Only specializations are. */
 template <class CPP_Type>                    struct traitsPythonType;
 template <class PYTHON_Type>                 static inline int          isAPython(PyObject * pyObj);


### PR DESCRIPTION
Now we use the -threads swig option to wrap c++ calls inside GIL
ensure/release calls.
In .i files SWIG_PYTHON_THREAD_BEGIN_BLOCK must be used in additional
wrapper methods.
Inside custom Python wrapper classes we use the new InterpreterUnlocker
helper class.
This fixes a bug where a bit too much of logging would freeze newer
versions of jupyter notebook, which now shows it by parsing stdout/stderr.
The CMAKE_SWIG_FLAGS variable can still be set to disable this if
necessary.

