### PR TITLE
Python getImplementation performs dynamic casting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@
 === Documentation ===
 
 === Python module ===
+ * Hide C++ getImplementation methods and add Python-specific getImplementation methods with automatic dynamic typecasting
 
 === Miscellaneous ===
 

--- a/python/doc/pyplots/ProductFunction.py
+++ b/python/doc/pyplots/ProductFunction.py
@@ -4,7 +4,7 @@ from openturns.viewer import View
 f1 = ot.SymbolicFunction(['x'], ['sin(x)'])
 f2 = ot.SymbolicFunction(['x'], ['x'])
 
-f = ot.ProductFunction(f1.getImplementation(), f2.getImplementation())
+f = f1 * f2
 graph = f.draw(0.0, 10.0)
 graph.setTitle('y=f1*f2')
 View(graph, figure_kw={'figsize': (8, 4)}, add_legend=True)

--- a/python/src/FunctionImplementation_doc.i.in
+++ b/python/src/FunctionImplementation_doc.i.in
@@ -264,7 +264,7 @@ OT_Function_getMarginal_doc
 Returns
 -------
 function : :class:`~openturns.FunctionImplementation`
-    The evaluation, gradient and hessian function.
+    A copy of the evaluation, gradient and hessian functions.
 
 Examples
 --------

--- a/python/src/InterfaceObject_doc.i.in
+++ b/python/src/InterfaceObject_doc.i.in
@@ -34,5 +34,5 @@ name : str
 Returns
 -------
 impl : Implementation
-    The implementation class."
-    
+    A copy of the underlying implementation object."
+

--- a/python/src/ProductFunction_doc.i.in
+++ b/python/src/ProductFunction_doc.i.in
@@ -16,12 +16,6 @@ Examples
 >>> import openturns as ot
 >>> g = ot.SymbolicFunction(['x1', 'x2'], ['x1'])
 >>> f = ot.SymbolicFunction(['x1', 'x2'], ['x2'])
->>> product = ot.ProductFunction(f.getImplementation(), g.getImplementation())
+>>> product = f * g
 >>> print(product([3, 4]))
-[12]
-
-Or, shorter:
-
->>> product = f * g"
-
-
+[12]"

--- a/python/src/SpaceFillingImplementation.i
+++ b/python/src/SpaceFillingImplementation.i
@@ -6,7 +6,5 @@
 
 %include SpaceFillingImplementation_doc.i
 
-%template(SpaceFillingImplementationdInterfaceObject)           OT::TypedInterfaceObject<OT::SpaceFillingImplementation>;
-
 %include openturns/SpaceFillingImplementation.hxx
 namespace OT { %extend SpaceFillingImplementation { SpaceFillingImplementation(const SpaceFillingImplementation & other) { return new OT::SpaceFillingImplementation(other); } } }

--- a/python/src/TemperatureProfileImplementation.i
+++ b/python/src/TemperatureProfileImplementation.i
@@ -6,7 +6,5 @@
 
 %include TemperatureProfileImplementation_doc.i
 
-%template(TemperatureProfileImplementationdInterfaceObject)           OT::TypedInterfaceObject<OT::TemperatureProfileImplementation>;
-
 %include openturns/TemperatureProfileImplementation.hxx
 namespace OT { %extend TemperatureProfileImplementation { TemperatureProfileImplementation(const TemperatureProfileImplementation & other) { return new OT::TemperatureProfileImplementation(other); } } }

--- a/python/src/TypedInterfaceObject.i
+++ b/python/src/TypedInterfaceObject.i
@@ -4,8 +4,6 @@
 #include "openturns/TypedInterfaceObject.hxx"
 %}
 
-%ignore OT::TypedInterfaceObject::swap;
-
 %define TypedInterfaceObjectImplementationHelper(Namespace, Interface, Implementation)
 
 %template(Implementation ## TypedInterfaceObject) OT::TypedInterfaceObject<Namespace::Implementation>;
@@ -40,4 +38,84 @@ TypedInterfaceObjectImplementationHelper(OT, Interface, Implementation)
 OTTypedInterfaceObjectImplementationHelper(Interface,Interface ## Implementation)
 %enddef
 
-%include openturns/TypedInterfaceObject.hxx
+
+/***************************************************************************
+ * This section contains the parts of TypedInterfaceObject.hxx
+ * that SWIG needs to generate a wrapper.
+ *
+ * Not all public methods are interfaced in Python.
+ * In particular, swap is not interfaced.
+ * The accessor getImplementation is also not interfaced and is replaced by
+ * a SWIG implementation provided under %extend (see below).
+ ***************************************************************************/
+
+BEGIN_NAMESPACE_OPENTURNS
+
+/**
+ * @class TypedInterfaceObject
+ * @brief Implements InterfaceObject for a specific class
+ * @internal
+ * @tparam T The class bound to the interface object
+ * @see PersistentObject
+ */
+template <class T>
+class TypedInterfaceObject
+  : public InterfaceObject
+{
+public:
+
+  typedef T                                                   ImplementationType;
+  typedef Pointer<ImplementationType>                         Implementation;
+
+  /** Constructor */
+  TypedInterfaceObject();
+  TypedInterfaceObject(const Implementation & impl);
+
+  /** Return a pointer to the underlying implementation object viewed as a PersistentObject */
+  inline virtual ImplementationAsPersistentObject getImplementationAsPersistentObject() const;
+
+  /** Set the pointer to the underlying implementation object */
+  inline virtual void setImplementationAsPersistentObject(const ImplementationAsPersistentObject & obj);
+
+  /** Name accessor */
+  inline virtual void setName(const String & name);
+
+  /** Name accessor */
+  inline virtual String getName() const;
+
+  /** Comparison Operator */
+  inline virtual
+  Bool operator == (const TypedInterfaceObject & other) const;
+
+  /** Comparison Operator */
+  inline virtual
+  Bool operator != (const TypedInterfaceObject & other) const;
+
+}; /* class TypedInterfaceObject */
+
+END_NAMESPACE_OPENTURNS
+
+
+
+/***************************************************************************
+ * TypedInterfaceObject class extension
+ *
+ * Provides a version of getImplementation that performs dynamic casting.
+ ***************************************************************************/
+namespace OT
+{
+  %extend TypedInterfaceObject
+  {
+    PyObject * getImplementation()
+    {
+      // Get child info
+      OT::String childname = "OT::";
+      childname.append($self->getImplementation()->getClassName());
+      childname.append("*");
+      swig_type_info * childinfo = SWIG_TypeQuery(childname.c_str());
+
+      // Return child pointer
+      return SWIG_NewPointerObj(SWIG_as_voidptr($self->getImplementation().get()), childinfo, 0 | 0);
+    }
+  }
+}

--- a/python/src/TypedInterfaceObject.i
+++ b/python/src/TypedInterfaceObject.i
@@ -45,9 +45,7 @@
 %typemap(out) OT::TypedInterfaceObject< Namespace::ParentImplementation >::Implementation
 {
   // Construct the SWIG identifier of the derived class we want to get (say ChildImplementation).
-  OT::String childname = "Namespace::";
-  childname.append($1->getClassName());
-  childname.append("*");
+  const OT::String childname = "Namespace::" + $1->getClassName() + "*";
   swig_type_info * childinfo = SWIG_TypeQuery(childname.c_str());
 
   // Make the result a PyObject* pointing to the ChildImplementation.

--- a/python/src/TypedInterfaceObject.i
+++ b/python/src/TypedInterfaceObject.i
@@ -31,20 +31,6 @@
 
 %enddef
 
-// Thread-safe initialization - initialize during Python module initialization
-%fragment("typedImplementationObject_reference_init", "init")
-{
-  typedImplementationObject_reference();
-}
-
-%fragment("typedImplementationObject_reference_function", "header", fragment="typedImplementationObject_reference_init")
-{
-  static PyObject *typedImplementationObject_reference()
-  {
-    static PyObject *typedImplementationObject_reference_string = SWIG_Python_str_FromChar("__typedImplementationObject_reference");
-    return typedImplementationObject_reference_string;
-  }
-}
 
 // SWIG typemaps to convert Pointer<ParentImplementation> objects to ChildImplementation.
 // The typemaps implement dynamic typecasting to ChildImplementation for the Python version of TypedInterfaceObject::getImplementation.
@@ -65,14 +51,7 @@
   swig_type_info * childinfo = SWIG_TypeQuery(childname.c_str());
 
   // Make the result a PyObject* pointing to the ChildImplementation.
-  $result = SWIG_NewPointerObj(SWIG_as_voidptr($1.get()), childinfo, 0 |  0 );
-}
-
-// Add an attribute to the resulting ChildImplementation that stores a reference to the original TypedInterfaceObject.
-// This prevents premature garbage collection of the TypedInterfaceObject.
-%typemap(ret, fragment="typedImplementationObject_reference_function") OT::TypedInterfaceObject< Namespace::ParentImplementation >::Implementation
-{
-  PyObject_SetAttr($result, typedImplementationObject_reference(), $self);
+  $result = SWIG_NewPointerObj(SWIG_as_voidptr($1.get()->clone()), childinfo, SWIG_POINTER_OWN);
 }
 
 %enddef

--- a/python/src/TypedInterfaceObject.i
+++ b/python/src/TypedInterfaceObject.i
@@ -117,5 +117,9 @@ namespace OT
       // Return child pointer
       return SWIG_NewPointerObj(SWIG_as_voidptr($self->getImplementation().get()), childinfo, 0 | 0);
     }
+
+    // Prevent premature garbage collection of the TypedInterfaceObject self
+    %pythonappend getImplementation
+    %{val.__typedInterfaceObject_reference = self%} // val is the Implementation proxy
   }
 }

--- a/python/test/t_CovarianceModel_std.py
+++ b/python/test/t_CovarianceModel_std.py
@@ -170,6 +170,18 @@ ott.assert_almost_equal(myModel.getAmplitude(), [3], 0, 0)
 ott.assert_almost_equal(myModel.getNu(), 1.5, 0, 0)
 test_model(myModel)
 
+# Retrieve a copy of the actual implementation from the interface class
+myModelInterface = ot.CovarianceModel(myModel)
+myModelImplementation = myModelInterface.getImplementation()
+
+# Works because myModelImplementation is a MaternModel
+myModelImplementation.setNu(2.5)
+ott.assert_almost_equal(myModelImplementation.getNu(), 2.5, 0, 0)
+
+# Original myModel still has the original nu because in Python
+# getImplementation clones the underlying implementation
+ott.assert_almost_equal(myModel.getNu(), 1.5, 0, 0)
+
 # 5) ExponentiallyDampedCosineModel
 myModel = ot.ExponentiallyDampedCosineModel([2.0], [3.0], 1)
 ott.assert_almost_equal(myModel.getScale(), [2], 0, 0)

--- a/python/test/t_SymbolicFunction_muparser.py
+++ b/python/test/t_SymbolicFunction_muparser.py
@@ -206,5 +206,6 @@ except:
     print(f, ", f([-1]) not defined")
 
 f = ot.SymbolicFunction("x", "sqrt(x)")
-f.getEvaluation().getImplementation().setCheckOutput(False)
-print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(f([-1.0])[0]))
+ev = f.getEvaluation()
+ev.setCheckOutput(False) # triggers copyOnWrite, ev is no longer the Evaluation of f
+print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(ev([-1.0])[0]))

--- a/python/test/t_SymbolicFunction_std.py
+++ b/python/test/t_SymbolicFunction_std.py
@@ -183,8 +183,9 @@ except:
     print(f, ", f([-1]) not defined")
 
 f = ot.SymbolicFunction("x", "sqrt(x)")
-f.getEvaluation().getImplementation().setCheckOutput(False)
-print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(f([-1.0])[0]))
+ev = f.getEvaluation()
+ev.setCheckOutput(False) # triggers copyOnWrite, ev is no longer the Evaluation of f
+print(f, ", f([-1]) is normal?", ot.SpecFunc.IsNormal(ev([-1.0])[0]))
 
 # joe copula bug
 f = ot.SymbolicFunction(['t'], ['(t*3)^(-1)'])


### PR DESCRIPTION
An alternative version of `TypedInterfaceObject.getImplementation` is implemented as a SWIG extension of the class`TypedInterfaceObject`.
It returns a handle with type the output of the C++ command  `getImplementation()->getClassName()`.

Fixes #1931 since it lets objects obtained from the Python version of `getImplementation` access all methods of the actual implementation class.

As an example, here is a code snippet:

```python
import openturns as ot

mat = ot.MaternModel()
cov = ot.CovarianceModel(mat)
imp = cov.getImplementation()
print(type(imp))
```

With OT version 1.18, the output is
```python
<class 'openturns.statistics.CovarianceModelImplementationPointer'>
```

With this PR, it is
```python
<class 'openturns.statistics.MaternModel'>
```

As a result, the following code now works:

```python
imp.setNu(0.75) # fails under OT 1.18 because CovarianceModelImplementation has no setNu method
print(imp)
```
Which prints:
```python
MaternModel(scale=[1], amplitude=[1], nu=0.75)
```