### PR TITLE
MetaModel: deprecate Function ctors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@
  * Removed deprecated SubsetSampling.getNumberOfSteps
  * coupling_tools.execute: deprecated get_stderr,get_stdout for capture_output, returns CompletedProcess
  * Deprecated Nlopt|Ceres|Bonmin|CMinpack|Ipopt|TBB|HMatrixFactory::IsAvailable in favor of PlatformInfo::HasFeature, see also GetFeatures
+ * Deprecated FunctionalChaosAlgorithm Function ctors
+ * Deprecated FunctionalChaosResult.getComposedModel
 
 === Documentation ===
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -70,12 +70,13 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Function & model,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy,
     const ProjectionStrategy & projectionStrategy)
-  : MetaModelAlgorithm( distribution, model )
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(projectionStrategy)
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
 {
-  // Nothing to do
+  LOGWARN(OSS() << "FunctionalChaosAlgorithm from Function is deprecated");
+  model_ = model;
 }
 
 /* Constructor */
@@ -84,7 +85,7 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy,
     const ProjectionStrategy & projectionStrategy)
-  : MetaModelAlgorithm(distribution, DatabaseFunction(inputSample, outputSample))
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(projectionStrategy)
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
@@ -97,6 +98,8 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
   projectionStrategy_.setWeights(Point(inputSample.getSize(), 1.0 / inputSample.getSize()));
   projectionStrategy_.setInputSample(inputSample);
   projectionStrategy_.setOutputSample(outputSample);
+  // deprecated
+  model_ = DatabaseFunction(inputSample, outputSample);
 }
 
 /* Constructor */
@@ -106,7 +109,7 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy,
     const ProjectionStrategy & projectionStrategy)
-  : MetaModelAlgorithm(distribution, DatabaseFunction(inputSample, outputSample))
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(projectionStrategy)
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
@@ -119,18 +122,21 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
   projectionStrategy_.setWeights(weights);
   projectionStrategy_.setInputSample(inputSample);
   projectionStrategy_.setOutputSample(outputSample);
+  // deprecated
+  model_ = DatabaseFunction(inputSample, outputSample);
 }
 
 /* Constructor */
 FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Function & model,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy)
-  : MetaModelAlgorithm( distribution, model )
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(LeastSquaresStrategy())
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
 {
-  // Nothing to do
+  LOGWARN(OSS() << "FunctionalChaosAlgorithm from Function is deprecated");
+  model_ = model;
 }
 
 /* Constructor */
@@ -138,20 +144,22 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
     const Sample & outputSample,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy)
-  : MetaModelAlgorithm(distribution, DatabaseFunction(inputSample, outputSample))
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(LeastSquaresStrategy(inputSample, outputSample))
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
 {
   // Check sample size
   if (inputSample.getSize() != outputSample.getSize()) throw InvalidArgumentException(HERE) << "Error: the input sample and the output sample must have the same size.";
+  // deprecated
+  model_ = DatabaseFunction(inputSample, outputSample);
 }
 
 
 /* Constructor */
 FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
     const Sample & outputSample)
-  : MetaModelAlgorithm(Distribution(), DatabaseFunction(inputSample, outputSample))
+  : MetaModelAlgorithm()
   , adaptiveStrategy_()
   , projectionStrategy_()
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
@@ -190,6 +198,8 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
   } // Large sample
   const UnsignedInteger totalSize = enumerate.getStrataCumulatedCardinal(maximumTotalDegree);
   adaptiveStrategy_ = FixedStrategy(basis, totalSize);
+  // deprecated
+  model_ = DatabaseFunction(inputSample, outputSample);
 }
 
 /* Constructor */
@@ -198,13 +208,15 @@ FunctionalChaosAlgorithm::FunctionalChaosAlgorithm(const Sample & inputSample,
     const Sample & outputSample,
     const Distribution & distribution,
     const AdaptiveStrategy & adaptiveStrategy)
-  : MetaModelAlgorithm(distribution, DatabaseFunction(inputSample, outputSample))
+  : MetaModelAlgorithm(distribution)
   , adaptiveStrategy_(adaptiveStrategy)
   , projectionStrategy_(LeastSquaresStrategy(inputSample, weights, outputSample))
   , maximumResidual_(ResourceMap::GetAsScalar( "FunctionalChaosAlgorithm-DefaultMaximumResidual" ))
 {
   // Check sample size
   if (inputSample.getSize() != outputSample.getSize()) throw InvalidArgumentException(HERE) << "Error: the input sample and the output sample must have the same size.";
+  // deprecated
+  model_ = DatabaseFunction(inputSample, outputSample);
 }
 
 
@@ -252,6 +264,7 @@ AdaptiveStrategy FunctionalChaosAlgorithm::getAdaptiveStrategy() const
 /* Computes the functional chaos */
 void FunctionalChaosAlgorithm::run()
 {
+  // deprecated, projectionStrategy_.getOutputSample().getDimension()
   const UnsignedInteger outputDimension = model_.getOutputDimension();
 
   // Get the measure upon which the orthogonal basis is built
@@ -276,8 +289,11 @@ void FunctionalChaosAlgorithm::run()
 
   // Build the composed model g = f o T^{-1}, which is a function of Z so it can be decomposed upon an orthonormal basis based on Z distribution
   const Bool noTransformation = (measure == distribution_);
+  
+  // deprecated, for computeCoefficients
   if (noTransformation) composedModel_ = model_;
   else composedModel_ = ComposedFunction(model_, inverseTransformation_);
+  
   // If the input and output databases have already been given to the projection strategy, transport them to the measure space
   const Sample initialInputSample(projectionStrategy_.getInputSample());
   if (databaseProjection && !noTransformation)
@@ -342,7 +358,7 @@ void FunctionalChaosAlgorithm::run()
     Psi_k.add(basis.build(i));
   }
   // Build the result
-  result_ = FunctionalChaosResult(model_, distribution_, transformation_, inverseTransformation_, composedModel_, basis, I_k, alpha_k, Psi_k, residuals, relativeErrors);
+  result_ = FunctionalChaosResult(distribution_, transformation_, inverseTransformation_, basis, I_k, alpha_k, Psi_k, residuals, relativeErrors);
 }
 
 /* Marginal computation */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
@@ -50,30 +50,25 @@ FunctionalChaosResult::FunctionalChaosResult()
 
 
 /* Default constructor */
-FunctionalChaosResult::FunctionalChaosResult(const Function & model,
-    const Distribution & distribution,
+FunctionalChaosResult::FunctionalChaosResult(const Distribution & distribution,
     const Function & transformation,
     const Function & inverseTransformation,
-    const Function & composedModel,
     const OrthogonalBasis & orthogonalBasis,
     const Indices & I,
     const Sample & alpha_k,
     const FunctionCollection & Psi_k,
     const Point & residuals,
     const Point & relativeErrors)
-  : MetaModelResult(model, Function(), residuals, relativeErrors)
+  : MetaModelResult(Function(), residuals, relativeErrors)
   , distribution_(distribution)
   , transformation_(transformation)
   , inverseTransformation_(inverseTransformation)
-  , composedModel_(composedModel)
   , orthogonalBasis_(orthogonalBasis)
   , I_(I)
   , alpha_k_(alpha_k)
   , Psi_k_(Psi_k)
-  , composedMetaModel_()
+  , composedMetaModel_(DualLinearCombinationFunction(Psi_k, alpha_k))
 {
-  // The composed meta model will be a dual linear combination
-  composedMetaModel_ = DualLinearCombinationFunction(Psi_k, alpha_k);
   if (transformation.getEvaluation().getImplementation()->getClassName() == "IdentityEvaluation")
     metaModel_ = composedMetaModel_;
   else
@@ -96,7 +91,6 @@ String FunctionalChaosResult::__repr__() const
          << " distribution=" << distribution_
          << " transformation=" << transformation_
          << " inverseTransformation=" << inverseTransformation_
-         << " composedModel=" << composedModel_
          << " orthogonalBasis=" << orthogonalBasis_
          << " indices=" << I_
          << " coefficients=" << alpha_k_
@@ -136,7 +130,8 @@ Function FunctionalChaosResult::getInverseTransformation() const
 /* Composed model accessor */
 Function FunctionalChaosResult::getComposedModel() const
 {
-  return composedModel_;
+  LOGWARN(OSS() << "FunctionalChaosResult.getComposedModel is deprecated");
+  return Function();
 }
 
 /* Orthogonal basis accessor */
@@ -176,7 +171,6 @@ void FunctionalChaosResult::save(Advocate & adv) const
   adv.saveAttribute( "distribution_", distribution_ );
   adv.saveAttribute( "transformation_", transformation_ );
   adv.saveAttribute( "inverseTransformation_", inverseTransformation_ );
-  adv.saveAttribute( "composedModel_", composedModel_ );
   adv.saveAttribute( "orthogonalBasis_", orthogonalBasis_ );
   adv.saveAttribute( "I_", I_ );
   adv.saveAttribute( "alpha_k_", alpha_k_ );
@@ -192,7 +186,6 @@ void FunctionalChaosResult::load(Advocate & adv)
   adv.loadAttribute( "distribution_", distribution_ );
   adv.loadAttribute( "transformation_", transformation_ );
   adv.loadAttribute( "inverseTransformation_", inverseTransformation_ );
-  adv.loadAttribute( "composedModel_", composedModel_ );
   adv.loadAttribute( "orthogonalBasis_", orthogonalBasis_ );
   adv.loadAttribute( "I_", I_ );
   adv.loadAttribute( "alpha_k_", alpha_k_ );

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosAlgorithm.hxx
@@ -50,7 +50,7 @@ public:
   /** Default constructor */
   FunctionalChaosAlgorithm();
 
-  /** Constructor */
+  /** Constructor @deprecated */
   FunctionalChaosAlgorithm(const Function & model,
                            const Distribution & distribution,
                            const AdaptiveStrategy & adaptiveStrategy,
@@ -71,7 +71,7 @@ public:
                            const AdaptiveStrategy & adaptiveStrategy,
                            const ProjectionStrategy & projectionStrategy);
 
-  /** Constructor */
+  /** Constructor @deprecated */
   FunctionalChaosAlgorithm(const Function & model,
                            const Distribution & distribution,
                            const AdaptiveStrategy & adaptiveStrategy);
@@ -140,7 +140,7 @@ private:
   /** The inverse isoprobabilistic transformation */
   Function inverseTransformation_;
 
-  /** The composed model */
+  /** @deprecated The composed model */
   Function composedModel_;
 
   /** The adaptive strategy */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
@@ -56,11 +56,9 @@ public:
   FunctionalChaosResult();
 
   /** Parameter constructor */
-  FunctionalChaosResult(const Function & model,
-                        const Distribution & distribution,
+  FunctionalChaosResult(const Distribution & distribution,
                         const Function & transformation,
                         const Function & inverseTransformation,
-                        const Function & composedModel,
                         const OrthogonalBasis & orthogonalBasis,
                         const Indices & I,
                         const Sample & alpha_k,
@@ -84,7 +82,7 @@ public:
   /** InverseIsoProbabilisticTransformation accessor */
   virtual Function getInverseTransformation() const;
 
-  /** Composed model accessor */
+  /** @deprecated Composed model accessor */
   virtual Function getComposedModel() const;
 
   /** Orthogonal basis accessor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/GeneralLinearModelResult.cxx
@@ -50,7 +50,7 @@ GeneralLinearModelResult::GeneralLinearModelResult(const Sample & inputSample,
     const PointCollection & trendCoefficients,
     const CovarianceModel & covarianceModel,
     const Scalar optimalLogLikelihood)
-  : MetaModelResult(DatabaseFunction(inputSample, outputSample), metaModel, residuals, relativeErrors)
+  : MetaModelResult(metaModel, residuals, relativeErrors)
   , inputData_(inputSample)
   , basis_(basis)
   , beta_(trendCoefficients)

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingResult.cxx
@@ -46,7 +46,7 @@ KrigingResult::KrigingResult(const Sample & inputSample,
                              const PointCollection & trendCoefficients,
                              const CovarianceModel & covarianceModel,
                              const Sample & covarianceCoefficients)
-  : MetaModelResult(DatabaseFunction(inputSample, outputSample), metaModel, residuals, relativeErrors)
+  : MetaModelResult(metaModel, residuals, relativeErrors)
   , inputSample_(inputSample)
   , outputSample_(outputSample)
   , basis_(basis)
@@ -72,7 +72,7 @@ KrigingResult::KrigingResult(const Sample & inputSample,
                              const Sample & covarianceCoefficients,
                              const TriangularMatrix & covarianceCholeskyFactor,
                              const HMatrix & covarianceHMatrix)
-  : MetaModelResult(DatabaseFunction(inputSample, outputSample), metaModel, residuals, relativeErrors)
+  : MetaModelResult(metaModel, residuals, relativeErrors)
   , inputSample_(inputSample)
   , outputSample_(outputSample)
   , basis_(basis)

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
@@ -53,7 +53,7 @@ LinearModelResult::LinearModelResult(const Sample & inputSample,
                                      const Point & leverages,
                                      const Point & cookDistances,
                                      const Scalar sigma2)
-  : MetaModelResult(DatabaseFunction(inputSample, outputSample), metaModel, Point(1, 0.0), Point(1, 0.0))
+  : MetaModelResult(metaModel, Point(1, 0.0), Point(1, 0.0))
   , inputSample_(inputSample)
   , basis_(basis)
   , design_(design)

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelAlgorithm.cxx
@@ -44,11 +44,9 @@ MetaModelAlgorithm::MetaModelAlgorithm()
 }
 
 /* Constructor with parameters */
-MetaModelAlgorithm::MetaModelAlgorithm(const Distribution & distribution,
-                                       const Function & model)
+MetaModelAlgorithm::MetaModelAlgorithm(const Distribution & distribution)
   : PersistentObject()
   , distribution_(distribution)
-  , model_(model)
 {
   // Nothing to do
 }
@@ -253,7 +251,6 @@ void MetaModelAlgorithm::save(Advocate & adv) const
   PersistentObject::save(adv);
   adv.saveAttribute( "distribution_", distribution_ );
   adv.saveAttribute( "model_", model_ );
-
 }
 
 /* Method load() reloads the object from the StorageManager */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/MetaModelResult.cxx
@@ -37,12 +37,10 @@ MetaModelResult::MetaModelResult()
 }
 
 /* Standard constructor */
-MetaModelResult::MetaModelResult(const Function & model,
-                                 const Function & metaModel,
+MetaModelResult::MetaModelResult(const Function & metaModel,
                                  const Point & residuals,
                                  const Point & relativeErrors)
   : PersistentObject()
-  , model_(model)
   , metaModel_(metaModel)
   , residuals_(residuals)
   , relativeErrors_(relativeErrors)
@@ -57,14 +55,15 @@ MetaModelResult * MetaModelResult::clone() const
 }
 
 /* Model accessor */
-void MetaModelResult::setModel(const Function & model)
+void MetaModelResult::setModel(const Function &)
 {
-  model_ = model;
+  LOGWARN(OSS() << "MetaModelResult.setModel is deprecated");
 }
 
 Function MetaModelResult::getModel() const
 {
-  return model_;
+  LOGWARN(OSS() << "MetaModelResult.getModel is deprecated");
+  return Function();
 }
 
 /* MetaModel accessor */
@@ -104,8 +103,7 @@ Point MetaModelResult::getRelativeErrors() const
 String MetaModelResult::__repr__() const
 {
   OSS oss;
-  oss << "model=" << model_
-      << " metaModel=" << metaModel_
+  oss << "metaModel=" << metaModel_
       << " residuals=" << residuals_
       << " relativeErrors=" << relativeErrors_;
   return oss;
@@ -115,7 +113,6 @@ String MetaModelResult::__repr__() const
 void MetaModelResult::save(Advocate & adv) const
 {
   PersistentObject::save(adv);
-  adv.saveAttribute( "model_", model_ );
   adv.saveAttribute( "metaModel_", metaModel_ );
   adv.saveAttribute( "residuals_", residuals_ );
   adv.saveAttribute( "relativeErrors_", relativeErrors_ );
@@ -125,7 +122,6 @@ void MetaModelResult::save(Advocate & adv) const
 void MetaModelResult::load(Advocate & adv)
 {
   PersistentObject::load(adv);
-  adv.loadAttribute( "model_", model_ );
   adv.loadAttribute( "metaModel_", metaModel_ );
   adv.loadAttribute( "residuals_", residuals_ );
   adv.loadAttribute( "relativeErrors_", relativeErrors_ );

--- a/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationAlgorithm.cxx
@@ -66,7 +66,7 @@ TensorApproximationAlgorithm::TensorApproximationAlgorithm(const Sample & inputS
     const OrthogonalProductFunctionFactory & basisFactory,
     const Indices & degrees,
     const UnsignedInteger maxRank)
-  : MetaModelAlgorithm(distribution, Function(FunctionImplementation(new DatabaseEvaluation(inputSample, outputSample))))
+  : MetaModelAlgorithm(distribution)
   , inputSample_(inputSample)
   , outputSample_(outputSample)
   , maxRank_(maxRank)
@@ -120,11 +120,7 @@ void TensorApproximationAlgorithm::run()
   inverseTransformation_ = transformation.inverse();
 
   // Build the composed model g = f o T^{-1}, which is a function of Z so it can be decomposed upon an orthonormal basis based on Z distribution
-  const Bool noTransformation = (measure == distribution_);
   LOGINFO("Transform the input sample in the measure space if needed");
-  if (noTransformation) composedModel_ = model_;
-  else composedModel_ = ComposedFunction(model_, inverseTransformation_);
-
   transformedInputSample_ = transformation_(inputSample_);
 
   FunctionCollection marginals(0);
@@ -135,7 +131,7 @@ void TensorApproximationAlgorithm::run()
     runMarginal(outputIndex, residuals[outputIndex], relativeErrors[outputIndex]);
   }
   // Build the result
-  result_ = TensorApproximationResult(distribution_, transformation_, inverseTransformation_, composedModel_, tensor_, residuals, relativeErrors);
+  result_ = TensorApproximationResult(distribution_, transformation_, inverseTransformation_, tensor_, residuals, relativeErrors);
 }
 
 /* Marginal computation */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/TensorApproximationResult.cxx
@@ -54,15 +54,13 @@ TensorApproximationResult::TensorApproximationResult(
   const Distribution & distribution,
   const Function & transformation,
   const Function & inverseTransformation,
-  const Function & composedModel,
   const Collection<CanonicalTensorEvaluation> & tensorCollection,
   const Point & residuals,
   const Point & relativeErrors)
-  : MetaModelResult(Function(), Function(), residuals, relativeErrors)
+  : MetaModelResult(Function(), residuals, relativeErrors)
   , distribution_(distribution)
   , transformation_(transformation)
   , inverseTransformation_(inverseTransformation)
-  , composedModel_(composedModel)
   , tensorCollection_(tensorCollection)
   , composedMetaModel_()
 {
@@ -96,7 +94,6 @@ String TensorApproximationResult::__repr__() const
          << " distribution=" << distribution_
          << " transformation=" << transformation_
          << " inverseTransformation=" << inverseTransformation_
-         << " composedModel=" << composedModel_
          << " relativeErrors=" << relativeErrors_
          << " composedMetaModel=" << composedMetaModel_
          << " metaModel=" << metaModel_;
@@ -131,7 +128,8 @@ Function TensorApproximationResult::getInverseTransformation() const
 /* Composed model accessor */
 Function TensorApproximationResult::getComposedModel() const
 {
-  return composedModel_;
+  LOGWARN(OSS() << "TensorApproximationResult.getComposedModel is deprecated");
+  return Function();
 }
 
 /* Composed meta model accessor */
@@ -152,7 +150,6 @@ void TensorApproximationResult::save(Advocate & adv) const
   adv.saveAttribute("distribution_", distribution_);
   adv.saveAttribute("transformation_", transformation_);
   adv.saveAttribute("inverseTransformation_", inverseTransformation_);
-  adv.saveAttribute("composedModel_", composedModel_);
   adv.saveAttribute("tensorCollection_", tensorCollection_);
   adv.saveAttribute("composedMetaModel_", composedMetaModel_);
 }
@@ -165,7 +162,6 @@ void TensorApproximationResult::load(Advocate & adv)
   adv.loadAttribute("distribution_", distribution_);
   adv.loadAttribute("transformation_", transformation_);
   adv.loadAttribute("inverseTransformation_", inverseTransformation_);
-  adv.loadAttribute("composedModel_", composedModel_);
   adv.loadAttribute("tensorCollection_", tensorCollection_);
   adv.loadAttribute("composedMetaModel_", composedMetaModel_);
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/openturns/TensorApproximationResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/TensorApproximation/openturns/TensorApproximationResult.hxx
@@ -59,7 +59,6 @@ public:
   TensorApproximationResult(const Distribution & distribution,
                             const Function & transformation,
                             const Function & inverseTransformation,
-                            const Function & composedModel,
                             const Collection<CanonicalTensorEvaluation> & tensorCollection,
                             const Point & residuals,
                             const Point & relativeErrors);
@@ -80,7 +79,7 @@ public:
   /** InverseIsoProbabilisticTransformation accessor */
   virtual Function getInverseTransformation() const;
 
-  /** Composed model accessor */
+  /** @deprecated Composed model accessor */
   virtual Function getComposedModel() const;
 
   /** Composed meta model accessor */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/openturns/MetaModelAlgorithm.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/openturns/MetaModelAlgorithm.hxx
@@ -47,8 +47,7 @@ public:
   MetaModelAlgorithm();
 
   /** Constructor with parameters */
-  MetaModelAlgorithm(const Distribution & distribution,
-                     const Function & model);
+  explicit MetaModelAlgorithm(const Distribution & distribution);
 
   /** Virtual constructor */
   MetaModelAlgorithm * clone() const override;
@@ -81,7 +80,7 @@ protected:
   /** The input vector distribution */
   Distribution distribution_;
 
-  /** The model */
+  /** @deprecated The model */
   Function model_;
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/openturns/MetaModelResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/openturns/MetaModelResult.hxx
@@ -44,15 +44,14 @@ public:
   MetaModelResult();
 
   /** Standard constructor */
-  MetaModelResult(const Function & model,
-                  const Function & metaModel,
+  MetaModelResult(const Function & metaModel,
                   const Point & residuals,
                   const Point & relativeErrors);
 
   /** Virtual constructor */
   MetaModelResult * clone() const override;
 
-  /** Model accessor */
+  /** @deprecated Model accessor */
   virtual void setModel(const Function & model);
   virtual Function getModel() const;
 
@@ -78,10 +77,6 @@ public:
   void load(Advocate & adv) override;
 
 protected:
-
-  // The initial model
-  Function model_;
-
   // The corresponding meta-model
   Function metaModel_;
 

--- a/python/src/FunctionalChaosAlgorithm_doc.i.in
+++ b/python/src/FunctionalChaosAlgorithm_doc.i.in
@@ -10,10 +10,6 @@ Available constructors:
 
     FunctionalChaosAlgorithm(*inputSample, outputSample, distribution, adaptiveStrategy, projectionStrategy*)
 
-    FunctionalChaosAlgorithm(*model, distribution, adaptiveStrategy*)
-
-    FunctionalChaosAlgorithm(*model, distribution, adaptiveStrategy, projectionStrategy*)
-
     FunctionalChaosAlgorithm(*inputSample, weights, outputSample, distribution, adaptiveStrategy*)
 
     FunctionalChaosAlgorithm(*inputSample, weights, outputSample, distribution, adaptiveStrategy, projectionStrategy*)
@@ -22,8 +18,6 @@ Parameters
 ----------
 inputSample, outputSample : 2-d sequence of float
     Sample of the input - output random vectors
-model : :class:`~openturns.Function`
-    Model :math:`g` such as :math:`\vect{Y} = g(\vect{X})`.
 distribution : :class:`~openturns.Distribution`
     Distribution of the random vector :math:`\vect{X}`
 adaptiveStrategy : :class:`~openturns.AdaptiveStrategy`
@@ -181,15 +175,20 @@ We keep all the polynomials of degree <= 4 (which corresponds to the 5 first one
 
 >>> adaptiveStrategy = ot.FixedStrategy(productBasis, indexMax)
 
-Define the evaluation strategy of the  coefficients:
+Define the design of experiments:
 
 >>> samplingSize = 50
->>> experiment = ot.MonteCarloExperiment(samplingSize)
->>> projectionStrategy = ot.LeastSquaresStrategy(experiment)
+>>> experiment = ot.MonteCarloExperiment(distribution, samplingSize)
+>>> X = experiment.generate()
+>>> Y = model(X)
+
+Define the evaluation strategy of the coefficients:
+
+>>> projectionStrategy = ot.LeastSquaresStrategy()
 
 Create the Functional Chaos Algorithm:
 
->>> algo = ot.FunctionalChaosAlgorithm(model, distribution, adaptiveStrategy,
+>>> algo = ot.FunctionalChaosAlgorithm(X, Y, distribution, adaptiveStrategy,
 ...                                    projectionStrategy)
 >>> algo.run()
 
@@ -200,10 +199,10 @@ Get the result:
 
 Test it:
 
->>> X = [0.5]
->>> print(model(X))
+>>> x = [0.5]
+>>> print(model(x))
 [0.239713]
->>> print(metamodel(X))
+>>> print(metamodel(x))
 [0.239514]"
 
 // ---------------------------------------------------------------------

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -39,16 +39,6 @@ metamodel : :class:`~openturns.Function`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::FunctionalChaosResult::getComposedModel
-"Get the composed model.
-
-Returns
--------
-composedModel : :class:`~openturns.Function`
-    :math:`f = g\circ T^{-1}`."
-
-// ---------------------------------------------------------------------
-
 %feature("docstring") OT::FunctionalChaosResult::getDistribution
 "Get the input distribution.
 

--- a/python/src/TensorApproximationResult_doc.i.in
+++ b/python/src/TensorApproximationResult_doc.i.in
@@ -39,16 +39,6 @@ metamodel : :class:`~openturns.Function`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::TensorApproximationResult::getComposedModel
-"Get the composed model.
-
-Returns
--------
-composedModel : :class:`~openturns.Function`
-    :math:`f = g\circ T^{-1}`."
-
-// ---------------------------------------------------------------------
-
 %feature("docstring") OT::TensorApproximationResult::getDistribution
 "Get the input distribution.
 


### PR DESCRIPTION
Rationale: FCA doesnt actually implement anything from a Function argument that cannot be done with the X/Y Sample counterparts.
This drops the Function argument from MetaModelResult/MetaModelAlgorithm ctors (we dont care about backwards compatibility there)
At the FunctionalChaosAlgorithm they are only deprecated (the attribute model_ has to stay until they are removed).