### PR TITLE
getSobolGroupedIndex does not document the marginal index

### DIFF
--- a/python/src/FunctionalChaosSobolIndices_doc.i.in
+++ b/python/src/FunctionalChaosSobolIndices_doc.i.in
@@ -94,14 +94,14 @@ Parameters
 i : int or sequence of int, :math:`0 \leq i < d - 1`
     Indice(s) of the variable(s) we want the associated Sobol indices. :math:`d`
     is the dimension of the input variables.
-out_marginal : int
-    Output marginal
-    Default value is 0
+marginalIndex : int
+    Output marginal index.
+    Default value is 0, i.e. the first output.
 
 Returns
 -------
 s : float
-    The Sobol indice."
+    The first order Sobol index."
 
 // ---------------------------------------------------------------------
 
@@ -113,14 +113,14 @@ Parameters
 i : int or sequence of int, :math:`0 \leq i < d - 1`
     Indice(s) of the variable(s) we want the associated total Sobol indices.
     :math:`d` is the dimension of the input variables.
-out_marginal : int
-    Output marginal
-    Default value is 0
+marginalIndex : int
+    Output marginal index.
+    Default value is 0, i.e. the first output.
 
 Returns
 -------
 s : float
-    The total Sobol indice."
+    The total Sobol index."
 
 // ---------------------------------------------------------------------
 
@@ -132,11 +132,14 @@ Parameters
 i : int or sequence of int, :math:`0 \leq i < d - 1`
     Indice(s) of the variable(s) we want the associated grouped Sobol indices.
     :math:`d` is the dimension of the input variables.
+marginalIndex : int
+    Output marginal index.
+    Default value is 0, i.e. the first output.
 
 Returns
 -------
 s : float
-    The grouped Sobol first order indice."
+    The grouped Sobol first order index."
 
 // ---------------------------------------------------------------------
 
@@ -148,11 +151,14 @@ Parameters
 i : int or sequence of int, :math:`0 \leq i < d - 1`
     Indice(s) of the variable(s) we want the associated grouped Sobol indices.
     :math:`d` is the dimension of the input variables.
+marginalIndex : int
+    Output marginal index.
+    Default value is 0, i.e. the first output.
 
 Returns
 -------
 s : float
-    The grouped Sobol total order indice."
+    The grouped Sobol total order index."
 
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
This PR documents the `FunctionalChaosSobolIndices` class.

The doc of the `getSobolIndex` and `getSobolTotalIndex` methods document the optional `out_marginal` input argument:

![image](https://user-images.githubusercontent.com/31351465/172647139-508b42e6-abf0-4758-97b5-f6393cb0d90f.png)

but `getSobolGroupedIndex` and `getSobolGroupedTotalIndex` methods do not:

![image](https://user-images.githubusercontent.com/31351465/172646845-25d069bc-099f-4f2a-8b45-d8f1f7b231d4.png)

This PR fixes that issue.
- Adds doc of `marginalIndex` for grouped Sobol' indices. 
- Uses consistent notations across the methods.