### PR TITLE
Gibbs-related stuff

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -485,6 +485,9 @@
   <GeneralizedParetoFactory-MaximumRelativeError    value_float="1.0e-10"        />
   <GeneralizedParetoFactory-MaximumEvaluationNumber value_int="1000" />
   <GeneralizedParetoFactory-SmallSize               value_int="20"   />
+
+  <!-- OT::Gibbs parameters -->
+  <Gibbs-DefaultUpdatingMethod       value_int="0"     />
   
   <!-- OT::InverseNormalFactory parameters -->
   <InverseNormalFactory-Method value_str="MLE" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1118,6 +1118,9 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("GeneralizedParetoFactory-MaximumEvaluationNumber", 1000);
   addAsUnsignedInteger("GeneralizedParetoFactory-SmallSize", 20);
 
+  // Gibbs parameters //
+  addAsUnsignedInteger("Gibbs-DefaultUpdatingMethod", 0);
+
   // InverseNormalFactory parameters //
   addAsString("InverseNormalFactory-Method", "MLE");
 

--- a/lib/src/Uncertainty/Bayesian/Gibbs.cxx
+++ b/lib/src/Uncertainty/Bayesian/Gibbs.cxx
@@ -23,6 +23,7 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Log.hxx"
 #include "openturns/SpecFunc.hxx"
+#include "openturns/RandomGenerator.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -40,9 +41,11 @@ Gibbs::Gibbs()
 
 
 /* Parameters constructor */
-Gibbs::Gibbs(const MetropolisHastingsCollection & samplers)
+Gibbs::Gibbs(const MetropolisHastingsCollection & samplers, const Bool isOrderRandom)
   : RandomVectorImplementation()
   , samplers_(samplers)
+  , isOrderRandom_(isOrderRandom)
+  , previouslyChosenSampler_(samplers.getSize()) // no sampler has that index
 {
   if (!samplers.getSize())
     throw InvalidArgumentException(HERE) << "Gibbs samplers list cannot be empty";
@@ -63,7 +66,8 @@ String Gibbs::__repr__() const
   return OSS() << "class=" << Gibbs::GetClassName()
          << " name=" << getName()
          << " derived from " << RandomVectorImplementation::__repr__()
-         << " samplers=" << samplers_;
+         << " samplers=" << samplers_
+         << " isOrderRandom=" << isOrderRandom_;
 }
 
 
@@ -76,6 +80,47 @@ UnsignedInteger Gibbs::getDimension() const
 {
   return currentState_.getDimension();
 }
+
+// Sequentially sample from the MH blocks
+void Gibbs::computeRealizationSequential() const
+{
+    for (UnsignedInteger j = 0; j < samplers_.getSize(); ++ j)
+    {
+      // get the current state from the previous sampler
+      samplers_[j].getImplementation()->currentState_ = currentState_;
+      if (recomputeLogPosterior_[j])
+        currentLogPosterior_ = samplers_[j].computeLogPosterior(currentState_);
+      samplers_[j].getImplementation()->currentLogPosterior_ = currentLogPosterior_;
+
+      // pass the current state to the next sampler
+      currentState_ = samplers_[j].getRealization();
+      currentLogPosterior_ = samplers_[j].getImplementation()->currentLogPosterior_;
+    }
+}
+
+// Sample from a randomly chosen MH block
+void Gibbs::computeRealizationRandomOrder() const
+{
+  // randomly choose the sampler
+  const UnsignedInteger chosenSampler = RandomGenerator::IntegerGenerate(samplers_.getSize());
+
+  if (chosenSampler != previouslyChosenSampler_)
+  {
+    // get the current state from the previous sampler
+    samplers_[chosenSampler].getImplementation()->currentState_ = currentState_;
+    if (recomputeLogPosterior_[chosenSampler])
+      currentLogPosterior_ = samplers_[chosenSampler].computeLogPosterior(currentState_);
+    samplers_[chosenSampler].getImplementation()->currentLogPosterior_ = currentLogPosterior_;
+  }
+
+  // pass the current state to the next sampler
+  currentState_ = samplers_[chosenSampler].getRealization();
+  currentLogPosterior_ = samplers_[chosenSampler].getImplementation()->currentLogPosterior_;
+
+  // store chosenSampler for the next iteration
+  previouslyChosenSampler_ = chosenSampler;
+}
+
 
 Point Gibbs::getRealization() const
 {
@@ -104,22 +149,29 @@ Point Gibbs::getRealization() const
     recomputeLogPosterior_ = Indices(nbSamplers);
     for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
       recomputeLogPosterior_[j] = (lp[j] != lp[(j + nbSamplers - 1) % nbSamplers]) ? 1 : 0;
-  }
+    if (isOrderRandom_) // if one of the blocks needs to recompute the log posterior, then all do
+    {
+      Bool recompute = false;
+      for (UnsignedInteger j = 0; j < nbSamplers; ++j)
+        if (recomputeLogPosterior_[j]) recompute = true;
+      if (recompute)
+      {
+        for (UnsignedInteger j = 0; j < nbSamplers; ++j)
+            recomputeLogPosterior_[j] = true;
+      }
+    } // random order  
+}
 
   // for each new sample
   for (UnsignedInteger i = 0; i < size; ++ i)
   {
-    for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
+    if (isOrderRandom_)
     {
-      // get the current state from the previous sampler
-      samplers_[j].getImplementation()->currentState_ = currentState_;
-      if (recomputeLogPosterior_[j])
-        currentLogPosterior_ = samplers_[j].computeLogPosterior(currentState_);
-      samplers_[j].getImplementation()->currentLogPosterior_ = currentLogPosterior_;
-
-      // pass the current state to the next sampler
-      currentState_ = samplers_[j].getRealization();
-      currentLogPosterior_ = samplers_[j].getImplementation()->currentLogPosterior_;
+      computeRealizationRandomOrder();
+    }
+    else
+    {
+      computeRealizationSequential();
     }
   }
   samplesNumber_ += size;
@@ -134,6 +186,22 @@ Point Gibbs::getRealization() const
 Gibbs::MetropolisHastingsCollection Gibbs::getMetropolisHastingsCollection() const
 {
   return samplers_;
+}
+
+/* Is order random accessors */
+void Gibbs::setIsOrderRandom(const Bool isOrderRandom)
+{
+  if (isOrderRandom != isOrderRandom_) // reset
+  {
+    samplesNumber_ = 0;
+    previouslyChosenSampler_ = samplers_.getSize(); // no sampler has that index
+  }
+  isOrderRandom_ = isOrderRandom;
+}
+
+Bool Gibbs::getIsOrderRandom() const
+{
+  return isOrderRandom_;
 }
 
 void Gibbs::setBurnIn(const UnsignedInteger burnIn)
@@ -182,6 +250,8 @@ void Gibbs::save(Advocate & adv) const
 {
   RandomVectorImplementation::save(adv);
   adv.saveAttribute("samplers_", samplers_);
+  adv.saveAttribute("isOrderRandom_", isOrderRandom_);
+  adv.saveAttribute("previouslyChosenSampler_", previouslyChosenSampler_);
   adv.saveAttribute("currentState_", currentState_);
   adv.saveAttribute("burnIn_", burnIn_);
   adv.saveAttribute("thinning_", thinning_);
@@ -192,6 +262,8 @@ void Gibbs::load(Advocate & adv)
 {
   RandomVectorImplementation::load(adv);
   adv.loadAttribute("samplers_", samplers_);
+  adv.loadAttribute("isOrderRandom_", isOrderRandom_);
+  adv.loadAttribute("previouslyChosenSampler_", previouslyChosenSampler_);
   adv.loadAttribute("currentState_", currentState_);
   adv.loadAttribute("burnIn_", burnIn_);
   adv.loadAttribute("thinning_", thinning_);

--- a/lib/src/Uncertainty/Bayesian/Gibbs.cxx
+++ b/lib/src/Uncertainty/Bayesian/Gibbs.cxx
@@ -79,13 +79,15 @@ UnsignedInteger Gibbs::getDimension() const
 
 Point Gibbs::getRealization() const
 {
+  const UnsignedInteger nbSamplers = samplers_.getSize();
+
   // perform burnin if necessary
   const UnsignedInteger size = getThinning() + ((samplesNumber_ < getBurnIn()) ? getBurnIn() : 0);
 
   // check the first log-posterior
   if (samplesNumber_ == 0)
   {
-    for (UnsignedInteger j = 0; j < samplers_.getSize(); ++ j)
+    for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
     {
       const Scalar currentLogPosterior = samplers_[j].computeLogPosterior(samplers_[j].getImplementation()->currentState_);
       if (currentLogPosterior <= SpecFunc::LowestScalar)
@@ -96,18 +98,18 @@ Point Gibbs::getRealization() const
   // see which components will need to recompute the posterior
   if (samplesNumber_ == 0)
   {
-    Point lp(getDimension());
-    for (UnsignedInteger j = 0; j < samplers_.getSize(); ++ j)
+    Point lp(nbSamplers);
+    for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
       lp[j] = samplers_[j].computeLogPosterior(samplers_[j].getImplementation()->currentState_);
-    recomputeLogPosterior_ = Indices(getDimension());
-    for (UnsignedInteger j = 0; j < samplers_.getSize(); ++ j)
-      recomputeLogPosterior_[j] = (lp[j] != lp[(j + getDimension() - 1) % getDimension()]) ? 1 : 0;
+    recomputeLogPosterior_ = Indices(nbSamplers);
+    for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
+      recomputeLogPosterior_[j] = (lp[j] != lp[(j + nbSamplers - 1) % nbSamplers]) ? 1 : 0;
   }
 
   // for each new sample
   for (UnsignedInteger i = 0; i < size; ++ i)
   {
-    for (UnsignedInteger j = 0; j < samplers_.getSize(); ++ j)
+    for (UnsignedInteger j = 0; j < nbSamplers; ++ j)
     {
       // get the current state from the previous sampler
       samplers_[j].getImplementation()->currentState_ = currentState_;

--- a/lib/src/Uncertainty/Bayesian/openturns/Gibbs.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/Gibbs.hxx
@@ -45,7 +45,7 @@ public:
   Gibbs();
 
   /** Constructor with parameters*/
-  Gibbs(const MetropolisHastingsCollection & samplers, const Bool isOrderRandom = false);
+  Gibbs(const MetropolisHastingsCollection & samplers);
 
   /** String converter */
   String __repr__() const override;
@@ -57,10 +57,6 @@ public:
 
   /** Samplers accessor */
   MetropolisHastingsCollection getMetropolisHastingsCollection() const;
-
-  /** Is order random accessors */
-  void setIsOrderRandom(const Bool isOrderRandom);
-  Bool getIsOrderRandom() const;
 
   /** Burnin accessor */
   void setBurnIn(const UnsignedInteger burnIn);
@@ -79,6 +75,11 @@ public:
   /** Dimension accessor */
   UnsignedInteger getDimension() const override;
 
+  /** Sampling method accessors */
+  enum UpdatingMethod { DETERMINISTIC_UPDATING, RANDOM_UPDATING };
+  void setUpdatingMethod(const UpdatingMethod updatingMethod);
+  UpdatingMethod getUpdatingMethod() const;
+
   /** Propose a new point in the chain */
   Point getRealization() const override;
 
@@ -91,10 +92,10 @@ public:
 
 protected:
   // Sequentially sample from the MH blocks
-  void computeRealizationSequential() const;
+  void computeRealizationDeterministicUpdating() const;
 
   // Sample from a randomly chosen MH block
-  void computeRealizationRandomOrder() const;
+  void computeRealizationRandomUpdating() const;
 
   mutable Point currentState_;
   mutable HistoryStrategy history_;
@@ -106,11 +107,11 @@ private:
   // collection of MH samplers
   MetropolisHastingsPersistentCollection samplers_;
 
-  // are MH samplers randomly called
-  Bool isOrderRandom_;
+  // sampling method: determines in which order the MH samplers are called
+  UnsignedInteger updatingMethod_ = 0;
 
-  // which MH sampler was previously called (used when isOrderRandom_ is true)
-  mutable UnsignedInteger previouslyChosenSampler_;
+  // which MH sampler was previously called (used when updatingMethod_ is RANDOM_UPDATING)
+  mutable UnsignedInteger previouslyChosenSampler_ = 0;
 
   // number of first samples discarded to reach stationary regime
   UnsignedInteger burnIn_ = 0;

--- a/lib/src/Uncertainty/Bayesian/openturns/Gibbs.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/Gibbs.hxx
@@ -45,7 +45,7 @@ public:
   Gibbs();
 
   /** Constructor with parameters*/
-  Gibbs(const MetropolisHastingsCollection & samplers);
+  Gibbs(const MetropolisHastingsCollection & samplers, const Bool isOrderRandom = false);
 
   /** String converter */
   String __repr__() const override;
@@ -57,6 +57,10 @@ public:
 
   /** Samplers accessor */
   MetropolisHastingsCollection getMetropolisHastingsCollection() const;
+
+  /** Is order random accessors */
+  void setIsOrderRandom(const Bool isOrderRandom);
+  Bool getIsOrderRandom() const;
 
   /** Burnin accessor */
   void setBurnIn(const UnsignedInteger burnIn);
@@ -86,6 +90,12 @@ public:
   HistoryStrategy getHistory() const;
 
 protected:
+  // Sequentially sample from the MH blocks
+  void computeRealizationSequential() const;
+
+  // Sample from a randomly chosen MH block
+  void computeRealizationRandomOrder() const;
+
   mutable Point currentState_;
   mutable HistoryStrategy history_;
 
@@ -95,6 +105,12 @@ private:
 
   // collection of MH samplers
   MetropolisHastingsPersistentCollection samplers_;
+
+  // are MH samplers randomly called
+  Bool isOrderRandom_;
+
+  // which MH sampler was previously called (used when isOrderRandom_ is true)
+  mutable UnsignedInteger previouslyChosenSampler_;
 
   // number of first samples discarded to reach stationary regime
   UnsignedInteger burnIn_ = 0;

--- a/lib/src/Uncertainty/Bayesian/openturns/OTBayesian.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/OTBayesian.hxx
@@ -31,6 +31,7 @@
 #include "openturns/GaussianNonLinearCalibration.hxx"
 #include "openturns/MetropolisHastingsImplementation.hxx"
 #include "openturns/RandomWalkMetropolisHastings.hxx"
+#include "openturns/RandomVectorMetropolisHastings.hxx"
 #include "openturns/IndependentMetropolisHastings.hxx"
 #include "openturns/Gibbs.hxx"
 

--- a/lib/test/t_Gibbs_regression.cxx
+++ b/lib/test/t_Gibbs_regression.cxx
@@ -167,6 +167,22 @@ int main(int, char *[])
     std::cout << "covariance=" << x_cov << std::endl;
     std::cout << "expected covariance=" << Qn_inv << std::endl;
     assert_almost_equal(x_cov, Qn_inv, 1e-3, 2e-2);
+
+    // check log-pdf is recomputed by the correct blocks
+    const Point initialState({0.5, 0.5, 0.5, 0.5});
+    RandomVectorMetropolisHastings rvmh1(RandomVector(Dirac({0.5, 0.5})), initialState, Indices({0, 1}));
+    RandomVectorMetropolisHastings rvmh2(RandomVector(Uniform(0.0, 1.0)), initialState, Indices({2}));
+    RandomWalkMetropolisHastings rwmh(SymbolicFunction({"x", "y", "z", "t"}, {"1"}), Interval(4), initialState, Uniform(), Indices({3}));
+    Gibbs::MetropolisHastingsCollection coll2;
+    coll2.add(rvmh1);
+    coll2.add(rvmh2);
+    coll2.add(rwmh);
+    Gibbs gibbs(coll2);
+    gibbs.getRealization();
+    Indices recompute(gibbs.getRecomputeLogPosterior());
+    assert_almost_equal(recompute[0], 1);
+    assert_almost_equal(recompute[1], 0);
+    assert_almost_equal(recompute[2], 1);
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_Gibbs_regression.cxx
+++ b/lib/test/t_Gibbs_regression.cxx
@@ -183,6 +183,28 @@ int main(int, char *[])
     assert_almost_equal(recompute[0], 1);
     assert_almost_equal(recompute[1], 0);
     assert_almost_equal(recompute[2], 1);
+    gibbs.setIsOrderRandom(true);
+    gibbs.getRealization();
+    recompute = gibbs.getRecomputeLogPosterior();
+    assert_almost_equal(recompute[0], 1);
+    assert_almost_equal(recompute[1], 1);
+    assert_almost_equal(recompute[2], 1);
+
+    // Check all blocks are called equally often under the random order option.
+    // Here there are 3 blocks:
+    // 1) a Dirac RandomVectorMetropolisHastings -- never moves
+    // 2) a Uniform RandomVectorMetropolisHastings -- always moves
+    // 3) a RandomWalkMetropolisHastings with average acceptance probability 1/2
+    // If 1) is selected or 3) is selected and the proposal is rejected, the chain does not move
+    // This happens with probability 1/3 + 1/3 * 1/2 = 1/2.
+    sample = gibbs.getSample(10000);
+    UnsignedInteger count_nomove = 0;
+    for ( UnsignedInteger j = 1; j < sample.getSize(); ++j )
+    {
+      if (sample[j] == sample[j-1]) count_nomove++;
+    }
+    const Scalar frequency_nomove = (Scalar)count_nomove / (Scalar)sample.getSize();
+    assert_almost_equal(frequency_nomove, 0.5, 0.02, 0.0);
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_Gibbs_regression.cxx
+++ b/lib/test/t_Gibbs_regression.cxx
@@ -183,7 +183,7 @@ int main(int, char *[])
     assert_almost_equal(recompute[0], 1);
     assert_almost_equal(recompute[1], 0);
     assert_almost_equal(recompute[2], 1);
-    gibbs.setIsOrderRandom(true);
+    gibbs.setUpdatingMethod(Gibbs::UpdatingMethod::RANDOM_UPDATING);
     gibbs.getRealization();
     recompute = gibbs.getRecomputeLogPosterior();
     assert_almost_equal(recompute[0], 1);

--- a/python/src/Gibbs_doc.i.in
+++ b/python/src/Gibbs_doc.i.in
@@ -8,13 +8,23 @@ Parameters
 samplers : sequence of :class:`~openturns.MetropolisHastings`
     List of samplers for each bloc of the chain
 
+isOrderRandom : bool, optional
+    If False (default), the samplers are sequentially called in the given order.
+    If True, one of the samplers is randomly selected to produce the next realization.
+
 Notes
 -----
 Assume we want to sample from a complicated joint distribution.
 The Gibbs algorithm is a Markov Chain Monte-Carlo algorithm
-which sequentially calls samplers
-(implemented as :class:`MetropolisHastings` objects)
-of the conditional distributions of one or several components.
+which calls samplers (implemented as :class:`MetropolisHastings` objects)
+in a predetermined sequence (by default)
+or randomly (if *isOrderRandom* is set to True).
+Each sampler samples from the conditional distributions of one or several components.
+
+Note that under the default behavior (*isOrderRandom* is False),
+all samplers are called in the specified order every time :meth:`getRealization` is called.
+By contrast, when *isOrderRandom* is True, only one sampler is called
+by :meth:`getRealization`, and this sampler is randomly chosen among all specified samplers.
 
 See Also
 --------
@@ -47,7 +57,7 @@ Examples
 >>> linkFunction = ot.ParametricFunction(fullModel, parametersSet, parametersValue)
 >>> # Calibration parameters
 >>> # Proposal distribution
->>> proposal = ot.Uniform(-1.0, 1.0)
+>>> prop = ot.Uniform(-1.0, 1.0)
 >>> # Prior distribution
 >>> sigma0 = [10.0]*chainDim
 >>> #  Covariance matrix
@@ -60,13 +70,16 @@ Examples
 >>> # Conditional distribution y~N(z, 1.0)
 >>> conditional = ot.Normal()
 >>> # Create a Gibbs sampler
->>> mh_coll = [ot.RandomWalkMetropolisHastings(prior, mu0, proposal, [i]) for i in range(chainDim)]
->>> for mh in mh_coll: mh.setLikelihood(conditional, y_obs, linkFunction, covariates)
->>> sampler = ot.Gibbs(mh_coll)
+>>> coll = [ot.RandomWalkMetropolisHastings(prior, mu0, prop, [i]) for i in range(chainDim)]
+>>> for mh in coll: mh.setLikelihood(conditional, y_obs, linkFunction, covariates)
+>>> sampler = ot.Gibbs(coll)
 >>> sampler.setBurnIn(20)
 >>> sampler.setThinning(10)
 >>> # Get a realization
->>> mu = sampler.getRealization()"
+>>> mu = sampler.getRealization()
+>>> # Create a Gibbs sampler which updates one randomly chosen component at each step
+>>> sampler2 = ot.Gibbs(coll, True)
+>>> mu2 = sampler2.getRealization()"
 
 // ---------------------------------------------------------------------
 
@@ -87,6 +100,28 @@ Returns
 -------
 samplers : sequence of :class:`MetropolisHastings`
     List of all Metropolis-Hastings samplers used in the Gibbs algorithm"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Gibbs::getIsOrderRandom
+"Get whether the samplers are randomly chosen.
+
+Returns
+-------
+isOrderRandom : bool
+    If False, the samplers are sequentially called in the given order.
+    If True, one of the samplers is randomly selected to produce the next realization."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Gibbs::setIsOrderRandom
+"Set whether the samplers are randomly chosen.
+
+Parameters
+----------
+isOrderRandom : bool
+    If False, the samplers are sequentially called in the given order.
+    If True, one of the samplers is randomly selected to produce the next realization."
 
 // ---------------------------------------------------------------------
 

--- a/python/src/Gibbs_doc.i.in
+++ b/python/src/Gibbs_doc.i.in
@@ -8,23 +8,16 @@ Parameters
 samplers : sequence of :class:`~openturns.MetropolisHastings`
     List of samplers for each bloc of the chain
 
-isOrderRandom : bool, optional
-    If False (default), the samplers are sequentially called in the given order.
-    If True, one of the samplers is randomly selected to produce the next realization.
-
 Notes
 -----
 Assume we want to sample from a complicated joint distribution.
 The Gibbs algorithm is a Markov Chain Monte-Carlo algorithm
-which calls samplers (implemented as :class:`MetropolisHastings` objects)
+which calls samplers (implemented as :class:`~openturns.MetropolisHastings` objects)
 in a predetermined sequence (by default)
-or randomly (if *isOrderRandom* is set to True).
+or randomly: see :meth:`setUpdatingMethod` to manually choose the behavior,
+and note the default behavior can be changed by setting the
+`Gibbs-DefaultUpdatingMethod` :class:`~openturns.ResourceMap` key.
 Each sampler samples from the conditional distributions of one or several components.
-
-Note that under the default behavior (*isOrderRandom* is False),
-all samplers are called in the specified order every time :meth:`getRealization` is called.
-By contrast, when *isOrderRandom* is True, only one sampler is called
-by :meth:`getRealization`, and this sampler is randomly chosen among all specified samplers.
 
 See Also
 --------
@@ -78,7 +71,8 @@ Examples
 >>> # Get a realization
 >>> mu = sampler.getRealization()
 >>> # Create a Gibbs sampler which updates one randomly chosen component at each step
->>> sampler2 = ot.Gibbs(coll, True)
+>>> sampler2 = ot.Gibbs(coll)
+>>> sampler2.setUpdatingMethod(ot.Gibbs.RANDOM_UPDATING)
 >>> mu2 = sampler2.getRealization()"
 
 // ---------------------------------------------------------------------
@@ -103,25 +97,42 @@ samplers : sequence of :class:`MetropolisHastings`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::Gibbs::getIsOrderRandom
-"Get whether the samplers are randomly chosen.
+%feature("docstring") OT::Gibbs::getUpdatingMethod
+"Get how the order of the samplers is determined.
+
+Available values are:
+
+  * 0 (Gibbs.DETERMINISTIC_UPDATING): the samplers are sequentially called in the given order.
+
+  * 1 (Gibbs.RANDOM_UPDATING): one of the samplers is randomly selected to produce the next realization.
+
+Refer to the :meth:`setUpdatingMethod` documentation for details.
 
 Returns
 -------
-isOrderRandom : bool
-    If False, the samplers are sequentially called in the given order.
-    If True, one of the samplers is randomly selected to produce the next realization."
+updatingMethod : int
+    See above for the possible values and their meaning."
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::Gibbs::setIsOrderRandom
-"Set whether the samplers are randomly chosen.
+%feature("docstring") OT::Gibbs::setUpdatingMethod
+"Set how the order of the samplers is determined.
+
+Available values are:
+
+  * 0 (Gibbs.DETERMINISTIC_UPDATING): the samplers are sequentially called in the given order.
+
+  * 1 (Gibbs.RANDOM_UPDATING): one of the samplers is randomly selected to produce the next realization.
+
+Note that under DETERMINISTIC_UPDATING,
+all samplers are called in the specified order every time :meth:`getRealization` is called.
+By contrast, under RANDOM_UPDATING, only one sampler is called
+by :meth:`getRealization`, and this sampler is randomly chosen among all specified samplers.
 
 Parameters
 ----------
-isOrderRandom : bool
-    If False, the samplers are sequentially called in the given order.
-    If True, one of the samplers is randomly selected to produce the next realization."
+updatingMethod : int
+    See above for the possible values and their meaning."
 
 // ---------------------------------------------------------------------
 

--- a/python/test/t_Gibbs_std.py
+++ b/python/test/t_Gibbs_std.py
@@ -202,7 +202,7 @@ rwmh = ot.RandomWalkMetropolisHastings(
 gibbs = ot.Gibbs([rvmh1, rvmh2, rwmh])
 gibbs.getRealization()
 assert gibbs.getRecomputeLogPosterior() == [1, 0, 1]
-gibbs.setIsOrderRandom(True)
+gibbs.setUpdatingMethod(ot.Gibbs.RANDOM_UPDATING)
 gibbs.getRealization()
 assert gibbs.getRecomputeLogPosterior() == [1, 1, 1]
 

--- a/python/test/t_Gibbs_std.py
+++ b/python/test/t_Gibbs_std.py
@@ -164,3 +164,12 @@ stddev = sample.computeStandardDeviation()
 print(mean, stddev)
 ott.assert_almost_equal(mean, [-0.015835, 0.169951, 20])
 ott.assert_almost_equal(stddev, [0.956516, 1.05469, 0])
+
+# check log-pdf is recomputed by the correct blocks
+initialState = [0.5] * 4
+rvmh1 = ot.RandomVectorMetropolisHastings(ot.RandomVector(ot.Dirac([0.5] * 2)), initialState, [0,1])
+rvmh2 = ot.RandomVectorMetropolisHastings(ot.RandomVector(ot.Uniform(0.0, 1.0)), initialState, [2])
+rwmh = ot.RandomWalkMetropolisHastings(ot.SymbolicFunction(["x", "y", "z", "t"], ["1"]), ot.Interval(4), initialState, ot.Uniform(), [3])
+gibbs = ot.Gibbs([rvmh1, rvmh2, rwmh])
+gibbs.getRealization()
+assert gibbs.getRecomputeLogPosterior() == [1, 0, 1]

--- a/python/test/t_Gibbs_std.py
+++ b/python/test/t_Gibbs_std.py
@@ -18,7 +18,7 @@ ot.TESTPREAMBLE()
 
 # observations
 size = 10
-realDist = ot.Normal(31., 1.2)
+realDist = ot.Normal(31.0, 1.2)
 
 data = realDist.getSample(size)
 
@@ -27,7 +27,7 @@ mean_instrumental = ot.Uniform(-2.0, 2.0)
 std_instrumental = ot.Uniform(-2.0, 2.0)
 
 # prior distribution
-mu0 = 25.
+mu0 = 25.0
 
 sigma0s = [0.1, 1.0]
 # sigma0s.append(2.0)
@@ -51,28 +51,29 @@ for i in range(len(sigma0s)):
 
     # create a Gibbs sampler
     mean_sampler = ot.RandomWalkMetropolisHastings(
-        prior, initialState, mean_instrumental, [0])
+        prior, initialState, mean_instrumental, [0]
+    )
     mean_sampler.setLikelihood(conditional, data)
     std_sampler = ot.RandomWalkMetropolisHastings(
-        prior, initialState, std_instrumental, [1])
+        prior, initialState, std_instrumental, [1]
+    )
     std_sampler.setLikelihood(conditional, data)
     sampler = ot.Gibbs([mean_sampler, std_sampler])
     sampler.setThinning(2)
     sampler.setBurnIn(500)
     realization = sampler.getRealization()
 
-    sigmay = ot.ConditionalDistribution(
-        ot.Normal(), prior).getStandardDeviation()[0]
-    w = size * sigma0 ** 2. / (size * sigma0 ** 2. + sigmay ** 2.0)
+    sigmay = ot.ConditionalDistribution(ot.Normal(), prior).getStandardDeviation()[0]
+    w = size * sigma0 ** 2.0 / (size * sigma0 ** 2.0 + sigmay ** 2.0)
 
-    print("prior variance= %.12g" % (sigma0 ** 2.))
+    print("prior variance= %.12g" % (sigma0 ** 2.0))
     print("  realization=", realization)
 
     print("  w= %.12g" % w)
 
     # the posterior for mu is analytical
-    mu_exp = (w * data.computeMean()[0] + (1. - w) * mu0)
-    sigma_exp = ((w * sigmay ** 2.0 / size) ** 0.5)
+    mu_exp = w * data.computeMean()[0] + (1.0 - w) * mu0
+    sigma_exp = (w * sigmay ** 2.0 / size) ** 0.5
     print("  expected posterior ~N( %.6g" % mu_exp, ",  %.6g" % sigma_exp, ")")
 
     # try to generate a sample
@@ -84,8 +85,10 @@ for i in range(len(sigma0s)):
     ott.assert_almost_equal(x_mu, mu_exp, 2e-1, 1e-1)
     ott.assert_almost_equal(x_sigma, sigma_exp, 1e-2, 1e-1)
 
-    print('acceptance rate=', [mh.getAcceptanceRate()
-                               for mh in sampler.getMetropolisHastingsCollection()])
+    print(
+        "acceptance rate=",
+        [mh.getAcceptanceRate() for mh in sampler.getMetropolisHastingsCollection()],
+    )
 
 
 # improper prior
@@ -105,12 +108,12 @@ class CensoredWeibull(ot.PythonDistribution):
         self.alpha = alpha
 
     def getRange(self):
-        return ot.Interval([0, 0], [1, 1], [True]*2, [False, True])
+        return ot.Interval([0, 0], [1, 1], [True] * 2, [False, True])
 
     def computeLogPDF(self, x):
         if not (self.alpha > 0.0 and self.beta > 0.0):
-            return float('-inf')
-        log_pdf = -(x[0] / self.beta)**self.alpha
+            return float("-inf")
+        log_pdf = -((x[0] / self.beta) ** self.alpha)
         log_pdf += (self.alpha - 1) * m.log(x[0] / self.beta) * x[1]
         log_pdf += m.log(self.alpha / self.beta) * x[1]
         return log_pdf
@@ -124,35 +127,51 @@ class CensoredWeibull(ot.PythonDistribution):
 
 
 conditional = ot.Distribution(CensoredWeibull())
-x = ot.Sample([[4380, 1], [1791, 1], [1611, 1], [1291, 1], [6132, 0], [
-              5694, 0], [5296, 0], [4818, 0], [4818, 0], [4380, 0]])
-logpdf = ot.SymbolicFunction(['beta', 'alpha'], ['-log(beta)'])
+x = ot.Sample(
+    [
+        [4380, 1],
+        [1791, 1],
+        [1611, 1],
+        [1291, 1],
+        [6132, 0],
+        [5694, 0],
+        [5296, 0],
+        [4818, 0],
+        [4818, 0],
+        [4380, 0],
+    ]
+)
+logpdf = ot.SymbolicFunction(["beta", "alpha"], ["-log(beta)"])
 support = ot.Interval([0] * 2, [1] * 2)
 support.setFiniteUpperBound([False] * 2)
 initialState = [1.0, 1.0]
 rwmh_beta = ot.RandomWalkMetropolisHastings(
-    logpdf, support, initialState, ot.Normal(0., 10000.0), [0])
+    logpdf, support, initialState, ot.Normal(0.0, 10000.0), [0]
+)
 rwmh_beta.setLikelihood(conditional, x)
 rwmh_alpha = ot.RandomWalkMetropolisHastings(
-    logpdf, support, initialState, ot.Normal(0., 0.5), [1])
+    logpdf, support, initialState, ot.Normal(0.0, 0.5), [1]
+)
 rwmh_alpha.setLikelihood(conditional, x)
 gibbs = ot.Gibbs([rwmh_beta, rwmh_alpha])
 sample = gibbs.getSample(1000)
-print('mu=', sample.computeMean())
-print('sigma=', sample.computeStandardDeviation())
+print("mu=", sample.computeMean())
+print("sigma=", sample.computeStandardDeviation())
 
 
 # check recompute indices, update bug
 initial_state = [0.0, 0.0, 20.0]
 target = ot.Normal(3)
-weird_target = ot.ComposedDistribution(
-    [ot.Normal(), ot.Normal(), ot.Dirac(20.0)])
+weird_target = ot.ComposedDistribution([ot.Normal(), ot.Normal(), ot.Dirac(20.0)])
 normal0_rwmh = ot.RandomWalkMetropolisHastings(
-    target, initial_state, ot.Uniform(-10, 10), [0])  # samples from Normal(0,1)
+    target, initial_state, ot.Uniform(-10, 10), [0]
+)  # samples from Normal(0,1)
 normal1_rwmh = ot.RandomWalkMetropolisHastings(
-    target, initial_state, ot.Uniform(-10, 10), [1])  # samples from Normal(0,1)
+    target, initial_state, ot.Uniform(-10, 10), [1]
+)  # samples from Normal(0,1)
 dirac_rwmh = ot.RandomWalkMetropolisHastings(
-    weird_target, initial_state, ot.Normal(), [2])     # samples from Dirac(20)
+    weird_target, initial_state, ot.Normal(), [2]
+)  # samples from Dirac(20)
 # samples from Normal(0,1) x Normal(0,1) x Dirac(20)
 gibbs = ot.Gibbs([normal0_rwmh, normal1_rwmh, dirac_rwmh])
 sample = gibbs.getSample(1000)
@@ -167,9 +186,36 @@ ott.assert_almost_equal(stddev, [0.956516, 1.05469, 0])
 
 # check log-pdf is recomputed by the correct blocks
 initialState = [0.5] * 4
-rvmh1 = ot.RandomVectorMetropolisHastings(ot.RandomVector(ot.Dirac([0.5] * 2)), initialState, [0,1])
-rvmh2 = ot.RandomVectorMetropolisHastings(ot.RandomVector(ot.Uniform(0.0, 1.0)), initialState, [2])
-rwmh = ot.RandomWalkMetropolisHastings(ot.SymbolicFunction(["x", "y", "z", "t"], ["1"]), ot.Interval(4), initialState, ot.Uniform(), [3])
+rvmh1 = ot.RandomVectorMetropolisHastings(
+    ot.RandomVector(ot.Dirac([0.5] * 2)), initialState, [0, 1]
+)
+rvmh2 = ot.RandomVectorMetropolisHastings(
+    ot.RandomVector(ot.Uniform(0.0, 1.0)), initialState, [2]
+)
+rwmh = ot.RandomWalkMetropolisHastings(
+    ot.SymbolicFunction(["x", "y", "z", "t"], ["1"]),
+    ot.Interval(4),
+    initialState,
+    ot.Uniform(),
+    [3],
+)
 gibbs = ot.Gibbs([rvmh1, rvmh2, rwmh])
 gibbs.getRealization()
 assert gibbs.getRecomputeLogPosterior() == [1, 0, 1]
+gibbs.setIsOrderRandom(True)
+gibbs.getRealization()
+assert gibbs.getRecomputeLogPosterior() == [1, 1, 1]
+
+# Check all blocks are called equally often under the random order option.
+# Here there are 3 blocks:
+# 1) a Dirac RandomVectorMetropolisHastings -- never moves
+# 2) a Uniform RandomVectorMetropolisHastings -- always moves
+# 3) a RandomWalkMetropolisHastings with average acceptance probability 1/2
+# If 1) is selected or 3) is selected and the proposal is rejected, the chain does not move
+# This happens with probability 1/3 + 1/3 * 1/2 = 1/2.
+sample = gibbs.getSample(10000)
+diffs = sample[1:] - sample[:-1]
+zeros = ot.Point(4)
+null_diffs = [point == zeros for point in diffs]
+frequency_nomove = sum(null_diffs) / len(null_diffs)
+ott.assert_almost_equal(frequency_nomove, 0.5, 0.02, 0.0)


### PR DESCRIPTION
### Bug fix

Fixes a bug that could cause an error in the detection of samplers which do not need to recompute the log-posterior density in the case where the overall dimension differs from the number of samplers.

### Enhancement

Add the option to randomly pick the next MetropolisHastings block to sample from instead of using the specified order. This variant is actually the original Gibbs algorithm.