### PR TITLE
Modification of parameters name of PythonFunction to be consistent with the documentation

### DIFF
--- a/python/src/Function.i
+++ b/python/src/Function.i
@@ -383,10 +383,10 @@ class PythonFunction(Function):
     [[  3 ]
      [ -1 ]]
     """
-    def __new__(self, n, p, func=None, func_sample=None, gradient=None, hessian=None, n_cpus=None, copy=False, functionLinearity=None, variablesLinearity=None):
+    def __new__(self, inputDim, outputDim, func=None, func_sample=None, gradient=None, hessian=None, n_cpus=None, copy=False, functionLinearity=None, variablesLinearity=None):
         if func is None and func_sample is None:
             raise RuntimeError('no func nor func_sample given.')
-        instance = OpenTURNSPythonFunction(n, p)
+        instance = OpenTURNSPythonFunction(inputDim, outputDim)
         if copy:
             instance._discard_openturns_memoryview = True
 


### PR DESCRIPTION
Hello,

In the doc of PythonFunction, the two first parameters are indicated as "n" and "p" in the signature of the class `class PythonFunction(n, p, func=None, func_sample=None, gradient=None, hessian=None, n_cpus=None, copy=False, functionLinearity=None, variablesLinearity=None)` whereas they are specified as `inputDim` and `outputDim` in the description of parameters. This pull request proposes to make the two consistent.
https://openturns.github.io/openturns/latest/user_manual/_generated/openturns.PythonFunction.html
