### PR TITLE
Modification of NAIS default rhoQuantile parameter

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -689,7 +689,7 @@
   <DirectionalSampling-MeanContributionIntegrationNodesNumber value_int="255" />
 
   <!-- OT::NAIS parameters -->
-  <NAIS-DefaultrhoQuantile value_float="0.25" />
+  <NAIS-DefaultRhoQuantile value_float="0.25" />
 
   <!-- OT::AdaptiveDirectionalStratification parameters -->
   <AdaptiveDirectionalStratification-DefaultGamma                          value_float="0.5"         />

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -688,6 +688,9 @@
   <!-- OT::DirectionalSampling parameters -->
   <DirectionalSampling-MeanContributionIntegrationNodesNumber value_int="255" />
 
+  <!-- OT::NAIS parameters -->
+  <NAIS-DefaultrhoQuantile value_float="0.25" />
+
   <!-- OT::AdaptiveDirectionalStratification parameters -->
   <AdaptiveDirectionalStratification-DefaultGamma                          value_float="0.5"         />
   <AdaptiveDirectionalStratification-DefaultMaximumStratificationDimension value_int="3" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1317,6 +1317,9 @@ void ResourceMap::loadDefaultConfiguration()
   addAsScalar("SubsetSampling-DefaultProposalRange", 2.0);
   addAsUnsignedInteger("SubsetSampling-DefaultMaximumOuterSampling", 10000);
 
+  // NAIS parameters //
+  addAsScalar("NAIS-DefaultrhoQuantile", 0.25);
+  
   // DirectionalSampling parameters //
   addAsUnsignedInteger("DirectionalSampling-MeanContributionIntegrationNodesNumber", 255);
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1318,7 +1318,7 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("SubsetSampling-DefaultMaximumOuterSampling", 10000);
 
   // NAIS parameters //
-  addAsScalar("NAIS-DefaultrhoQuantile", 0.25);
+  addAsScalar("NAIS-DefaultRhoQuantile", 0.25);
   
   // DirectionalSampling parameters //
   addAsUnsignedInteger("DirectionalSampling-MeanContributionIntegrationNodesNumber", 255);

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
@@ -45,7 +45,7 @@ public:
 
   /** Default constructor */
   NAIS(const RandomVector & event,
-       const Scalar rhoQuantile = 0.7);
+       const Scalar rhoQuantile = 0.25);
 
   /** Virtual constructor */
   NAIS * clone() const override;

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
@@ -44,7 +44,7 @@ public:
   NAIS();
 
   /** Default constructor */
-  NAIS(const RandomVector & event,
+explicit  NAIS(const RandomVector & event,
        const Scalar rhoQuantile = 0.25);
 
   /** Virtual constructor */

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
@@ -44,8 +44,8 @@ public:
   NAIS();
 
   /** Default constructor */
-explicit  NAIS(const RandomVector & event,
-       const Scalar rhoQuantile = ResourceMap::GetAsScalar("NAIS-DefaultrhoQuantile"));
+  explicit  NAIS(const RandomVector & event,
+       const Scalar rhoQuantile = ResourceMap::GetAsScalar("NAIS-DefaultRhoQuantile"));
 
   /** Virtual constructor */
   NAIS * clone() const override;

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
@@ -45,7 +45,7 @@ public:
 
   /** Default constructor */
 explicit  NAIS(const RandomVector & event,
-       const Scalar rhoQuantile = 0.25);
+       const Scalar rhoQuantile = ResourceMap::GetAsScalar("NAIS-DefaultrhoQuantile"));
 
   /** Virtual constructor */
   NAIS * clone() const override;


### PR DESCRIPTION
Hello,

This PR proposes a modification of the default value for `rhoQuantile` parameter ofNAIS algorithm : from 0.7 to 0.25.
Parameter value above 0.5 is  unproper for the algorithm convergence. 
This PR does not change the test files and the examples as the default value of  `rhoQuantile` is overided in the corresponding files.

Regards,

Loïc and Mathieu