### PR TITLE
Automatic example galleries in API pages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@
  * Deprecated oldest LinearModelAlgorithm(X, basis, Y) and LinearModelStepwiseAlgorithm(X, basis, Y,...) ctors
 
 === Documentation ===
+ * Added example galleries at the end of API doc pages
 
 === Python module ===
 

--- a/python/doc/_templates/Copula.rst_t
+++ b/python/doc/_templates/Copula.rst_t
@@ -44,3 +44,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/CovarianceModel.rst_t
+++ b/python/doc/_templates/CovarianceModel.rst_t
@@ -70,3 +70,6 @@
   {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/Distribution.rst_t
+++ b/python/doc/_templates/Distribution.rst_t
@@ -80,3 +80,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/DistributionFactory.rst_t
+++ b/python/doc/_templates/DistributionFactory.rst_t
@@ -46,3 +46,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/DistributionHighDimension.rst_t
+++ b/python/doc/_templates/DistributionHighDimension.rst_t
@@ -69,3 +69,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/FilteringWindow.rst_t
+++ b/python/doc/_templates/FilteringWindow.rst_t
@@ -29,3 +29,6 @@
   {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/LowDiscrepancySequence.rst_t
+++ b/python/doc/_templates/LowDiscrepancySequence.rst_t
@@ -30,3 +30,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/ODESolver.rst_t
+++ b/python/doc/_templates/ODESolver.rst_t
@@ -55,3 +55,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/OrthogonalUniVariateFunctionFamily.rst_t
+++ b/python/doc/_templates/OrthogonalUniVariateFunctionFamily.rst_t
@@ -42,3 +42,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/Process.rst_t
+++ b/python/doc/_templates/Process.rst_t
@@ -34,3 +34,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/Solver.rst_t
+++ b/python/doc/_templates/Solver.rst_t
@@ -57,3 +57,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/SpectralModel.rst_t
+++ b/python/doc/_templates/SpectralModel.rst_t
@@ -25,3 +25,6 @@
   {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/StratifiedExperiment.rst_t
+++ b/python/doc/_templates/StratifiedExperiment.rst_t
@@ -33,3 +33,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/class.rst_t
+++ b/python/doc/_templates/class.rst_t
@@ -10,3 +10,5 @@
    {% endblock %}
 
 
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/classWithPlot.rst_t
+++ b/python/doc/_templates/classWithPlot.rst_t
@@ -11,3 +11,6 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the class

--- a/python/doc/_templates/function.rst_t
+++ b/python/doc/_templates/function.rst_t
@@ -4,3 +4,6 @@
 .. currentmodule:: {{ module }}
 
 .. autofunction:: {{ objname }}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the function

--- a/python/doc/_templates/functionWithPlot.rst_t
+++ b/python/doc/_templates/functionWithPlot.rst_t
@@ -7,3 +7,6 @@
 .. currentmodule:: {{ module }}
 
 .. autofunction:: {{ objname }}
+
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading: Examples using the function

--- a/python/doc/conf.py.in
+++ b/python/doc/conf.py.in
@@ -122,6 +122,16 @@ sphinx_gallery_conf = {
                                         'examples/graphs',]),
      'show_signature': False,
 
+    # directory where function/class granular galleries are stored
+    'backreferences_dir'  : 'gen_modules/backreferences',
+
+    # Modules for which function/class level galleries are created.
+    'doc_module'          : ('openturns'),
+
+    # objects to exclude from implicit backreferences. The default option
+    # is an empty set, i.e. exclude nothing.
+    'exclude_implicit_doc': {},
+
 }
 
 


### PR DESCRIPTION
Following the discussion at yesterday's meeting, I have implemented @mdelozzo's suggestion of adding minigalleries of exampls in API doc pages.


It seems to me there is no need to exclude often used classes like Point and Sample, because the minigallery is at the end of the page and thus unobstrusive. The minigallery is however mentioned in the table of contents at the top right-hand corner, so it can be quickly accessed if needed.

As an example, here is the top of the KrigingAlgorithm page:

![image](https://user-images.githubusercontent.com/31989332/190578805-1169167e-d3db-446e-aad4-f36ace26819d.png)

And here the bottom of the KrigingAlgorithm page:

![image](https://user-images.githubusercontent.com/31989332/190579309-677127ba-fd89-464a-8723-37035c8d94ad.png)

Closes #2115

