### PR TITLE
Explicit link with atomic

### DIFF
--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -100,6 +100,8 @@ endif ()
 target_link_libraries (OT PUBLIC ${OPENTURNS_LIBRARIES})
 target_link_libraries (OT PRIVATE ${OPENTURNS_PRIVATE_LIBRARIES})
 
+target_link_options(OT PUBLIC "-Wl,--push-state,--no-as-needed,-latomic,--pop-state")
+
 target_include_directories (OT INTERFACE $<INSTALL_INTERFACE:include>)
 target_include_directories (OT PUBLIC ${OPENTURNS_INCLUDE_DIRS})
 


### PR DESCRIPTION
Needed for Debian:
https://sources.debian.org/src/openturns/1.19-3/debian/patches/linker_flags_for_armel.patch/