### PR TITLE
Deprecate BoxCoxFactory::build(..., BasisCollection)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@
  * Deprecated SampleImplementation.storeToTemporaryFile|streamToRFormat
  * Deprecated GaussianProcess.GIBBS in favor of GaussianProcess.GALLIGAOGIBBS
  * Deprecated FunctionalChaosSobolIndices::summary in favor of __str__
+ * Deprecated BoxCoxFactory::build method using collection of basis
 
 === Documentation ===
  * Added example galleries at the end of API doc pages


### PR DESCRIPTION
As `GLM(BasisCollection)` is already deprecated, we do the same here for `BoxCoxFactory::build(...,BasisCollection)`.

`BoxCoxFactory::build(...Basis)` was relying on the previous method thus we reimplement this method to not rely anymore on the deprecated method and to avoid useless `deprecate warning msg`
