### PR TITLE
Enhance EllipticalDistribution

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@
  * GeneralLinearModelResult.getTrendCoefficients now returns a single Point
  * KrigingResult.getBasisCollection was removed in favor of KrigingResult.getBasis which returns a single Basis
  * GeneralLinearModelResult.getBasisCollection was removed in favor of GeneralLinearModelResult.getBasis which returns a single Basis
+ * Deprecated EllipticalDistribution::getInverseCorrelation
 
 === Documentation ===
  * Add API documentation to common use cases pages

--- a/TODO
+++ b/TODO
@@ -1,1 +1,2 @@
 Remove DomainIntersection|Union|DisjunctiveUnion(Domain, Domain) ctors
+Remove EllipticalDistribution::getInverseCorrelation

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -403,18 +403,18 @@
 
   <!-- OT::Matrix parameters -->
   <Matrix-size-visible-in-str-from value_int="5" />
+  <Matrix-DefaultSmallPivot value_float="1.0e-7"  />
+  <Matrix-LargestEigenValueRelativeError value_float="1.0e-4" />
+  <Matrix-SymmetryThreshold value_float="1.0e-12" />
+  <Matrix-LargestEigenValueIterations value_int="50" />
+  <Matrix-MaximalScaling  value_float="1.0e-5" />
+  <Matrix-StartingScaling value_float="1.0e-13" />
 
   <!-- OT::Tensor parameters -->
   <Tensor-size-visible-in-str-from value_int="5" />
 
   <!-- OT::Tensor parameters -->
   <ComplexTensor-size-visible-in-str-from value_int="6" />
-
-  <!-- OT::MatrixImplementation parameters -->
-  <Matrix-DefaultSmallPivot value_float="1.0e-7"  />
-  <Matrix-LargestEigenValueRelativeError value_float="1.0e-4" />
-  <Matrix-SymmetryThreshold value_float="1.0e-12" />
-  <Matrix-LargestEigenValueIterations value_int="50"  />
 
   <!-- OT::BernsteinCopulaFactory parameters -->
   <BernsteinCopulaFactory-alpha                    value_float="1.0"             />
@@ -749,15 +749,11 @@
   <GeneralLinearModelAlgorithm-DefaultOptimizationLowerBound    value_float="1.0e-2"  />
   <GeneralLinearModelAlgorithm-DefaultOptimizationScaleFactor   value_float="2.0"     />
   <GeneralLinearModelAlgorithm-DefaultOptimizationUpperBound    value_float="1.0e2"   />
-  <GeneralLinearModelAlgorithm-MaximalScaling                   value_float="1.0e-5"   />
   <GeneralLinearModelAlgorithm-MeanEpsilon                      value_float="1.0e-12" />
-  <GeneralLinearModelAlgorithm-StartingScaling                  value_float="1.0e-13" />
   <GeneralLinearModelAlgorithm-DefaultOptimizationAlgorithm     value_str="TNC"     />
   <GeneralLinearModelAlgorithm-LinearAlgebra                    value_str="LAPACK"  />
 
   <!-- OT::KrigingAlgorithm parameters -->
-  <KrigingAlgorithm-MaximalScaling  value_float="1.0e-5"   />
-  <KrigingAlgorithm-StartingScaling value_float="1.0e-13" />
   <KrigingAlgorithm-LinearAlgebra   value_str="LAPACK"  />
 
   <!-- OT::SquaredExponential parameters -->
@@ -866,8 +862,6 @@
   <HMatrix-ValidationRerun      value_int="0"    />
 
   <!-- OT::GaussianProcess parameters -->
-  <GaussianProcess-StartingScaling       value_float="1.0e-13"       />
-  <GaussianProcess-MaximalScaling        value_float="1.0e-5"        />
   <GaussianProcess-GibbsMaximumIteration value_int="100" />
 
   <!-- OT::SpectralGaussianProcess parameters -->
@@ -923,10 +917,7 @@
   <!-- OT::ARMALikelihoodFactoryFactory parameters -->
   <ARMALikelihoodFactory-DefaultRhoBeg             value_float="0.01"            />
   <ARMALikelihoodFactory-DefaultRhoEnd             value_float="1.0e-10"         />
-  <ARMALikelihoodFactory-DefaultStartingPointScale value_float="1.0"             />
-  <ARMALikelihoodFactory-MaximalScaling            value_float="1.0e-5"          />
   <ARMALikelihoodFactory-RootEpsilon               value_float="1.0e-6"          />
-  <ARMALikelihoodFactory-StartingScaling           value_float="1.0e-13"         />
   <ARMALikelihoodFactory-DefaultMaximumEvaluationNumber             value_int="10000" />
 
   <!-- OT::FittingTest parameters -->

--- a/lib/src/Base/Algo/CholeskyMethod.cxx
+++ b/lib/src/Base/Algo/CholeskyMethod.cxx
@@ -255,10 +255,9 @@ Point CholeskyMethod::solve(const Point & rhs)
   const MatrixImplementation psiAk(computeWeightedDesign());
   const Point c(psiAk.genVectProd(b, true));
   // We first solve Ly=b then L^Tx=y. The flags given to solveLinearSystemTri() are:
-  // 1) To keep the matrix intact
-  // 2) To say that the matrix L is lower triangular
-  // 3) To say that it is L^Tx=y that is solved instead of Lx=y
-  return l_.getImplementation()->solveLinearSystemTri(l_.solveLinearSystem(c), true, true, true);
+  // 1) To say that the matrix L is lower triangular
+  // 2) To say that it is L^Tx=y that is solved instead of Lx=y
+  return l_.getImplementation()->solveLinearSystemTri(l_.solveLinearSystem(c), true, true);
 }
 
 
@@ -279,10 +278,9 @@ Point CholeskyMethod::solveNormal(const Point & rhs)
     for (UnsignedInteger i = 0; i < size; ++i) b[i] *= weight_[i];
   }
   // We first solve Ly=b then L^Tx=y. The flags given to solveLinearSystemTri() are:
-  // 1) To keep the matrix intact
-  // 2) To say that the matrix L is lower triangular
-  // 3) To say that it is L^Tx=y that is solved instead of Lx=y
-  return l_.getImplementation()->solveLinearSystemTri(l_.solveLinearSystem(b), true, true, true);
+  // 1) To say that the matrix L is lower triangular
+  // 2) To say that it is L^Tx=y that is solved instead of Lx=y
+  return l_.getImplementation()->solveLinearSystemTri(l_.solveLinearSystem(b), true, true);
 }
 
 

--- a/lib/src/Base/Algo/EnclosingSimplexAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/EnclosingSimplexAlgorithmImplementation.cxx
@@ -301,7 +301,7 @@ Bool EnclosingSimplexAlgorithmImplementation::checkPointInSimplex(const Point & 
   Point v(dimension + 1, 1.0);
   for (UnsignedInteger i = 0; i < dimension; ++i)
     v[i] = point[i];
-  const Point coordinates(simplexMatrix.solveLinearSystem(v, false));
+  const Point coordinates(simplexMatrix.solveLinearSystemInPlace(v));
   for (UnsignedInteger i = 0; i <= dimension; ++i)
     if (!(coordinates[i] >= 0.0 && coordinates[i] <= 1.0))
       return false;

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -221,7 +221,7 @@ void PenalizedLeastSquaresAlgorithm::run(const DesignProxy & proxy)
     {
       LOGINFO("In PenalizedLeastSquaresAlgorithm::run(), use normal equation");
       CovarianceMatrix normalMatrix(basisMatrix.computeGram(true));
-      setCoefficients(normalMatrix.solveLinearSystem(basisMatrix.genVectProd(rightHandSide, true), false));
+      setCoefficients(normalMatrix.solveLinearSystemInPlace(basisMatrix.genVectProd(rightHandSide, true)));
       isSolved = true;
     }
     catch (const NotDefinedException & ex)

--- a/lib/src/Base/Algo/QRMethod.cxx
+++ b/lib/src/Base/Algo/QRMethod.cxx
@@ -125,7 +125,7 @@ Point QRMethod::solve(const Point & rhs)
   }
   // compute c = Q^t b
   const Point c(q_.getImplementation()->genVectProd(b, true)); // transpose
-  const Point coefficients(r_.getImplementation()->solveLinearSystemTri(c, true, false, false)); // rhs, keep, lower, transpose
+  const Point coefficients(r_.getImplementation()->solveLinearSystemTri(c, false, false)); // rhs, lower, transpose
   return coefficients;
 }
 
@@ -141,8 +141,8 @@ Point QRMethod::solveNormal(const Point & rhs)
     const UnsignedInteger size = rhs.getSize();
     for (UnsignedInteger i = 0; i < size; ++i) b[i] *= weight_[i];
   }
-  const Point c(r_.getImplementation()->solveLinearSystemTri(b, true, false, true)); // rhs, keep, lower, transpose
-  const Point coefficients(r_.getImplementation()->solveLinearSystemTri(c, true, false, false)); // rhs, keep, lower, transpose
+  const Point c(r_.getImplementation()->solveLinearSystemTri(b, false, true)); // rhs, lower, transpose
+  const Point coefficients(r_.getImplementation()->solveLinearSystemTri(c, false, false)); // rhs, lower, transpose
   return coefficients;
 }
 
@@ -185,7 +185,7 @@ CovarianceMatrix QRMethod::getGramInverse() const
   // G^{-1}=R^-1*R*^-T
   const UnsignedInteger basisSize = currentIndices_.getSize();
   const MatrixImplementation b(*IdentityMatrix(basisSize).getImplementation());
-  Matrix invR(r_.getImplementation()->solveLinearSystemTri(b, true, false));
+  Matrix invR(r_.getImplementation()->solveLinearSystemTri(b, false));
   // Compute gram matrix (false --> M.M^t)
   return invR.computeGram(false);
 }
@@ -196,7 +196,7 @@ Point QRMethod::getGramInverseDiag() const
   const UnsignedInteger dimension = r_.getNbRows();
   const UnsignedInteger basisSize = currentIndices_.getSize();
   const MatrixImplementation b(*IdentityMatrix(dimension).getImplementation());
-  const MatrixImplementation invRT(r_.getImplementation()->solveLinearSystemTri(b, true, false, true));
+  const MatrixImplementation invRT(r_.getImplementation()->solveLinearSystemTri(b, false, true));
 
   Point diag(dimension);
   MatrixImplementation::const_iterator invRT_iterator(invRT.begin());
@@ -218,7 +218,7 @@ Scalar QRMethod::getGramInverseTrace() const
   // G^{-1}=R^-1*R*^-T
   const UnsignedInteger dimension = r_.getNbRows();
   const MatrixImplementation b(*IdentityMatrix(dimension).getImplementation());
-  const MatrixImplementation invRT(r_.getImplementation()->solveLinearSystemTri(b, true, false, true));
+  const MatrixImplementation invRT(r_.getImplementation()->solveLinearSystemTri(b, false, true));
 
   Scalar traceInverse = 0.0;
   for (MatrixImplementation::const_iterator it = invRT.begin(); it != invRT.end(); ++it)

--- a/lib/src/Base/Algo/openturns/CholeskyMethod.hxx
+++ b/lib/src/Base/Algo/openturns/CholeskyMethod.hxx
@@ -85,7 +85,7 @@ public:
 
 protected:
   // cholesky decomposition A=LL^T (lower triangular)
-  mutable TriangularMatrix l_;
+  TriangularMatrix l_;
 
 }; /* class CholeskyMethod */
 

--- a/lib/src/Base/Algo/openturns/QRMethod.hxx
+++ b/lib/src/Base/Algo/openturns/QRMethod.hxx
@@ -86,7 +86,7 @@ public:
 protected:
 
   Matrix q_;
-  mutable Matrix r_;
+  Matrix r_;
 
 }; /* class QRMethod */
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1031,18 +1031,18 @@ void ResourceMap::loadDefaultConfiguration()
 
   // Matrix parameters
   addAsUnsignedInteger("Matrix-size-visible-in-str-from", 5);
+  addAsScalar("Matrix-DefaultSmallPivot", 1.0e-7 );
+  addAsScalar("Matrix-LargestEigenValueRelativeError", 1.0e-4);
+  addAsScalar("Matrix-SymmetryThreshold", 1.0e-12);
+  addAsUnsignedInteger("Matrix-LargestEigenValueIterations", 50);
+  addAsScalar("Matrix-MaximalScaling", 1.0e-5);
+  addAsScalar("Matrix-StartingScaling", 1.0e-13);
 
   // Tensor parameters
   addAsUnsignedInteger("Tensor-size-visible-in-str-from", 5);
 
   // Tensor parameters
   addAsUnsignedInteger("ComplexTensor-size-visible-in-str-from", 6);
-
-  // MatrixImplementation parameters //
-  addAsScalar("Matrix-DefaultSmallPivot", 1.0e-7 );
-  addAsScalar("Matrix-LargestEigenValueRelativeError", 1.0e-4);
-  addAsScalar("Matrix-SymmetryThreshold", 1.0e-12);
-  addAsUnsignedInteger("Matrix-LargestEigenValueIterations", 50);
 
   // BernsteinCopulaFactory parameters //
   addAsScalar("BernsteinCopulaFactory-alpha", 1.0);
@@ -1377,15 +1377,11 @@ void ResourceMap::loadDefaultConfiguration()
   addAsScalar("GeneralLinearModelAlgorithm-DefaultOptimizationLowerBound", 1.0e-2);
   addAsScalar("GeneralLinearModelAlgorithm-DefaultOptimizationScaleFactor", 2.0);
   addAsScalar("GeneralLinearModelAlgorithm-DefaultOptimizationUpperBound", 1.0e2);
-  addAsScalar("GeneralLinearModelAlgorithm-MaximalScaling", 1.0e-5);
   addAsScalar("GeneralLinearModelAlgorithm-MeanEpsilon", 1.0e-12);
-  addAsScalar("GeneralLinearModelAlgorithm-StartingScaling", 1.0e-13);
   addAsString("GeneralLinearModelAlgorithm-DefaultOptimizationAlgorithm", "TNC");
   addAsString("GeneralLinearModelAlgorithm-LinearAlgebra", "LAPACK");
 
   // KrigingAlgorithm parameters //
-  addAsScalar("KrigingAlgorithm-MaximalScaling", 1.0e-5);
-  addAsScalar("KrigingAlgorithm-StartingScaling", 1.0e-13);
   addAsString("KrigingAlgorithm-LinearAlgebra", "LAPACK");
 
   // SquaredExponential parameters //
@@ -1490,8 +1486,6 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("HMatrix-ValidationRerun", 0);
 
   // GaussianProcess parameters //
-  addAsScalar("GaussianProcess-MaximalScaling", 1.0e-5);
-  addAsScalar("GaussianProcess-StartingScaling", 1.0e-13);
   addAsUnsignedInteger("GaussianProcess-GibbsMaximumIteration", 100);
 
   // SpectralGaussianProcess parameters //
@@ -1547,10 +1541,7 @@ void ResourceMap::loadDefaultConfiguration()
   // ARMALikelihoodFactory parameters //
   addAsScalar("ARMALikelihoodFactory-DefaultRhoBeg", 0.01);
   addAsScalar("ARMALikelihoodFactory-DefaultRhoEnd", 1.0e-10);
-  addAsScalar("ARMALikelihoodFactory-DefaultStartingPointScale", 1.0);
-  addAsScalar("ARMALikelihoodFactory-MaximalScaling", 1.0e-5);
   addAsScalar("ARMALikelihoodFactory-RootEpsilon", 1.0e-6);
-  addAsScalar("ARMALikelihoodFactory-StartingScaling", 1.0e-13);
   addAsUnsignedInteger("ARMALikelihoodFactory-DefaultMaximumEvaluationNumber", 10000);
 
   // FittingTest parameters //

--- a/lib/src/Base/Geom/Mesh.cxx
+++ b/lib/src/Base/Geom/Mesh.cxx
@@ -258,7 +258,7 @@ Bool Mesh::checkPointInSimplexWithCoordinates(const Point & point,
   buildSimplexMatrix(index, matrix);
   Point v(point);
   v.add(1.0);
-  coordinates = matrix.solveLinearSystem(v, false);
+  coordinates = matrix.solveLinearSystemInPlace(v);
   for (UnsignedInteger i = 0; i <= dimension_; ++i) if ((coordinates[i] < -epsilon) || (coordinates[i] > 1.0 + epsilon)) return false;
   return true;
 }

--- a/lib/src/Base/Optim/OptimizationResult.cxx
+++ b/lib/src/Base/Optim/OptimizationResult.cxx
@@ -476,7 +476,7 @@ Point OptimizationResult::computeLagrangeMultipliers(const Point & x) const
         rhs.add(Point(inputDimension));
     }
   } // Inequality constraints
-  return Matrix(inputDimension, rhs.getDimension() / inputDimension, rhs).solveLinearSystem(lhs, false);
+  return Matrix(inputDimension, rhs.getDimension() / inputDimension, rhs).solveLinearSystemInPlace(lhs);
 }
 
 

--- a/lib/src/Base/Stat/CovarianceMatrix.cxx
+++ b/lib/src/Base/Stat/CovarianceMatrix.cxx
@@ -117,16 +117,24 @@ TriangularMatrix CovarianceMatrix::computeRegularizedCholesky() const
 }
 
 /* Resolution of a linear system */
-Point CovarianceMatrix::solveLinearSystem(const Point & b,
-    const Bool keepIntact)
+Point CovarianceMatrix::solveLinearSystemInPlace(const Point & b)
 {
-  return getImplementation()->solveLinearSystemCov(b, keepIntact);
+  return getImplementation()->solveLinearSystemCovInPlace(b);
 }
 
-Matrix CovarianceMatrix::solveLinearSystem(const Matrix & b,
-    const Bool keepIntact)
+Point CovarianceMatrix::solveLinearSystem(const Point & b) const
 {
-  return Implementation(getImplementation()->solveLinearSystemCov(*b.getImplementation(), keepIntact).clone());
+  return getImplementation()->solveLinearSystemCov(b);
+}
+
+Matrix CovarianceMatrix::solveLinearSystemInPlace(const Matrix & b)
+{
+  return Implementation(getImplementation()->solveLinearSystemCovInPlace(*b.getImplementation()).clone());
+}
+
+Matrix CovarianceMatrix::solveLinearSystem(const Matrix & b) const
+{
+  return Implementation(getImplementation()->solveLinearSystemCov(*b.getImplementation()).clone());
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Stat/CovarianceMatrix.cxx
+++ b/lib/src/Base/Stat/CovarianceMatrix.cxx
@@ -110,6 +110,11 @@ TriangularMatrix CovarianceMatrix::computeCholesky(const Bool keepIntact)
   return Implementation(getImplementation()->computeCholesky(keepIntact).clone());
 }
 
+/* Build the regularized Cholesky factorization of the matrix */
+TriangularMatrix CovarianceMatrix::computeRegularizedCholesky() const
+{
+  return getImplementation()->computeRegularizedCholesky();
+}
 
 /* Resolution of a linear system */
 Point CovarianceMatrix::solveLinearSystem(const Point & b,

--- a/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
@@ -79,6 +79,9 @@ public:
   /** Build the Cholesky factorization of the matrix */
   virtual TriangularMatrix computeCholesky(const Bool keepIntact = true);
 
+  /** Build the regularize Cholesky factorization of the matrix */
+  virtual TriangularMatrix computeRegularizedCholesky() const;
+
   /** Resolution of a linear system */
   Point solveLinearSystem(const Point & b,
                           const Bool keepIntact = true);

--- a/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceMatrix.hxx
@@ -83,11 +83,10 @@ public:
   virtual TriangularMatrix computeRegularizedCholesky() const;
 
   /** Resolution of a linear system */
-  Point solveLinearSystem(const Point & b,
-                          const Bool keepIntact = true);
-
-  Matrix solveLinearSystem(const Matrix & b,
-                           const Bool keepIntact = true);
+  Point solveLinearSystemInPlace(const Point & b);
+  Point solveLinearSystem(const Point & b) const;
+  Matrix solveLinearSystemInPlace(const Matrix & b);
+  Matrix solveLinearSystem(const Matrix & b) const;
 
 protected:
 

--- a/lib/src/Base/Type/ComplexMatrix.cxx
+++ b/lib/src/Base/Type/ComplexMatrix.cxx
@@ -94,16 +94,24 @@ ComplexMatrix::ComplexMatrix(const HermitianMatrix & hermitian)
 
 
 /* Resolution of a linear system */
-ComplexMatrix::ComplexCollection ComplexMatrix::solveLinearSystem(const ComplexCollection & b,
-    const Bool keepIntact)
+ComplexMatrix::ComplexCollection ComplexMatrix::solveLinearSystemInPlace(const ComplexCollection & b)
 {
-  return getImplementation()->solveLinearSystemRect(b, keepIntact);
+  return getImplementation()->solveLinearSystemRectInPlace(b);
 }
 
-ComplexMatrix ComplexMatrix::solveLinearSystem(const ComplexMatrix & b,
-    const Bool keepIntact)
+ComplexMatrix::ComplexCollection ComplexMatrix::solveLinearSystem(const ComplexCollection & b) const
 {
-  return Implementation(getImplementation()->solveLinearSystemRect(*(b.getImplementation()), keepIntact).clone());
+  return getImplementation()->solveLinearSystemRect(b);
+}
+
+ComplexMatrix ComplexMatrix::solveLinearSystemInPlace(const ComplexMatrix & b)
+{
+  return Implementation(getImplementation()->solveLinearSystemRectInPlace(*(b.getImplementation())).clone());
+}
+
+ComplexMatrix ComplexMatrix::solveLinearSystem(const ComplexMatrix & b) const
+{
+  return Implementation(getImplementation()->solveLinearSystemRect(*(b.getImplementation())).clone());
 }
 
 /* Set small elements to zero */

--- a/lib/src/Base/Type/Matrix.cxx
+++ b/lib/src/Base/Type/Matrix.cxx
@@ -227,16 +227,24 @@ Matrix Matrix::operator/ (const Scalar s) const
 }
 
 /* Resolution of a linear system */
-Point Matrix::solveLinearSystem(const Point & b,
-                                const Bool keepIntact)
+Point Matrix::solveLinearSystemInPlace(const Point & b)
 {
-  return getImplementation()->solveLinearSystemRect(b, keepIntact);
+  return getImplementation()->solveLinearSystemRectInPlace(b);
 }
 
-Matrix Matrix::solveLinearSystem(const Matrix & b,
-                                 const Bool keepIntact)
+Point Matrix::solveLinearSystem(const Point & b) const
 {
-  return Implementation(getImplementation()->solveLinearSystemRect(*(b.getImplementation()), keepIntact).clone());
+  return getImplementation()->solveLinearSystemRect(b);
+}
+
+Matrix Matrix::solveLinearSystemInPlace(const Matrix & b)
+{
+  return Implementation(getImplementation()->solveLinearSystemRectInPlace(*(b.getImplementation())).clone());
+}
+
+Matrix Matrix::solveLinearSystem(const Matrix & b) const
+{
+  return Implementation(getImplementation()->solveLinearSystemRect(*(b.getImplementation())).clone());
 }
 
 /* Compute singular values */

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -1269,6 +1269,8 @@ Bool MatrixImplementation::computeLargestEigenValueModuleSquare(Scalar & maximum
   Point currentEigenVector(dimension, 1.0);
   Point nextEigenVector(genVectProd(currentEigenVector));
   Scalar nextEigenValue = nextEigenVector.norm();
+  if (!SpecFunc::IsNormal(nextEigenValue))
+    throw InvalidArgumentException(HERE) << "Cannot compute eigen value due to nan/inf values";
   maximumModule = nextEigenValue / std::sqrt(1.0 * dimension);
   Bool found = false;
   Scalar precision = 0.0;
@@ -1295,6 +1297,8 @@ Bool MatrixImplementation::computeLargestEigenValueModuleSym(Scalar & maximumMod
   Point currentEigenVector(dimension, 1.0);
   Point nextEigenVector(symVectProd(currentEigenVector));
   Scalar nextEigenValue = nextEigenVector.norm();
+  if (!SpecFunc::IsNormal(nextEigenValue))
+    throw InvalidArgumentException(HERE) << "Cannot compute eigen value due to nan/inf values";
   maximumModule = nextEigenValue / std::sqrt(1.0 * dimension);
   Bool found = false;
   Scalar precision = 0.0;

--- a/lib/src/Base/Type/SquareMatrix.cxx
+++ b/lib/src/Base/Type/SquareMatrix.cxx
@@ -166,16 +166,24 @@ SquareMatrix SquareMatrix::power(const UnsignedInteger n) const
 }
 
 /* Resolution of a linear system */
-Point SquareMatrix::solveLinearSystem(const Point & b,
-                                      const Bool keepIntact)
+Point SquareMatrix::solveLinearSystemInPlace(const Point & b)
 {
-  return getImplementation()->solveLinearSystemSquare(b, keepIntact);
+  return getImplementation()->solveLinearSystemSquareInPlace(b);
 }
 
-Matrix SquareMatrix::solveLinearSystem(const Matrix & b,
-                                       const Bool keepIntact)
+Point SquareMatrix::solveLinearSystem(const Point & b) const
 {
-  return Implementation(getImplementation()->solveLinearSystemSquare(*b.getImplementation(), keepIntact).clone());
+  return getImplementation()->solveLinearSystemSquare(b);
+}
+
+Matrix SquareMatrix::solveLinearSystemInPlace(const Matrix & b)
+{
+  return Implementation(getImplementation()->solveLinearSystemSquareInPlace(*b.getImplementation()).clone());
+}
+
+Matrix SquareMatrix::solveLinearSystem(const Matrix & b) const
+{
+  return Implementation(getImplementation()->solveLinearSystemSquare(*b.getImplementation()).clone());
 }
 
 /* Compute determinant */

--- a/lib/src/Base/Type/SymmetricMatrix.cxx
+++ b/lib/src/Base/Type/SymmetricMatrix.cxx
@@ -250,16 +250,24 @@ SymmetricMatrix SymmetricMatrix::power(const UnsignedInteger n) const
 }
 
 /* Resolution of a linear system */
-Point SymmetricMatrix::solveLinearSystem(const Point & b,
-    const Bool keepIntact)
+Point SymmetricMatrix::solveLinearSystemInPlace(const Point & b)
 {
-  return getImplementation()->solveLinearSystemSym(b, keepIntact);
+  return getImplementation()->solveLinearSystemSymInPlace(b);
 }
 
-Matrix SymmetricMatrix::solveLinearSystem(const Matrix & b,
-    const Bool keepIntact)
+Point SymmetricMatrix::solveLinearSystem(const Point & b) const
 {
-  return getImplementation()->solveLinearSystemSym(*b.getImplementation(), keepIntact);
+  return getImplementation()->solveLinearSystemSym(b);
+}
+
+Matrix SymmetricMatrix::solveLinearSystemInPlace(const Matrix & b)
+{
+  return getImplementation()->solveLinearSystemSymInPlace(*b.getImplementation());
+}
+
+Matrix SymmetricMatrix::solveLinearSystem(const Matrix & b) const
+{
+  return getImplementation()->solveLinearSystemSym(*b.getImplementation());
 }
 
 /* Compute determinant */

--- a/lib/src/Base/Type/TriangularMatrix.cxx
+++ b/lib/src/Base/Type/TriangularMatrix.cxx
@@ -251,16 +251,24 @@ TriangularMatrix TriangularMatrix::operator / (const Scalar s) const
 
 
 /* Resolution of a linear system */
-Point TriangularMatrix::solveLinearSystem (const Point & b,
-    const Bool keepIntact)
+Point TriangularMatrix::solveLinearSystem(const Point & b) const
 {
-  return getImplementation()->solveLinearSystemTri(b, keepIntact, isLowerTriangular_);
+  return getImplementation()->solveLinearSystemTri(b, isLowerTriangular_);
 }
 
-Matrix TriangularMatrix::solveLinearSystem (const Matrix & b,
-    const Bool keepIntact)
+Point TriangularMatrix::solveLinearSystemInPlace(const Point & b)
 {
-  return getImplementation()->solveLinearSystemTri(*b.getImplementation(), keepIntact, isLowerTriangular_);
+  return getImplementation()->solveLinearSystemTriInPlace(b, isLowerTriangular_);
+}
+
+Matrix TriangularMatrix::solveLinearSystem(const Matrix & b) const
+{
+  return getImplementation()->solveLinearSystemTri(*b.getImplementation(), isLowerTriangular_);
+}
+
+Matrix TriangularMatrix::solveLinearSystemInPlace(const Matrix & b)
+{
+  return getImplementation()->solveLinearSystemTriInPlace(*b.getImplementation(), isLowerTriangular_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Type/openturns/ComplexMatrix.hxx
+++ b/lib/src/Base/Type/openturns/ComplexMatrix.hxx
@@ -101,10 +101,10 @@ public:
   virtual ComplexMatrix clean(const Scalar threshold) const;
 
   /** Resolution of a linear system */
-  ComplexMatrix solveLinearSystem(const ComplexMatrix & b,
-                                  const Bool keepIntact = true);
-  ComplexCollection solveLinearSystem(const ComplexCollection & b,
-                                      const Bool keepIntact = true);
+  ComplexMatrix solveLinearSystemInPlace(const ComplexMatrix & b);
+  ComplexMatrix solveLinearSystem(const ComplexMatrix & b) const;
+  ComplexCollection solveLinearSystemInPlace(const ComplexCollection & b);
+  ComplexCollection solveLinearSystem(const ComplexCollection & b) const;
 
   /** String converter */
   String __repr__() const override;

--- a/lib/src/Base/Type/openturns/ComplexMatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/ComplexMatrixImplementation.hxx
@@ -92,11 +92,10 @@ public:
   ComplexMatrixImplementation * clone() const override;
 
   /** Resolution of a linear system in case of a rectangular matrix */
-  ComplexCollection solveLinearSystemRect(const ComplexCollection & b,
-                                          const Bool keepIntact = true);
-
-  ComplexMatrixImplementation solveLinearSystemRect(const ComplexMatrixImplementation & b,
-      const Bool keepIntact = true);
+  ComplexCollection solveLinearSystemRectInPlace(const ComplexCollection & b);
+  ComplexCollection solveLinearSystemRect(const ComplexCollection & b) const;
+  ComplexMatrixImplementation solveLinearSystemRectInPlace(const ComplexMatrixImplementation & b);
+  ComplexMatrixImplementation solveLinearSystemRect(const ComplexMatrixImplementation & b) const;
 
   /** Set small elements to zero */
   virtual ComplexMatrixImplementation clean(const Scalar threshold) const;

--- a/lib/src/Base/Type/openturns/Matrix.hxx
+++ b/lib/src/Base/Type/openturns/Matrix.hxx
@@ -152,10 +152,10 @@ public:
   Matrix operator / (const Scalar s) const;
 
   /** Resolution of a linear system */
-  Point solveLinearSystem(const Point & b,
-                          const Bool keepIntact = true);
-  Matrix solveLinearSystem(const Matrix & b,
-                           const Bool keepIntact = true);
+  Point solveLinearSystemInPlace(const Point & b);
+  Point solveLinearSystem(const Point & b) const;
+  Matrix solveLinearSystemInPlace(const Matrix & b);
+  Matrix solveLinearSystem(const Matrix & b) const;
 
   /** Compute singular values */
   Point computeSingularValues(const Bool keepIntact = true);

--- a/lib/src/Base/Type/openturns/MatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/MatrixImplementation.hxx
@@ -190,39 +190,44 @@ public:
   void triangularize(const Bool isLowerTriangular) const;
 
   /** Resolution of a linear system in case of a rectangular matrix */
-  Point solveLinearSystemRect(const Point & b,
-                              const Bool keepIntact = true);
-  MatrixImplementation solveLinearSystemRect(const MatrixImplementation & b,
-      const Bool keepIntact = true);
+  Point solveLinearSystemRect(const Point & b) const;
+  Point solveLinearSystemRectInPlace(const Point & b);
+
+  MatrixImplementation solveLinearSystemRect(const MatrixImplementation & b) const;
+  MatrixImplementation solveLinearSystemRectInPlace(const MatrixImplementation & b);
 
   /** Resolution of a linear system in case of a square matrix */
-  Point solveLinearSystemSquare(const Point & b,
-                                const Bool keepIntact = true);
-  MatrixImplementation solveLinearSystemSquare(const MatrixImplementation & b,
-      const Bool keepIntact = true);
+  Point solveLinearSystemSquareInPlace(const Point & b);
+  Point solveLinearSystemSquare(const Point & b) const;
+  MatrixImplementation solveLinearSystemSquareInPlace(const MatrixImplementation & b);
+  MatrixImplementation solveLinearSystemSquare(const MatrixImplementation & b) const;
 
   /** Resolution of a linear system in case of a triangular matrix */
   Point solveLinearSystemTri(const Point & b,
-                             const Bool keepIntact = true,
                              const Bool lower = true,
-                             const Bool transpose = false);
+                             const Bool transpose = false) const;
+  Point solveLinearSystemTriInPlace(const Point & b,
+                                    const Bool lower = true,
+                                    const Bool transpose = false);
 
   MatrixImplementation solveLinearSystemTri(const MatrixImplementation & b,
-      const Bool keepIntact = true,
-      const Bool lower = true,
-      const Bool transpose = false);
+                                            const Bool lower = true,
+                                            const Bool transpose = false) const;
+  MatrixImplementation solveLinearSystemTriInPlace(const MatrixImplementation & b,
+                                                  const Bool lower = true,
+                                                  const Bool transpose = false);
 
   /** Resolution of a linear system in case of a symmetric matrix */
-  Point solveLinearSystemSym(const Point & b,
-                             const Bool keepIntact = true);
-  MatrixImplementation solveLinearSystemSym(const MatrixImplementation & b,
-      const Bool keepIntact = true);
+  Point solveLinearSystemSymInPlace(const Point & b);
+  Point solveLinearSystemSym(const Point & b) const;
+  MatrixImplementation solveLinearSystemSymInPlace(const MatrixImplementation & b);
+  MatrixImplementation solveLinearSystemSym(const MatrixImplementation & b) const;
 
   /** Resolution of a linear system in case of a covariance matrix */
-  Point solveLinearSystemCov(const Point & b,
-                             const Bool keepIntact = true);
-  MatrixImplementation solveLinearSystemCov(const MatrixImplementation & b,
-      const Bool keepIntact = true);
+  Point solveLinearSystemCovInPlace(const Point & b);
+  Point solveLinearSystemCov(const Point & b) const;
+  MatrixImplementation solveLinearSystemCovInPlace(const MatrixImplementation & b);
+  MatrixImplementation solveLinearSystemCov(const MatrixImplementation & b) const;
 
   /** Triangular matrix product : side argument L/R for the position of the triangular matrix, up/lo to tell if it  */
   MatrixImplementation triangularProd(const MatrixImplementation & m,

--- a/lib/src/Base/Type/openturns/MatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/MatrixImplementation.hxx
@@ -281,6 +281,9 @@ public:
   /** Build the Cholesky factorization of the matrix */
   virtual MatrixImplementation computeCholesky(const Bool keepIntact = true);
 
+  /** Build the regularized Cholesky factorization of the matrix */
+  virtual MatrixImplementation computeRegularizedCholesky() const;
+
 #ifndef SWIG
   /** Update in-place the Cholesky factor L of an SPD matrix M given a rank-one update vv^T, ie L becomes Lnew such that LnewLnew^t = Mnew with Mnew = M + vv^t */
   static void CholeskyUpdate(MatrixImplementation & cholesky,

--- a/lib/src/Base/Type/openturns/SquareMatrix.hxx
+++ b/lib/src/Base/Type/openturns/SquareMatrix.hxx
@@ -121,11 +121,10 @@ public:
   SquareMatrix operator / (const Scalar s) const;
 
   /** Resolution of a linear system */
-  Point solveLinearSystem(const Point & b,
-                          const Bool keepIntact = true);
-
-  Matrix solveLinearSystem(const Matrix & b,
-                           const Bool keepIntact = true);
+  Point solveLinearSystemInPlace(const Point & b);
+  Point solveLinearSystem(const Point & b) const;
+  Matrix solveLinearSystemInPlace(const Matrix & b);
+  Matrix solveLinearSystem(const Matrix & b) const;
 
   /** Compute determinant */
   Scalar computeLogAbsoluteDeterminant(Scalar & signOut,

--- a/lib/src/Base/Type/openturns/SymmetricMatrix.hxx
+++ b/lib/src/Base/Type/openturns/SymmetricMatrix.hxx
@@ -139,11 +139,10 @@ public:
   SymmetricMatrix operator / (const Scalar & s) const;
 
   /** Resolution of a linear system */
-  Point solveLinearSystem(const Point & b,
-                          const Bool keepIntact = true);
-
-  Matrix solveLinearSystem(const Matrix & b,
-                           const Bool keepIntact = true);
+  Point solveLinearSystemInPlace(const Point & b);
+  Point solveLinearSystem(const Point & b) const;
+  Matrix solveLinearSystemInPlace(const Matrix & b);
+  Matrix solveLinearSystem(const Matrix & b) const;
 
   /** Compute determinant */
   Scalar computeLogAbsoluteDeterminant(Scalar & signOut,

--- a/lib/src/Base/Type/openturns/TriangularMatrix.hxx
+++ b/lib/src/Base/Type/openturns/TriangularMatrix.hxx
@@ -139,11 +139,11 @@ public:
   TriangularMatrix operator / (const Scalar s) const;
 
   /** Resolution of a linear system */
-  Point solveLinearSystem(const Point & b,
-                          const Bool keepIntact = true);
+  Point solveLinearSystem(const Point & b) const;
+  Point solveLinearSystemInPlace(const Point & b);
 
-  Matrix solveLinearSystem(const Matrix & b,
-                           const Bool keepIntact = true);
+  Matrix solveLinearSystem(const Matrix & b) const;
+  Matrix solveLinearSystemInPlace(const Matrix & b);
 private:
 
   /** Boolean information : is the matrix triangular lower or upper? */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingAlgorithm.cxx
@@ -91,8 +91,8 @@ void KrigingAlgorithm::computeGamma()
   }
   else
   {
-    // Arguments are keepIntact=true, matrix_lower=true & solving_transposed=true
-    gamma_ = covarianceCholeskyFactor_.getImplementation()->solveLinearSystemTri(rho_, true, true, true);
+    // Arguments are matrix_lower=true & solving_transposed=true
+    gamma_ = covarianceCholeskyFactor_.getImplementation()->solveLinearSystemTri(rho_, true, true);
   }
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
@@ -602,8 +602,8 @@ Scalar LinearModelStepwiseAlgorithm::computeLogLikelihood()
   Matrix R;
   currentQ_ = currentX_.computeQR(R, size < p, true);
   const MatrixImplementation b(*IdentityMatrix(p).getImplementation());
-  //                                                     keep intact, lower, transposed
-  currentInvRt_ = R.getImplementation()->solveLinearSystemTri(b, false, false, true);
+  //                                                                    lower, transposed
+  currentInvRt_ = R.getImplementation()->solveLinearSystemTriInPlace(b, false, true);
 
   // residual = Y - Q*Q^T*Y
   const Matrix QtY = currentQ_.getImplementation()->genProd(*(Y_.getImplementation()), true, false);

--- a/lib/src/Uncertainty/Distribution/InverseWishart.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseWishart.cxx
@@ -199,7 +199,7 @@ Scalar InverseWishart::computeLogPDF(const CovarianceMatrix & m) const
     logPDF += logNormalizationFactor_;
     // Trace(V M^{-1}) = Trace(C C' X'^{-1} X^{-1}) = Trace(C'X'^{-1} X^{-1}C)
     //                 = Trace(A'A) with A = X^{-1}C
-    const TriangularMatrix A(X.solveLinearSystem(cholesky_, false).getImplementation());
+    const TriangularMatrix A(X.solveLinearSystemInPlace(cholesky_).getImplementation());
     logPDF -= 0.5 * A.computeGram(true).computeTrace();
     return logPDF;
   }
@@ -353,8 +353,7 @@ void InverseWishart::setV(const CovarianceMatrix & v)
   CovarianceMatrix vInverse(T.computeGram(true));
   // Flag false means that vInverse is not preserved, non const because we solve a linear system with this matrix
   TriangularMatrix vInverseCholesky(vInverse.computeCholesky(false));
-  // Flag false means that vInverse is not preserved
-  inverseCholeskyInverse_ = vInverseCholesky.solveLinearSystem(IdentityMatrix(p), false).getImplementation();
+  inverseCholeskyInverse_ = vInverseCholesky.solveLinearSystemInPlace(IdentityMatrix(p)).getImplementation();
   setDimension((p * (p + 1)) / 2);
   isAlreadyComputedMean_ = false;
   isAlreadyComputedCovariance_ = false;

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -176,8 +176,7 @@ Point Normal::getRealization() const
     return value;
   }
   // General case
-  TriangularMatrix inverseCholesky(inverseCholesky_);
-  return inverseCholesky.solveLinearSystem(value) + mean_;
+  return inverseCholesky_.solveLinearSystem(value) + mean_;
 }
 
 Sample Normal::getSample(const UnsignedInteger size) const
@@ -649,8 +648,7 @@ Point Normal::computeSequentialConditionalQuantile(const Point & q) const
       result[i] = mean_[i] + sigma_[i] * DistFunc::qNormal(q[i]);
     return result;
   }
-  TriangularMatrix inverseCholesky(inverseCholesky_);
-  return mean_ + inverseCholesky.solveLinearSystem(DistFunc::qNormal(q));
+  return mean_ + inverseCholesky_.solveLinearSystem(DistFunc::qNormal(q));
 }
 
 /* Get the i-th marginal distribution */

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -176,7 +176,8 @@ Point Normal::getRealization() const
     return value;
   }
   // General case
-  return cholesky_ * value + mean_;
+  TriangularMatrix inverseCholesky(inverseCholesky_);
+  return inverseCholesky.solveLinearSystem(value) + mean_;
 }
 
 Sample Normal::getSample(const UnsignedInteger size) const
@@ -190,7 +191,11 @@ Sample Normal::getSample(const UnsignedInteger size) const
     for (UnsignedInteger i = 0; i < size; ++i)
       for (UnsignedInteger j = 0; j < dimension; ++j) result(i, j) = DistFunc::rNormal();
     if (hasIndependentCopula_) result *= sigma_;
-    else result = cholesky_.getImplementation()->genSampleProd(result, true, false, 'R');
+    else
+    {
+      const TriangularMatrix cholesky(getCholesky());
+      result = cholesky.getImplementation()->genSampleProd(result, true, false, 'R');
+    }
   }
   result += mean_;
   result.setName(getName());
@@ -644,7 +649,8 @@ Point Normal::computeSequentialConditionalQuantile(const Point & q) const
       result[i] = mean_[i] + sigma_[i] * DistFunc::qNormal(q[i]);
     return result;
   }
-  return mean_ + cholesky_ * DistFunc::qNormal(q);
+  TriangularMatrix inverseCholesky(inverseCholesky_);
+  return mean_ + inverseCholesky.solveLinearSystem(DistFunc::qNormal(q));
 }
 
 /* Get the i-th marginal distribution */
@@ -720,7 +726,7 @@ Scalar Normal::getRoughness() const
   else
   {
     for (UnsignedInteger d = 0; d < dimension_; ++d)
-      roughness *= 0.2820947917738781434740398 / cholesky_(d, d);
+      roughness *= 0.2820947917738781434740398 * inverseCholesky_(d, d);
   }
   return roughness;
 }

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -172,8 +172,7 @@ Point Student::getRealization() const
   Point value(dimension);
   // First, a realization of independent standard normal coordinates
   for (UnsignedInteger i = 0; i < dimension; ++i) value[i] = DistFunc::rNormal();
-  TriangularMatrix inverseCholesky(inverseCholesky_);
-  return std::sqrt(0.5 * nu_ / DistFunc::rGamma(0.5 * nu_)) * inverseCholesky.solveLinearSystem(value) + mean_;
+  return std::sqrt(0.5 * nu_ / DistFunc::rGamma(0.5 * nu_)) * inverseCholesky_.solveLinearSystem(value) + mean_;
 }
 
 

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -172,7 +172,8 @@ Point Student::getRealization() const
   Point value(dimension);
   // First, a realization of independent standard normal coordinates
   for (UnsignedInteger i = 0; i < dimension; ++i) value[i] = DistFunc::rNormal();
-  return std::sqrt(0.5 * nu_ / DistFunc::rGamma(0.5 * nu_)) * (cholesky_ * value) + mean_;
+  TriangularMatrix inverseCholesky(inverseCholesky_);
+  return std::sqrt(0.5 * nu_ / DistFunc::rGamma(0.5 * nu_)) * inverseCholesky.solveLinearSystem(value) + mean_;
 }
 
 
@@ -191,7 +192,10 @@ Sample Student::getSample(const UnsignedInteger size) const
   if (dimension == 1)
     result = normalSample * sigma_[0];
   else
-    result = (cholesky_.getImplementation()->genSampleProd(normalSample, true, false, 'R'));
+  {
+    const TriangularMatrix cholesky(getCholesky());
+    result = (cholesky.getImplementation()->genSampleProd(normalSample, true, false, 'R'));
+  }
   for (UnsignedInteger i = 0; i < size; ++i)
   {
     const Scalar alpha = std::sqrt(0.5 * nu_ / gammaDeviates[i]);
@@ -398,10 +402,11 @@ Scalar Student::computeConditionalPDF(const Scalar x,
   UnsignedInteger stop = conditioningDimension;
   UnsignedInteger shift = 0;
   Point yCentered(conditioningDimension);
+  const TriangularMatrix cholesky(getCholesky());
   for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
   {
     yCentered[i] = y[i] - mean_[i];
-    std::copy(cholesky_.getImplementation()->begin() + start, cholesky_.getImplementation()->begin() + stop, cholY.begin() + shift);
+    std::copy(cholesky.getImplementation()->begin() + start, cholesky.getImplementation()->begin() + stop, cholY.begin() + shift);
     start += dimension_ + 1;
     stop += dimension_;
     shift += conditioningDimension + 1;
@@ -449,10 +454,11 @@ Scalar Student::computeConditionalCDF(const Scalar x,
   UnsignedInteger stop = conditioningDimension;
   UnsignedInteger shift = 0;
   Point yCentered(conditioningDimension);
+  const TriangularMatrix cholesky(getCholesky());
   for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
   {
     yCentered[i] = y[i] - mean_[i];
-    std::copy(cholesky_.getImplementation()->begin() + start, cholesky_.getImplementation()->begin() + stop, cholY.begin() + shift);
+    std::copy(cholesky.getImplementation()->begin() + start, cholesky.getImplementation()->begin() + stop, cholY.begin() + shift);
     start += dimension_ + 1;
     stop += dimension_;
     shift += conditioningDimension + 1;
@@ -498,10 +504,11 @@ Scalar Student::computeConditionalQuantile(const Scalar q,
   UnsignedInteger stop = conditioningDimension;
   UnsignedInteger shift = 0;
   Point yCentered(conditioningDimension);
+  const TriangularMatrix cholesky(getCholesky());
   for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
   {
     yCentered[i] = y[i] - mean_[i];
-    std::copy(cholesky_.getImplementation()->begin() + start, cholesky_.getImplementation()->begin() + stop, cholY.begin() + shift);
+    std::copy(cholesky.getImplementation()->begin() + start, cholesky.getImplementation()->begin() + stop, cholY.begin() + shift);
     start += dimension_ + 1;
     stop += dimension_;
     shift += conditioningDimension + 1;

--- a/lib/src/Uncertainty/Distribution/openturns/InverseWishart.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/InverseWishart.hxx
@@ -125,7 +125,7 @@ private:
   void update();
 
   /** The main parameter set of the distribution */
-  mutable TriangularMatrix cholesky_;
+  TriangularMatrix cholesky_;
   Scalar nu_;
 
   /** The inverse of the Cholesky factor of the inverse of the scale matrix V */

--- a/lib/src/Uncertainty/Distribution/openturns/Wishart.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Wishart.hxx
@@ -130,7 +130,7 @@ private:
   void update();
 
   /** The main parameter set of the distribution */
-  mutable TriangularMatrix cholesky_;
+  TriangularMatrix cholesky_;
   Scalar nu_;
 
   /** The log-normalization factor */

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -3295,10 +3295,7 @@ TriangularMatrix DistributionImplementation::getCholesky() const
 TriangularMatrix DistributionImplementation::getInverseCholesky() const
 {
   // Compute its Cholesky factor
-  TriangularMatrix cholesky(getCholesky());
-
-  const TriangularMatrix inverseCholesky(cholesky.solveLinearSystem(IdentityMatrix(dimension_), false).getImplementation());
-
+  const TriangularMatrix inverseCholesky(getCholesky().solveLinearSystem(IdentityMatrix(dimension_)).getImplementation());
   return inverseCholesky;
 }
 

--- a/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
@@ -131,7 +131,7 @@ public:
   /** Denormalize the given point x_i = mu_i + sigma_i * x_i */
   Point denormalize(const Point & u) const;
 
-  /** Inverse correlation matrix accessor */
+  /** @deprecated Inverse correlation matrix accessor */
   SquareMatrix getInverseCorrelation() const;
 
   /** Cholesky factor of the correlation matrix accessor */
@@ -178,9 +178,6 @@ protected:
 
   /** The shape matrix of the distribution = Diag(sigma_) * R_ * Diag(sigma_) */
   mutable CovarianceMatrix shape_;
-
-  /** The inverse of the correlation matrix of the distribution */
-  SymmetricMatrix inverseR_;
 
   /** The Cholesky factor of the shape matrix shape_ = cholesky_ * cholesky_.transpose() */
   TriangularMatrix cholesky_;

--- a/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
@@ -171,10 +171,10 @@ public:
 protected:
 
   /** The sigma vector of the distribution */
-  mutable Point sigma_;
+  Point sigma_;
 
   /** The correlation matrix (Rij) of the distribution */
-  mutable CorrelationMatrix R_;
+  CorrelationMatrix R_;
 
   /** The inverse Cholesky factor of the covariance matrix */
   TriangularMatrix inverseCholesky_;

--- a/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
@@ -176,9 +176,6 @@ protected:
   /** The correlation matrix (Rij) of the distribution */
   mutable CorrelationMatrix R_;
 
-  /** The Cholesky factor of the shape matrix shape = cholesky_ * cholesky_.transpose() */
-  TriangularMatrix cholesky_;
-
   /** The inverse Cholesky factor of the covariance matrix */
   TriangularMatrix inverseCholesky_;
 

--- a/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
@@ -176,10 +176,7 @@ protected:
   /** The correlation matrix (Rij) of the distribution */
   mutable CorrelationMatrix R_;
 
-  /** The shape matrix of the distribution = Diag(sigma_) * R_ * Diag(sigma_) */
-  mutable CovarianceMatrix shape_;
-
-  /** The Cholesky factor of the shape matrix shape_ = cholesky_ * cholesky_.transpose() */
+  /** The Cholesky factor of the shape matrix shape = cholesky_ * cholesky_.transpose() */
   TriangularMatrix cholesky_;
 
   /** The inverse Cholesky factor of the covariance matrix */
@@ -188,7 +185,7 @@ protected:
   /** The normalization factor of the distribution */
   Scalar normalizationFactor_;
 
-  /** The scaling factor of the covariance matrix covariance = covarianceScalingFactor_ * shape_*/
+  /** The scaling factor of the covariance matrix covariance = covarianceScalingFactor_ * shape */
   Scalar covarianceScalingFactor_;
 
 private:
@@ -253,6 +250,9 @@ private:
 
   /** Compute the value of the auxiliary attributes */
   void update();
+
+  /** The shape matrix of the distribution = Diag(sigma_) * R_ * Diag(sigma_) */
+  CovarianceMatrix getShape() const;
 
 }; /* class EllipticalDistribution */
 

--- a/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/EllipticalDistribution.hxx
@@ -124,13 +124,13 @@ protected:
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
 
-public:
   /** Normalize the given point u_i = (x_i - mu_i) / sigma_i */
   Point normalize(const Point & x) const;
 
   /** Denormalize the given point x_i = mu_i + sigma_i * x_i */
   Point denormalize(const Point & u) const;
 
+public:
   /** @deprecated Inverse correlation matrix accessor */
   SquareMatrix getInverseCorrelation() const;
 

--- a/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
+++ b/lib/src/Uncertainty/Process/KarhunenLoeveQuadratureAlgorithm.cxx
@@ -317,7 +317,7 @@ void KarhunenLoeveQuadratureAlgorithm::run()
   // Transform the eigenvectors to the generalized ones
   // Last time we need cholesky, so we can overwrite it by eigenVectors
   LOGINFO("Get the generalized eigenvectors");
-  eigenVectors = choleskyBlock.transpose().solveLinearSystem(eigenVectors, false).getImplementation();
+  eigenVectors = choleskyBlock.transpose().solveLinearSystemInPlace(eigenVectors).getImplementation();
   LOGINFO("Post-process the eigenvalue problem");
   Collection< std::pair<Scalar, UnsignedInteger> > eigenPairs(augmentedDimension);
   for (UnsignedInteger i = 0; i < augmentedDimension; ++i)

--- a/lib/src/Uncertainty/StatTests/LinearModelTest.cxx
+++ b/lib/src/Uncertainty/StatTests/LinearModelTest.cxx
@@ -373,7 +373,7 @@ TestResult LinearModelTest::LinearModelDurbinWatson(const Sample & firstSample,
   CovarianceMatrix XtX(X.computeGram());
   const SquareMatrix XAXQt(XtX.solveLinearSystem(AX.transpose() * X).getImplementation());
   const Scalar P = 2 * (residualSize - 1) - XAXQt.computeTrace();
-  const Scalar XAXTrace = XtX.solveLinearSystem(AX.computeGram(), false).getImplementation()->computeTrace();
+  const Scalar XAXTrace = XtX.solveLinearSystemInPlace(AX.computeGram()).getImplementation()->computeTrace();
   const Scalar Q = 2 * (3 * residualSize - 4) - 2 * XAXTrace + (XAXQt * XAXQt).getImplementation()->computeTrace();
   const Scalar dmean = P / (residualSize - basisSize);
   const Scalar dvar = 2.0 / ((residualSize - basisSize) * (residualSize - basisSize + 2)) * (Q - P * dmean);

--- a/python/src/CovarianceMatrix_doc.i.in
+++ b/python/src/CovarianceMatrix_doc.i.in
@@ -71,7 +71,20 @@ This uses LAPACK's `DPOTRF <http://www.netlib.org/lapack/lapack-3.1.1/html/dpotr
 
 Returns
 -------
-cholesky_factor : :class:`~openturns.SquareMatrix`
+cholesky_factor : :class:`~openturns.TriangularMatrix`
+    The left (lower) Cholesky factor."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::CovarianceMatrix::computeRegularizedCholesky
+"Compute the regularized Cholesky factor.
+
+Similar to :meth:`computeCholesky` but with a regularization loop according
+to the largest eigenvalue and keys `Matrix-StartingScaling` and `Matrix-MaximalScaling`.
+
+Returns
+-------
+cholesky_factor : :class:`~openturns.TriangularMatrix`
     The left (lower) Cholesky factor."
 
 // ---------------------------------------------------------------------

--- a/python/src/Matrix_doc.i.in
+++ b/python/src/Matrix_doc.i.in
@@ -245,9 +245,6 @@ Parameters
 ----------
 rhs : :class:`~openturns.Point` or :class:`~openturns.Matrix` with :math:`n_r` values or rows, respectively
     The right hand side member of the linear system.
-keep_intact : bool, optional
-    A flag telling whether the present matrix can be overwritten or not.
-    Default is *True* and leaves the present matrix unchanged.
 
 Returns
 -------
@@ -274,6 +271,16 @@ Examples
 >>> b = ot.Point([1.0] * 3)
 >>> x = M.solveLinearSystem(b)
 >>> np.testing.assert_array_almost_equal(M * x, b)"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Matrix::solveLinearSystemInPlace
+"Solve a rectangular linear system whose the present matrix is the operator.
+
+Similar to :meth:`solveLinearSystem` except the matrix is modified in-place
+during the resolution avoiding the need to allocate an extra copy if the
+original copy is not re-used.
+"
 
 // ---------------------------------------------------------------------
 

--- a/python/src/SquareMatrix_doc.i.in
+++ b/python/src/SquareMatrix_doc.i.in
@@ -237,9 +237,6 @@ Parameters
 ----------
 rhs : sequence of float or :class:`~openturns.Matrix` with :math:`n_r` values or rows, respectively
     The right hand side member of the linear system.
-keep_intact : bool, optional
-    A flag telling whether the present matrix can be overwritten or not.
-    Default is *True* and leaves the present matrix unchanged.
 
 Returns
 -------

--- a/python/test/t_CovarianceMatrix_std.py
+++ b/python/test/t_CovarianceMatrix_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -61,3 +62,9 @@ sym[2, 2] = 1.0e-02
 sym[0, 1] = 7.0e-04
 ot.CovarianceMatrix(sym)
 print("ok")
+
+# regularized cholesky
+A = ot.CovarianceMatrix([[1.0] * 10] * 10)
+L = A.computeRegularizedCholesky()
+B = L * L.transpose()
+ott.assert_almost_equal(A, B)

--- a/python/test/t_CovarianceMatrix_std.py
+++ b/python/test/t_CovarianceMatrix_std.py
@@ -44,7 +44,7 @@ b[0, 1] = 10.0
 b[1, 1] = 1.0
 b[0, 2] = 15.0
 b[1, 2] = 2.0
-result2 = matrix1.solveLinearSystem(b, True)
+result2 = matrix1.solveLinearSystem(b)
 print("result2=" + repr(result2))
 
 matrix3 = ot.CovarianceMatrix(3)

--- a/python/test/t_Matrix_solve.py
+++ b/python/test/t_Matrix_solve.py
@@ -59,7 +59,7 @@ pt3.add(1.0)
 print("pt3=" + repr(pt3))
 
 result3 = ot.Point()
-result3 = matrix3.solveLinearSystem(pt3, True)
+result3 = matrix3.solveLinearSystem(pt3)
 print("result3=" + repr(result3))
 
 b1 = ot.Matrix(2, 4)
@@ -72,14 +72,14 @@ b1[1, 2] = 3.0
 b1[0, 3] = 20.0
 b1[1, 3] = 4.0
 print("b1=" + repr(b1))
-result4 = matrix1.solveLinearSystem(b1, True)
+result4 = matrix1.solveLinearSystem(b1)
 print("result4=" + repr(result4))
-result4 = matrix1.solveLinearSystem(b1, False)
+result4 = matrix1.solveLinearSystemInPlace(b1)
 print("result4=" + repr(result4))
 
-result5 = matrix2.solveLinearSystem(b1, True)
+result5 = matrix2.solveLinearSystem(b1)
 print("result5=" + repr(result5))
-result5 = matrix2.solveLinearSystem(b1, False)
+result5 = matrix2.solveLinearSystemInPlace(b1)
 print("result5=" + repr(result5))
 
 b2 = ot.Matrix(3, 4)
@@ -96,7 +96,7 @@ b2[0, 3] = 20.0
 b2[1, 3] = 4.0
 b2[2, 3] = -8.0
 print("b2=" + repr(b2))
-result6 = matrix3.solveLinearSystem(b2, True)
+result6 = matrix3.solveLinearSystem(b2)
 print("result6=" + repr(result6))
-result6 = matrix3.solveLinearSystem(b2, False)
+result6 = matrix3.solveLinearSystemInPlace(b2)
 print("result6 = " + repr(result6))

--- a/python/test/t_Normal_std.expout
+++ b/python/test/t_Normal_std.expout
@@ -41,6 +41,7 @@ mean= class=Point name=Unnamed dimension=1 values=[0]
 standard deviation= class=Point name=Unnamed dimension=1 values=[1]
 skewness= class=Point name=Unnamed dimension=1 values=[0]
 kurtosis= class=Point name=Unnamed dimension=1 values=[3]
+roughness=0.282095
 covariance= class=CovarianceMatrix dimension=1 implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[1]
 parameters= [class=PointWithDescription name=Marginal 1 dimension=2 description=[mean_0,standard_deviation_0] values=[0,1]]
 density generator=0.352067
@@ -113,6 +114,7 @@ mean= class=Point name=Unnamed dimension=2 values=[0,0]
 standard deviation= class=Point name=Unnamed dimension=2 values=[1,2]
 skewness= class=Point name=Unnamed dimension=2 values=[0,0]
 kurtosis= class=Point name=Unnamed dimension=2 values=[3,3]
+roughness=0.045944
 covariance= class=CovarianceMatrix dimension=2 implementation=class=MatrixImplementation name=Unnamed rows=2 columns=2 values=[1,1,1,4]
 parameters= [class=PointWithDescription name=Marginal 1 dimension=2 description=[mean_0,standard_deviation_0] values=[0,1],class=PointWithDescription name=Marginal 2 dimension=2 description=[mean_1,standard_deviation_1] values=[0,2],class=PointWithDescription name=dependence dimension=1 description=[R_1_0] values=[0.5]]
 density generator=0.123951
@@ -182,6 +184,7 @@ mean= class=Point name=Unnamed dimension=3 values=[0,0,0]
 standard deviation= class=Point name=Unnamed dimension=3 values=[1,2,3]
 skewness= class=Point name=Unnamed dimension=3 values=[0,0,0]
 kurtosis= class=Point name=Unnamed dimension=3 values=[3,3,3]
+roughness=0.005291
 covariance= class=CovarianceMatrix dimension=3 implementation=class=MatrixImplementation name=Unnamed rows=3 columns=3 values=[1,1,0,1,4,3,0,3,9]
 parameters= [class=PointWithDescription name=Marginal 1 dimension=2 description=[mean_0,standard_deviation_0] values=[0,1],class=PointWithDescription name=Marginal 2 dimension=2 description=[mean_1,standard_deviation_1] values=[0,2],class=PointWithDescription name=Marginal 3 dimension=2 description=[mean_2,standard_deviation_2] values=[0,3],class=PointWithDescription name=dependence dimension=3 description=[R_1_0,R_2_0,R_2_1] values=[0.5,0,0.5]]
 density generator=0.043639
@@ -256,6 +259,7 @@ mean= class=Point name=Unnamed dimension=4 values=[0,0,0,0]
 standard deviation= class=Point name=Unnamed dimension=4 values=[1,2,3,4]
 skewness= class=Point name=Unnamed dimension=4 values=[0,0,0,0]
 kurtosis= class=Point name=Unnamed dimension=4 values=[3,3,3,3]
+roughness=0.000472
 covariance= class=CovarianceMatrix dimension=4 implementation=class=MatrixImplementation name=Unnamed rows=4 columns=4 values=[1,1,0,0,1,4,3,0,0,3,9,6,0,0,6,16]
 parameters= [class=PointWithDescription name=Marginal 1 dimension=2 description=[mean_0,standard_deviation_0] values=[0,1],class=PointWithDescription name=Marginal 2 dimension=2 description=[mean_1,standard_deviation_1] values=[0,2],class=PointWithDescription name=Marginal 3 dimension=2 description=[mean_2,standard_deviation_2] values=[0,3],class=PointWithDescription name=Marginal 4 dimension=2 description=[mean_3,standard_deviation_3] values=[0,4],class=PointWithDescription name=dependence dimension=6 description=[R_1_0,R_2_0,R_2_1,R_3_0,R_3_1,R_3_2] values=[0.5,0,0.5,0,0,0.5]]
 density generator=0.015364

--- a/python/test/t_Normal_std.py
+++ b/python/test/t_Normal_std.py
@@ -291,5 +291,4 @@ for dim in range(1, 5):
 dist = ot.Normal(
     [0] * 3, ot.CovarianceMatrix([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 )
-assert dist.getCorrelation()[0, 0] > 1.0, "not regularized"
 sample = dist.getSample(10)

--- a/python/test/t_Normal_std.py
+++ b/python/test/t_Normal_std.py
@@ -187,6 +187,8 @@ for dim in range(1, 5):
     print("skewness=", repr(skewness))
     kurtosis = distribution.getKurtosis()
     print("kurtosis=", repr(kurtosis))
+    roughness = distribution.getRoughness()
+    print("roughness=%.6f" % roughness)
     covariance = distribution.getCovariance()
     print("covariance=", repr(covariance))
     parameters = distribution.getParametersCollection()


### PR DESCRIPTION
- Add Matrix::computeRegularizedCholesky to uniformize regularization in various classes: GLM, GP, ConditionedGP, & Elliptical
- Save memory by not storing inverse correlation (only used for computePDFGradient) & shape matrix (used only in computeCovariance) when these services are not called

We had in mind to also spare the cholesky factor & inverse cholesky, but it turns out these are used in several services, this might complexify the code for no actual gains:
- inverseCholesky_: computeDDF/PDF/LogPDF, computeConditionalQuantile, computeConditionalCDF, computeSequentialConditionalCDF
- cholesky_: getRealization, getSample, computeSequentialConditionalQuantile, getRoughness

so in a compromise between code complexity and memory optimization I choose not to cache these.

note that it's not only caching attributes, we must also take care to instanciate them before any TBB parallel region by overriding parent calling methods, else it can segfault

cc @mbaudin47 