### PR TITLE
Added SpecFunc::AccurateSum

### DIFF
--- a/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
+++ b/lib/src/Base/Func/SpecFunc/SpecFunc.cxx
@@ -874,6 +874,7 @@ Scalar SpecFunc::HyperGeom_1_1(const Scalar p1,
 #endif
 }
 
+
 // Complex hypergeometric function of type (1,1): HyperGeom_1_1(p1, q1, x) = \sum_{n=0}^{\infty} [\prod_{k=0}^{n-1} (p1 + k) / (q1 + k)] * x^n / n!
 Complex SpecFunc::HyperGeom_1_1(const Scalar p1,
                                 const Scalar q1,
@@ -1346,5 +1347,26 @@ UnsignedInteger SpecFunc::BinomialCoefficient(const UnsignedInteger n,
   return value;
 }
 
+Scalar SpecFunc::AccurateSum(const Point & v)
+{
+#ifdef OPENTURNS_HAVE_MPFR
+  boost::multiprecision::mpfr_float_500 sum(0.0);
+  for (UnsignedInteger i = 0; i < v.getSize(); ++i)
+    sum += v[i];
+  return sum.convert_to<Scalar>();
+#else
+  // Here we use Kahan's compensated summation
+  Scalar sum = 0.0;
+  Scalar error = 0.0;
+  for (UnsignedInteger i = 0; i < v.getSize(); ++i)
+    {
+      const Scalar y = v[i] - error;
+      const Scalar t = sum + y;
+      error = (t - sum) - y;
+      sum = t;
+    }
+  return sum;
+#endif
+}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
+++ b/lib/src/Base/Func/SpecFunc/openturns/SpecFunc.hxx
@@ -23,6 +23,7 @@
 
 #include "openturns/OTprivate.hxx"
 #include "openturns/ResourceMap.hxx"
+#include "openturns/Point.hxx"
 #include <limits>
 
 BEGIN_NAMESPACE_OPENTURNS
@@ -240,6 +241,9 @@ OT_API Scalar Cbrt(const Scalar x);
 // binomial coefficient C(n, k)
 OT_API UnsignedInteger BinomialCoefficient(const UnsignedInteger n,
     const UnsignedInteger k);
+
+// Accurate summation
+OT_API Scalar AccurateSum(const Point & v);
 
 } /* SpecFunc */
 

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -997,6 +997,7 @@ Scalar DistributionImplementation::computeProbabilityGeneral(const Interval & in
     // and n(c) = Card({c_i == a_i, i = 1, ..., n})
     probability = 0.0;
     const UnsignedInteger iMax = 1 << dimension_;
+    Point probabilities(iMax);
     for( UnsignedInteger i = 0; i < iMax; ++i )
     {
       Bool evenLower = true;
@@ -1011,9 +1012,9 @@ Scalar DistributionImplementation::computeProbabilityGeneral(const Interval & in
         }
       } // j
       const Scalar cdf = computeCDF(c);
-      probability += (evenLower ? cdf : -cdf);
+      probabilities[i] = (evenLower ? cdf : -cdf);
     } // i
-
+    probability = SpecFunc::AccurateSum(probabilities);
   } // not independent
 
   // clip to [0, 1]

--- a/python/doc/user_manual/functions.rst
+++ b/python/doc/user_manual/functions.rst
@@ -201,6 +201,7 @@ as Python functions.
     :toctree: _generated/
     :template: function.rst_t
 
+    SpecFunc.AccurateSum
     SpecFunc.BesselI0
     SpecFunc.BesselI1
     SpecFunc.BesselK

--- a/python/src/SpecFunc_doc.i.in
+++ b/python/src/SpecFunc_doc.i.in
@@ -1184,3 +1184,19 @@ Returns
 -------
 result : float"
 
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::SpecFunc::AccurateSum
+"Accurate summation.
+
+Returns the value :math:`\sum_{i=0}^{n-1}x_i` using extended precision (if
+available) or Kahan's method
+
+Parameters
+----------
+x : sequence of float
+
+Returns
+-------
+result : float"
+

--- a/python/test/t_SpecFunc_std.py
+++ b/python/test/t_SpecFunc_std.py
@@ -38,3 +38,9 @@ print(
     "ibeta(0.0, 1.0, 0.95, tail)=",
     ot.SpecFunc.RegularizedIncompleteBeta(0.0, 1.0, 0.95, True),
 )
+
+x = [1.0, 2.0**53, -2.0**53]
+s1 = sum(x)
+s2 = ot.SpecFunc.AccurateSum(x)
+assert s1 == 0.0, "sum(x) nonzero"
+assert s2 == 1.0, "accurate sum(x) not 1"


### PR DESCRIPTION
This method allows to compute the sum of a sequence of floats with an extended precision, using either MPFR or Kahan's method.