### PR TITLE
Fixed LARS

### DIFF
--- a/lib/src/Base/Func/LARS.cxx
+++ b/lib/src/Base/Func/LARS.cxx
@@ -81,7 +81,7 @@ void LARS::updateBasis(LeastSquaresMethod & method,
   if (!(sampleSize > 0)) throw InvalidArgumentException( HERE ) << "Output sample cannot be empty.";
   if (y.getDimension() != 1) throw InvalidArgumentException( HERE ) << "Output sample should be unidimensional (dim=" << y.getDimension() << ").";
   if (y.getSize() != sampleSize) throw InvalidArgumentException( HERE ) << "Samples should be equally sized (in=" << sampleSize << " out=" << y.getSize() << ").";
-//   if (x.getDimension() != psi.getDimension()) throw InvalidArgumentException( HERE ) << "Sample dimension (" << x.getDimension() << ") does not match basis dimension (" << psi.getDimension() << ").";
+  //   if (x.getDimension() != psi.getDimension()) throw InvalidArgumentException( HERE ) << "Sample dimension (" << x.getDimension() << ") does not match basis dimension (" << psi.getDimension() << ").";
 
   // get y as as point
   const Point mY(y.getImplementation()->getData());
@@ -107,21 +107,28 @@ void LARS::updateBasis(LeastSquaresMethod & method,
   if (iterations == 0) inPredictors_ = Indices(basisSize, 0);
   if ((iterations < maximumNumberOfIterations) && (relativeConvergence_ > maximumRelativeConvergence_))
   {
-    // find the predictor most correlated with the current residual
-    const Point cC(mPsiX_.getImplementation()->genVectProd(mY - mu_, true));
     UnsignedInteger candidatePredictor = 0;
+    // find the predictor most correlated with the current residual only after
+    // the constant function has been introduced
+    const Point cC(mPsiX_.getImplementation()->genVectProd(mY - mu_, true));
     Scalar cMax = -1.0;
-    for (UnsignedInteger j = 0; j < basisSize; ++ j)
-      if (!inPredictors_[j])
-      {
-        const Scalar cAbs = std::abs(cC[j]);
-        if (cAbs > cMax)
+    if (iterations == 0)
+    {
+      cMax = std::abs(cC[0]);
+    }
+    else
+    {
+      for (UnsignedInteger j = 0; j < basisSize; ++ j)
+        if (!inPredictors_[j])
         {
-          cMax = cAbs;
-          candidatePredictor = j;
-        }
-      } // if
-
+          const Scalar cAbs = std::abs(cC[j]);
+          if (cAbs > cMax)
+          {
+            cMax = cAbs;
+            candidatePredictor = j;
+          }
+        } // if
+    }
     if (getVerbose()) LOGINFO(OSS() << "predictor=" << candidatePredictor << " residual=" << cMax);
 
     // add the predictor index

--- a/python/test/t_FieldFunctionalChaosSobolIndices_std.py
+++ b/python/test/t_FieldFunctionalChaosSobolIndices_std.py
@@ -81,8 +81,8 @@ sobol_0 = sensitivity.getFirstOrderIndices()
 sobol_0t = sensitivity.getTotalOrderIndices()
 print(f"first order={sobol_0}")
 print(f"total order={sobol_0t}")
-ott.assert_almost_equal(sobol_0, [0.0671066, 0.43925, 0.0946414, 0.278936])
-ott.assert_almost_equal(sobol_0t, [0.0907787, 0.463361, 0.191124, 0.374894])
+ott.assert_almost_equal(sobol_0, [0.0673166,0.439809,0.0946051,0.278286])
+ott.assert_almost_equal(sobol_0t, [0.0908364,0.463752,0.191125,0.374326])
 graph = sensitivity.draw()
 # ot.Show(graph)
 
@@ -90,7 +90,7 @@ sobol2 = dict(
     [((j, i), sensitivity.getSobolIndex([i, j])) for i in range(4) for j in range(i)]
 )
 print(sobol2)
-ott.assert_almost_equal(sobol2[(0, 1)], 0.529936)
+ott.assert_almost_equal(sobol2[(0, 1)], 0.530589)
 
 # rerun with block indices
 blockIndices = [[0], [1], [2, 3]]
@@ -104,7 +104,7 @@ sobol_0 = sensitivity.getFirstOrderIndices()
 sobol_0t = sensitivity.getTotalOrderIndices()
 print(f"first order={sobol_0}")
 print(f"total order={sobol_0t}")
-ott.assert_almost_equal(sobol_0, [0.0662528, 0.434932, 0.474861])
-ott.assert_almost_equal(sobol_0t, [0.0897672, 0.458886, 0.475398])
+ott.assert_almost_equal(sobol_0, [0.06653,0.434889,0.474891])
+ott.assert_almost_equal(sobol_0t, [0.0897988,0.458579,0.475371])
 graph = sensitivity.draw()
 # ot.Show(graph)

--- a/python/test/t_FieldToPointFunctionalChaosAlgorithm_std.py
+++ b/python/test/t_FieldToPointFunctionalChaosAlgorithm_std.py
@@ -79,7 +79,7 @@ xm = x.computeMean()
 print("f(xm)=", f(xm))
 fhat_xm = metamodel(xm)
 print("f^(xm)=", fhat_xm)
-ott.assert_almost_equal(fhat_xm, [1.09112])
+ott.assert_almost_equal(fhat_xm, [1.09018], 1e-3, 1e-3)
 
 # test residual
 residuals = result.getFCEResult().getResiduals()

--- a/python/test/t_LeastSquaresMethod_std.expout
+++ b/python/test/t_LeastSquaresMethod_std.expout
@@ -53,8 +53,8 @@ getGramInverse: [[  2.06431   -1.16342    0.152433  ]
 getGramInverseDiag: [2.06431,0.696429,0.0132002]
 getGramInverseTrace: 2.7739
 -- method: SparseMethod
-solve: [0,0.276282,-0.0496824]
-residual: 0.176725
+solve: [0.738901,-0.118098,0]
+residual: 0.100929
 -no solveNormal-
 getHDiag: [0.562574,0.447462,0.459268,0.571429,0.959268]
 getGramInverse: [[  2.06431   -1.16342    0.152433  ]
@@ -93,8 +93,8 @@ getGramInverse: [[  2.06431   -1.16342    0.152433  ]
 getGramInverseDiag: [2.06431,0.696429,0.0132002]
 getGramInverseTrace: 2.7739
 -- method: SparseMethod
-solve: [0,0.276282,-0.0496824]
-residual: 0.176725
+solve: [0.738901,-0.118098,0]
+residual: 0.100929
 -no solveNormal-
 getHDiag: [0.562574,0.447462,0.459268,0.571429,0.959268]
 getGramInverse: [[  2.06431   -1.16342    0.152433  ]


### PR DESCRIPTION
The constant function, which has the index 0 in any orthogonal basis by convention, must be accepted first in the sequential exploration otherwise the correlation computation through a matrix/vector product is wrong. One easy way to enforce this is to deactivate the selection step based on correlation at the first iteration.

This fix is quite urgent as CERFACS partners are blocked by the bug...