### PR TITLE
Improve doc

### DIFF
--- a/python/doc/examples/data_analysis/distribution_fitting/plot_smoothing_mixture.py
+++ b/python/doc/examples/data_analysis/distribution_fitting/plot_smoothing_mixture.py
@@ -144,25 +144,28 @@ view = otv.View(graph)
 # %%
 hArray = [0.05, 0.54, 0.18]
 nLen = len(hArray)
-fig = pl.figure(figsize=(10, 8))
+grid = ot.GridLayout(1, len(hArray))
+index = 0
 for i in range(nLen):
-    ax = fig.add_subplot(2, 2, i + 1)
     fit = factory.build(sample, [hArray[i]])
     graph = fit.drawPDF()
-    graph.setColors(["dodgerblue3"])
-    graph.setLegends(["h=%.4f" % (hArray[i])])
     exact = distribution.drawPDF()
     curve = exact.getDrawable(0)
-    curve.setColor("darkorange1")
     curve.setLegend("Mixture")
     curve.setLineStyle("dashed")
     graph.add(curve)
-    graph.setLegendPosition("topleft")
     graph.setXTitle("X")
-    view = otv.View(graph, figure=fig, axes=[ax])
-    pl.ylim(top=0.5)  # Common y-range
+    graph.setTitle("h=%.4f" % (hArray[i]))
+    graph.setLegends([""])
+    graph.setColors(ot.Drawable.BuildDefaultPalette(2))
+    bounding_box = graph.getBoundingBox()
+    upper_bound = bounding_box.getUpperBound()
+    upper_bound[1] = 0.5  # Common y-range
+    graph.setBoundingBox(bounding_box)
+    grid.setGraph(0, index, graph)
+    index += 1
 
-view = otv.View(graph)
+view = otv.View(grid, figure_kw={"figsize": (10.0, 4.0)})
 # %%
 # We see that when the bandwidth is too small, the resulting kernel smoothing has many more modes than the distribution it is supposed to approximate.
 # When the bandwidth is too large, the approximated distribution is too smooth and has only one mode instead of the expected two modes which are in the mixture distribution.
@@ -199,27 +202,30 @@ factory.getBandwidth()[0]
 hArray = [h1, h2, h3]
 legends = ["Silverman", "Plugin", "Mixed"]
 nLen = len(hArray)
-fig = pl.figure(figsize=(10, 8))
+grid = ot.GridLayout(1, len(hArray))
+index = 0
 for i in range(nLen):
-    ax = fig.add_subplot(2, 2, i + 1)
     fit = factory.build(sample, [hArray[i]])
     graph = fit.drawPDF()
-    graph.setColors(["dodgerblue3"])
-    graph.setLegends(["h=%.4f, %s" % (hArray[i], legends[i])])
     exact = distribution.drawPDF()
     curve = exact.getDrawable(0)
-    curve.setColor("darkorange1")
     curve.setLegend("Mixture")
     curve.setLineStyle("dashed")
     graph.add(curve)
-    graph.setLegendPosition("topleft")
+    graph.setLegends([""])
+    graph.setTitle("h=%.4f, %s" % (hArray[i], legends[i]))
     graph.setXTitle("X")
+    graph.setColors(ot.Drawable.BuildDefaultPalette(2))
     if i > 0:
         graph.setYTitle("")
-    view = otv.View(graph, figure=fig, axes=[ax])
-    pl.ylim(top=0.5)  # Common y-range
+    bounding_box = graph.getBoundingBox()
+    upper_bound = bounding_box.getUpperBound()
+    upper_bound[1] = 0.5  # Common y-range
+    graph.setBoundingBox(bounding_box)
+    grid.setGraph(0, index, graph)
+    index += 1
 
-view = otv.View(graph)
+view = otv.View(grid, figure_kw={"figsize": (10.0, 4.0)})
 
 otv.View.ShowAll()
 # %%

--- a/python/doc/examples/data_analysis/distribution_fitting/plot_smoothing_mixture.py
+++ b/python/doc/examples/data_analysis/distribution_fitting/plot_smoothing_mixture.py
@@ -7,7 +7,15 @@ Bandwidth sensitivity in kernel smoothing
 # Introduction
 # ------------
 #
-# We consider the distribution
+# When we have a sample, we may estimate the probability density function of the
+# underlying distribution using kernel smoothing.
+# One of the parameters of this method is the bandwidth, which can be either
+# set by the user, or estimated from the data.
+# This is especially true when the density is multimodal.
+# In this example, we consider a bimodal distribution and see how the bandwidth
+# can change the estimated probability density function.
+#
+# We consider the distribution:
 #
 # .. math::
 #    f_1(x) = w_1 f_A(x) + w_2 f_B(x)
@@ -46,7 +54,6 @@ Bandwidth sensitivity in kernel smoothing
 # %%
 import openturns as ot
 import openturns.viewer as otv
-import pylab as pl
 
 # %%
 # We choose a rather large sample size: :math:`n=1000`.

--- a/python/doc/examples/meta_modeling/fields_metamodels/plot_fieldfunction_metamodel.py
+++ b/python/doc/examples/meta_modeling/fields_metamodels/plot_fieldfunction_metamodel.py
@@ -6,14 +6,14 @@ Metamodel of a field function
 #
 # In this example we are going to create a metamodel of a field function following these steps:
 #
-# 1. Creation of a field model over an 1-d mesh.
-# 2. Creation of a Gaussian process.
-# 3. Karhunen-Loeve decomposition of a process with known covariance function.
-# 4. Karhunen-Loeve decomposition of a process with known trajectories.
-# 5. Projection of fields.
-# 6. Functional chaos decomposition between the coefficients of the input and output processes.
-# 7. Build a metamodel of the whole field model.
-# 8. Validate the metamodel.
+# 1. creation of a field model over an 1-d mesh ;
+# 2. creation of a Gaussian process ;
+# 3. Karhunen-Loeve decomposition of a process with known covariance function ;
+# 4. Karhunen-Loeve decomposition of a process with known trajectories ;
+# 5. projection of fields ;
+# 6. functional chaos decomposition between the coefficients of the input and output processes ;
+# 7. build a metamodel of the whole field model ;
+# 8. validate the metamodel.
 #
 
 # %%
@@ -24,7 +24,8 @@ from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# Input model
+# Create the input model.
+
 print("Create the input process")
 # Domain bound
 a = 1
@@ -41,7 +42,7 @@ process_X = ot.GaussianProcess(covariance_X, mesh)
 
 
 # %%
-# for some pretty graphs
+# The next function plots the K.-L. modes.
 def drawKL(scaledKL, KLev, mesh, title="Scaled KL modes"):
     graph_modes = scaledKL.drawMarginal()
     graph_modes.setTitle(title + " scaled KL modes")
@@ -66,8 +67,7 @@ def drawKL(scaledKL, KLev, mesh, title="Scaled KL modes"):
 
 
 # %%
-# Karhunen-Loeve decomposition of the input process
-print("Compute the decomposition of the input process")
+# Compute the decomposition of the input process.
 threshold = 0.0001
 algo_X = ot.KarhunenLoeveP1Algorithm(mesh, process_X.getCovarianceModel(), threshold)
 algo_X.run()
@@ -80,14 +80,15 @@ view = viewer.View(graph_modes_X)
 
 
 # %%
-# Input database generation
+# Sample the input process.
 print("Sample the input process")
 size = 500
 sample_X = process_X.getSample(size)
 
-
 # %%
-# The field model: convolution over an 1-d mesh
+# Create a class to perform the convolution over an 1-d mesh.
+
+
 class ConvolutionP1(ot.OpenTURNSPythonFieldFunction):
     def __init__(self, p, mesh):
         # 1 = input dimension, the dimension of the input field
@@ -115,19 +116,16 @@ class ConvolutionP1(ot.OpenTURNSPythonFieldFunction):
 
 
 # %%
-# Dynamical model: convolution wrt kernel p
-print("Create the convolution function")
+# Create the convolution function.
 p = ot.SymbolicFunction("x", "exp(-(x/" + str(h) + ")^2)")
 myConvolution = ot.FieldFunction(ConvolutionP1(p, mesh))
 
 # %%
-# Output database generation
-print("Sample the output process")
+# Sample the output process.
 sample_Y = myConvolution(sample_X)
 
 # %%
-# Karhunen-Loeve decomposition of the output process
-print("Compute the decomposition of the output process")
+# Compute the decomposition of the output process.
 algo_Y = ot.KarhunenLoeveSVDAlgorithm(sample_Y, threshold)
 algo_Y.run()
 result_Y = algo_Y.getResult()
@@ -137,7 +135,7 @@ graph_modes_Y, graph_ev_Y = drawKL(phi_Y, lambda_Y, mesh, "Y")
 view = viewer.View(graph_modes_Y)
 
 # %%
-# Compare eigenvalues of X and Y
+# Compare eigenvalues of X and Y.
 graph_ev_X.add(graph_ev_Y)
 graph_ev_X.setTitle("Input/output eigenvalues comparison")
 graph_ev_X.setYTitle(r"$\lambda_X, \lambda_Y$")
@@ -147,7 +145,7 @@ graph_ev_X.setLegendPosition("topright")
 view = viewer.View(graph_ev_X)
 
 # %%
-# Polynomial chaos between KL coefficients
+# Perform the polynomial chaos expansion between KL coefficients.
 print("project sample_X")
 sample_xi_X = result_X.project(sample_X)
 
@@ -203,7 +201,7 @@ meta_model_field = ot.FieldToFieldConnection(
 
 
 # %%
-# Meta_model validation
+# Perform the validation of the metamodel.
 iMax = 10
 sample_X_validation = process_X.getSample(iMax)
 sample_Y_validation = myConvolution(sample_X_validation)

--- a/python/doc/examples/meta_modeling/fields_metamodels/plot_fieldfunction_metamodel.py
+++ b/python/doc/examples/meta_modeling/fields_metamodels/plot_fieldfunction_metamodel.py
@@ -6,11 +6,11 @@ Metamodel of a field function
 #
 # In this example we are going to create a metamodel of a field function following these steps:
 #
-# 1. creation of a field model over an 1-d mesh ;
-# 2. creation of a Gaussian process ;
+# 1. create a field model over an 1-d mesh ;
+# 2. create a Gaussian process ;
 # 3. Karhunen-Loeve decomposition of a process with known covariance function ;
 # 4. Karhunen-Loeve decomposition of a process with known trajectories ;
-# 5. projection of fields ;
+# 5. fields projection ;
 # 6. functional chaos decomposition between the coefficients of the input and output processes ;
 # 7. build a metamodel of the whole field model ;
 # 8. validate the metamodel.
@@ -42,7 +42,7 @@ process_X = ot.GaussianProcess(covariance_X, mesh)
 
 
 # %%
-# The next function plots the K.-L. modes.
+# The next function plots the Karhunen-Loève. modes.
 def drawKL(scaledKL, KLev, mesh, title="Scaled KL modes"):
     graph_modes = scaledKL.drawMarginal()
     graph_modes.setTitle(title + " scaled KL modes")
@@ -86,7 +86,7 @@ size = 500
 sample_X = process_X.getSample(size)
 
 # %%
-# Create a class to perform the convolution over an 1-d mesh.
+# Create a class to perform the convolution over a 1-d mesh.
 
 
 class ConvolutionP1(ot.OpenTURNSPythonFieldFunction):
@@ -145,7 +145,7 @@ graph_ev_X.setLegendPosition("topright")
 view = viewer.View(graph_ev_X)
 
 # %%
-# Perform the polynomial chaos expansion between KL coefficients.
+# Perform the polynomial chaos expansion between Karhunen-Loève coefficients.
 print("project sample_X")
 sample_xi_X = result_X.project(sample_X)
 
@@ -201,7 +201,7 @@ meta_model_field = ot.FieldToFieldConnection(
 
 
 # %%
-# Perform the validation of the metamodel.
+# Validate the metamodel.
 iMax = 10
 sample_X_validation = process_X.getSample(iMax)
 sample_Y_validation = myConvolution(sample_X_validation)

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
@@ -7,14 +7,14 @@ Create a linear least squares model
 # function:
 #
 # .. math::
-#     \underline{y} \, \approx \, \widehat{h}(\underline{x}) \,
-#    = \, \sum_{j=0}^{n_X} \; a_j \; \psi_j(\underline{x})
+#     \vect{y} \, \approx \, \widehat{h}(\vect{x}) \,
+#    = \, \sum_{j=0}^{n_X} \; a_j \; \psi_j(\vect{x})
 #
 #
-# Here
+# where :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
 #
 # .. math::
-#    h(x) = [cos(x_1 + x_2), (x2 + 1)* e^{x_1 - 2* x_2}]
+#    h(\vect{x}) = \left(\cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right)
 #
 
 # %%
@@ -24,7 +24,7 @@ from matplotlib import pylab as plt
 
 ot.Log.Show(ot.Log.NONE)
 
-# Prepare an input sample
+# Prepare an input sample.
 x = [[0.5, 0.5], [-0.5, -0.5], [-0.5, 0.5], [0.5, -0.5]]
 x += [[0.25, 0.25], [-0.25, -0.25], [-0.25, 0.25], [0.25, -0.25]]
 
@@ -40,19 +40,19 @@ algo = ot.LinearLeastSquares(x, y)
 algo.run()
 
 # %%
-# get the linear term
+# Get the linear term.
 algo.getLinear()
 
 # %%
-# get the constant term
+# Get the constant term.
 algo.getConstant()
 
 # %%
-# get the metamodel
+# Get the metamodel.
 responseSurface = algo.getMetaModel()
 
 # %%
-# plot 2nd output of our model with x1=0.5
+# Plot 2nd output of our model with x1=0.5.
 graph = (
     ot.ParametricFunction(responseSurface, [0], [0.5]).getMarginal(1).draw(-0.5, 0.5)
 )

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
@@ -3,19 +3,52 @@ Create a linear least squares model
 ===================================
 """
 # %%
-# In this example we are going to create a global approximation of a model response using  a linear
-# function:
+# In this example we are going to create a global approximation of a model
+# response based on a linear function using the :class:`~openturns.LinearLeastSquares` class.
 #
-# .. math::
-#     \vect{y} \, \approx \, \widehat{h}(\vect{x}) \,
-#    = \, \sum_{j=0}^{n_X} \; a_j \; \psi_j(\vect{x})
-#
-#
-# where :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
+# We consider the function :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
 #
 # .. math::
 #    h(x_1, x_2) = \left(\cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right)
 #
+# for any :math:`\vect{x} \in \Rset^2`.
+# Since the output is a dimension 2 vector, the model has vector
+# coefficients.
+# We use the linear model:
+#
+# .. math::
+#     \vect{y} \, \approx \, \widehat{\vect{h}}(\vect{x}) \,
+#     = \, \sum_{k=0}^2 \; \vect{a}_k \; \psi_k(\vect{x})
+#
+#
+# for any :math:`\vect{x} \in \Rset^2` where :math:`\left\{\vect{a}_k \in \Rset^2\right\}_{k = 0,..., 2}`
+# are the vector coefficients and :math:`\left\{\psi_k : \Rset^2 \rightarrow \Rset\right\}_{k = 0, ..., 2}`
+# are the basis functions.
+# This implies that each marginal output :math:`\widehat{h}_i(\vect{x})`
+# is approximated by the linear model:
+#
+# .. math::
+#     \widehat{h}_i(\vect{x}) \,
+#     = \, \sum_{k=0}^2 \; a_{ki} \; \psi_k(\vect{x})
+#
+# for any :math:`\vect{x} \in \Rset^2` and any :math:`i = 1, 2`
+# where :math:`a_{ki}` is the :math:`k`-th coefficient of the :math:`i`-th output
+# marginal:
+#
+# .. math::
+#      \vect{a}_k = \begin{pmatrix}a_{k1} \\ a_{k2} \end{pmatrix}
+#
+# for :math:`k = 0, 1, 2`.
+# We consider the basis functions:
+#
+# .. math::
+#
+#      \psi_0(\vect{x}) & = 1 \\
+#      \psi_1(\vect{x}) & = x_1 \\
+#      \psi_2(\vect{x}) & = x_2 \\
+#
+# for any :math:`\vect{x} \in \Rset^2`.
+
 
 # %%
 import openturns as ot
@@ -24,27 +57,52 @@ from matplotlib import pylab as plt
 
 ot.Log.Show(ot.Log.NONE)
 
+# %%
+# Define the model
+# ~~~~~~~~~~~~~~~~
+
+# %%
 # Prepare an input sample.
-x = [[0.5, 0.5], [-0.5, -0.5], [-0.5, 0.5], [0.5, -0.5]]
-x += [[0.25, 0.25], [-0.25, -0.25], [-0.25, 0.25], [0.25, -0.25]]
+# Each point is a pair of coordinates :math:`(x_1, x_2)`.
+
+# %%
+inputTrain = [[0.5, 0.5], [-0.5, -0.5], [-0.5, 0.5], [0.5, -0.5]]
+inputTrain += [[0.25, 0.25], [-0.25, -0.25], [-0.25, 0.25], [0.25, -0.25]]
+inputTrain = ot.Sample(inputTrain)
+inputTrain.setDescription(["x1", "x2"])
+inputTrain
 
 # %%
 # Compute the output sample from the input sample and a function.
+
+# %%
 formulas = ["cos(x1 + x2)", "(x2 + 1) * exp(x1 - 2 * x2)"]
 model = ot.SymbolicFunction(["x1", "x2"], formulas)
-y = model(x)
+model.setOutputDescription(["y1", "y2"])
+outputTrain = model(inputTrain)
+outputTrain
+
+# %%
+# Linear least squares
+# ~~~~~~~~~~~~~~~~~~~~
 
 # %%
 # Create a linear least squares model.
-algo = ot.LinearLeastSquares(x, y)
+
+# %%
+algo = ot.LinearLeastSquares(inputTrain, outputTrain)
 algo.run()
 
 # %%
 # Get the linear term.
+
+# %%
 algo.getLinear()
 
 # %%
 # Get the constant term.
+
+# %%
 algo.getConstant()
 
 # %%
@@ -53,19 +111,20 @@ responseSurface = algo.getMetaModel()
 
 # %%
 # Plot the second output of our model with :math:`x_1=0.5`.
-graph = (
-    ot.ParametricFunction(responseSurface, [0], [0.5]).getMarginal(1).draw(-0.5, 0.5)
-)
-graph.setLegends(["linear LS"])
+
+# %%
+graph = ot.ParametricFunction(model, [0], [0.5]).getMarginal(1).draw(-0.5, 0.5)
+graph.setLegends(["Model"])
 curve = (
-    ot.ParametricFunction(model, [0], [0.5])
+    ot.ParametricFunction(responseSurface, [0], [0.5])
     .getMarginal(1)
     .draw(-0.5, 0.5)
     .getDrawable(0)
 )
-curve.setColor("red")
-curve.setLegend("model")
+curve.setLineStyle("dashed")
+curve.setLegend("Linear L.S.")
 graph.add(curve)
 graph.setLegendPosition("topright")
+graph.setColors(ot.Drawable.BuildDefaultPalette(2))
 view = viewer.View(graph)
 plt.show()

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_create_linear_least_squares_model.py
@@ -14,7 +14,7 @@ Create a linear least squares model
 # where :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
 #
 # .. math::
-#    h(\vect{x}) = \left(\cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right)
+#    h(x_1, x_2) = \left(\cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right)
 #
 
 # %%
@@ -52,7 +52,7 @@ algo.getConstant()
 responseSurface = algo.getMetaModel()
 
 # %%
-# Plot 2nd output of our model with x1=0.5.
+# Plot the second output of our model with :math:`x_1=0.5`.
 graph = (
     ot.ParametricFunction(responseSurface, [0], [0.5]).getMarginal(1).draw(-0.5, 0.5)
 )

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_taylor_approximation.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_taylor_approximation.py
@@ -3,20 +3,25 @@ Taylor approximations
 =====================
 """
 # %%
-# In this example we are going to build a local approximation of a model using the Taylor decomposition:
+# In this example we build a local approximation of a model using the
+# Taylor decomposition using the :class:`~openturns.LinearTaylor` class.
 #
-# Here is the decomposition at the first order:
-#
-# .. math::
-#    \vect{y} \, \approx \, \widehat{h}(\vect{x}) \,
-#          = \, h(\vect{x}_0) \, +
-#         \, \sum_{i=1}^{n_{X}} \; \frac{\partial h}{\partial x_i}(\vect{x}_0).\left(x_i - x_{0,i} \right)
-#
-# where :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
+# We consider the function :math:`h : \Rset^2 \rightarrow \Rset^2` defined by:
 #
 # .. math::
 #    h(\vect{x}) = \left( \cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right).
 #
+# for any :math:`\vect{x} \in \Rset^2`.
+# The metamodel :math:`\widehat{h}` is is an approximation of the model :math:`h`:
+#
+# .. math::
+#    \vect{y} \, \approx \, \widehat{h}(\vect{x})
+#
+# for any :math:`\vect{x} \in \Rset^2`.
+# In this example, we consider two different approximations:
+#
+# - the first order Taylor expansion,
+# - the second order Taylor expansion.
 
 # %%
 import openturns as ot
@@ -25,16 +30,40 @@ from matplotlib import pylab as plt
 
 ot.Log.Show(ot.Log.NONE)
 
+# %%
+# Define the model
+# ~~~~~~~~~~~~~~~~
+
+# %%
 # Prepare some data.
 formulas = ["cos(x1 + x2)", "(x2 + 1) * exp(x1 - 2 * x2)"]
 model = ot.SymbolicFunction(["x1", "x2"], formulas)
 
+# %%
 # Center of the approximation.
 x0 = [-0.4, -0.4]
 
+# %%
 # Drawing bounds.
 a = -0.4
 b = 0.0
+
+# %%
+# First order Taylor expansion
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# Let :math:`\vect{x}_0 \in \Rset^2` be a reference point where
+# the linear approximation is evaluated.
+# The first order Taylor expansion is:
+#
+# .. math::
+#    \widehat{h}(\vect{x}) \,
+#    = \, h(\vect{x}_0) \, +
+#      \, \sum_{i=1}^{n_{X}} \; \frac{\partial h}{\partial x_i}(\vect{x}_0).\left(x_i - x_{0,i} \right)
+#
+# for any :math:`\vect{x} \in \Rset^2`.
+
 
 # %%
 # Create a linear (first-order) Taylor approximation.
@@ -44,42 +73,60 @@ responseSurface = algo.getMetaModel()
 
 # %%
 # Plot the second output of our model with :math:`x_1=x_{0,1}`.
-graph = ot.ParametricFunction(responseSurface, [0], [x0[1]]).getMarginal(1).draw(a, b)
-graph.setLegends(["taylor"])
+
+# %%
+graph = ot.ParametricFunction(model, [0], [x0[1]]).getMarginal(1).draw(a, b)
+graph.setLegends(["Model"])
 curve = (
-    ot.ParametricFunction(model, [0], [x0[1]]).getMarginal(1).draw(a, b).getDrawable(0)
+    ot.ParametricFunction(responseSurface, [0], [x0[1]]).getMarginal(1).draw(a, b).getDrawable(0)
 )
-curve.setColor("red")
-curve.setLegend("model")
+curve.setLegend("Taylor")
+curve.setLineStyle("dashed")
 graph.add(curve)
 graph.setLegendPosition("topright")
+graph.setColors(ot.Drawable.BuildDefaultPalette(2))
 view = viewer.View(graph)
 
 # %%
-# Here is the decomposition at the second order:
+# Second order Taylor expansion
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# Let :math:`\vect{x}_0 \in \Rset^2` be a reference point where
+# the quadratic approximation is evaluated.
+# The second order Taylor expansion is:
 #
-# .. math::\vect{y} \, \approx \, \widehat{h}(\vect{x}) \, = \,
-#         h(\vect{x}_0) \, + \, \sum_{i=1}^{n_{X}} \;
-#       \frac{\partial h}{\partial x_i}(\vect{x}_0).\left(x_i - x_{0,i} \right) \, +
-#      \, \frac{1}{2} \; \sum_{i,j=1}^{n_X} \;
-#       \frac{\partial^2 h}{\partial x_i \partial x_j}(\vect{x}_0).\left(x_i - x_{0,i} \right).\left(x_j - x_{0,j} \right):math:``
+# .. math::
+#
+#     \widehat{h}(\vect{x}) \, = \,
+#     h(\vect{x}_0) \, + \, \sum_{i=1}^{n_{X}} \;
+#     \frac{\partial h}{\partial x_i}(\vect{x}_0).\left(x_i - x_{0,i} \right) \, +
+#     \, \frac{1}{2} \; \sum_{i,j=1}^{n_X} \;
+#     \frac{\partial^2 h}{\partial x_i \partial x_j}(\vect{x}_0).\left(x_i - x_{0,i} \right).\left(x_j - x_{0,j} \right)
+#
+# for any :math:`\vect{x} \in \Rset^2`.
 
 # %%
 # Create a quadratic (second-order) Taylor approximation.
+
+# %%
 algo = ot.QuadraticTaylor(x0, model)
 algo.run()
 responseSurface = algo.getMetaModel()
 
 # %%
 # Plot second output of our model with :math:`x_1=x_{0,1}`.
-graph = ot.ParametricFunction(responseSurface, [0], [x0[1]]).getMarginal(1).draw(a, b)
-graph.setLegends(["taylor"])
+
+# %%
+graph = ot.ParametricFunction(model, [0], [x0[1]]).getMarginal(1).draw(a, b)
+graph.setLegends(["Model"])
 curve = (
-    ot.ParametricFunction(model, [0], [x0[1]]).getMarginal(1).draw(a, b).getDrawable(0)
+    ot.ParametricFunction(responseSurface, [0], [x0[1]]).getMarginal(1).draw(a, b).getDrawable(0)
 )
-curve.setColor("red")
-curve.setLegend("model")
+curve.setLegend("Taylor")
+curve.setLineStyle("dashed")
 graph.add(curve)
 graph.setLegendPosition("topright")
+graph.setColors(ot.Drawable.BuildDefaultPalette(2))
 view = viewer.View(graph)
 plt.show()

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_taylor_approximation.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_taylor_approximation.py
@@ -12,8 +12,10 @@ Taylor approximations
 #          = \, h(\vect{x}_0) \, +
 #         \, \sum_{i=1}^{n_{X}} \; \frac{\partial h}{\partial x_i}(\vect{x}_0).\left(x_i - x_{0,i} \right)
 #
+# where :math:`h : \Rset^2 \rightarrow \Rset^2` is defined by:
 #
-# Here :math:`h(x) = [cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2}]`.
+# .. math::
+#    h(\vect{x}) = \left( \cos(x_1 + x_2), (x_2 + 1) e^{x_1 - 2 x_2} \right).
 #
 
 # %%

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_enumeratefunction.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_enumeratefunction.py
@@ -89,21 +89,21 @@ view = otv.View(graph, axes_kw={"aspect": "equal"})
 # We observe the exponential increase of the number of terms with the dimension
 # :math:`d` (curse of dimensionality).
 graph = ot.Graph(
-    "Full tensorized basis", "Total degree", "Number of coefficients", True
+    "Linear enumeration", "Total degree", "Number of coefficients", True
 )
 degree_maximum = 10
-list_of_polynomial_degrees = [1, 5, 10, 15, 20]
+list_of_dimensions = [1, 5, 10, 15, 20]
 point_styles = ["bullet", "circle", "fdiamond", "fsquare", "triangleup"]
-palette = ot.DrawableImplementation.BuildDefaultPalette(len(list_of_polynomial_degrees))
-for i in range(len(list_of_polynomial_degrees)):
-    d = list_of_polynomial_degrees[i]
+palette = ot.DrawableImplementation.BuildDefaultPalette(len(list_of_dimensions))
+for i in range(len(list_of_dimensions)):
+    dimension = list_of_dimensions[i]
     number_of_coeff_array = ot.Sample(degree_maximum, 2)
-    for p in range(1, 1 + degree_maximum):
-        number_of_coeff_array[p - 1, 0] = p
-        number_of_coeff_array[p - 1, 1] = m.comb(p + d, p)
+    for degree in range(1, 1 + degree_maximum):
+        number_of_coeff_array[degree - 1, 0] = degree
+        number_of_coeff_array[degree - 1, 1] = m.comb(degree + dimension, degree)
     cloud = ot.Cloud(number_of_coeff_array)
     cloud.setPointStyle(point_styles[i])
-    cloud.setLegend(f"$d={d}$")
+    cloud.setLegend(f"dim.={dimension}")
     cloud.setColor(palette[i])
     graph.add(cloud)
 graph.setLegendPosition("topleft")
@@ -170,7 +170,7 @@ view = otv.View(grid, axes_kw={"aspect": "equal"})
 # in the numbers of terms of an order of magnitude.
 dim = 5
 graph = ot.Graph(
-    "Full tensorized basis. d = %d" % (dim),
+    "Hyperbolic enumeration. dim. = %d" % (dim),
     "Total degree",
     "Number of coefficients",
     True,
@@ -178,7 +178,7 @@ graph = ot.Graph(
 degree_maximum = 10
 q_list = [0.2, 0.4, 0.6, 0.8, 1.0]
 point_styles = ["bullet", "circle", "fdiamond", "fsquare", "triangleup"]
-palette = ot.DrawableImplementation.BuildDefaultPalette(len(list_of_polynomial_degrees))
+palette = ot.DrawableImplementation.BuildDefaultPalette(len(list_of_dimensions))
 for i in range(len(q_list)):
     q = q_list[i]
     enum_func = ot.HyperbolicAnisotropicEnumerateFunction(dim, q)

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
@@ -1,6 +1,73 @@
 """
 Polynomial chaos exploitation
 =============================
+
+The goal of this example is to create a polynomial chaos expansion using the
+:class:`~openturns.FunctionalChaosAlgorithm` class and see the different methods
+of the :class:`~openturns.FunctionalChaosResult` class.
+In order to understand the different results, let us review some notations associated to the
+polynomial chaos expansion.
+
+We first introduce the physical input, output and model:
+- the random vector :math:`\\vect{X}` is the physical input random vector,
+- the output random vector :math:`\\vect{Y}` is the output of the physical model,
+- the physical model :math:`g` is a function of the physical input:
+
+.. math:: \\vect{Y} = g(\\vect{X}).
+
+Then we introduce the iso-probabilistic transformation:
+
+- the random vector :math:`\\vect{Z}` is the standardized input random vector,
+- the transformation :math:`T` is the iso-probabilistic transformation mapping
+  from the physical input to the standardized input:
+
+.. math:: \\vect{Z} = T(\\vect{X}),
+
+- the standard distribution :math:`\\mu` of the standardized random vector :math:`\\vect{Z}`.
+
+We expand the model on the multivariate basis:
+
+- the full (i.e. unselected) multivariate basis is :math:`\\left(\\Psi_k\\right)_{k \\in \\mathbb{N}}`,
+- the composition of each polynomial of the truncated multivariate basis :math:`\\Psi_k`,
+- the full set of coefficients of the polynomial expansion is the set :math:`(\\vect{a}_k)_{k \\in \\mathbb{N}}`,
+- the composed model :math:`h` is a function of the standardized random vector :math:`\\vect{Z}`:
+
+.. math:: \\vect{Y} = h(\\vect{Z}) = g \\circ T^{-1}(\\vect{Z})
+
+Then we use a model selection method (e.g. from the :class:`~openturns.LARS` class):
+
+- the set :math:`\\mathcal{K} \\subseteq \\mathbb{N}` is the set of indices corresponding to the
+  result of the selection method,
+- the truncated (i.e. selected) multivariate basis is :math:`\\left(\\Psi_k\\right)_{k \\in \\mathcal{K}}`,
+- the selected set of coefficients of the polynomial expansion is the set :math:`(\\vect{a}_k)_{k \\in \\mathcal{K}}`,
+- the composed meta model :math:`\\hat{h}` is the function
+  of the standardized variables based on the truncated
+  multivariate basis :math:`\\left(\\Psi_k\\right)_{k \\in \\mathcal{K}}`.
+- the meta model is a function of the physical input:
+
+.. math:: \\vect{Y} = \\hat{g} (\\vect{X}) = \\hat{h} \\circ T(\\vect{X}).
+
+
+Based on the previous definitions, the composed model is:
+
+.. math::
+
+    h(\\vect{Z}) =  \\sum_{k \\in \\mathbb{N}} \\vect{a}_k \\Psi_k(\\vect{Z}),
+
+the composed metamodel is:
+
+.. math::
+
+    \\hat{h}(\\vect{Z}) = \\sum_{k \\in \\mathcal{K}} \\vect{a}_k \\Psi_k(\\vect{Z}),
+
+and the metamodel is:
+
+.. math::
+
+    \\hat{g}(\\vect{X}) = \\sum_{k \\in \\mathcal{K}} \\vect{a}_k \\Psi_k \\circ T(\\vect{X}).
+
+The three previous mathematical functions are implemented as instances of the
+:class:`~openturns.Function` class.
 """
 # %%
 # In this example we are going to create a global approximation of a model response using functional chaos and expose the associated results:
@@ -25,7 +92,11 @@ import openturns as ot
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# Prepare some X/Y data.
+# Prepare some input and output samples.
+# We define a model which has two inputs and two outputs.
+# Then we define a normal input random vector with independent marginals,
+# and we generate a sample from the input random vector.
+# Finally, we evaluate the output sample from the model.
 ot.RandomGenerator.SetSeed(0)
 dimension = 2
 input_names = ["x1", "x2"]
@@ -36,32 +107,42 @@ x = distribution.getSample(30)
 y = model(x)
 
 # %%
-# create a functional chaos algorithm
+# Create a functional chaos algorithm.
 algo = ot.FunctionalChaosAlgorithm(x, y)
+
+# %%
+# The previous constructor is the simplest since it has only two inputs arguments.
+# In this case, the algorithm has to retrieve the distribution from the `x`
+# sample, which can be difficult, especially if the sample size is small.
+# Notice, however, that the input distribution is known in our simple case.
+# This is why we update the previous script and give the input distribution as a third
+# input argument of the constructor.
+algo = ot.FunctionalChaosAlgorithm(x, y, distribution)
 algo.run()
 
 # %%
-# Stream out the result
+# Get the result.
 result = algo.getResult()
 result
 
 # %%
-# Get the polynomial chaos coefficients
+# In the next cells, we observe several methods of the `result` object.
+# First, we get the polynomial chaos coefficients.
 result.getCoefficients()
 
 # %%
-# The coefficients of marginal i
+# The coefficients of the i-th output marginal.
 i = 1
 result.getCoefficients()[i]
 
 # %%
-# Get the indices of the selected polynomials : K
+# Get the indices of the selected polynomials.
 subsetK = result.getIndices()
 subsetK
 
 # %%
 # Get the composition of the polynomials
-# of the truncated multivariate basis
+# of the truncated multivariate basis.
 for i in range(subsetK.getSize()):
     print(
         "Polynomial number ",
@@ -75,27 +156,30 @@ for i in range(subsetK.getSize()):
 
 # %%
 # Get the multivariate basis
-# as a collection of Function
+# as a collection of :class:`~openturns.Function`.
 reduced = result.getReducedBasis()
 
 # %%
-# Get the orthogonal basis
+# Get the orthogonal basis.
 orthgBasis = result.getOrthogonalBasis()
 
 # %%
-# Get the distribution of variables Z
+# Get the standard distribution :math:`\mu` of the standardized
+# random vector :math:`\vect{Z}`.
 orthgBasis.getMeasure()
 
 # %%
-# Get the composed meta model which is the model of the reduced variables Z
-# within the reduced polynomials basis
+# Get the composed meta model :math:`\hat{h}` which is
+# the model of the standardized random vector :math:`\vect{Z}`
+# within the reduced polynomials basis.
 result.getComposedMetaModel()
 
 # %%
-# Get the meta model which is the composed meta model combined with the
-# iso probabilistic transformation
+# Get the meta model :math:`\hat{g}` which is the composed meta model composed with the
+# iso probabilistic transformation :math:`T`.
 result.getMetaModel()
 
 # %%
-# Get the projection strategy
+# Get the projection strategy: this is the method to estimate
+# the coefficients, i.e. regression or integration.
 algo.getProjectionStrategy()

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
@@ -9,6 +9,7 @@ In order to understand the different results, let us review some notations assoc
 polynomial chaos expansion.
 
 We first introduce the physical input, output and model:
+
 - the random vector :math:`\\vect{X}` is the physical input random vector,
 - the output random vector :math:`\\vect{Y}` is the output of the physical model,
 - the physical model :math:`g` is a function of the physical input:
@@ -156,7 +157,7 @@ for i in range(subsetK.getSize()):
 
 # %%
 # Get the multivariate basis
-# as a collection of :class:`~openturns.Function`.
+# as a collection of :class:`~openturns.Function` objects.
 reduced = result.getReducedBasis()
 
 # %%

--- a/python/doc/theory/data_analysis/bic.rst
+++ b/python/doc/theory/data_analysis/bic.rst
@@ -6,13 +6,13 @@ Bayesian Information Criterion (BIC)
 This method deals with the modelling of a probability distribution of a
 random vector :math:`\vect{X} = \left( X^1,\ldots,X^{n_X} \right)`. It
 seeks to rank variable candidate distributions by using a sample of data
-:math:`\left\{ \vect{x}_1,\vect{x}_2,\ldots,\vect{x}_N \right\}`.
+:math:`\left\{ \vect{x}_1,\vect{x}_2,\ldots,\vect{x}_n \right\}`.
 The Bayesian Information Criterion (BIC) allows one to
 answer this question in the one dimensional case :math:`n_X =1`.
 
-Let us limit the case to :math:`n_X = 1`. Thus we denote
-:math:`\vect{X} = X^1 = X`. Moreover, let us denote by :math:`\cM_1`,\dots,
-:math:`\cM_K` the parametric models envisaged by user among the
+Let us consider the particular case where :math:`n_X = 1`. Thus we denote
+:math:`\vect{X} = X^1 = X`. Moreover, let us denote by
+:math:`\cM_1, \dots, \cM_K` the parametric models among the
 :ref:`parametric models <parametric_distribution_factories>`. We
 suppose here that the parameters of these models have been estimated
 previously by :ref:`Maximum Likelihood <maximum_likelihood>`
@@ -28,7 +28,7 @@ one would almost always favor complex models involving many parameters.
 If such models provide indeed a large numbers of degrees-of-freedom that
 can be used to fit the sample, one has to keep in mind that complex
 models may be less robust that simpler models with less parameters.
-Actually, the limited available information (:math:`N` data points) does
+Actually, the limited available information (:math:`n` data points) does
 not allow one to estimate robustly too many parameters.
 
 The BIC criterion can be used to avoid this problem. The principle is to
@@ -41,7 +41,7 @@ rank :math:`\cM_1,\dots,\cM_K` according to the following quantity:
      \end{aligned}
 
 where :math:`p_i` denotes the number of parameters being adjusted for
-the model :math:`\cM_i`. The smaller :math:`\textrm{BIC}_i`, the better
+the model :math:`\cM_i`. The smaller the :math:`\textrm{BIC}_i`, the better
 the model. Note that the idea is to introduce a penalization term that
 increases with the numbers of parameters to be estimated. A complex
 model will then have a good score only if the gain in terms of
@@ -51,11 +51,16 @@ The term "Bayesian Information Criterion" comes the interpretation of
 the quantity :math:`\textrm{BIC}_i`. In a bayesian context, the unknown
 "true" model may be seen as a random variable. Suppose now that the user
 does not have any informative prior information on which model is more
-relevant among :math:`\cM_1`,\dots, :math:`\cM_K`; all the models are thus
+relevant among :math:`\cM_1, \dots, \cM_K`; all the models are thus
 equally likely from the point of view of the user. Then, one can show
 that :math:`\textrm{BIC}_i` is an approximation of the posterior
 distribution's logarithm for the model :math:`\cM_i`.
 
+This criterion is a valuable criterion to reject
+a model which is not relevant, but can be tricky to interpret in
+some cases.
+For example, if two models have very close BIC, these two models should
+be considered instead of keeping only the model which has the lowest BIC.
 
 .. topic:: API:
 

--- a/python/doc/theory/probabilistic_modeling/process_definitions.rst
+++ b/python/doc/theory/probabilistic_modeling/process_definitions.rst
@@ -3,6 +3,9 @@
 Stochastic process definitions
 ==============================
 
+Notations
+---------
+
 In this document, we note:
 
 -  :math:`X: \Omega \times\cD \rightarrow \Rset^d` a multivariate
@@ -27,18 +30,25 @@ In this document, we note:
    :math:`m(\vect{t})=\Expect{X_{\vect{t}}}`,
 
 -  :math:`C : \cD \times \cD \rightarrow  \cM_{d \times d}(\Rset)` its
-   *covariance function*, defined by
-   :math:`C(\vect{s}, \vect{t})=\Expect{(X_{\vect{s}}-m(\vect{s}))(X_{\vect{t}}-m(\vect{t}))^t}`,
+   *covariance function*, defined by:
+
+.. math::
+   \operatorname{Cov}(\vect{s}, \vect{t})
+   = \Expect{(X_{\vect{s}} - m(\vect{s}))(X_{\vect{t}} - m(\vect{t}))^t},
 
 -  :math:`R : \cD \times \cD \rightarrow  \mathcal{M}_{d \times d}(\Rset)`
    its *correlation function*, defined for all
    :math:`(\vect{s}, \vect{t})`, by :math:`R(\vect{s}, \vect{t})` such
-   that for all :math:`(i,j)`,
-   :math:`R_{ij}(\vect{s}, \vect{t})=C_{ij}(\vect{s}, \vect{t})/\sqrt{C_{ii}(\vect{s}, \vect{t})C_{jj}(\vect{s}, \vect{t})}`.
+   that for all :math:`(i,j)`:
+
+.. math::
+   R_{ij}(\vect{s}, \vect{t})
+   = \frac{\operatorname{Cov}_{ij}(\vect{s}, \vect{t})}{\sqrt{\operatorname{Cov}_{ij}(\vect{s}, \vect{s}) \operatorname{Cov}_{ij}(\vect{t}, \vect{t})}}.
 
 We recall here some useful definitions.
 
-**Spatial (temporal) and Stochastic Mean**
+Spatial (temporal) and Stochastic Mean
+--------------------------------------
 
 The *spatial mean* of the process :math:`X` is the function
 :math:`m: \Omega \rightarrow \Rset^d` defined by:
@@ -78,7 +88,8 @@ If :math:`n=1` and if the mesh is a regular grid
 
     \forall \omega\in \Omega, \, \forall \vect{t} \in \cM, \, m(\omega)=  g(\vect{t})  = \vect{c}
 
-**Normal process**
+Normal process
+--------------
 
 A stochastic process is *normal* if all its finite
 dimensional joint distributions are normal, which means that for all
@@ -114,7 +125,8 @@ A normal process is entirely defined by its mean function :math:`m`
 and its covariance function :math:`C` (or correlation function
 :math:`R`).
 
-**Weak stationarity (second order stationarity)**
+Weak stationarity (second order stationarity)
+---------------------------------------------
 
 A process
 :math:`X` is *weakly stationary* or *stationary of second order* if
@@ -136,7 +148,8 @@ discrete case, :math:`\cD` is a lattice
 :math:`\mathcal{L}=(\delta_1 \Zset \times \dots \times \delta_n \Zset)`
 where :math:`\forall i, \delta_i >0`.
 
-**Stationarity**
+Stationarity
+------------
 
 A process :math:`X` is *stationary* if its
 distribution is invariant by translation: :math:`\forall k \in \Nset`,
@@ -148,7 +161,8 @@ distribution is invariant by translation: :math:`\forall k \in \Nset`,
 
     \forall k \in \Nset, \, \forall (\vect{t}_1, \dots, \vect{t}_k) \in \cD, \, \forall \vect{h}\in \Rset^n, \, (X_{\vect{t}_1}, \dots, X_{\vect{t}_k}) \stackrel{\mathcal{D}}{=} (X_{\vect{t}_1+\vect{h}}, \dots, X_{\vect{t}_k+\vect{h}})
 
-**Spectral density function**
+Spectral density function
+-------------------------
 
 If :math:`X` is a zero-mean weakly
 stationary continuous process and if for all :math:`(i,j)`,

--- a/python/doc/theory/probabilistic_modeling/process_definitions.rst
+++ b/python/doc/theory/probabilistic_modeling/process_definitions.rst
@@ -33,8 +33,9 @@ In this document, we note:
    *covariance function*, defined by:
 
 .. math::
-   \operatorname{Cov}(\vect{s}, \vect{t})
-   = \Expect{(X_{\vect{s}} - m(\vect{s}))(X_{\vect{t}} - m(\vect{t}))^t},
+   C(\vect{s}, \vect{t})
+   & := \Cov{X_{\vect{s}}, X_{\vect{t}}} \\
+   & \; = \Expect{(X_{\vect{s}} - m(\vect{s}))(X_{\vect{t}} - m(\vect{t}))^t},
 
 -  :math:`R : \cD \times \cD \rightarrow  \mathcal{M}_{d \times d}(\Rset)`
    its *correlation function*, defined for all
@@ -43,7 +44,8 @@ In this document, we note:
 
 .. math::
    R_{ij}(\vect{s}, \vect{t})
-   = \frac{\operatorname{Cov}_{ij}(\vect{s}, \vect{t})}{\sqrt{\operatorname{Cov}_{ij}(\vect{s}, \vect{s}) \operatorname{Cov}_{ij}(\vect{t}, \vect{t})}}.
+   & := \Cor{X_{\vect{s}}, X_{\vect{t}}} \\
+   & \; = \frac{C_{ij}(\vect{s}, \vect{t})}{\sqrt{C_{ij}(\vect{s}, \vect{s}) C_{ij}(\vect{t}, \vect{t})}}.
 
 We recall here some useful definitions.
 

--- a/python/doc/theory/probabilistic_modeling/random_mixture.rst
+++ b/python/doc/theory/probabilistic_modeling/random_mixture.rst
@@ -1,19 +1,22 @@
 .. _random_mixture:
 
-Random Mixture: affine combination of independent univariate distributions
---------------------------------------------------------------------------
+Affine combination of independent univariate random variables
+-------------------------------------------------------------
+
+Introduction
+~~~~~~~~~~~~
 
 Let :math:`\vect{Y}` be the random vector defined as the
-affine transform of :math:`n` independent univariate random variable.
+affine transform of :math:`n` independent univariate random variables.
 More precisely, consider:
 
 .. math::
-  :label: RandomMixtureFormula
+  :label: LinearCombinationFormula
 
    \vect{Y}=\vect{y}_0+\mat{M}\,\vect{X}
 
-where :math:`\vect{y}_0\in\mathbb{R}^d` is a deterministic vector with
-:math:`d\in\{1,2,3\}`, :math:`\mat{M}\in\mathcal{M}_{d,n}(\mathbb{R})` is a
+where :math:`\vect{y}_0 \in \Rset^d` is a deterministic vector with
+:math:`d \in \{1,2,3\}`, :math:`\mat{M} \in \mathcal{M}_{d,n}(\Rset)` is a
 deterministic matrix and :math:`\left(X_k\right)_{ 1 \leq k \leq n}` are
 independent random variables.
 In this case, it is possible to directly evaluate the distribution of
@@ -23,23 +26,23 @@ functions, quantiles (in dimension 1 only)...
 In this document, we present a method using the Poisson summation
 formula to evaluate the distribution of :math:`\vect{Y}`.
 
-Evaluation of the probability density function of the Random Mixture
---------------------------------------------------------------------
+Evaluation of the probability density function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since, by hypothesis, the univariate random variables :math:`X_i` are independent, the
-characteristic function of :math:`\vect{Y}`, denoted :math:`\phi_Y`, is
+characteristic function of :math:`\vect{Y}`, denoted :math:`\phi_{\vect{Y}}`, is
 easily defined from the characteristic function of :math:`X_k` denoted
 :math:`\phi_{X_k}` as follows:
 
 .. math::
   :label: CharactFuncY
 
-   \phi_Y(u_1,\hdots,u_d)
+   \phi_{\vect{Y}}(u_1,\hdots,u_d)
    = \prod_{j=1}^d e^{iu_j{y_0}_j} \prod_{k=1}^n\phi_{X_k}\left(\left(M^t u\right)_k\right),
 
-for any :math:`\vect{u}\in\mathbb{R}^d`.
-Once :math:`\phi_Y` is evaluated, it is possible to evaluate the
-probability density function of :math:`Y`, denoted :math:`p_Y` :
+for any :math:`\vect{u} \in \Rset^d`.
+Once :math:`\phi_{\vect{Y}}` is evaluated, it is possible to evaluate the
+probability density function of :math:`\vect{Y}`, denoted :math:`p_{\vect{Y}}` :
 several techniques are possible, as the inversion of the Fourier
 transformation, but this method is not easy to implement.
 We can alternatively use the Poisson summation formula:
@@ -47,46 +50,47 @@ We can alternatively use the Poisson summation formula:
 .. math::
   :label: PoissonSum
 
-   & \sum_{j_1\in\mathbb{Z}}\hdots\sum_{j_d\in\mathbb{Z}} p_Y\left(y_1+\frac{2\pi j_1}{h_1},\hdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
-   & = \left(\prod_{j=1}^d \frac{h_j}{2 \pi} \right) \sum_{k_1\in\mathbb{Z}}\hdots\sum_{k_d\in\mathbb{Z}}\phi\left(k_1h_1,\hdots,k_dh_d\right)e^{-\imath \left(\sum_{m=1}^{d}k_m h_m y_m\right)}
+   & \sum_{j_1 \in \Zset}\hdots\sum_{j_d \in \Zset} p_{\vect{Y}}\left(y_1+\frac{2\pi j_1}{h_1},\hdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
+   & = \left(\prod_{j=1}^d \frac{h_j}{2 \pi} \right) \sum_{k_1 \in \Zset}\hdots\sum_{k_d \in \Zset}\phi\left(k_1h_1,\hdots,k_dh_d\right)e^{-\imath \left(\sum_{m=1}^{d}k_m h_m y_m\right)}
 
-where :math:`\imath` is the complex imaginary number, i.e. :math:`\imath^2 = -1`.
+where :math:`h_1, \hdots, h_d \in \Rset` and
+:math:`\imath` is the complex imaginary number, i.e. :math:`\imath^2 = -1`.
 If :math:`h_1,\hdots,h_d` are close to zero, then:
 
-.. math:: \frac{2k\pi}{h_j} \approx +\infty
+.. math:: \frac{2k\pi}{h_j} \approx + \in fty
 
 and:
 
-.. math:: p_Y\left(\hdots,\frac{2k\pi}{h_j},\hdots\right) \approx 0
+.. math:: p_{\vect{Y}}\left(\hdots,\frac{2k\pi}{h_j},\hdots\right) \approx 0
 
-because of the decreasing properties of :math:`p_Y`. Thus the nested sums of the left
+because of the decreasing properties of :math:`p_{\vect{Y}}`. Thus the nested sums of the left
 term of :eq:`PoissonSum` are reduced to the central term
 :math:`j_1=\hdots=j_d = 0`: the left term is approximately equal to
-:math:`p_Y(y)`.
+:math:`p_{\vect{Y}}(y)`.
 Furthermore, the right term of :eq:`PoissonSum` is a series which
 converges very fast: few terms of the series are enough to get
 machine-precision accuracy. Let us note that the factors
-:math:`\phi_Y(k_1 h_1,\hdots,k_d,h_d)`, which are expensive to
+:math:`\phi_{\vect{Y}}(k_1 h_1,\hdots,k_d,h_d)`, which are expensive to
 evaluate, do not depend on :math:`y` and are evaluated once only.
 
 It is also possible to greatly improve the performance of the
-algorithm by noticing that the equation is linear between :math:`p_Y` and
-:math:`\phi_Y`. We denote by :math:`q_Y` and :math:`\psi_Y` respectively
+algorithm by noticing that the equation is linear between :math:`p_{\vect{Y}}` and
+:math:`\phi_{\vect{Y}}`. We denote by :math:`q_Y` and :math:`\psi_Y` respectively
 the density and the characteristic function of the multivariate normal
 distribution with the same mean :math:`\vect{\mu}` and same covariance
-matrix :math:`\vect{C}` as the random mixture. By applying this
+matrix :math:`\vect{C}` as the affine combination. By applying this
 multivariate normal distribution to the equation, we obtain by
 subtraction:
 
 .. math::
     :label: algoPoisson
 
-     p_Y\left(y\right)
-     & = \sum_{j\in\mathbb{Z}^d} q_Y\left(y_1+\frac{2\pi j_1}{h_1},\cdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
+     p_{\vect{Y}}\left(y\right)
+     & = \sum_{j \in \Zset^d} q_Y\left(y_1+\frac{2\pi j_1}{h_1},\cdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
      & \quad + \frac{H}{2^d\pi^d}\sum_{|k_1|\leq N}\cdots\sum_{|k_d|\leq N} \delta_Y\left(k_1h_1,\cdots,k_dh_d\right)e^{-\imath \left(\sum_{m=1}^{d}k_m h_m y_m\right)}
 
 where :math:`H = h_1\times\cdots\times h_d`,
-:math:`j=(j_1,\cdots,j_d)` and :math:`\delta_Y:=\phi_Y - \psi_Y`.
+:math:`j=(j_1,\cdots,j_d)` and :math:`\delta_Y:=\phi_{\vect{Y}} - \psi_Y`.
 In the case where :math:`n \gg 1`, using the limit central theorem,
 the law of :math:`\vect{Y}` tends to the normal distribution density
 :math:`q`, which will drastically reduce :math:`N`. The sum on
@@ -109,11 +113,11 @@ The parameter :math:`N` is dynamically calibrated: we start with
 :math:`N=8` then we double :math:`N` value until the total contribution
 of the additional terms is negligible.
 
-Evaluation of the moments of the Random Mixture
------------------------------------------------
+Evaluation of the moments
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The relation :eq:`RandomMixtureFormula` enables to evaluate all the
-moments of the random mixture, if mathematically defined. For example,
+The relation :eq:`LinearCombinationFormula` enables to evaluate all the
+moments of the affine combination, if mathematically defined. For example,
 we have:
 
 .. math::
@@ -122,7 +126,7 @@ we have:
       \Cov{\vect{Y}} & = \mat{M}\,\Cov{\vect{X}}\mat{M}^t
 
 Computation on a regular grid
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We want to compute the density function on a regular grid and
 to get an approximation quickly.
@@ -133,7 +137,7 @@ The regular grid is:
 
    \:y_{r,m}=\mu_r+b\left(\frac{2m+1}{M} - 1\right)\sigma_r
 
-for all :math:`r\in\{1,\hdots,d\}` and :math:`m\in\{0,\hdots,M-1\}`.
+for all :math:`r \in \{1,\hdots,d\}` and :math:`m \in \{0,\hdots,M-1\}`.
 Denoting :math:`p_{m_1,\hdots,m_d}=p_{\vect{Y}}(y_{1,m_1},\hdots,y_{d,m_d})`:
 
 .. math::
@@ -159,7 +163,7 @@ The aim is to rewrite the previous expression as a :math:`d`- discrete
 Fourier transform, in order to apply Fast Fourier Transform (*FFT*) for
 its evaluation.
 We set :math:`M=N` and
-:math:`\forall j \in\{1,\hdots,d\},\: h_j=\frac{\pi}{b\sigma_j}` and
+:math:`\forall j  \in \{1,\hdots,d\},\: h_j=\frac{\pi}{b\sigma_j}` and
 :math:`\tau_j=\frac{\mu_j}{b\sigma_j}`. For convenience, we introduce
 the functions:
 

--- a/python/doc/theory/probabilistic_modeling/random_mixture.rst
+++ b/python/doc/theory/probabilistic_modeling/random_mixture.rst
@@ -13,10 +13,10 @@ More precisely, consider:
    \vect{Y}=\vect{y}_0+\mat{M}\,\vect{X}
 
 where :math:`\vect{y}_0\in\mathbb{R}^d` is a deterministic vector with
-:math:`d\in\{1,2,3\}`, :math:`\mat{M}\in\mathcal{M}_{d,n}(\mathbb{R})` a
+:math:`d\in\{1,2,3\}`, :math:`\mat{M}\in\mathcal{M}_{d,n}(\mathbb{R})` is a
 deterministic matrix and :math:`\left(X_k\right)_{ 1 \leq k \leq n}` are
 independent random variables.
-In this case, it is possible to evaluate directly the distribution of
+In this case, it is possible to directly evaluate the distribution of
 :math:`\vect{Y}` and then to ask :math:`\vect{Y}` any request compatible
 with a distribution: moments, probability and cumulative density
 functions, quantiles (in dimension 1 only)...
@@ -38,7 +38,7 @@ easily defined from the characteristic function of :math:`X_k` denoted
    = \prod_{j=1}^d e^{iu_j{y_0}_j} \prod_{k=1}^n\phi_{X_k}\left(\left(M^t u\right)_k\right),
 
 for any :math:`\vect{u}\in\mathbb{R}^d`.
-Once :math:`\phi_Y` evaluated, it is possible to evaluate the
+Once :math:`\phi_Y` is evaluated, it is possible to evaluate the
 probability density function of :math:`Y`, denoted :math:`p_Y` :
 several techniques are possible, as the inversion of the Fourier
 transformation, but this method is not easy to implement.
@@ -64,14 +64,14 @@ term of :eq:`PoissonSum` are reduced to the central term
 :math:`j_1=\hdots=j_d = 0`: the left term is approximately equal to
 :math:`p_Y(y)`.
 Furthermore, the right term of :eq:`PoissonSum` is a series which
-converges very fast: only few terms of the series are enough to get
+converges very fast: few terms of the series are enough to get
 machine-precision accuracy. Let us note that the factors
 :math:`\phi_Y(k_1 h_1,\hdots,k_d,h_d)`, which are expensive to
 evaluate, do not depend on :math:`y` and are evaluated once only.
 
 It is also possible to greatly improve the performance of the
-algorithm by noticing that equation is linear between :math:`p_Y` and
-:math:`\phi_Y`. We denote :math:`q_Y` and :math:`\psi_Y` respectively
+algorithm by noticing that the equation is linear between :math:`p_Y` and
+:math:`\phi_Y`. We denote by :math:`q_Y` and :math:`\psi_Y` respectively
 the density and the characteristic function of the multivariate normal
 distribution with the same mean :math:`\vect{\mu}` and same covariance
 matrix :math:`\vect{C}` as the random mixture. By applying this

--- a/python/doc/theory/probabilistic_modeling/random_mixture.rst
+++ b/python/doc/theory/probabilistic_modeling/random_mixture.rst
@@ -3,88 +3,97 @@
 Random Mixture: affine combination of independent univariate distributions
 --------------------------------------------------------------------------
 
-A multivariate random variable :math:`\vect{Y}` may be defined as an
-affine transform of :math:`n` independent univariate random variable, as
-follows:
+Let :math:`\vect{Y}` be the random vector defined as the
+affine transform of :math:`n` independent univariate random variable.
+More precisely, consider:
 
 .. math::
   :label: RandomMixtureFormula
 
-   \displaystyle \vect{Y}=\vect{y}_0+\mat{M}\,\vect{X}
+   \vect{Y}=\vect{y}_0+\mat{M}\,\vect{X}
 
 where :math:`\vect{y}_0\in\mathbb{R}^d` is a deterministic vector with
 :math:`d\in\{1,2,3\}`, :math:`\mat{M}\in\mathcal{M}_{d,n}(\mathbb{R})` a
-deterministic matrix and :math:`(X_k)_{ 1 \leq k \leq n}` are some
-independent univariate distributions.
-
-In such a case, it is possible to evaluate directly the distribution of
+deterministic matrix and :math:`\left(X_k\right)_{ 1 \leq k \leq n}` are
+independent random variables.
+In this case, it is possible to evaluate directly the distribution of
 :math:`\vect{Y}` and then to ask :math:`\vect{Y}` any request compatible
 with a distribution: moments, probability and cumulative density
-functions, quantiles (in dimension 1 only) ...
+functions, quantiles (in dimension 1 only)...
+In this document, we present a method using the Poisson summation
+formula to evaluate the distribution of :math:`\vect{Y}`.
 
-**Evaluation of the probability density function of the Random Mixture**
+Evaluation of the probability density function of the Random Mixture
+--------------------------------------------------------------------
 
-As the univariate random variables :math:`X_i` are independent, the
+Since, by hypothesis, the univariate random variables :math:`X_i` are independent, the
 characteristic function of :math:`\vect{Y}`, denoted :math:`\phi_Y`, is
 easily defined from the characteristic function of :math:`X_k` denoted
-:math:`\phi_{X_k}` as follows :
+:math:`\phi_{X_k}` as follows:
 
 .. math::
   :label: CharactFuncY
 
-   \displaystyle \phi_Y(u_1,\hdots,u_d)=\prod_{j=1}^de^{iu_j{y_0}_j}\prod_{k=1}^n\phi_{X_k}((M^tu)_k), \mbox{  for } \vect{u}\in\mathbb{R}^d
+   \phi_Y(u_1,\hdots,u_d)
+   = \prod_{j=1}^d e^{iu_j{y_0}_j} \prod_{k=1}^n\phi_{X_k}\left(\left(M^t u\right)_k\right),
 
-| Once :math:`\phi_Y` evaluated, it is possible to evaluate the
-  probability density function of :math:`Y`, denoted :math:`p_Y` :
-  several techniques are possible, as the inversion of the Fourier
-  transformation. This technique is not easy to implement.
-| Another technique is used, based on the Poisson sum
-  formulation, defined as follows:
+for any :math:`\vect{u}\in\mathbb{R}^d`.
+Once :math:`\phi_Y` evaluated, it is possible to evaluate the
+probability density function of :math:`Y`, denoted :math:`p_Y` :
+several techniques are possible, as the inversion of the Fourier
+transformation, but this method is not easy to implement.
+We can alternatively use the Poisson summation formula:
 
-  .. math::
-    :label: PoissonSum
+.. math::
+  :label: PoissonSum
 
-     \displaystyle \sum_{j_1\in\mathbb{Z}}\hdots\sum_{j_d\in\mathbb{Z}} p_Y\left(y_1+\frac{2\pi j_1}{h_1},\hdots,y_d+\frac{2\pi j_d}{h_d}\right)=
-         \prod_{j=1}^d \frac{h_j}{2*\pi}\sum_{k_1\in\mathbb{Z}}\hdots\sum_{k_d\in\mathbb{Z}}\phi\left(k_1h_1,\hdots,k_dh_d\right)e^{-\imath(\sum_{m=1}^{d}k_m h_m y_m)}
+   & \sum_{j_1\in\mathbb{Z}}\hdots\sum_{j_d\in\mathbb{Z}} p_Y\left(y_1+\frac{2\pi j_1}{h_1},\hdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
+   & = \left(\prod_{j=1}^d \frac{h_j}{2 \pi} \right) \sum_{k_1\in\mathbb{Z}}\hdots\sum_{k_d\in\mathbb{Z}}\phi\left(k_1h_1,\hdots,k_dh_d\right)e^{-\imath \left(\sum_{m=1}^{d}k_m h_m y_m\right)}
 
-| By fixing :math:`h_1,\hdots,h_d` small enough,
-  :math:`\frac{2k\pi}{h_j} \approx +\infty` and
-  :math:`p_Y(\hdots,\frac{2k\pi}{h_j},\hdots) \approx 0` because of the
-  decreasing properties of :math:`p_Y`. Thus the nested sums of the left
-  term of :eq:`PoissonSum` are reduced to the central term
-  :math:`j_1=\hdots=j_d = 0`: the left term is approximatively equal to
-  :math:`p_Y(y)`.
-| Furthermore, the right term of :eq:`PoissonSum` is a series which
-  converges very fast: only few terms of the series are enough to get
-  machine-precision accuracy. Let us note that the factors
-  :math:`\phi_Y(k_1 h_1,\hdots,k_d,h_d)`, which are expensive to
-  evaluate, do not depend on :math:`y` and are evaluated once only.
+where :math:`\imath` is the complex imaginary number, i.e. :math:`\imath^2 = -1`.
+If :math:`h_1,\hdots,h_d` are close to zero, then:
 
-| It is also possible to greatly improve the performance of the
-  algorithm by noticing that equation  is linear between :math:`p_Y` and
-  :math:`\phi_Y`. We denote :math:`q_Y` and :math:`\psi_Y` respectively
-  the density and the characteristic function of the multivariate normal
-  distribution with the same mean :math:`\vect{\mu}` and same covariance
-  matrix :math:`\vect{C}` as the random mixture. By applying this
-  multivariate normal distribution to the equation , we obtain by
-  subtraction:
+.. math:: \frac{2k\pi}{h_j} \approx +\infty
 
-  .. math::
+and:
+
+.. math:: p_Y\left(\hdots,\frac{2k\pi}{h_j},\hdots\right) \approx 0
+
+because of the decreasing properties of :math:`p_Y`. Thus the nested sums of the left
+term of :eq:`PoissonSum` are reduced to the central term
+:math:`j_1=\hdots=j_d = 0`: the left term is approximately equal to
+:math:`p_Y(y)`.
+Furthermore, the right term of :eq:`PoissonSum` is a series which
+converges very fast: only few terms of the series are enough to get
+machine-precision accuracy. Let us note that the factors
+:math:`\phi_Y(k_1 h_1,\hdots,k_d,h_d)`, which are expensive to
+evaluate, do not depend on :math:`y` and are evaluated once only.
+
+It is also possible to greatly improve the performance of the
+algorithm by noticing that equation is linear between :math:`p_Y` and
+:math:`\phi_Y`. We denote :math:`q_Y` and :math:`\psi_Y` respectively
+the density and the characteristic function of the multivariate normal
+distribution with the same mean :math:`\vect{\mu}` and same covariance
+matrix :math:`\vect{C}` as the random mixture. By applying this
+multivariate normal distribution to the equation, we obtain by
+subtraction:
+
+.. math::
     :label: algoPoisson
 
-     \displaystyle  p_Y\left(y\right) = \sum_{j\in\mathbb{Z}^d} q_Y\left(y_1+\frac{2\pi j_1}{h_1},\cdots,y_d+\frac{2\pi j_d}{h_d}\right)+
-       \frac{H}{2^d\pi^d}\sum_{|k_1|\leq N}\cdots\sum_{|k_d|\leq N} \delta_Y\left(k_1h_1,\cdots,k_dh_d\right)e^{-\imath(\sum_{m=1}^{d}k_m h_m y_m)}
+     p_Y\left(y\right)
+     & = \sum_{j\in\mathbb{Z}^d} q_Y\left(y_1+\frac{2\pi j_1}{h_1},\cdots,y_d+\frac{2\pi j_d}{h_d}\right) \\
+     & \quad + \frac{H}{2^d\pi^d}\sum_{|k_1|\leq N}\cdots\sum_{|k_d|\leq N} \delta_Y\left(k_1h_1,\cdots,k_dh_d\right)e^{-\imath \left(\sum_{m=1}^{d}k_m h_m y_m\right)}
 
 where :math:`H = h_1\times\cdots\times h_d`,
-:math:`j=(j_1,\cdots,j_d)`, :math:`\delta_Y:=\phi_Y - \psi_Y`
-
-| In the case where :math:`n \gg 1`, using the limit central theorem,
-  the law of :math:`\vect{Y}` tends to the normal distribution density
-  :math:`q`, which will drastically reduce :math:`N`. The sum on
-  :math:`q` will become the most CPU-intensive part, because in the
-  general case we will have to keep more terms than the central one in
-  this sum, since the parameters :math:`h_1, \dots  h_d` were
-  calibrated with respect to :math:`p` and not :math:`q`.
+:math:`j=(j_1,\cdots,j_d)` and :math:`\delta_Y:=\phi_Y - \psi_Y`.
+In the case where :math:`n \gg 1`, using the limit central theorem,
+the law of :math:`\vect{Y}` tends to the normal distribution density
+:math:`q`, which will drastically reduce :math:`N`. The sum on
+:math:`q` will become the most CPU-intensive part, because in the
+general case we will have to keep more terms than the central one in
+this sum, since the parameters :math:`h_1, \dots  h_d` were
+calibrated with respect to :math:`p` and not :math:`q`.
 
 The parameters :math:`h_1, \dots  h_d` are calibrated using the
 following formula:
@@ -96,12 +105,12 @@ where :math:`\sigma_\ell=\sqrt{\Cov{\vect{Y}}_{\ell,\ell}}` and
 deviations covered by the marginal distribution (:math:`\alpha=5` by
 default) and :math:`\beta` the number of marginal deviations beyond
 which the density is negligible (:math:`\beta=8.5` by default).
-
-The :math:`N` parameter is dynamically calibrated: we start with
+The parameter :math:`N` is dynamically calibrated: we start with
 :math:`N=8` then we double :math:`N` value until the total contribution
 of the additional terms is negligible.
 
-**Evaluation of the moments of the Random Mixture**
+Evaluation of the moments of the Random Mixture
+-----------------------------------------------
 
 The relation :eq:`RandomMixtureFormula` enables to evaluate all the
 moments of the random mixture, if mathematically defined. For example,
@@ -109,74 +118,65 @@ we have:
 
 .. math::
 
-    \left\{
-    \begin{array}{lcl}
-      \Expect{\vect{Y}} & = & \vect{y_0} + \mat{M}\Expect{\vect{X}} \\
-      \Cov{\vect{Y}} & = & \mat{M}\,\Cov{\vect{X}}\mat{M}^t
-    \end{array}\right\}
+      \Expect{\vect{Y}} & = \vect{y_0} + \mat{M}\Expect{\vect{X}} \\
+      \Cov{\vect{Y}} & = \mat{M}\,\Cov{\vect{X}}\mat{M}^t
 
-**Computation on a regular grid**
+Computation on a regular grid
+-----------------------------
 
-The interest is to compute the density function on a regular grid.
-Purposes are to get an approximation quickly. The regular grid is of
-form:
+We want to compute the density function on a regular grid and
+to get an approximation quickly.
+The regular grid is:
 
 .. math::
 
-   \begin{aligned}
-       \forall r\in\{1,\hdots,d\},\forall m\in\{0,\hdots,M-1\},\:y_{r,m}=\mu_r+b\left(\frac{2m+1}{M} - 1\right)\sigma_r
-     \end{aligned}
 
-By denoting :math:`p_{m_1,\hdots,m_d}=p_{\vect{Y}}(y_{1,m_1},\hdots,y_{d,m_d})`:
+   \:y_{r,m}=\mu_r+b\left(\frac{2m+1}{M} - 1\right)\sigma_r
+
+for all :math:`r\in\{1,\hdots,d\}` and :math:`m\in\{0,\hdots,M-1\}`.
+Denoting :math:`p_{m_1,\hdots,m_d}=p_{\vect{Y}}(y_{1,m_1},\hdots,y_{d,m_d})`:
 
 .. math::
 
-   \begin{aligned}
-       p_{m_1,\hdots,m_d}= Q_{m_1,\hdots,m_d}+S_{m_1,\hdots,m_d}
-     \end{aligned}
+   p_{m_1,\hdots,m_d}= Q_{m_1,\hdots,m_d}+S_{m_1,\hdots,m_d}
 
 for which the term :math:`S_{m_1,\hdots,m_d}` is the most CPU
 consuming. This term rewrites:
 
 .. math::
 
-   \begin{aligned}
-     S_{m_1,\hdots,m_d}=&\frac{H}{2^d\pi^d}\sum_{k_1=-N}^{N}\hdots\sum_{k_d=-N}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right)
-     E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \label{Eq:S}
-     \end{aligned}
+   S_{m_1,\hdots,m_d}=&\frac{H}{2^d\pi^d}\sum_{k_1=-N}^{N}\hdots\sum_{k_d=-N}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right)
+   E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
 
 with:
 
 .. math::
 
-   \begin{aligned}
-       \delta\left(k_1h_1,\hdots,k_dh_d\right)&=(\phi-\psi)\left(k_1h_1,\hdots,k_dh_d\right)\\
-       E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)&=e^{-i\sum_{j=1}^d k_jh_j\left(\mu_j+b\left(\frac{2m_j+1}{M}-1\right)\sigma_j\right)}
-     \end{aligned}
+   \delta\left(k_1h_1,\hdots,k_dh_d\right) & = (\phi-\psi)\left(k_1h_1,\hdots,k_dh_d\right)\\
+   E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) & = e^{-i\sum_{j=1}^d k_jh_j\left(\mu_j+b\left(\frac{2m_j+1}{M}-1\right)\sigma_j\right)}
 
 The aim is to rewrite the previous expression as a :math:`d`- discrete
 Fourier transform, in order to apply Fast Fourier Transform (*FFT*) for
 its evaluation.
-
 We set :math:`M=N` and
 :math:`\forall j \in\{1,\hdots,d\},\: h_j=\frac{\pi}{b\sigma_j}` and
 :math:`\tau_j=\frac{\mu_j}{b\sigma_j}`. For convenience, we introduce
 the functions:
 
-.. math:: f_j(k) = e^{-i\pi (k+1)\left(\tau_j-1+\frac{1}{N}\right)}
+.. math::
+
+    f_j(k) = e^{-i\pi (k+1)\left(\tau_j-1+\frac{1}{N}\right)}
 
 We use :math:`k+1` instead of :math:`k` in this function to simplify
 expressions below.
-
 We obtain:
 
 .. math::
 
-   \begin{aligned}
-     E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)&=e^{-i\sum_{j=1}^{d} k_jh_jb\sigma_j\left(\frac{\mu_j}{b\sigma_j}+\frac{2m_j}{N}+\frac{1}{N}-1\right)}\notag\\
-       &=e^{-2i\pi\left(\frac{\sum_{j=1}^{d}k_j m_j}{N}\right)}e^{-i\pi\sum_{j=1}^{d} k_j\left(\tau_j-1+\frac{1}{N}\right)} \notag\\
-       &=e^{-2i\pi\left(\frac{\sum_{j=1}^{d}k_j m_j}{N}\right)} f_1(k_1-1) \times\hdots\times f_d(k_d-1) \label{Eq:E}
-     \end{aligned}
+   & E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+   & = e^{-i\sum_{j=1}^{d} k_jh_jb\sigma_j\left(\frac{\mu_j}{b\sigma_j}+\frac{2m_j}{N}+\frac{1}{N}-1\right)}\\
+   & = e^{-2i\pi\left(\frac{\sum_{j=1}^{d}k_j m_j}{N}\right)}e^{-i\pi\sum_{j=1}^{d} k_j\left(\tau_j-1+\frac{1}{N}\right)} \\
+   & = e^{-2i\pi\left(\frac{\sum_{j=1}^{d}k_j m_j}{N}\right)} f_1(k_1-1) \times \hdots \times f_d(k_d-1)
 
 For performance reasons, we want to use the discrete Fourier transform
 with the following convention in dimension 1:
@@ -185,97 +185,79 @@ with the following convention in dimension 1:
 
 which extension to dimensions 2 and 3 are respectively:
 
-.. math:: A_{m,n} = \sum_{k=0}^{N-1}\sum_{l=0}^{N-1} a_{k,l} e^{-2i\pi\frac{km}{N}} e^{-2i\pi\frac{ln}{N}}\\
+.. math::
 
-.. math:: A_{m,n,p} = \sum_{k=0}^{N-1}\sum_{l=0}^{N-1}\sum_{s=0}^{N-1} a_{k,l,s} e^{-2i\pi\frac{km}{N}} e^{-2i\pi\frac{ln}{N}} e^{-2i\pi\frac{sp}{N}}
+    A_{m,n} & = \sum_{k=0}^{N-1}\sum_{l=0}^{N-1} a_{k,l} e^{-2i\pi\frac{km}{N}} e^{-2i\pi\frac{ln}{N}}\\
+    A_{m,n,p} & = \sum_{k=0}^{N-1}\sum_{l=0}^{N-1}\sum_{s=0}^{N-1} a_{k,l,s} e^{-2i\pi\frac{km}{N}} e^{-2i\pi\frac{ln}{N}} e^{-2i\pi\frac{sp}{N}}
 
-We decompose sums of  on the interval :math:`[-N,N]` into three parts:
+We decompose sums of on the interval :math:`[-N,N]` into three parts:
 
 .. math::
  :label: decomposition-sum
 
-   \begin{aligned}
-     \sum_{k_j=-N}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
-       = & \sum_{k_j=-N}^{-1} \delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \notag\\
-       & + \delta\left(k_1h_1,\hdots,0,\hdots,k_dh_d\right) E_{m_1,\hdots,0,\hdots,m_d}(k_1,\hdots,0,\hdots,k_d) \notag\\
-       & + \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
-     \end{aligned}
+     & \sum_{k_j=-N}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+     & = \sum_{k_j=-N}^{-1} \delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+     & \quad + \delta\left(k_1h_1,\hdots,0,\hdots,k_dh_d\right) E_{m_1,\hdots,0,\hdots,m_d}(k_1,\hdots,0,\hdots,k_d) \\
+     & \quad+ \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
 
-If we already computed :math:`E` for dimension :math:`d-1`, then the
+If we compute :math:`E` for dimension :math:`d-1`, then the
 middle term in this sum is trivial.
 
-To compute the last sum of equation, we apply a change of variable
-:math:`k_j'=k_j-1`:
+To compute the last sum, we apply a change of variable :math:`k_j' = k_j-1`:
 
 .. math::
 
-   \begin{aligned}
-     \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
-     = & \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j+1)h_j,\hdots,k_dh_d\right) \times\notag\\
-       & \hspace*{3cm} E_{m_1,\hdots,m_d}(k_1,\hdots,k_j+1,\hdots,k_d)
-     \end{aligned}
+     & \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+     & = \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j+1)h_j,\hdots,k_dh_d\right) \times\\
+     & \quad E_{m_1,\hdots,m_d}(k_1,\hdots,k_j+1,\hdots,k_d)
 
-Equation gives:
+This implies:
 
 .. math::
 
-   \begin{aligned}
-     E_{m_1,\hdots,m_d}(k_1,\hdots,k_j+1,\hdots,k_d)
-     &=
-         e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N} +\frac{m_j}{N}\right)}
-         f_1(k_1-1)\times\hdots\times f_j(k_j)\times\hdots\times f_d(k_d-1)\notag\\
-     &=
-         e^{-2i\pi\left(\frac{m_j}{N}\right)}
-         e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
-         f_1(k_1-1)\times\hdots\times f_j(k_j)\times\hdots\times f_d(k_d-1)
-     \end{aligned}
+     & E_{m_1,\hdots,m_d}(k_1, \hdots, k_j+1, \hdots, k_d) \\
+     &= e^{-2i\pi\left(\frac{\sum_{l = 1}^{d}k_l m_l}{N} +\frac{m_j}{N}\right)}
+         f_1(k_1 - 1)\times \hdots \times f_j(k_j) \times \hdots \times f_d(k_d - 1) \\
+     &= e^{-2i\pi\left(\frac{m_j}{N}\right)}
+         e^{-2i\pi\left(\frac{\sum_{l = 1}^{d}k_l m_l}{N}\right)}
+         f_1(k_1 - 1)\times \hdots \times f_j(k_j) \times \hdots \times f_d(k_d - 1)
 
-Thus
+Thus:
 
 .. math::
 
-   \begin{aligned}
-     \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}&(k_1,\hdots,k_d)
-       = e^{-2i\pi\left(\frac{m_j}{N}\right)} \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j+1)h_j,\hdots,k_dh_d\right) \times\notag\\
-       & e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
-         f_1(k_1-1)\times\hdots\times f_j(k_j)\times\hdots\times f_d(k_d-1) \label{Eq:j-sigma+}
-     \end{aligned}
+     & \sum_{k_j=1}^{N}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+     & = e^{-2i\pi\left(\frac{m_j}{N}\right)} \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j+1)h_j,\hdots,k_dh_d\right) \times \\
+     & \quad e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
+         f_1(k_1-1)\times \hdots \times f_j(k_j)\times \hdots \times f_d(k_d-1)
 
 To compute the first sum of equation, we apply a change of variable
 :math:`k_j'=N+k_j`:
 
 .. math::
 
-   \begin{aligned}
-     \sum_{k_j=-N}^{-1}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d)
-     = & \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j-N)h_j,\hdots,k_dh_d\right) \times\notag\\
-       & \hspace*{3cm} E_{m_1,\hdots,m_d}(k_1,\hdots,k_j-N,\hdots,k_d)
-     \end{aligned}
+     & \sum_{k_j=-N}^{-1}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}(k_1,\hdots,k_d) \\
+     &=  \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j-N)h_j,\hdots,k_dh_d\right) \times \\
+       & \quad  E_{m_1,\hdots,m_d}(k_1,\hdots,k_j-N,\hdots,k_d)
 
-Equation  gives:
+This implies:
 
 .. math::
 
-   \begin{aligned}
-     E_{m_1,\hdots,m_d}(k_1,\hdots,k_j-N,\hdots,k_d)
-     &=
-         e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N} -m_j\right)}
-         f_1(k_1-1)\times\hdots\times f_j(k_j-1-N)\times\hdots\times f_d(k_d-1) \notag\\
-     &=
-         e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
-         f_1(k_1-1)\times\hdots\times \overline{f}_j(N-1-k_j)\times\hdots\times f_d(k_d-1)
-     \end{aligned}
+     & E_{m_1,\hdots,m_d}(k_1,\hdots,k_j-N,\hdots,k_d) \\
+     &= e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N} -m_j\right)}
+         f_1(k_1-1)\times \hdots \times f_j(k_j-1-N)\times \hdots \times f_d(k_d-1) \\
+     & = e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
+         f_1(k_1-1)\times \hdots \times \overline{f}_j(N-1-k_j)\times \hdots \times f_d(k_d-1)
 
 Thus:
 
 .. math::
 
-   \begin{aligned}
-     \sum_{k_j=-N}^{-1}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d}&(k_1,\hdots,k_d)
-       = \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j-N)h_j,\hdots,k_dh_d\right) \times\notag\\
-       & e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
-         f_1(k_1-1)\times\hdots\times \overline{f}_j(N-1-k_j)\times\hdots\times f_d(k_d-1) \label{Eq:j-sigma-}
-     \end{aligned}
+     & \sum_{k_j=-N}^{-1}\delta\left(k_1h_1,\hdots,k_dh_d\right) E_{m_1,\hdots,m_d} (k_1,\hdots,k_d) \\
+     & = \sum_{k_j=0}^{N-1}\delta\left(k_1h_1,\hdots,(k_j-N)h_j,\hdots,k_dh_d\right) \times \\
+     & \quad e^{-2i\pi\left(\frac{\sum_{l=1}^{d}k_l m_l}{N}\right)}
+         f_1(k_1-1)\times \hdots \times \overline{f}_j(N-1-k_j)\times \hdots \times f_d(k_d-1)
 
 To summarize:
 

--- a/python/doc/usecases/use_case_viscous_fall.rst
+++ b/python/doc/usecases/use_case_viscous_fall.rst
@@ -3,7 +3,6 @@
 A viscous free fall example
 ===========================
 
-
 Introduction
 -------------
 
@@ -13,21 +12,19 @@ The fluid generates a drag force which limits the speed of the solid and we assu
 .. math::
    m \frac{dv}{dt} = - m g - c v
 
-
 for any :math:`t \in [0, t_{max}]` where:
 
-    - :math:`v` is the speed :math:`[m/s]`,
-    - :math:`t` is the time :math:`[s]`,
-    - :math:`t_{max}` is the maximum time :math:`[s]`,
-    - :math:`g = 9.81` is the gravitational acceleration :math:`[m.s^{-2}]`,
-    - :math:`m` is the mass :math:`[kg]`,
-    - :math:`c` is the linear drag coefficient :math:`[kg.s^{-1}]`.
+- :math:`v` is the speed :math:`[m/s]`,
+- :math:`t` is the time :math:`[s]`,
+- :math:`t_{max}` is the maximum time :math:`[s]`,
+- :math:`g = 9.81` is the gravitational acceleration :math:`[m.s^{-2}]`,
+- :math:`m` is the mass :math:`[kg]`,
+- :math:`c` is the linear drag coefficient :math:`[kg.s^{-1}]`.
 
-The previous differential equation has the exact solution:
+The exact solution of the previous differential equation is:
 
 .. math::
    z(t) = z_0 + v_{inf} t + \tau (v_0 - v_{inf})\left(1 - e^{-\frac{t}{\tau}}\right)
-
 
 for any :math:`t \in [0, t_{max}]`
 
@@ -46,18 +43,15 @@ where:
 .. math::
    \tau=\frac{m}{c}.
 
-
 The stationnary speed limit at infinite time is equal to :math:`v_{inf}`:
 
 .. math::
    \lim_{t\rightarrow+\infty} v(t)= v_{inf}.
 
-
 When there is no drag, i.e. when :math:`c=0`, the trajectory depends quadratically on :math:`t`:
 
 .. math::
    z(t) = z_0 + v_0 t -g t^2
-
 
 for any :math:`t \in [0, t_{max}]`.
 
@@ -74,11 +68,10 @@ Probabilistic model
 
 The parameters :math:`z_0`, :math:`v_0`, :math:`m` and :math:`c` are probabilistic:
 
-    - :math:`z_0 \sim \mathcal{U}(100, 150)`,
-    - :math:`v_0 \sim \mathcal{N}(55, 10)`,
-    - :math:`m \sim \mathcal{N}(80, 8)`,
-    - :math:`c \sim \mathcal{U}(0, 30)`.
-
+- :math:`z_0 \sim \mathcal{U}(100, 150)`,
+- :math:`v_0 \sim \mathcal{N}(55, 10)`,
+- :math:`m \sim \mathcal{N}(80, 8)`,
+- :math:`c \sim \mathcal{U}(0, 30)`.
 
 References
 ----------

--- a/python/src/AdaptiveStieltjesAlgorithm_doc.i.in
+++ b/python/src/AdaptiveStieltjesAlgorithm_doc.i.in
@@ -21,7 +21,7 @@ following dot-products: :math:`R_n=\langle Q_n, Q_n\rangle` and
 :math:`S_n=\langle xQ_n, Q_n\rangle` where :math:`Q_n` is the monic polynomial
 associated to the orthonormal polynomial :math:`P_n`, needed to compute the
 coefficients of the three-terms recurrence relation that defines :math:`P_n`
-(see :class:`~openturns.OrthogonalUnivariatePolynomialFamily`):
+(see :class:`~openturns.OrthogonalUniVariatePolynomialFamily`):
 
 .. math::
 

--- a/python/src/AdaptiveStieltjesAlgorithm_doc.i.in
+++ b/python/src/AdaptiveStieltjesAlgorithm_doc.i.in
@@ -25,7 +25,7 @@ coefficients of the three-terms recurrence relation that defines :math:`P_n`
 
 .. math::
 
-    a_n = 1/\sqrt{\beta_{n+1}}\quad b_n = -\alpha_n/sqrt{\beta_{n+1}}\quad c_n = -\sqrt{\beta_n/\beta_{n+1}}
+    a_n = 1/\sqrt{\beta_{n+1}}\quad b_n = -\alpha_n/\sqrt{\beta_{n+1}}\quad c_n = -\sqrt{\beta_n/\beta_{n+1}}
 
-where :math:`\alpha_n = S_n / R_n` and :math:`\beta_n  = R_n / R_{n-1}, n>0, \beta_0 = 0`.
+where :math:`\alpha_n = S_n / R_n`, :math:`\beta_n  = R_n / R_{n-1}`, :math:`n>0` and :math:`\beta_0 = 0`.
 "

--- a/python/src/DistFunc_doc.i.in
+++ b/python/src/DistFunc_doc.i.in
@@ -392,6 +392,7 @@ Notes
 This method allows one to compute the *exact* margin factor :math:`k` of a
 pool of :math:`m` Normal populations of size :math:`n` with unknown
 means :math:`\mu_i` and unknown common variance :math:`\sigma^2`.
+This implements the standard NF ISO 16269-6. 
 Let :math:`m_i=\dfrac{1}{n}\sum_{j=1}^nX_{ij}` be the empirical mean
 of the ith population :math:`(X_{i1},\dots,X_{in})` and
 :math:`\sigma^2_{mn}=\dfrac{}{}\sum_{i=1}^m\sum_{j=1}^n(X_{ij}-m_i)^2`
@@ -453,6 +454,7 @@ This method allows one to compute the *exact* margin factor :math:`k` of a
 Normal population of size :math:`n` with unknown
 means :math:`\mu_i` and unknown common variance :math:`\sigma^2`. It
 is equivalent to the pooled version with :math:`m=1`.
+This implements the standard NF ISO 16269-6. 
 
 Examples
 --------

--- a/python/src/EnumerateFunctionImplementation_doc.i.in
+++ b/python/src/EnumerateFunctionImplementation_doc.i.in
@@ -92,7 +92,7 @@ OT_EnumerateFunction_getDimension_doc
 // ---------------------------------------------------------------------
 
 %define OT_EnumerateFunction_getMaximumDegreeCardinal_doc
-"Get the number of terms of total degree below a threshold.
+"Get the number of multi-indices of total degree lower or equal to a threshold.
 
 Parameters
 ----------
@@ -102,12 +102,12 @@ max_deg : int
 Returns
 -------
 cardinal : int
-    Number of terms in the basis of total degree :math:`\leq max_deg`.
+    Number of multi-indices in the basis of total degree :math:`\leq \max_{deg}`.
 
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this is also the cumulated cardinal of stratas of index :math:`\leq max_deg`.
+this is also the cumulated cardinal of stratas of index :math:`\leq \max_{deg}`.
 
 Examples
 --------
@@ -123,7 +123,7 @@ OT_EnumerateFunction_getMaximumDegreeCardinal_doc
 // ---------------------------------------------------------------------
 
 %define OT_EnumerateFunction_getMaximumDegreeStrataIndex_doc
-"Get the largest index of the strata containing terms of maximum degree.
+"Get the largest index of the strata containing multi-indices lower or equal to the given maximum degree.
 
 Parameters
 ----------
@@ -133,12 +133,12 @@ max_deg : int
 Returns
 -------
 index : int
-    Index of the last strata that contains terms of total degree :math:`\leq max_deg`.
+    Index of the last strata that contains multi-indices of total degree :math:`\leq \max_{deg}`.
 
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this is the strata of index *max_deg*.
+this is the strata of index `max_deg`.
 
 Examples
 --------
@@ -154,7 +154,7 @@ OT_EnumerateFunction_getMaximumDegreeStrataIndex_doc
 // ---------------------------------------------------------------------
 
 %define OT_EnumerateFunction_getStrataCardinal_doc
-"Get the number of terms in the basis inside a given strata.
+"Get the number of multi-indices in the basis inside a given strata.
 
 Parameters
 ----------
@@ -164,12 +164,12 @@ strataIndex : int
 Returns
 -------
 cardinal : int
-    Number of terms in the basis inside the strata *strataIndex*.
+    Number of multi-indices in the basis inside the strata *strataIndex*.
 
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-the strata *strataIndex* consists of a hyperplane of all the terms of total degree
+the strata *strataIndex* consists of a hyperplane of all the multi-indices of total degree
 *strataIndex*, and its cardinal is *strataIndex* + 1.
 
 Examples
@@ -186,7 +186,7 @@ OT_EnumerateFunction_getStrataCardinal_doc
 // ---------------------------------------------------------------------
 
 %define OT_EnumerateFunction_getStrataCumulatedCardinal_doc
-"Get the number of terms in the basis inside a range of stratas.
+"Get the number of multi-indices in the basis inside a range of stratas.
 
 Parameters
 ----------
@@ -196,13 +196,13 @@ strataIndex : int
 Returns
 -------
 cardinal : int
-    Number of terms in the basis inside the stratas of index lower of equal to *strataIndex*.
+    Number of multi-indices in the basis inside the stratas of index lower of equal to *strataIndex*.
 
 Notes
 -----
-The number of terms is the total of terms inside each consecutive stratas.
+The number of multi-indices is the total of multi-indices inside each consecutive stratas.
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this returns the number of terms of maximal total degree *strataIndex*.
+this returns the number of multi-indices of maximal total degree *strataIndex*.
 
 Examples
 --------
@@ -278,12 +278,12 @@ max_deg : int
 Returns
 -------
 size : int
-    Number of terms in the basis of total degree :math:`\leq max_deg`.
+    Number of multi-indices in the basis of total degree :math:`\leq \max_{deg}`.
 
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this is also the cumulated cardinal of stratas up to *max_deg*.
+this is also the cumulated cardinal of stratas up to `max_deg`.
     
 Examples
 --------

--- a/python/src/EnumerateFunctionImplementation_doc.i.in
+++ b/python/src/EnumerateFunctionImplementation_doc.i.in
@@ -138,7 +138,7 @@ index : int
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this is the strata of index `max_deg`.
+this is the strata of index *max_deg*.
 
 Examples
 --------
@@ -196,11 +196,11 @@ strataIndex : int
 Returns
 -------
 cardinal : int
-    Number of multi-indices in the basis inside the stratas of index lower of equal to *strataIndex*.
+    Number of multi-indices in the basis inside the stratas of index lower or equal to *strataIndex*.
 
 Notes
 -----
-The number of multi-indices is the total of multi-indices inside each consecutive stratas.
+The number of multi-indices is the total of multi-indices inside the stratas.
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
 this returns the number of multi-indices of maximal total degree *strataIndex*.
 
@@ -283,7 +283,7 @@ size : int
 Notes
 -----
 In the specific context of a linear enumeration (:class:`LinearEnumerateFunction`)
-this is also the cumulated cardinal of stratas up to `max_deg`.
+this is also the cumulated cardinal of stratas up to *max_deg*.
     
 Examples
 --------

--- a/python/src/FejerAlgorithm_doc.i.in
+++ b/python/src/FejerAlgorithm_doc.i.in
@@ -32,31 +32,61 @@ with :math:`f: \Rset^d \mapsto \Rset^p`, :math:`\vect{a}, \vect{b}\in\Rset^d` us
 
     \int_{\vect{a}}^\vect{b} f(\vect{t})\di{\vect{t}} = \sum_{\vect{n}\in \cN}\left(\prod_{i=1}^d w^{N_i}_{n_i}\right)f(\xi^{N_1}_{n_1},\dots,\xi^{N_d}_{n_d})
 
-where :math:`\xi^{N_i}_{n_i}` is the :math:`n_i`th node of the :math:`N_i`-points and :math:`w^{N_i}_{n_i}` the associated weight.
+where :math:`\xi^{N_i}_{n_i}` is the :math:`n_i` -th node of the :math:`N_i` points and :math:`w^{N_i}_{n_i}` are the associated weight.
 
-Let us note :math:`\theta_k=\dfrac{k\pi}{n}, k=0,1,...,n-1`, :math:`x_k = cos(\theta_k)`. The Clenshaw-Curtis nodes are :math:`x_k`
-and its associated weights are given as follows:
-
-.. math::
-
-    w_k =\dfrac{c_k}{n}\left(1-\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{b_j}{4j^2-1}\cos\left(2j\theta_k\right)\right)
-
-with :math:`b_j= 2` if :math:`j < n/2` else :math:`b_j=1`. Also, :math:`c_k = 1` if :math:`if k = 0[n]` else :math:`c_k = 2`
-
-The type-1 Fejer quadrature rule relies on :math:`x_k = cos(\theta_{k+1/2})` nodes and associated weights are the following:
+For any :math:`k=0,1,...,n-1`, let :math:`\theta_k = \dfrac{k\pi}{n}`. 
+The Clenshaw-Curtis nodes are:
 
 .. math::
 
-    w_k=\dfrac{2}{n}\left(1-2\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{1}{4j^2-1}\cos\left(j\theta_{2k+1}\right)\right)
+    x_k = cos(\theta_k)
 
+for any :math:`k=0,1,...,n-1` and its associated weights are:
 
-Finally, the type-2 Fejer quadrature rule is very close to the Clenshaw-Curtis one. The two method do share the same
-nodes (except the endpoints that are set to `0` within the `Fejer` method).  Its associated weights are given as follows:
+.. math::
+
+    w_k = \dfrac{c_k}{n}\left(1-\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{b_j}{4j^2-1}\cos\left(2j\theta_k\right)\right)
+
+where:
+
+.. math::
+
+    b_j = 
+    \begin{cases}
+    2 & \textrm{ if } j < n/2, \\
+    1 & \textrm{ otherwise},
+    \end{cases}
+
+and:
+
+.. math::
+
+    c_k = 
+    \begin{cases}
+    1 & \textrm{ if } k = 0 \textrm{ or } n - 1, \\
+    2 & \textrm{ otherwise}.
+    \end{cases}
+
+The type-1 Fejer quadrature rule uses the nodes:
+
+.. math::
+
+    x_k = cos(\theta_{k + 1/2})
+
+for any :math:`k=0,1,...,n-1` and associated weights are:
+
+.. math::
+
+    w_k = \dfrac{2}{n}\left(1-2\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{1}{4j^2-1}\cos\left(j\theta_{2k+1}\right)\right)
+
+Finally, the type-2 Fejer quadrature rule is very close to the Clenshaw-Curtis one. The two methods share the same
+nodes (except the endpoints that are set to `0` within the `Fejer` method).  Its associated weights are:
 
 .. math::
 
     w_k=\dfrac{4}{n+1}\sin\theta_k\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{\sin\left((2j-1)\theta_k\right)}{2j-1}
 
+for any :math:`k=0,1,...,n-1`.
 
 Examples
 --------

--- a/python/src/FejerAlgorithm_doc.i.in
+++ b/python/src/FejerAlgorithm_doc.i.in
@@ -39,7 +39,7 @@ The Clenshaw-Curtis nodes are:
 
 .. math::
 
-    x_k = cos(\theta_k)
+    x_k = \cos(\theta_k)
 
 for any :math:`k=0,1,...,n-1` and its associated weights are:
 
@@ -71,16 +71,16 @@ The type-1 Fejer quadrature rule uses the nodes:
 
 .. math::
 
-    x_k = cos(\theta_{k + 1/2})
+    x_k = \cos(\theta_{k + 1/2})
 
-for any :math:`k=0,1,...,n-1` and associated weights are:
+for any :math:`k=0,1,...,n-1` and the associated weights are:
 
 .. math::
 
     w_k = \dfrac{2}{n}\left(1-2\sum_{j=1}^{\lfloor n/2\rfloor}\dfrac{1}{4j^2-1}\cos\left(j\theta_{2k+1}\right)\right)
 
-Finally, the type-2 Fejer quadrature rule is very close to the Clenshaw-Curtis one. The two methods share the same
-nodes (except the endpoints that are set to `0` within the `Fejer` method).  Its associated weights are:
+Finally, the type-2 Fejer quadrature rule is very close to the Clenshaw-Curtis rule. The two methods share the same
+nodes (except the endpoints that are set to `0` within the `Fejer` method).  The weights of the type-2 Fejer quadrature rule are:
 
 .. math::
 

--- a/python/src/FunctionImplementation_doc.i.in
+++ b/python/src/FunctionImplementation_doc.i.in
@@ -665,12 +665,12 @@ marginal with respect to the variation of :math:`x_i` in the interval
 Then OpenTURNS draws the graph:
 
 .. math::
-    y = f_k{(i)}(s)
+    y = f_k^{(i)}(s)
 
-for any :math:`s \in [x_i^{min}, x_i^{max}]` where :math:`f_k{(i)}(s)` is defined by the equation:
+for any :math:`s \in [x_i^{min}, x_i^{max}]` where :math:`f_k^{(i)}(s)` is defined by the equation:
 
 .. math::
-    f_k{(i)}(s) = f_k(c_1, \dots, c_{i-1}, s,  c_{i+1} \dots, c_n).
+    f_k^{(i)}(s) = f_k(c_1, \dots, c_{i-1}, s,  c_{i+1} \dots, c_n).
 
 - In the second usage:
 
@@ -679,17 +679,17 @@ function of the given 2D *firstInputMarg* and *secondInputMarg* marginals
 with respect to the variation of :math:`(x_i, x_j)` in the interval
 :math:`[x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]`, when all the
 other components of :math:`\vect{x}` are fixed to the corresponding ones of the
-central point *centralPoint* :math:`c`.
+*centralPoint* :math:`c`.
 Then OpenTURNS draws the graph:
 
 .. math::
-    y = f_k^{(i,j)}(c_1, \dots, c_{i-1}, s, c_{i+1}, \dots, c_{j-1}, t,  c_{j+1} \dots, c_n)
+    y = f_k^{(i,j)}(s, t)
 
-for any :math:`(s, t) \in [x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]` where :math:f_k^{(i,j)}` 
+for any :math:`(s, t) \in [x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]` where :math:`f_k^{(i,j)}` 
 is defined by the equation:
 
 .. math::
-    f_k^{(i,j)}(s,t) = f_k(c_1, \dots, c_{i-1}, s, c_{i+1}, \dots, c_{j-1}, t,  c_{j+1} \dots, c_n)`.
+    f_k^{(i,j)}(s,t) = f_k(c_1, \dots, c_{i-1}, s, c_{i+1}, \dots, c_{j-1}, t,  c_{j+1} \dots, c_n).
 
 - In the third usage:
 

--- a/python/src/FunctionImplementation_doc.i.in
+++ b/python/src/FunctionImplementation_doc.i.in
@@ -623,9 +623,9 @@ OT_Function_getParameterDimension_doc
 "Draw the output of function as a :class:`~openturns.Graph`.
 
 Available usages:
-    draw(*inputMarg, outputMarg, CP, xiMin, xiMax, ptNb*)
+    draw(*inputMarg, outputMarg, a, xiMin, xiMax, ptNb*)
 
-    draw(*firstInputMarg, secondInputMarg, outputMarg, CP, xiMin_xjMin, xiMax_xjMax, ptNbs*)
+    draw(*firstInputMarg, secondInputMarg, outputMarg, a, xiMin_xjMin, xiMax_xjMax, ptNbs*)
 
     draw(*xiMin, xiMax, ptNb*)
 
@@ -639,8 +639,8 @@ outputMarg, inputMarg : int, :math:`outputMarg, inputMarg \geq 0`
 firstInputMarg, secondInputMarg : int, :math:`firstInputMarg, secondInputMarg \geq 0`
     In the 2D case, the marginal *outputMarg* is drawn as a function of the
     two marginals with indexes *firstInputMarg* and *secondInputMarg*.
-CP : sequence of float
-    Central point.
+centralPoint : sequence of float
+    Central point with dimension :math:`n` where :math:`n` is the input dimension of the function.
 xiMin, xiMax : float
     Define the interval where the curve is plotted.
 xiMin_xjMin, xiMax_xjMax : sequence of float of dimension 2.
@@ -652,7 +652,7 @@ Notes
 -----
 We note :math:`f: \Rset^n \rightarrow \Rset^p`
 where :math:`\vect{x} = (x_1, \dots, x_n)` and
-:math:`f(\vect{x}) = (f_1(\vect{x}), \dots,f_p(\vect{x}))`,
+:math:`f(\vect{x}) = (f_1(\vect{x}), \dots, f_p(\vect{x}))`,
 with :math:`n\geq 1` and :math:`p\geq 1`.
 
 - In the first usage:
@@ -661,9 +661,16 @@ Draws graph of the given 1D *outputMarg* marginal
 :math:`f_k: \Rset^n \rightarrow \Rset` as a function of the given 1D *inputMarg*
 marginal with respect to the variation of :math:`x_i` in the interval
 :math:`[x_i^{min}, x_i^{max}]`, when all the other components of
-:math:`\vect{x}` are fixed to the corresponding ones of the central point *CP*.
+:math:`\vect{x}` are fixed to the corresponding ones of the *centralPoint* :math:`c`.
 Then OpenTURNS draws the graph:
-:math:`t\in [x_i^{min}, x_i^{max}] \mapsto f_k(CP_1, \dots, CP_{i-1}, t,  CP_{i+1} \dots, CP_n)`.
+
+.. math::
+    y = f_k{(i)}(s)
+
+for any :math:`s \in [x_i^{min}, x_i^{max}]` where :math:`f_k{(i)}(s)` is defined by the equation:
+
+.. math::
+    f_k{(i)}(s) = f_k(c_1, \dots, c_{i-1}, s,  c_{i+1} \dots, c_n).
 
 - In the second usage:
 
@@ -672,8 +679,17 @@ function of the given 2D *firstInputMarg* and *secondInputMarg* marginals
 with respect to the variation of :math:`(x_i, x_j)` in the interval
 :math:`[x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]`, when all the
 other components of :math:`\vect{x}` are fixed to the corresponding ones of the
-central point *CP*. Then OpenTURNS draws the graph:
-:math:`(t,u) \in [x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}] \mapsto f_k(CP_1, \dots, CP_{i-1}, t, CP_{i+1}, \dots, CP_{j-1}, u,  CP_{j+1} \dots, CP_n)`.
+central point *centralPoint* :math:`c`.
+Then OpenTURNS draws the graph:
+
+.. math::
+    y = f_k^{(i,j)}(c_1, \dots, c_{i-1}, s, c_{i+1}, \dots, c_{j-1}, t,  c_{j+1} \dots, c_n)
+
+for any :math:`(s, t) \in [x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]` where :math:f_k^{(i,j)}` 
+is defined by the equation:
+
+.. math::
+    f_k^{(i,j)}(s,t) = f_k(c_1, \dots, c_{i-1}, s, c_{i+1}, \dots, c_{j-1}, t,  c_{j+1} \dots, c_n)`.
 
 - In the third usage:
 

--- a/python/src/FunctionImplementation_doc.i.in
+++ b/python/src/FunctionImplementation_doc.i.in
@@ -623,9 +623,9 @@ OT_Function_getParameterDimension_doc
 "Draw the output of function as a :class:`~openturns.Graph`.
 
 Available usages:
-    draw(*inputMarg, outputMarg, a, xiMin, xiMax, ptNb*)
+    draw(*inputMarg, outputMarg, centralPoint, xiMin, xiMax, ptNb*)
 
-    draw(*firstInputMarg, secondInputMarg, outputMarg, a, xiMin_xjMin, xiMax_xjMax, ptNbs*)
+    draw(*firstInputMarg, secondInputMarg, outputMarg, centralPoint, xiMin_xjMin, xiMax_xjMax, ptNbs*)
 
     draw(*xiMin, xiMax, ptNb*)
 
@@ -640,7 +640,7 @@ firstInputMarg, secondInputMarg : int, :math:`firstInputMarg, secondInputMarg \g
     In the 2D case, the marginal *outputMarg* is drawn as a function of the
     two marginals with indexes *firstInputMarg* and *secondInputMarg*.
 centralPoint : sequence of float
-    Central point with dimension :math:`n` where :math:`n` is the input dimension of the function.
+    Central point with dimension equal to the input dimension of the function.
 xiMin, xiMax : float
     Define the interval where the curve is plotted.
 xiMin_xjMin, xiMax_xjMax : sequence of float of dimension 2.
@@ -661,7 +661,7 @@ Draws graph of the given 1D *outputMarg* marginal
 :math:`f_k: \Rset^n \rightarrow \Rset` as a function of the given 1D *inputMarg*
 marginal with respect to the variation of :math:`x_i` in the interval
 :math:`[x_i^{min}, x_i^{max}]`, when all the other components of
-:math:`\vect{x}` are fixed to the corresponding ones of the *centralPoint* :math:`c`.
+:math:`\vect{x}` are fixed to the corresponding components of the *centralPoint* :math:`\vect{c}`.
 Then OpenTURNS draws the graph:
 
 .. math::
@@ -678,8 +678,8 @@ Draws the iso-curves of the given *outputMarg* marginal :math:`f_k` as a
 function of the given 2D *firstInputMarg* and *secondInputMarg* marginals
 with respect to the variation of :math:`(x_i, x_j)` in the interval
 :math:`[x_i^{min}, x_i^{max}] \times [x_j^{min}, x_j^{max}]`, when all the
-other components of :math:`\vect{x}` are fixed to the corresponding ones of the
-*centralPoint* :math:`c`.
+other components of :math:`\vect{x}` are fixed to the corresponding components of the
+*centralPoint* :math:`\vect{c}`.
 Then OpenTURNS draws the graph:
 
 .. math::

--- a/python/src/GaussianLinearCalibration_doc.i.in
+++ b/python/src/GaussianLinearCalibration_doc.i.in
@@ -31,7 +31,7 @@ gradientObservations : 2-d sequence of float
 
 Notes
 -----
-GaussianLinearCalibration implements the Maximum A Posteriori (MAP) estimator for a linear model
+This class implements the Maximum A Posteriori (MAP) estimator for a linear model
 under the Bayesian hypothesis that the prior and the observation errors have Gaussian distributions. 
 This is also known as the Kalman filter. 
 

--- a/python/src/GaussianNonLinearCalibration_doc.i.in
+++ b/python/src/GaussianNonLinearCalibration_doc.i.in
@@ -19,7 +19,7 @@ errorCovariance : 2-d sequence of float
 
 Notes
 -----
-GaussianNonLinearCalibration implements the Maximum A Posteriori (MAP) estimator for a nonlinear model
+This class implements the Maximum A Posteriori (MAP) estimator for a nonlinear model
 under the Bayesian hypothesis that the prior and the observation errors have Gaussian distributions. 
 This algorithm is also known as *3DVAR*. 
 

--- a/python/src/SymbolicFunction_doc.i.in
+++ b/python/src/SymbolicFunction_doc.i.in
@@ -123,8 +123,11 @@ This slope is then used in the computation of the height `H`.
 >>> import openturns as ot
 >>> inputs = ['Q', 'Ks', 'Zv', 'Zm', 'Hd', 'Zb', 'L', 'B']
 >>> outputs = ['H', 'S']
->>> formula = 'var alpha := (Zm - Zv)/L; H := (Q/(Ks*B*sqrt(alpha)))^(3.0/5.0);'
->>> formula += 'var Zc := H + Zv; var Zd := Zb + Hd; S := Zc - Zd'
+>>> formula = 'var alpha := (Zm - Zv)/L;'
+>>> formula += 'H := (Q / (Ks * B * sqrt(alpha)))^(3.0 / 5.0);'
+>>> formula += 'var Zc := H + Zv;'
+>>> formula += 'var Zd := Zb + Hd;'
+>>> formula += 'S := Zc - Zd'
 >>> myFunction = ot.SymbolicFunction(inputs, outputs, formula)
 >>> X = [1013.0, 30.0, 50.0, 55.0, 8, 55.5, 5000.0, 300.0]
 >>> print(myFunction(X))


### PR DESCRIPTION
This PR fixes several bugs.
- The BIC help page has issues: #2199 
- Improved KS example #2138 
- Fixed correlation function #2104 
- Fixed linear least squares model as a part of #1935
- Improved example of Taylor expansion as a part of #1935
- Fixed SymbolicFunction draw method doc as a part of #1935
- Fixed the AdaptiveStieljesAlgorithm doc as a part of #1935
- Fixed the viscous free fall example, as a part of #1935
- Fixed the "Random Mixture: affine combination of independent univariate distributions" as a part of #1935
- Fixed the Fejer help page as a part of #1935
- Improved "Metamodel of a field function" as a part of #1935