### PR TITLE
Fixed KernelSmoothing

### DIFF
--- a/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelSmoothing.cxx
@@ -513,27 +513,18 @@ TruncatedDistribution KernelSmoothing::buildAsTruncatedDistribution(const Sample
   if (bandwidth.getDimension() != dimension) throw InvalidDimensionException(HERE) << "Error: the given bandwidth must have the same dimension as the given sample, here bandwidth dimension=" << bandwidth.getDimension() << " and sample dimension=" << dimension;
   if (dimension > 1) throw InternalException(HERE) << "Error: cannot make boundary correction on samples with dimension>1, here dimension=" << dimension;
   setBandwidth(bandwidth);
-  Scalar xMin = 0.0;
-  Scalar xMax = 0.0;
-  if ((boundingOption_ == LOWER) || (boundingOption_ == BOTH))
+  Scalar xMin = sample.getMin()[0];
+  Scalar xMax = sample.getMax()[0];
+  if (((boundingOption_ == LOWER) || (boundingOption_ == BOTH)) && (!automaticLowerBound_))
   {
-    xMin = sample.getMin()[0];
-    if (!automaticLowerBound_)
-    {
-      // Check the sample against the user-defined bounds
-      if (!(lowerBound_ <= xMin)) throw InvalidArgumentException(HERE) << "Error: expected a sample with a minimum value at least equal to lowerBound=" << lowerBound_ << ", got xMin=" << xMin;
-      xMin = lowerBound_;
-    } // !automaticLowerBound
+    // Check the sample against the user-defined bounds
+    if (!(lowerBound_ <= xMin)) throw InvalidArgumentException(HERE) << "Error: expected a sample with a minimum value at least equal to lowerBound=" << lowerBound_ << ", got xMin=" << xMin;
+    xMin = lowerBound_;
   } // Boundary correction on the lower bound
-  if ((boundingOption_ == UPPER) || (boundingOption_ == BOTH))
+  if (((boundingOption_ == UPPER) || (boundingOption_ == BOTH)) && (!automaticUpperBound_))
   {
-    xMax = sample.getMax()[0];
-    if (!automaticUpperBound_)
-    {
-      // Check the sample against the user-defined bounds
-      if (!(upperBound_ >= xMax)) throw InvalidArgumentException(HERE) << "Error: expected a sample with a maximum value at most equal to upperBound=" << upperBound_ << ", got xMax=" << xMax;
-      xMax = upperBound_;
-    } // !automaticUpperBound
+    if (!(upperBound_ >= xMax)) throw InvalidArgumentException(HERE) << "Error: expected a sample with a maximum value at most equal to upperBound=" << upperBound_ << ", got xMax=" << xMax;
+    xMax = upperBound_;
   } // Boundary correction on the upper bound
   // Here we are in the 1D case with boundary boundary correction
   Point newSampleData(sample.asPoint());

--- a/lib/test/t_KernelSmoothing_std.cxx
+++ b/lib/test/t_KernelSmoothing_std.cxx
@@ -123,64 +123,78 @@ int main(int, char *[])
     }
     // Test with varying boundary corrections
     {
-      Point left(1, -0.9);
-      Point right(1, 0.9);
-      sample = Uniform().getSample(500);
-      KernelSmoothing algo1(Normal(), false);
-      algo1.setBoundingOption(KernelSmoothing::NONE);
-      Distribution ks1 = algo1.build(sample);
-      fullprint << "with no boundary correction, pdf(left)=" << std::setprecision(4) << ks1.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks1.computePDF(right) << std::endl;
+      Collection<Distribution> coll(2);
+      coll[0] = Uniform(-1.0, 1.0);
+      coll[1] = Uniform(0.0, 2.0);
+      
+      Point left(2);
+      left[0] = -0.9;
+      left[1] = 0.1;
+      Point right(2);
+      right[0] = 0.9;
+      right[1] = 1.9;
+      Point lowerBound(2);
+      for (UnsignedInteger nDist = 0; nDist < coll.getSize(); ++nDist)
+	{
+	  const Distribution baseDistribution(coll[nDist]);
+	  fullprint << "Base distribution=" << baseDistribution << std::endl;
+	  sample = baseDistribution.getSample(500);
+	  KernelSmoothing algo1(Normal(), false);
+	  algo1.setBoundingOption(KernelSmoothing::NONE);
+	  Distribution ks1 = algo1.build(sample);
+	  fullprint << "with no boundary correction, pdf(left)=" << std::setprecision(4) << ks1.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks1.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo2(Normal(), false);
+	  algo2.setBoundingOption(KernelSmoothing::LOWER);
+	  algo2.setAutomaticLowerBound(true);
+	  Distribution ks2 = algo2.build(sample);
+	  fullprint << "with automatic lower boundary correction, pdf(left)=" << std::setprecision(4) << ks2.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks2.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo3(Normal(), false);
+	  algo3.setBoundingOption(KernelSmoothing::LOWER);
+	  algo3.setLowerBound(baseDistribution.getRange().getLowerBound()[0]);
+	  algo3.setAutomaticLowerBound(false);
+	  Distribution ks3 = algo3.build(sample);
+	  fullprint << "with user defined lower boundary correction, pdf(left)=" << std::setprecision(4) << ks3.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks3.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo4(Normal(), false);
+	  algo4.setBoundingOption(KernelSmoothing::UPPER);
+	  algo4.setAutomaticUpperBound(true);
+	  Distribution ks4 = algo4.build(sample);
+	  fullprint << "with automatic upper boundary correction, pdf(left)=" << std::setprecision(4) << ks4.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks4.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo5(Normal(), false);
+	  algo5.setBoundingOption(KernelSmoothing::UPPER);
+	  algo5.setUpperBound(baseDistribution.getRange().getUpperBound()[0]);
+	  algo5.setAutomaticLowerBound(false);
+	  Distribution ks5 = algo5.build(sample);
+	  fullprint << "with user defined upper boundary correction, pdf(left)=" << std::setprecision(4) << ks5.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks5.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo6(Normal(), false);
+	  algo6.setBoundingOption(KernelSmoothing::BOTH);
+	  Distribution ks6 = algo6.build(sample);
+	  fullprint << "with automatic boundaries correction, pdf(left)=" << std::setprecision(4) << ks6.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks6.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo7(Normal(), false);
+	  algo7.setBoundingOption(KernelSmoothing::BOTH);
+	  algo7.setLowerBound(baseDistribution.getRange().getLowerBound()[0]);
+	  Distribution ks7 = algo7.build(sample);
+	  fullprint << "with user defined lower/automatic upper boundaries correction, pdf(left)=" << std::setprecision(4) << ks7.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks7.computePDF(right[nDist]) << std::endl;
+	  
+	  KernelSmoothing algo8(Normal(), false);
+	  algo8.setBoundingOption(KernelSmoothing::BOTH);
+	  algo8.setUpperBound(baseDistribution.getRange().getUpperBound()[0]);
+	  Distribution ks8 = algo8.build(sample);
+	  fullprint << "with automatic lower/user defined upper boundaries correction, pdf(left)=" << std::setprecision(4) << ks8.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks8.computePDF(right[nDist]) << std::endl;
 
-      KernelSmoothing algo2(Normal(), false);
-      algo2.setBoundingOption(KernelSmoothing::LOWER);
-      algo2.setAutomaticLowerBound(true);
-      Distribution ks2 = algo2.build(sample);
-      fullprint << "with automatic lower boundary correction, pdf(left)=" << std::setprecision(4) << ks2.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks2.computePDF(right) << std::endl;
-
-      KernelSmoothing algo3(Normal(), false);
-      algo3.setBoundingOption(KernelSmoothing::LOWER);
-      algo3.setLowerBound(-1.0);
-      algo3.setAutomaticLowerBound(false);
-      Distribution ks3 = algo3.build(sample);
-      fullprint << "with user defined lower boundary correction, pdf(left)=" << std::setprecision(4) << ks3.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks3.computePDF(right) << std::endl;
-
-      KernelSmoothing algo4(Normal(), false);
-      algo4.setBoundingOption(KernelSmoothing::UPPER);
-      algo4.setAutomaticUpperBound(true);
-      Distribution ks4 = algo4.build(sample);
-      fullprint << "with automatic upper boundary correction, pdf(left)=" << std::setprecision(4) << ks4.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks4.computePDF(right) << std::endl;
-
-      KernelSmoothing algo5(Normal(), false);
-      algo5.setBoundingOption(KernelSmoothing::UPPER);
-      algo5.setUpperBound(1.0);
-      algo5.setAutomaticLowerBound(false);
-      Distribution ks5 = algo5.build(sample);
-      fullprint << "with user defined upper boundary correction, pdf(left)=" << std::setprecision(4) << ks5.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks5.computePDF(right) << std::endl;
-
-      KernelSmoothing algo6(Normal(), false);
-      algo6.setBoundingOption(KernelSmoothing::BOTH);
-      Distribution ks6 = algo6.build(sample);
-      fullprint << "with automatic boundaries correction, pdf(left)=" << std::setprecision(4) << ks6.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks6.computePDF(right) << std::endl;
-
-      KernelSmoothing algo7(Normal(), false);
-      algo7.setBoundingOption(KernelSmoothing::BOTH);
-      algo7.setLowerBound(-1.0);
-      Distribution ks7 = algo7.build(sample);
-      fullprint << "with user defined lower/automatic upper boundaries correction, pdf(left)=" << std::setprecision(4) << ks7.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks7.computePDF(right) << std::endl;
-
-      KernelSmoothing algo8(Normal(), false);
-      algo8.setBoundingOption(KernelSmoothing::BOTH);
-      algo8.setUpperBound(1.0);
-      Distribution ks8 = algo8.build(sample);
-      fullprint << "with automatic lower/user defined upper boundaries correction, pdf(left)=" << std::setprecision(4) << ks8.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks8.computePDF(right) << std::endl;
-
-      KernelSmoothing algo9(Normal(), false);
-      algo9.setBoundingOption(KernelSmoothing::BOTH);
-      algo9.setLowerBound(-1.0);
-      algo9.setUpperBound(1.0);
-      Distribution ks9 = algo9.build(sample);
-      fullprint << "with user defined boundaries correction, pdf(left)=" << std::setprecision(4) << ks9.computePDF(left) << ", pdf(right)=" << std::setprecision(4) << ks9.computePDF(right) << std::endl;
-    }
+	  KernelSmoothing algo9(Normal(), false);
+	  algo9.setBoundingOption(KernelSmoothing::BOTH);
+	  algo9.setLowerBound(baseDistribution.getRange().getLowerBound()[0]);
+	  algo9.setUpperBound(baseDistribution.getRange().getUpperBound()[0]);
+	  Distribution ks9 = algo9.build(sample);
+	  fullprint << "with user defined boundaries correction, pdf(left)=" << std::setprecision(4) << ks9.computePDF(left[nDist]) << ", pdf(right)=" << std::setprecision(4) << ks9.computePDF(right[nDist]) << std::endl;
+	} // for nDist
+    } // Test with varying boundary corrections
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_KernelSmoothing_std.expout
+++ b/lib/test/t_KernelSmoothing_std.expout
@@ -155,6 +155,7 @@ Bounded underlying distribution? True bounded reconstruction? True
 with low  bin count, pdf=0.367
 with high bin count, pdf=0.3673
 without   binning,   pdf=0.3673
+Base distribution=class=Uniform name=Uniform dimension=1 a=-1 b=1
 with no boundary correction, pdf(left)=0.4125, pdf(right)=0.3749
 with automatic lower boundary correction, pdf(left)=0.5426, pdf(right)=0.3749
 with user defined lower boundary correction, pdf(left)=0.534, pdf(right)=0.3749
@@ -164,3 +165,13 @@ with automatic boundaries correction, pdf(left)=0.5426, pdf(right)=0.4963
 with user defined lower/automatic upper boundaries correction, pdf(left)=0.534, pdf(right)=0.4963
 with automatic lower/user defined upper boundaries correction, pdf(left)=0.5426, pdf(right)=0.4958
 with user defined boundaries correction, pdf(left)=0.534, pdf(right)=0.4958
+Base distribution=class=Uniform name=Uniform dimension=1 a=0 b=2
+with no boundary correction, pdf(left)=0.4061, pdf(right)=0.4149
+with automatic lower boundary correction, pdf(left)=0.5106, pdf(right)=0.4149
+with user defined lower boundary correction, pdf(left)=0.507, pdf(right)=0.4149
+with automatic upper boundary correction, pdf(left)=0.4061, pdf(right)=0.5355
+with user defined upper boundary correction, pdf(left)=0.4061, pdf(right)=0.5298
+with automatic boundaries correction, pdf(left)=0.5106, pdf(right)=0.5355
+with user defined lower/automatic upper boundaries correction, pdf(left)=0.507, pdf(right)=0.5355
+with automatic lower/user defined upper boundaries correction, pdf(left)=0.5106, pdf(right)=0.5298
+with user defined boundaries correction, pdf(left)=0.507, pdf(right)=0.5298

--- a/python/test/t_KernelSmoothing_std.expout
+++ b/python/test/t_KernelSmoothing_std.expout
@@ -164,11 +164,20 @@ with automatic boundaries correction, pdf(left)=0.521626 , pdf(right)=0.506744
 with user defined lower/automatic upper boundaries correction, pdf(left)=0.506571 , pdf(right)=0.506744
 with automatic lower/user defined upper boundaries correction, pdf(left)=0.521626 , pdf(right)=0.505152
 with user defined boundaries correction, pdf(left)=0.506571 , pdf(right)=0.505152
+with no boundary correction, pdf(left)=0.379383 , pdf(right)=0.404847
+with automatic lower boundary correction, pdf(left)=0.485563 , pdf(right)=0.404847
+with user defined lower boundary correction, pdf(left)=0.466624 , pdf(right)=0.404847
+with automatic upper boundary correction, pdf(left)=0.379383 , pdf(right)=0.512248
+with user defined upper boundary correction, pdf(left)=0.379383 , pdf(right)=0.511777
+with automatic boundaries correction, pdf(left)=0.485563 , pdf(right)=0.512248
+with user defined lower/automatic upper boundaries correction, pdf(left)=0.466624 , pdf(right)=0.512248
+with automatic lower/user defined upper boundaries correction, pdf(left)=0.485563 , pdf(right)=0.511777
+with user defined boundaries correction, pdf(left)=0.466624 , pdf(right)=0.511777
 0 : [ -7  0  8 ]
 1 : [ -7  0  8 ]
 2 : [ -7  0  8 ]
     [ d7       a23      d8       ]
-0 : [ -7        2.24363  8       ]
-1 : [ -7        2.24139  8       ]
-2 : [ -7        2.82444  8       ]
+0 : [ -7        2.82969  8       ]
+1 : [ -7        2.35796  8       ]
+2 : [ -7        2.08774  8       ]
 with reduced cutoff. h=0.769339

--- a/python/test/t_KernelSmoothing_std.py
+++ b/python/test/t_KernelSmoothing_std.py
@@ -109,94 +109,97 @@ print("with low  bin count, pdf=%.6g" % ks1.computePDF(point))
 print("with high bin count, pdf=%.6g" % ks2.computePDF(point))
 print("without   binning,   pdf=%.6g" % ks3.computePDF(point))
 # Test with varying boundary corrections
-left = [-0.9]
-right = [0.9]
-sample = ot.Uniform().getSample(500)
-algo1 = ot.KernelSmoothing(ot.Normal(), False)
-algo1.setBoundingOption(ot.KernelSmoothing.NONE)
-ks1 = algo1.build(sample)
-print(
-    "with no boundary correction, pdf(left)=%.6g" % ks1.computePDF(left),
-    ", pdf(right)=%.6g" % ks1.computePDF(right),
-)
+coll = [ot.Uniform(-1.0, 1.0), ot.Uniform(0.0, 2.0)]
+left = [-0.9, 0.1]
+right = [0.9, 1.9]
+for nDist in range(len(coll)):
+    baseDist = coll[nDist]
+    sample = baseDist.getSample(500)
+    algo1 = ot.KernelSmoothing(ot.Normal(), False)
+    algo1.setBoundingOption(ot.KernelSmoothing.NONE)
+    ks1 = algo1.build(sample)
+    print(
+        "with no boundary correction, pdf(left)=%.6g" % ks1.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks1.computePDF(right[nDist]),
+    )
 
-algo2 = ot.KernelSmoothing(ot.Normal(), False)
-algo2.setBoundingOption(ot.KernelSmoothing.LOWER)
-algo2.setAutomaticLowerBound(True)
-ks2 = algo2.build(sample)
-print(
-    "with automatic lower boundary correction, pdf(left)=%.6g" % ks2.computePDF(left),
-    ", pdf(right)=%.6g" % ks2.computePDF(right),
-)
+    algo2 = ot.KernelSmoothing(ot.Normal(), False)
+    algo2.setBoundingOption(ot.KernelSmoothing.LOWER)
+    algo2.setAutomaticLowerBound(True)
+    ks2 = algo2.build(sample)
+    print(
+        "with automatic lower boundary correction, pdf(left)=%.6g" % ks2.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks2.computePDF(right[nDist]),
+    )
 
-algo3 = ot.KernelSmoothing(ot.Normal(), False)
-algo3.setBoundingOption(ot.KernelSmoothing.LOWER)
-algo3.setLowerBound(-1.0)
-algo3.setAutomaticLowerBound(False)
-ks3 = algo3.build(sample)
-print(
-    "with user defined lower boundary correction, pdf(left)=%.6g"
-    % ks3.computePDF(left),
-    ", pdf(right)=%.6g" % ks3.computePDF(right),
-)
+    algo3 = ot.KernelSmoothing(ot.Normal(), False)
+    algo3.setBoundingOption(ot.KernelSmoothing.LOWER)
+    algo3.setLowerBound(baseDist.getRange().getLowerBound()[0])
+    algo3.setAutomaticLowerBound(False)
+    ks3 = algo3.build(sample)
+    print(
+        "with user defined lower boundary correction, pdf(left)=%.6g"
+        % ks3.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks3.computePDF(right[nDist]),
+    )
 
-algo4 = ot.KernelSmoothing(ot.Normal(), False)
-algo4.setBoundingOption(ot.KernelSmoothing.UPPER)
-algo4.setAutomaticUpperBound(True)
-ks4 = algo4.build(sample)
-print(
-    "with automatic upper boundary correction, pdf(left)=%.6g" % ks4.computePDF(left),
-    ", pdf(right)=%.6g" % ks4.computePDF(right),
-)
+    algo4 = ot.KernelSmoothing(ot.Normal(), False)
+    algo4.setBoundingOption(ot.KernelSmoothing.UPPER)
+    algo4.setAutomaticUpperBound(True)
+    ks4 = algo4.build(sample)
+    print(
+        "with automatic upper boundary correction, pdf(left)=%.6g" % ks4.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks4.computePDF(right[nDist]),
+    )
 
-algo5 = ot.KernelSmoothing(ot.Normal(), False)
-algo5.setBoundingOption(ot.KernelSmoothing.UPPER)
-algo5.setUpperBound(1.0)
-algo5.setAutomaticLowerBound(False)
-ks5 = algo5.build(sample)
-print(
-    "with user defined upper boundary correction, pdf(left)=%.6g"
-    % ks5.computePDF(left),
-    ", pdf(right)=%.6g" % ks5.computePDF(right),
-)
+    algo5 = ot.KernelSmoothing(ot.Normal(), False)
+    algo5.setBoundingOption(ot.KernelSmoothing.UPPER)
+    algo5.setUpperBound(baseDist.getRange().getUpperBound()[0])
+    algo5.setAutomaticLowerBound(False)
+    ks5 = algo5.build(sample)
+    print(
+        "with user defined upper boundary correction, pdf(left)=%.6g"
+        % ks5.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks5.computePDF(right[nDist]),
+    )
 
-algo6 = ot.KernelSmoothing(ot.Normal(), False)
-algo6.setBoundingOption(ot.KernelSmoothing.BOTH)
-ks6 = algo6.build(sample)
-print(
-    "with automatic boundaries correction, pdf(left)=%.6g" % ks6.computePDF(left),
-    ", pdf(right)=%.6g" % ks6.computePDF(right),
-)
+    algo6 = ot.KernelSmoothing(ot.Normal(), False)
+    algo6.setBoundingOption(ot.KernelSmoothing.BOTH)
+    ks6 = algo6.build(sample)
+    print(
+        "with automatic boundaries correction, pdf(left)=%.6g" % ks6.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks6.computePDF(right[nDist]),
+    )
 
-algo7 = ot.KernelSmoothing(ot.Normal(), False)
-algo7.setBoundingOption(ot.KernelSmoothing.BOTH)
-algo7.setLowerBound(-1.0)
-ks7 = algo7.build(sample)
-print(
-    "with user defined lower/automatic upper boundaries correction, pdf(left)=%.6g"
-    % ks7.computePDF(left),
-    ", pdf(right)=%.6g" % ks7.computePDF(right),
-)
+    algo7 = ot.KernelSmoothing(ot.Normal(), False)
+    algo7.setBoundingOption(ot.KernelSmoothing.BOTH)
+    algo7.setLowerBound(baseDist.getRange().getLowerBound()[0])
+    ks7 = algo7.build(sample)
+    print(
+        "with user defined lower/automatic upper boundaries correction, pdf(left)=%.6g"
+        % ks7.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks7.computePDF(right[nDist]),
+    )
 
-algo8 = ot.KernelSmoothing(ot.Normal(), False)
-algo8.setBoundingOption(ot.KernelSmoothing.BOTH)
-algo8.setUpperBound(1.0)
-ks8 = algo8.build(sample)
-print(
-    "with automatic lower/user defined upper boundaries correction, pdf(left)=%.6g"
-    % ks8.computePDF(left),
-    ", pdf(right)=%.6g" % ks8.computePDF(right),
-)
+    algo8 = ot.KernelSmoothing(ot.Normal(), False)
+    algo8.setBoundingOption(ot.KernelSmoothing.BOTH)
+    algo8.setUpperBound(baseDist.getRange().getUpperBound()[0])
+    ks8 = algo8.build(sample)
+    print(
+        "with automatic lower/user defined upper boundaries correction, pdf(left)=%.6g"
+        % ks8.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks8.computePDF(right[nDist]),
+    )
 
-algo9 = ot.KernelSmoothing(ot.Normal(), False)
-algo9.setBoundingOption(ot.KernelSmoothing.BOTH)
-algo9.setLowerBound(-1.0)
-algo9.setUpperBound(1.0)
-ks9 = algo9.build(sample)
-print(
-    "with user defined boundaries correction, pdf(left)=%.6g" % ks9.computePDF(left),
-    ", pdf(right)=%.6g" % ks9.computePDF(right),
-)
+    algo9 = ot.KernelSmoothing(ot.Normal(), False)
+    algo9.setBoundingOption(ot.KernelSmoothing.BOTH)
+    algo9.setLowerBound(baseDist.getRange().getLowerBound()[0])
+    algo9.setUpperBound(baseDist.getRange().getUpperBound()[0])
+    ks9 = algo9.build(sample)
+    print(
+        "with user defined boundaries correction, pdf(left)=%.6g" % ks9.computePDF(left[nDist]),
+        ", pdf(right)=%.6g" % ks9.computePDF(right[nDist]),
+    )
 
 # full degenerate case
 sample = ot.ComposedDistribution(


### PR DESCRIPTION
When the bounding option is activated and the bound is given, the algorithhm may consider that the sample has constant values due to a wrong initialization of variables.