### PR TITLE
BoxCox & LinearModel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 
 === Library ===
 
+==== Major changes ====
+ * BoxCoxFactory handles linear model
+
 ==== New classes ====
  * SmolyakExperiment (openturns.experimental)
 

--- a/lib/src/Base/Func/BoxCoxEvaluation.cxx
+++ b/lib/src/Base/Func/BoxCoxEvaluation.cxx
@@ -129,7 +129,7 @@ struct BoxCoxEvaluationComputeSamplePolicy
         const Scalar lambda_j = evaluation_.getLambda()[j];
         const Scalar logX = log(input_(i, j) + evaluation_.getShift()[j]);
         if (std::abs(lambda_j * logX) < 1e-8) output_(i, j) = logX * (1.0 + 0.5 * lambda_j * logX);
-        else output_(i, j) = expm1(lambda_j * logX) / lambda_j;
+        else output_(i, j) = std::expm1(lambda_j * logX) / lambda_j;
       } // j
     } // i
   } // operator ()
@@ -169,7 +169,7 @@ Point BoxCoxEvaluation::operator() (const Point & inP) const
     const Scalar lambda_i = lambda_[index];
     const Scalar logX = log(x);
     if (std::abs(lambda_i * logX) < 1e-8) result[index] = logX * (1.0 + 0.5 * lambda_i * logX);
-    else result[index] = expm1(lambda_i * logX) / lambda_i;
+    else result[index] = std::expm1(lambda_i * logX) / lambda_i;
   }
   callsNumber_.increment();
   return result;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
@@ -49,8 +49,10 @@ LinearModelAlgorithm::LinearModelAlgorithm(const Sample & inputSample,
   if (inputSample.getSize() != outputSample.getSize())
     throw InvalidArgumentException(HERE) << "In LinearModelAlgorithm::LinearModelAlgorithm, input sample size (" << inputSample.getSize() << ") does not match output sample size (" << outputSample.getSize() << ").";
 
+  if (outputSample.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "LinearModelAlgorithm can only handle and 1-d output sample.";
+
   const UnsignedInteger inputDimension = inputSample_.getDimension();
-#ifdef OPENTURNS_HAVE_ANALYTICAL_PARSER
   Collection<Function> functions;
   Description inputDescription(inputSample_.getDescription());
   try
@@ -69,9 +71,6 @@ LinearModelAlgorithm::LinearModelAlgorithm(const Sample & inputSample,
     functions.add(SymbolicFunction(inputDescription, Description(1, inputDescription[i])));
   }
   basis_ = Basis(functions);
-#else
-  basis_ = LinearBasisFactory(inputDimension).build();
-#endif
 }
 
 

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
@@ -35,6 +35,11 @@
 #include "openturns/MethodBoundEvaluation.hxx"
 #include "openturns/GeneralLinearModelAlgorithm.hxx"
 #include "openturns/MemoizeFunction.hxx"
+#include "openturns/LinearModelAlgorithm.hxx"
+#include "openturns/DesignProxy.hxx"
+#include "openturns/LeastSquaresMethod.hxx"
+#include "openturns/LinearBasisFactory.hxx"
+#include "openturns/LinearCombinationFunction.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -206,6 +211,111 @@ private:
   CovarianceModel covarianceModel_;
   Basis basis_;
   Scalar sumLog_;
+};
+
+class BoxCoxLMOptimizationEvaluation : public EvaluationImplementation
+{
+
+public:
+  BoxCoxLMOptimizationEvaluation(const Sample & inputSample,
+                                 const Sample & shiftedOutputSample,
+                                 const Basis & basis)
+      : inputSample_(inputSample)
+      , shiftedOutputSample_(shiftedOutputSample)
+      , basis_(basis)
+      , sumLog_(0.0)
+      , algo_()
+  {
+    initialize();
+    computeSumLog();
+  }
+
+  void initialize()
+  {
+    const UnsignedInteger size = inputSample_.getSize();
+    if (shiftedOutputSample_.getDimension() != 1)
+      throw InvalidArgumentException(HERE) << "We can only handle and 1-d output sample.";
+
+    const UnsignedInteger basisSize = basis_.getSize();
+    // basisSize should be < size (not <=)
+    // In case of =, residual sample is always 0 and not possible to perform an optimization
+    // to set the optimal lambda value
+    if (!(basisSize < size))
+      throw InvalidArgumentException(HERE) << "Number of basis elements is greater than sample size. Data size = " << shiftedOutputSample_.getSize()
+                                           << ", basis size = " << basisSize;
+
+    // No particular strategy : using the full basis
+    Indices indices(basis_.getSize());
+    indices.fill();
+
+    // Define the design proxy
+    const DesignProxy proxy(inputSample_, basis_);
+
+    // Compute using a least squares method
+    algo_ = LeastSquaresMethod::Build(ResourceMap::GetAsString("LinearModelAlgorithm-DecompositionMethod"), proxy, indices);
+  }
+  BoxCoxLMOptimizationEvaluation *clone() const override
+  {
+    return new BoxCoxLMOptimizationEvaluation(*this);
+  }
+
+  UnsignedInteger getInputDimension() const override
+  {
+    return 1;
+  }
+
+  UnsignedInteger getOutputDimension() const override
+  {
+    return 1;
+  }
+
+  // It is a simple call to the likelihood function
+  Point operator()(const Point &lambda) const override
+  {
+    // Define BoxCox transformation for output sample
+    const BoxCoxEvaluation myBoxFunction(lambda);
+    // compute the mean of the transformed sample using the Box-Cox function
+    const Sample transformedOutputSample(myBoxFunction(shiftedOutputSample_));
+
+    // Solve linear system
+    const Point coefficients(algo_.solve(transformedOutputSample.asPoint()));
+
+    // Define the linear model
+    const LinearCombinationFunction metaModel(basis_, coefficients);
+
+    // Residual sample
+    const Sample residualSample(transformedOutputSample - metaModel(inputSample_));
+
+    // noise variance
+    const UnsignedInteger size = shiftedOutputSample_.getSize();
+    const Scalar sigma2 = residualSample.computeRawMoment(2)[0];
+    const Scalar result = -0.5 * size * std::log(sigma2) + (lambda[0] - 1.0) * sumLog_;
+    return Point(1, result);
+  }
+
+  void computeSumLog()
+  {
+    // Compute the sum of the log-data
+    const UnsignedInteger size = shiftedOutputSample_.getSize();
+    const UnsignedInteger dimension = shiftedOutputSample_.getDimension();
+    sumLog_ = 0.0;
+    for (UnsignedInteger k = 0; k < size; ++k)
+      for (UnsignedInteger d = 0; d < dimension; ++d)
+        sumLog_ += std::log(shiftedOutputSample_(k, d));
+  }
+
+  Scalar getSumLog() const
+  {
+    return sumLog_;
+  }
+
+private:
+  /** only used to pass data to be used in computeLogLikeliHood */
+  Sample inputSample_;
+  Sample shiftedOutputSample_;
+  Basis basis_;
+  Scalar sumLog_;
+  mutable LeastSquaresMethod algo_;
 };
 
 /* Constructor with parameters */
@@ -413,6 +523,66 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
                                      GeneralLinearModelResult & result)
 {
   return build(inputSample, outputSample, covarianceModel, Basis(), shift, result);
+}
+
+/** Build the factory from data by estimating the best generalized linear model */
+BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+                                     const Sample &outputSample,
+                                     const Basis &basis,
+                                     const Point &shift,
+                                     LinearModelResult &linearModelResult)
+{
+  // Check the input size
+  const UnsignedInteger size = inputSample.getSize();
+  if (size == 0)
+    throw InvalidArgumentException(HERE) << "Error: cannot build a Box-Cox factory from empty data";
+
+  if (size != outputSample.getSize())
+    throw InvalidArgumentException(HERE) << "Error: input and output sample have different size. Could not perform linear model & Box-Cox algorithms";
+
+  // Check the dimensions
+  const UnsignedInteger dimension = outputSample.getDimension();
+
+  if (shift.getDimension() != dimension)
+    throw InvalidArgumentException(HERE) << "Error: the shift has a dimension=" << shift.getDimension() << " different from the output sample dimension=" << dimension;
+
+  // Keep the shifted marginal samples
+  Sample shiftedSample(outputSample);
+  shiftedSample += shift;
+
+  // optimization process
+  const BoxCoxLMOptimizationEvaluation boxCoxOptimization(inputSample, shiftedSample, basis);
+  const Function objectiveFunction(boxCoxOptimization);
+  MemoizeFunction objectiveMemoizeFunction(objectiveFunction, Full());
+  objectiveMemoizeFunction.enableCache();
+  OptimizationProblem problem(objectiveMemoizeFunction);
+  problem.setMinimization(false);
+  solver_.setProblem(problem);
+  solver_.setStartingPoint(Point(1, 1.0));
+  // run Optimization problem
+  solver_.run();
+  // Return optimization point
+  const Point optpoint(solver_.getResult().getOptimalPoint());
+
+  // Define BoxCox transformation for output sample
+  const BoxCoxEvaluation myBoxFunction(optpoint, shift);
+  // compute the transformed output sample using the Box-Cox function
+  const Sample transformedOutputSample(myBoxFunction(outputSample));
+  // Build the LinearModelResult
+  LinearModelAlgorithm algo(inputSample, transformedOutputSample, basis);
+  algo.run();
+  // Get result
+  linearModelResult = algo.getResult();
+  return BoxCoxTransform(optpoint, shift);
+}
+
+BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+                                     const Sample &outputSample,
+                                     const Point &shift,
+                                     LinearModelResult &linearModelResult)
+{
+  const Basis basis(LinearBasisFactory(inputSample.getDimension()).build());
+  return build(inputSample, outputSample, basis, shift, linearModelResult);
 }
 
 /* String converter */

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
@@ -462,7 +462,7 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
                                      const CovarianceModel & covarianceModel,
                                      const Basis & basis,
                                      const Point & shift,
-                                     GeneralLinearModelResult & result)
+                                     GeneralLinearModelResult & generalLinearModelResult)
 {
   // Check the input size
   const UnsignedInteger size = inputSample.getSize();
@@ -512,17 +512,17 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
   GeneralLinearModelAlgorithm algo(inputSample, transformedOutputSample, covarianceModel, basis);
   algo.run();
   // Get result
-  result = algo.getResult();
+  generalLinearModelResult = algo.getResult();
   return BoxCoxTransform(optpoint, shift);
 }
 
-BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
-                                     const Sample & outputSample,
-                                     const CovarianceModel & covarianceModel,
-                                     const Point & shift,
-                                     GeneralLinearModelResult & result)
+BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+                                     const Sample &outputSample,
+                                     const CovarianceModel &covarianceModel,
+                                     const Point &shift,
+                                     GeneralLinearModelResult &generalLinearModelResult)
 {
-  return build(inputSample, outputSample, covarianceModel, Basis(), shift, result);
+  return build(inputSample, outputSample, covarianceModel, Basis(), shift, generalLinearModelResult);
 }
 
 /** Build the factory from data by estimating the best generalized linear model */

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
@@ -61,14 +61,19 @@ public:
 
   /** Build the factory from data by estimating the best \lambda which maximizes the log-likelihood function */
   BoxCoxTransform build(const Field & timeSeries) const;
+
   BoxCoxTransform build(const Field & timeSeries,
                         const Point & shift) const;
+
   BoxCoxTransform build(const Field & timeSeries,
                         const Point & shift,
                         Graph & graph) const;
+
   BoxCoxTransform build(const Sample & sample) const;
+
   BoxCoxTransform build(const Sample & sample,
                         const Point & shift) const;
+
   BoxCoxTransform build(const Sample & sample,
                         const Point & shift,
                         Graph & graph) const;

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
@@ -31,6 +31,7 @@
 #include "openturns/CovarianceModel.hxx"
 #include "openturns/Basis.hxx"
 #include "openturns/GeneralLinearModelResult.hxx"
+#include "openturns/LinearModelResult.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -85,6 +86,17 @@ public:
                         const CovarianceModel & covarianceModel,
                         const Point & shift,
                         GeneralLinearModelResult & result);
+
+  BoxCoxTransform build(const Sample &inputSample,
+                        const Sample &outputSample,
+                        const Basis &basis,
+                        const Point &shift,
+                        LinearModelResult &linearModelResult);
+
+  BoxCoxTransform build(const Sample &inputSample,
+                        const Sample &outputSample,
+                        const Point &shift,
+                        LinearModelResult &linearModelResult);
 
   /** Optimization solver accessor */
   OptimizationAlgorithm getOptimizationAlgorithm() const;

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
@@ -74,18 +74,18 @@ public:
                         Graph & graph) const;
 
   /** Build the factory from data by estimating the best generalized linear model */
-  BoxCoxTransform build(const Sample & inputSample,
-                        const Sample & outputSample,
-                        const CovarianceModel & covarianceModel,
-                        const Basis & basis,
-                        const Point & shift,
-                        GeneralLinearModelResult & result);
+  BoxCoxTransform build(const Sample &inputSample,
+                        const Sample &outputSample,
+                        const CovarianceModel &covarianceModel,
+                        const Basis &basis,
+                        const Point &shift,
+                        GeneralLinearModelResult &generalLinearModelResult);
 
   BoxCoxTransform build(const Sample & inputSample,
                         const Sample & outputSample,
                         const CovarianceModel & covarianceModel,
                         const Point & shift,
-                        GeneralLinearModelResult & result);
+                        GeneralLinearModelResult & generalLinearModelResult);
 
   BoxCoxTransform build(const Sample &inputSample,
                         const Sample &outputSample,

--- a/lib/test/CMakeLists.txt
+++ b/lib/test/CMakeLists.txt
@@ -564,6 +564,7 @@ ot_check_test (IsoProbabilisticTransformation_EllipticalCopula)
 ot_check_test (IsoProbabilisticTransformation_EllipticalDistribution)
 ot_check_test (BoxCoxFactory_std)
 ot_check_test (BoxCoxFactory_glm)
+ot_check_test (BoxCoxFactory_lm IGNOREOUT)
 ot_check_test (TrendFactory_std)
 
 # Calibration

--- a/lib/test/t_BoxCoxFactory_lm.cxx
+++ b/lib/test/t_BoxCoxFactory_lm.cxx
@@ -1,0 +1,81 @@
+//                                               -*- C++ -*-
+/**
+ *  @brief The test file of class BoxCoxFactory for standard methods using GLM
+ *
+ *  Copyright 2005-2023 Airbus-EDF-IMACS-ONERA-Phimeca
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "openturns/OT.hxx"
+#include "openturns/OTtestcode.hxx"
+
+using namespace OT;
+using namespace OT::Test;
+
+int main(int, char *[])
+{
+  TESTPREAMBLE;
+  OStream fullprint(std::cout);
+  setRandomGenerator();
+
+  try
+  {
+    const UnsignedInteger size = 200;
+
+    // input sample
+    const Sample inputSample = Uniform(-1.0, 1.0).getSample(size);
+    Sample outputSample(inputSample);
+
+    // Evaluation of y = ax + b (a: scale, b: translate)
+    // scale
+    const Point scale = {3.0};
+    outputSample *= scale;
+
+    // translate sample
+    const Point translate = {10.0};
+    outputSample += translate;
+
+    // Finally inverse transform using an arbitrary lambda
+    const Point lambda = {2.0};
+    const InverseBoxCoxEvaluation boxCoxFunction(lambda);
+
+    // transform y using BoxCox function
+    outputSample = boxCoxFunction(outputSample);
+
+    // Add small noise
+    const Sample epsilon = Normal(0, 1e-3).getSample(size);
+    outputSample +=  epsilon;
+    // Now we build the factory
+    BoxCoxFactory factory;
+
+    // Creation of the BoxCoxTransform
+    LinearModelResult result;
+    const Point shift = {1e-10};
+    BoxCoxTransform myBoxCox = factory.build(inputSample, outputSample, shift, result);
+    // estimated lambda =  1.99098;
+    // beta = [9.90054,2.95995]
+    assert_almost_equal(myBoxCox.getLambda(), lambda, 1e-2, 1e-2);
+    const Point trendCoefficients = {9.90054, 2.95995};
+    assert_almost_equal(result.getCoefficients(), trendCoefficients, 1e-3, 1e-3);
+  }
+  catch (TestFailed & ex)
+  {
+    std::cerr << ex << std::endl;
+    return ExitCode::Error;
+  }
+
+
+  return ExitCode::Success;
+}

--- a/python/doc/pyplots/BoxCoxFactory.py
+++ b/python/doc/pyplots/BoxCoxFactory.py
@@ -39,12 +39,11 @@ graphMarginal1.setLegendPosition("")
 # Initiate a BoxCoxFactory
 myBoxCoxFactory = ot.BoxCoxFactory()
 
-graph = ot.Graph()
 shift = [0.0]
 
 # We estimate the lambda parameter from the field myField
 # All values of the field are positive
-myModelTransform = myBoxCoxFactory.build(myField, shift, graph)
+myModelTransform, graph = myBoxCoxFactory.build(myField, shift)
 graphMarginal2 = (
     ot.KernelSmoothing().build(myModelTransform(myField).getValues()).drawPDF()
 )

--- a/python/doc/theory/probabilistic_modeling/boxcox_transformation.rst
+++ b/python/doc/theory/probabilistic_modeling/boxcox_transformation.rst
@@ -249,9 +249,62 @@ Remarks :
    Indeed a linear model is a specific case of general linear model where the correlation model is a
    Dirac covariance model.
 
--  We get hare a double loop optimization. For each :math:`\lambda` value, we optimize the parameters of the underlying
-   general linear model. Some practitioners use to freeze first general linear model parameters and then preform a one loop
-   optimization selecting only the best :math:`\lambda` value
+Note that such estimate might be heavy as we get a double loop optimization. Indeed for each :math:`\lambda` value, we optimize
+the parameters of the underlying general linear model. Some practitioners are used to freeze the first general linear model parameters
+and then preform a one loop optimization selecting only the best :math:`\lambda` value.
+
+| **Estimation of the Box Cox transformation in the frame of linear models:**
+
+In the frame of linear models, we consider a functional relation between some input and
+output values. Let us consider the following dataset:
+:math:`\left(\left(\vect{x}^{(i)}, y^{(i)}\right), i = 1, \ldots, m\right)`.
+
+The general linear model aims at assessing the following
+prior model :
+
+.. math:: Y(\vect{x}) = \Tr{\vect{\phi}(\vect{x})} \vect{\alpha} + \epsilon
+
+where:
+
+-  :math:`\Tr{\vect{\phi}(\vect{x})} \vect{\alpha}` is a general linear
+   model based upon a functional basis
+   :math:`\vect{\phi} = \left(\phi_j, j = 1, \ldots, p\right)` and a vector of
+   coefficients
+   :math:`\vect{\alpha} = \left(\alpha_j, j = 1, \ldots, p\right)`,
+
+-  :math:`\epsilon` is a zero-mean stationary white noise process.
+
+
+The optimal parameters of such model are estimated by maximizing a log-likelihood function.
+
+Here we suppose a gaussian prior on :math:`h_\lambda(y)`. Thus, if we write our various hypotheses,
+we get the following log-likelihood function to be optimized:
+
+  .. math::
+    :label: lLambdalm
+
+    \ell(\lambda) = \log L( \hat{\beta}(\lambda), \hat{\sigma}(\lambda),\lambda ) = C -
+    \frac{m}{2}
+    \log\left[\hat{\sigma}^2(\lambda)\right]
+    \;+\;
+    \left(\lambda - 1 \right) \sum_{k=1}^{m} \log(y_k)\,,
+
+where :math:`C` is a constant,
+
+   .. math::
+    :label: betasigmalm
+
+    \epsilon_k = y_k - \Tr{\vect{\phi}(\vect{x_k})} \vect{\alpha}, k=1...m \\
+    \hat{\beta}(\lambda) = \frac{1}{m} \sum_{k=1}^{m} h_{\lambda}(\epsilon_k) \\
+    \hat{\sigma}^2(\lambda) = \frac{1}{m} \sum_{k=1}^{m} (h_{\lambda}(\epsilon_k) - \beta(\lambda))^2
+
+As a remark, the above case is a particular case of :eq:`lLambdalm`. Indeed if a linear model is a specific case of general linear model
+where the correlation model is a Dirac covariance model (White noise model).
+
+In term of costs, a factorization (QR or SVD) is done once for the regression matrix and the parameters defined in :eq:`betasigmalm`
+are easily obtained, for each new :math:`\lambda` value, solving the corresponding linear systems.
+Sometimes, people perform a grid search for example varying for example :math:`\lambda` from -3 to 3 using a small step. It allows one
+to get both the optimal and assess the robustness of the optimum.
 
 .. topic:: API:
 
@@ -259,6 +312,7 @@ Remarks :
     - See :class:`~openturns.InverseBoxCoxTransform`
     - See :class:`~openturns.BoxCoxFactory`
     - See :class:`~openturns.GeneralLinearModelAlgorithm`
+    - See :class:`~openturns.LinearModelAlgorithm`
 
 .. topic:: Examples:
 

--- a/python/src/BoxCoxFactory.i
+++ b/python/src/BoxCoxFactory.i
@@ -1,5 +1,9 @@
 // SWIG file BoxCoxFactory.i
 
+// do not pass argument by reference, return it as tuple item
+%typemap(in, numinputs=0) OT::LinearModelResult & linearModelResult ($*ltype temp) %{ temp = OT::LinearModelResult(); $1 = &temp; %}
+%typemap(argout) OT::LinearModelResult & linearModelResult %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::LinearModelResult(*$1), SWIGTYPE_p_OT__LinearModelResult, SWIG_POINTER_OWN |  0 )); %}
+
 %{
 #include "openturns/BoxCoxFactory.hxx"
 %}

--- a/python/src/BoxCoxFactory.i
+++ b/python/src/BoxCoxFactory.i
@@ -7,6 +7,8 @@
 %typemap(in, numinputs=0) OT::GeneralLinearModelResult & generalLinearModelResult ($*ltype temp) %{ temp = OT::GeneralLinearModelResult(); $1 = &temp; %}
 %typemap(argout) OT::GeneralLinearModelResult & generalLinearModelResult %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::GeneralLinearModelResult(*$1), SWIGTYPE_p_OT__GeneralLinearModelResult, SWIG_POINTER_OWN |  0 )); %}
 
+%typemap(in, numinputs=0) OT::Graph & graph ($*ltype temp) %{ temp = OT::Graph(); $1 = &temp; %}
+%typemap(argout) OT::Graph & graph %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::Graph(*$1), SWIGTYPE_p_OT__Graph, SWIG_POINTER_OWN |  0 )); %}
 
 
 %{

--- a/python/src/BoxCoxFactory.i
+++ b/python/src/BoxCoxFactory.i
@@ -4,6 +4,11 @@
 %typemap(in, numinputs=0) OT::LinearModelResult & linearModelResult ($*ltype temp) %{ temp = OT::LinearModelResult(); $1 = &temp; %}
 %typemap(argout) OT::LinearModelResult & linearModelResult %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::LinearModelResult(*$1), SWIGTYPE_p_OT__LinearModelResult, SWIG_POINTER_OWN |  0 )); %}
 
+%typemap(in, numinputs=0) OT::GeneralLinearModelResult & generalLinearModelResult ($*ltype temp) %{ temp = OT::GeneralLinearModelResult(); $1 = &temp; %}
+%typemap(argout) OT::GeneralLinearModelResult & generalLinearModelResult %{ $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(new OT::GeneralLinearModelResult(*$1), SWIGTYPE_p_OT__GeneralLinearModelResult, SWIG_POINTER_OWN |  0 )); %}
+
+
+
 %{
 #include "openturns/BoxCoxFactory.hxx"
 %}

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -32,34 +32,34 @@ The objective is to estimate the most likely surrogate model (general linear mod
 %feature("docstring") OT::BoxCoxFactory::build
 "Estimate the Box Cox transformation.
 
-Available usages with time series:
-    build(*myField*)
+Available usages with time series & fields:
+    build(*myField*) -> myBoxCoxTransform
 
-    build(*myField, shift*)
+    build(*myField, shift*) -> Tuple[myBoxCoxTransform, myGraph]
 
 Available usages with data only:
 
-    build(*mySample*)
+    build(*mySample*) -> myBoxCoxTransform
 
-    build(*mySample, shift*)
+    build(*mySample, shift*) -> Tuple[myBoxCoxTransform, myGraph]
 
 Available usages with a general linear model:
 
-    build(*inputSample, outputSample, covarianceModel, basis, shift*)
+    build(*inputSample, outputSample, covarianceModel, basis, shift*) -> Tuple[myBoxCoxTransform, myGeneralLinearModelResult]
 
-    build(*inputSample, outputSample, covarianceModel, shift*)
+    build(*inputSample, outputSample, covarianceModel, shift*) -> Tuple[myBoxCoxTransform, myGeneralLinearModelResult]
 
 Available usages with a linear model:
 
-    build(*inputSample, outputSample, basis, shift*)
+    build(*inputSample, outputSample, basis, shift*) -> Tuple[myBoxCoxTransform, myLinearModelResult]
 
-    build(*inputSample, outputSample, shift*)
+    build(*inputSample, outputSample, shift*) -> Tuple[myBoxCoxTransform, myLinearModelResult]
 
 Parameters
 ----------
 myField : :class:`~openturns.Field`
     One realization of a  process.
-mySample : :class:`~openturns.Sample`
+mySample : 2-d sequence of float
     A set of *iid* values.
 shift : :class:`~openturns.Point`
     It ensures that when shifted, the data are all positive.
@@ -67,11 +67,8 @@ shift : :class:`~openturns.Point`
 inputSample, outputSample : :class:`~openturns.Sample` or 2d-array
     The input and output samples of a model evaluated apart.
 basis : :class:`~openturns.Basis`
-    Functional basis to estimate the trend.
-    If the output dimension is greater than 1, the same basis is used for all marginals.
-multivariateBasis : collection of :class:`~openturns.Basis`
-    Collection of functional basis: one basis for each marginal output.
-    If the trend is not estimated, the collection must be empty.
+    Functional basis to estimate the trend: :math:`(\varphi_j)_{1 \leq j \leq n_1}: \Rset^n \rightarrow \Rset`.
+    If :math:`d>1`, the same basis is used for each marginal output.
 covarianceModel : :class:`~openturns.CovarianceModel`
     Covariance model.
     Should have input dimension equal to input sample's dimension and dimension equal to output sample's dimension.
@@ -81,21 +78,15 @@ Returns
 -------
 myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
     The estimated Box Cox transformation.
-likelihoodGraph : :class:`~openturns.Graph`
-    An empty graph that is fulfilled later with the log-likelihood of the mapped variables with respect to the :math:`lambda` parameter for each component.
-generalLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
-    Empty structure that contains results of general linear model algorithm.
-linearModelResult : :class:`~openturns.LinearModelResult`
-    Empty structure that contains results of linear model algorithm.
+myGraph : :class:`~openturns.Graph`
+    A graph that is fulfilled with the log-likelihood of the mapped variables with respect to the :math:`lambda` parameter for each component.
+myGeneralLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
+    The structure that contains results of general linear model algorithm.
+myLinearModelResult : :class:`~openturns.LinearModelResult`
+    The structure that contains results of linear model algorithm.
 
 Notes
 -----
-We get `likelihoodGraph` with the two usages corresponding to the `field` or `sample` but only if we set at the sample time the
-data & shift.
-
-We get `generalLinearModelResult` with the two usages corresponding to the `general linear model application`.
-
-We get `linearModelResult` with the two usages corresponding to the `linear model application`.
 
 We describe the estimation in the univariate case, in the case of no surrogate model estimate. Only the parameter :math:`\lambda` is estimated. To clarify the notations, we omit the mention of :math:`\alpha` in :math:`h_\lambda`.
 

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -39,9 +39,10 @@ Available usages with time series:
 
     build(*myTimeSeries, shift, likelihoodGraph*)
 
-    build(*mySample*)
 
 Available usages with data only:
+
+    build(*mySample*)
 
     build(*mySample, shift*)
 

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -33,20 +33,15 @@ The objective is to estimate the most likely surrogate model (general linear mod
 "Estimate the Box Cox transformation.
 
 Available usages with time series:
-    build(*myTimeSeries*)
+    build(*myField*)
 
-    build(*myTimeSeries, shift*)
-
-    build(*myTimeSeries, shift, likelihoodGraph*)
-
+    build(*myField, shift*)
 
 Available usages with data only:
 
     build(*mySample*)
 
     build(*mySample, shift*)
-
-    build(*mySample, shift, likelihoodGraph*)
 
 Available usages with a general linear model:
 
@@ -62,15 +57,13 @@ Available usages with a linear model:
 
 Parameters
 ----------
-myTimeSeries : :class:`~openturns.TimeSeries`
+myField : :class:`~openturns.Field`
     One realization of a  process.
 mySample : :class:`~openturns.Sample`
     A set of *iid* values.
 shift : :class:`~openturns.Point`
     It ensures that when shifted, the data are all positive.
     By default the opposite of the min vector of the data is used if some data are negative.
-likelihoodGraph : :class:`~openturns.Graph`
-    An empty graph that is fulfilled later with the log-likelihood of the mapped variables with respect to the :math:`lambda` parameter for each component.
 inputSample, outputSample : :class:`~openturns.Sample` or 2d-array
     The input and output samples of a model evaluated apart.
 basis : :class:`~openturns.Basis`
@@ -88,6 +81,8 @@ Returns
 -------
 myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
     The estimated Box Cox transformation.
+likelihoodGraph : :class:`~openturns.Graph`
+    An empty graph that is fulfilled later with the log-likelihood of the mapped variables with respect to the :math:`lambda` parameter for each component.
 generalLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
     Empty structure that contains results of general linear model algorithm.
 linearModelResult : :class:`~openturns.LinearModelResult`
@@ -95,6 +90,8 @@ linearModelResult : :class:`~openturns.LinearModelResult`
 
 Notes
 -----
+We get `likelihoodGraph` with the two usages corresponding to the `field` or `sample` but only if we set at the sample time the
+data & shift.
 
 We get `generalLinearModelResult` with the two usages corresponding to the `general linear model application`.
 
@@ -218,14 +215,14 @@ Estimate the Box Cox transformation from a sample:
 
 Estimate the Box Cox transformation from a field:
 
->>> myIndices= ot.Indices([10, 5])
->>> myMesher=ot.IntervalMesher(myIndices)
+>>> myIndices = ot.Indices([10, 5])
+>>> myMesher = ot.IntervalMesher(myIndices)
 >>> myInterval = ot.Interval([0.0, 0.0], [2.0, 1.0])
->>> myMesh=myMesher.build(myInterval)
->>> amplitude=[1.0]
->>> scale=[0.2, 0.2]
->>> myCovModel=ot.ExponentialModel(scale, amplitude)
->>> myXproc=ot.GaussianProcess(myCovModel, myMesh)
+>>> myMesh = myMesher.build(myInterval)
+>>> amplitude = [1.0]
+>>> scale = [0.2, 0.2]
+>>> myCovModel = ot.ExponentialModel(scale, amplitude)
+>>> myXproc = ot.GaussianProcess(myCovModel, myMesh)
 >>> g = ot.SymbolicFunction(['x1'],  ['exp(x1)'])
 >>> myDynTransform = ot.ValueFunction(g, myMesh)
 >>> myXtProcess = ot.CompositeProcess(myDynTransform, myXproc)

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -49,9 +49,9 @@ Available usages with data only:
 
 Available usages with a general linear model:
 
-    build(*inputSample, outputSample, covarianceModel, basis, shift, generalLinearModelResult*)
+    build(*inputSample, outputSample, covarianceModel, basis, shift*)
 
-    build(*inputSample, outputSample, covarianceModel, shift, generalLinearModelResult*)
+    build(*inputSample, outputSample, covarianceModel, shift*)
 
 Available usages with a linear model:
 
@@ -82,18 +82,20 @@ covarianceModel : :class:`~openturns.CovarianceModel`
     Covariance model.
     Should have input dimension equal to input sample's dimension and dimension equal to output sample's dimension.
     See note for some particular applications.
-generalLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
-    Empty structure that contains results of general linear model algorithm.
 
 Returns
 -------
 myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
     The estimated Box Cox transformation.
-linearModelResult : :class:`~openturns.lLinearModelResult`
+generalLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
+    Empty structure that contains results of general linear model algorithm.
+linearModelResult : :class:`~openturns.LinearModelResult`
     Empty structure that contains results of linear model algorithm.
 
 Notes
 -----
+
+We get `generalLinearModelResult` with the two usages corresponding to the `general linear model application`.
 
 We get `linearModelResult` with the two usages corresponding to the `linear model application`.
 
@@ -232,6 +234,7 @@ Estimate the Box Cox transformation from a field:
 
 Estimation of a general linear model:
 
+>>> ot.RandomGenerator.SetSeed(0)
 >>> inputSample = ot.Uniform(-1.0, 1.0).getSample(20)
 >>> outputSample = ot.Sample(inputSample)
 >>> # Evaluation of y = ax + b (a: scale, b: translate)
@@ -241,11 +244,10 @@ Estimation of a general linear model:
 >>> inv_transfo = ot.PythonFunction(1,1, f)
 >>> outputSample = inv_transfo(outputSample) + ot.Normal(0, 1.0e-2).getSample(20)
 >>> # Estimation
->>> result = ot.GeneralLinearModelResult()
 >>> basis = ot.LinearBasisFactory(1).build()
 >>> covarianceModel = ot.DiracCovarianceModel()
 >>> shift = [1.0e-1]
->>> myBoxCox = ot.BoxCoxFactory().build(inputSample, outputSample, covarianceModel, basis, shift, result)
+>>> myBoxCox, result = ot.BoxCoxFactory().build(inputSample, outputSample, covarianceModel, basis, shift)
 
 Estimation of a linear model:
 

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -32,7 +32,7 @@ The objective is to estimate the most likely surrogate model (general linear mod
 %feature("docstring") OT::BoxCoxFactory::build
 "Estimate the Box Cox transformation.
 
-Available usages:
+Available usages with time series:
     build(*myTimeSeries*)
 
     build(*myTimeSeries, shift*)
@@ -41,13 +41,23 @@ Available usages:
 
     build(*mySample*)
 
+Available usages with data only:
+
     build(*mySample, shift*)
 
     build(*mySample, shift, likelihoodGraph*)
 
+Available usages with a general linear model:
+
     build(*inputSample, outputSample, covarianceModel, basis, shift, generalLinearModelResult*)
 
     build(*inputSample, outputSample, covarianceModel, shift, generalLinearModelResult*)
+
+Available usages with a linear model:
+
+    build(*inputSample, outputSample, basis, shift*)
+
+    build(*inputSample, outputSample, shift*)
 
 Parameters
 ----------
@@ -79,9 +89,13 @@ Returns
 -------
 myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
     The estimated Box Cox transformation.
+linearModelResult : :class:`~openturns.lLinearModelResult`
+    Empty structure that contains results of linear model algorithm.
 
 Notes
 -----
+
+We get `linearModelResult` with the two usages corresponding to the `linear model application`.
 
 We describe the estimation in the univariate case, in the case of no surrogate model estimate. Only the parameter :math:`\lambda` is estimated. To clarify the notations, we omit the mention of :math:`\alpha` in :math:`h_\lambda`.
 
@@ -232,4 +246,18 @@ Estimation of a general linear model:
 >>> covarianceModel = ot.DiracCovarianceModel()
 >>> shift = [1.0e-1]
 >>> myBoxCox = ot.BoxCoxFactory().build(inputSample, outputSample, covarianceModel, basis, shift, result)
+
+Estimation of a linear model:
+
+>>> ot.RandomGenerator.SetSeed(0)
+>>> x = ot.Uniform(-1.0, 1.0).getSample(20)
+>>> y = ot.Sample(x)
+>>> # Evaluation of y = ax + b (a: scale, b: translate)
+>>> y = y * [3] + [3.1]
+>>> # inverse transformation
+>>> inv_transformation = ot.SymbolicFunction('x', 'exp(x)')
+>>> y = inv_transformation(y) + ot.Normal(0, 1.0e-4).getSample(20)
+>>> # Estimation
+>>> shift = [1.0e-1]
+>>> myBoxCox, result = ot.BoxCoxFactory().build(x, y, shift)
 "

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -415,6 +415,7 @@ ot_pyinstallcheck_test (IsoProbabilisticTransformation_EllipticalCopula)
 ot_pyinstallcheck_test (IsoProbabilisticTransformation_IndependentCopula)
 ot_pyinstallcheck_test (BoxCoxFactory_std)
 ot_pyinstallcheck_test (BoxCoxFactory_glm)
+ot_pyinstallcheck_test (BoxCoxFactory_lm IGNOREOUT)
 ot_pyinstallcheck_test (TrendFactory_std)
 ot_pyinstallcheck_test (DistributionTransformation_std)
 

--- a/python/test/t_BoxCoxFactory_glm.py
+++ b/python/test/t_BoxCoxFactory_glm.py
@@ -35,12 +35,11 @@ outputSample += epsilon
 factory = ot.BoxCoxFactory()
 
 # Creation of the BoxCoxTransform
-result = ot.GeneralLinearModelResult()
 basis = ot.LinearBasisFactory(1).build()
 covarianceModel = ot.DiracCovarianceModel()
 shift = [1.0e-10]
-myBoxCox = factory.build(
-    inputSample, outputSample, covarianceModel, basis, shift, result
+myBoxCox, result = factory.build(
+    inputSample, outputSample, covarianceModel, basis, shift
 )
 
 print("myBoxCox (GLM) =", myBoxCox)

--- a/python/test/t_BoxCoxFactory_lm.py
+++ b/python/test/t_BoxCoxFactory_lm.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+
+import openturns as ot
+import openturns.testing as ott
+
+ot.TESTPREAMBLE()
+
+ot.RandomGenerator.SetSeed(0)
+
+size = 200
+
+# input sample
+inputSample = ot.Uniform(-1.0, 1.0).getSample(size)
+outputSample = ot.Sample(inputSample)
+
+# Evaluation of y = ax + b (a: scale, b: translate)
+
+# scale
+scale = [3.0]
+outputSample *= scale
+
+# translate sample
+translate = [10]
+outputSample += translate
+
+# Finally inverse transform using an arbitrary lambda
+lamb = [2.0]
+boxCoxFunction = ot.InverseBoxCoxEvaluation(lamb)
+
+# transform y using BoxCox function
+outputSample = boxCoxFunction(outputSample)
+
+# Add small noise
+epsilon = ot.Normal(0, 1.0e-3).getSample(size)
+outputSample += epsilon
+
+# Now we build the factory
+factory = ot.BoxCoxFactory()
+
+# Creation of the BoxCoxTransform
+result = ot.LinearModelResult()
+basis = ot.LinearBasisFactory(1).build()
+shift = [1.0e-10]
+myBoxCox, result = factory.build(inputSample, outputSample, shift)
+
+# estimated lambda =  1.99098,  beta = [9.90054,2.95995]
+beta = [9.90054, 2.95995]
+rtol = 1e-2
+atol = 5e-3
+ott.assert_almost_equal(myBoxCox.getLambda(), lamb, rtol, atol)
+ott.assert_almost_equal(result.getCoefficients(), beta, rtol, atol)

--- a/python/test/t_BoxCoxFactory_std.py
+++ b/python/test/t_BoxCoxFactory_std.py
@@ -33,13 +33,8 @@ print("myBoxCox (sample)     =", factory.build(sample))
 
 # Creation of the BoxCoxTransform using shift
 shift = ot.Point(1, 1.0)
-myBoxCoxShift = factory.build(timeSeries, shift)
+myBoxCoxShift, graph = factory.build(timeSeries, shift)
 
 print("myBoxCox with shift (time-series)=", myBoxCoxShift)
 print("myBoxCox with shift (sample)     =", factory.build(sample, shift))
-
-# Creation of the BoxCoxTransform using shift with graph
-graph = ot.Graph()
-myBoxCoxShiftGraph = factory.build(timeSeries, shift, graph)
-
 print("BoxCox graph (time-series)=", graph)


### PR DESCRIPTION
This PR allows to apply BoxCoxFactory with LinearModel

Before this PR, it was possible to do it using the GLM case + DiracCovarianceModel

Now  we implement this well known usage using directly DesignProxy/LeastSquaresMethod classes instead of LinearModelAlgorithm in order to have only one factorization and solve linear systems for each new lambda value. 

It allows having an efficient algorithm
