### PR TITLE
Boost performances in HSIC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,7 +44,7 @@
 === Miscellaneous ===
 
 === Bug fixes ===
-
+ * HSIC Target sensitivity bad filtering
 
 == 1.20 release (2022-11-08) == #release-1.20
 

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -349,6 +349,7 @@
   <FAST-DefaultResamplingSize     value_int="1" />
 
   <!-- OT::HSICEstimator parameters -->
+  <HSICEstimator-ParallelPValues value_bool="true" />
   <HSICEstimator-PermutationSize value_int="100" />
 
   <!-- OT::RandomGenerator parameters -->

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -977,6 +977,7 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("FAST-DefaultResamplingSize", 1);
 
   // HSIC parameters //
+  addAsBool("HSICEstimator-ParallelPValues", true);
   addAsUnsignedInteger("HSICEstimator-PermutationSize", 100);
 
   // RandomGenerator parameters //

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -20,6 +20,7 @@
  */
 #include <cstdlib>
 #include <functional>
+#include <numeric>
 #include <cstring> // std::memset
 
 #include "openturns/MatrixImplementation.hxx"
@@ -1826,16 +1827,7 @@ Scalar MatrixImplementation::computeSumElements() const
   if (nbColumns_ == 0) throw InvalidDimensionException(HERE) << "Matrices should have positive number of columns!";
 
   /* Result */
-  Scalar sum = 0.0;
-
-  /* TODO: is there any better implementation ? */
-  for(UnsignedInteger j = 0; j < nbColumns_; ++j)
-  {
-    for(UnsignedInteger i = 0; i < nbRows_; ++i)
-    {
-      sum += (*this)(i, j);
-    }
-  }
+  const Scalar sum = std::accumulate(begin(), end(), 0.0);
 
   return sum;
 }

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorConditionalSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorConditionalSensitivity.cxx
@@ -40,6 +40,7 @@ HSICEstimatorConditionalSensitivity::HSICEstimatorConditionalSensitivity(
   : HSICEstimatorImplementation(covarianceModelCollection, X, Y, HSICVStat())
 {
   weightFunction_ = weightFunction;
+  computeCovarianceMatrices();
 }
 
 /* Virtual constructor */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
@@ -50,8 +50,7 @@ HSICEstimatorGlobalSensitivity* HSICEstimatorGlobalSensitivity::clone() const
 /* Compute the weight matrix */
 SquareMatrix HSICEstimatorGlobalSensitivity::computeWeightMatrix(const Sample&) const
 {
-  const IdentityMatrix mat(n_);
-  return mat;
+  return IdentityMatrix(n_);
 }
 
 /* Get the asymptotic p-values */
@@ -91,7 +90,8 @@ void HSICEstimatorGlobalSensitivity::run() const
   /* Compute the p-values by permutation */
   if(!(isAlreadyComputedPValuesPermutation_))
   {
-    computePValuesPermutation();
+    // In order to avoid th
+    (void) getPValuesPermutation();
   }
 
   /* Compute the p-values asymptotically */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
@@ -38,7 +38,7 @@ HSICEstimatorGlobalSensitivity::HSICEstimatorGlobalSensitivity(
   const HSICStat & estimatorType)
   : HSICEstimatorImplementation(covarianceModelCollection, X, Y, estimatorType)
 {
-  // Nothing to do
+  computeCovarianceMatrices();
 }
 
 /* Virtual constructor */
@@ -50,7 +50,7 @@ HSICEstimatorGlobalSensitivity* HSICEstimatorGlobalSensitivity::clone() const
 /* Compute the weight matrix */
 SquareMatrix HSICEstimatorGlobalSensitivity::computeWeightMatrix(const Sample&) const
 {
-  IdentityMatrix mat(n_);
+  const IdentityMatrix mat(n_);
   return mat;
 }
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
@@ -347,8 +347,8 @@ void HSICEstimatorImplementation::computePValuesPermutationParallel() const
                                       HSICobs,
                                       *this,
                                       result);
-  
-  TBBImplementation::ParallelFor( 0, permutationSize_, policy );
+
+  TBBImplementation::ParallelForIf(weightFunction_.getImplementation()->isParallel(), 0, permutationSize_, policy);
   // Here we want to divide the sum by (size+1) instead of size, so we multiply the mean by
   // size/(size+1)=1-1/(size+1)
   PValuesPermutation_ = result.computeMean() * (1.0 - 1.0 / (permutationSize_ + 1.0));

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
@@ -568,6 +568,7 @@ void HSICEstimatorImplementation::resetIndices()
   PValuesPermutation_ = Point();
   isAlreadyComputedIndices_ = false;
   isAlreadyComputedPValuesPermutation_ = false;
+  isAlreadyComputedPValuesAsymptotic_ = false;
 }
 
 /* Get the dimension of the indices: the number of marginals */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
@@ -20,8 +20,6 @@
  *
  */
 #include "openturns/HSICEstimatorImplementation.hxx"
-#include "openturns/HSICEstimator.hxx"
-#include "openturns/Pointer.hxx"
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Exception.hxx"
 #include "openturns/Log.hxx"
@@ -31,6 +29,7 @@
 #include "openturns/Curve.hxx"
 #include "openturns/Pie.hxx"
 #include "openturns/Text.hxx"
+#include "openturns/TBBImplementation.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 CLASSNAMEINIT(HSICEstimatorImplementation)
@@ -51,6 +50,8 @@ HSICEstimatorImplementation::HSICEstimatorImplementation()
   , HSIC_YY_()
   , R2HSICIndices_()
   , PValuesPermutation_()
+  , inputCovarianceMatrixCollection_()
+  , outputCovarianceMatrix_()
   , permutationSize_(ResourceMap::GetAsUnsignedInteger("HSICEstimator-PermutationSize"))
 {
 // Nothing
@@ -74,11 +75,13 @@ HSICEstimatorImplementation::HSICEstimatorImplementation(
   , HSIC_XX_ ()
   , HSIC_YY_ ()
   , R2HSICIndices_ ()
+  , inputCovarianceMatrixCollection_(n_)
+  , outputCovarianceMatrix_ ()
   , permutationSize_(ResourceMap::GetAsUnsignedInteger("HSICEstimator-PermutationSize"))
 {
-  if(covarianceModelCollection_.getSize() != (inputSample_.getDimension() + outputSample_.getDimension())) throw InvalidDimensionException(HERE) << "The number of covariance momdels is the dimension of the input +1";
-  if(outputSample_.getDimension() != 1) throw InvalidDimensionException(HERE) << "The dimension of the output is 1.";
-  if(inputSample_.getSize() != outputSample_.getSize()) throw InvalidDimensionException(HERE) << "Input and output samples must have the same size";
+  if (covarianceModelCollection_.getSize() != (inputSample_.getDimension() + outputSample_.getDimension())) throw InvalidDimensionException(HERE) << "The number of covariance momdels is the dimension of the input +1";
+  if (outputSample_.getDimension() != 1) throw InvalidDimensionException(HERE) << "The dimension of the output is 1.";
+  if (inputSample_.getSize() != outputSample_.getSize()) throw InvalidDimensionException(HERE) << "Input and output samples must have the same size";
 }
 
 /* Virtual constructor */
@@ -87,6 +90,17 @@ HSICEstimatorImplementation * HSICEstimatorImplementation::clone() const
   return new HSICEstimatorImplementation(*this);
 }
 
+/* Compute the covariance matrices associated to the inputs and outputs */
+void HSICEstimatorImplementation::computeCovarianceMatrices()
+{
+  for(UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+  {
+	inputCovarianceMatrixCollection_[dim] = covarianceModelCollection_[dim].discretize(inputSample_.getMarginal(dim));
+  }
+  outputCovarianceMatrix_ = covarianceModelCollection_[inputDimension_].discretize(outputSample_);
+}
+
+
 /* Compute the weight matrix from the weight function */
 SquareMatrix HSICEstimatorImplementation::computeWeightMatrix(const Sample&) const
 {
@@ -94,20 +108,18 @@ SquareMatrix HSICEstimatorImplementation::computeWeightMatrix(const Sample&) con
 }
 
 /* Compute a HSIC index (one marginal) by using the underlying estimator (biased or not) */
-Scalar HSICEstimatorImplementation::computeHSICIndex(const Sample & inSample,
-    const Sample & outSample,
-    const CovarianceModel & inCovariance,
-    const CovarianceModel & outCovariance,
+Scalar HSICEstimatorImplementation::computeHSICIndex(const CovarianceMatrix & covMat1,
+    const CovarianceMatrix & covMat2,
     const SquareMatrix & weightMatrix) const
 {
-  return estimatorType_.computeHSICIndex(inSample, outSample, inCovariance, outCovariance, weightMatrix);
+  return estimatorType_.computeHSICIndex(covMat1, covMat2, weightMatrix);
 }
 
 /* Compute HSIC and R2-HSIC indices */
 void HSICEstimatorImplementation::computeIndices() const
 {
   /* Compute weights */
-  const SquareMatrix W = computeWeightMatrix(outputSample_);
+  const SquareMatrix W(computeWeightMatrix(outputSample_));
 
   /* Init */
   HSIC_XX_ = Point(inputDimension_);
@@ -115,19 +127,18 @@ void HSICEstimatorImplementation::computeIndices() const
   HSIC_YY_ = Point(1);
 
   /* Loop over marginals: HSIC indices */
-  for(UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+  for (UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
   {
-    const Sample xdim(inputSample_.getMarginal(dim));
-    HSIC_XY_[dim] = computeHSICIndex(xdim, outputSample_, covarianceModelCollection_[dim], covarianceModelCollection_[inputDimension_], W);
-    HSIC_XX_[dim] = computeHSICIndex(xdim, xdim, covarianceModelCollection_[dim], covarianceModelCollection_[dim], W);
+    HSIC_XY_[dim] = computeHSICIndex(inputCovarianceMatrixCollection_[dim], outputCovarianceMatrix_, W);
+    HSIC_XX_[dim] = computeHSICIndex(inputCovarianceMatrixCollection_[dim], inputCovarianceMatrixCollection_[dim], W);
   }
-  HSIC_YY_[0] = computeHSICIndex(outputSample_, outputSample_, covarianceModelCollection_[inputDimension_], covarianceModelCollection_[inputDimension_], W);
+  HSIC_YY_[0] = computeHSICIndex(outputCovarianceMatrix_, outputCovarianceMatrix_, W);
 
   /* Compute R2-HSIC */
   R2HSICIndices_ = Point(inputDimension_);
-  for(UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+  for (UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
   {
-    R2HSICIndices_[dim] = HSIC_XY_[dim] / sqrt(HSIC_XX_[dim] * HSIC_YY_[0]);
+    R2HSICIndices_[dim] = HSIC_XY_[dim] / std::sqrt(HSIC_XX_[dim] * HSIC_YY_[0]);
   }
 
   isAlreadyComputedIndices_ = true ;
@@ -151,35 +162,196 @@ UnsignedInteger HSICEstimatorImplementation::getPermutationSize() const
 void HSICEstimatorImplementation::computePValuesPermutation() const
 {
   const SquareMatrix Wobs(computeWeightMatrix(outputSample_));
+  Point HSICobs(inputDimension_);
+  for (UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+  {
+    HSICobs[dim] = computeHSICIndex(inputCovarianceMatrixCollection_[dim], outputCovarianceMatrix_, Wobs);
+  }
+  
   PValuesPermutation_ = Point(inputDimension_);
-  Collection<Sample> shuffleCollection(permutationSize_);
-  Collection<SquareMatrix> weightMatrixCollection(permutationSize_);
-
-  for( UnsignedInteger b = 0; b < permutationSize_; ++b)
+  Sample shuffledSample(outputSample_);
+  CovarianceMatrix shuffledCovariance(outputCovarianceMatrix_);
+  SquareMatrix shuffledWeight(Wobs);
+  for (UnsignedInteger b = 0; b < permutationSize_; ++b)
   {
-    const Sample shuffledSample = shuffledCopy(outputSample_);
-    shuffleCollection[b] = shuffledSample;
-    weightMatrixCollection[b] = computeWeightMatrix(shuffledSample);
+    const Indices indices(shuffleIndices(outputSample_.getSize()));
+    for (UnsignedInteger j = 0; j < outputCovarianceMatrix_.getDimension(); ++j)
+      {
+        const UnsignedInteger newJ = indices[j];
+        shuffledSample[j] = outputSample_[newJ];
+        for (UnsignedInteger i = j; i < outputCovarianceMatrix_.getDimension(); ++i)
+          {
+            const UnsignedInteger newI = indices[i];
+            shuffledCovariance(i, j) = outputCovarianceMatrix_(newI, newJ);
+          } // i
+      } // j
+    shuffledWeight = computeWeightMatrix(shuffledSample);
+    for (UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+      {
+        const Scalar HSICloc = computeHSICIndex(inputCovarianceMatrixCollection_[dim], shuffledCovariance, shuffledWeight);
+        if (HSICloc > HSICobs[dim]) ++PValuesPermutation_[dim];
+      }
+  } // b
+  PValuesPermutation_ /= (permutationSize_ + 1.0);
+
+  isAlreadyComputedPValuesPermutation_ = true;
+}
+
+// Helper for the parallel version of the pvalue-permutation computation
+struct HSICPValuesPermutationFunctor
+{
+  const Collection<Indices> indicesCollection_;
+  const Point HSICobs_;
+  const Collection<CovarianceMatrix> inputCovarianceMatrixCollection_;
+  const Sample outputSample_;
+  const CovarianceMatrix outputCovarianceMatrix_;
+  const Pointer<HSICEstimatorImplementation> p_hsic_;
+  Point accumulator_;
+
+  HSICPValuesPermutationFunctor(const Collection<Indices> & indicesCollection,
+                                const Point & HSICobs,
+                                const Collection<CovarianceMatrix> & inputCovarianceMatrixCollection,
+                                const Sample & outputSample,
+                                const CovarianceMatrix & outputCovarianceMatrix,
+                                const HSICEstimatorImplementation & hsic)
+    : indicesCollection_(indicesCollection)
+    , HSICobs_(HSICobs)
+    , inputCovarianceMatrixCollection_(inputCovarianceMatrixCollection)
+    , outputSample_(outputSample)
+    , outputCovarianceMatrix_(outputCovarianceMatrix)
+    , p_hsic_(hsic.clone())
+    , accumulator_(HSICobs.getDimension())
+  {}
+
+  HSICPValuesPermutationFunctor(const HSICPValuesPermutationFunctor & other,
+                                TBBImplementation::Split)
+    : indicesCollection_(other.indicesCollection_)
+    , HSICobs_(other.HSICobs_)
+    , inputCovarianceMatrixCollection_(other.inputCovarianceMatrixCollection_)
+    , outputSample_(other.outputSample_)
+    , outputCovarianceMatrix_(other.outputCovarianceMatrix_)
+    , p_hsic_(other.p_hsic_)
+    , accumulator_(other.accumulator_)
+  {}
+
+  inline void operator()( const TBBImplementation::BlockedRange<UnsignedInteger> & r )
+  {
+    Sample shuffledSample(outputSample_.getSize(), outputSample_.getDimension());
+    CovarianceMatrix shuffledCovariance(outputCovarianceMatrix_.getDimension());
+    SquareMatrix shuffledWeight;
+    for (UnsignedInteger b = r.begin(); b != r.end(); ++b)
+      {
+        const Indices indices(indicesCollection_[b]);
+        for (UnsignedInteger j = 0; j < outputCovarianceMatrix_.getDimension(); ++j)
+          {
+            const UnsignedInteger newJ = indices[j];
+            shuffledSample[j] = outputSample_[newJ];
+            for (UnsignedInteger i = j; i < outputCovarianceMatrix_.getDimension(); ++i)
+              {
+                const UnsignedInteger newI = indices[i];
+                shuffledCovariance(i, j) = outputCovarianceMatrix_(newI, newJ);
+              } // i
+          } // j
+        shuffledWeight = p_hsic_->computeWeightMatrix(shuffledSample);
+        for (UnsignedInteger dim = 0; dim < accumulator_.getDimension(); ++dim)
+          {
+            const Scalar HSICloc = p_hsic_->computeHSICIndex(inputCovarianceMatrixCollection_[dim], shuffledCovariance, shuffledWeight);
+            if (HSICloc > HSICobs_[dim]) ++accumulator_[dim];
+          }
+      } // b
+  } // operator()
+
+  inline void join(const HSICPValuesPermutationFunctor & other)
+  {
+    accumulator_ += other.accumulator_;
   }
 
-  for(UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+}; // struct HSICPValuesPermutationFunctor
+
+struct HSICPValuesPermutationPolicy
+{
+  const Collection<Indices> indicesCollection_;
+  const Point HSICobs_;
+  const Pointer<HSICEstimatorImplementation> p_hsic_;
+  Sample & output_;
+
+  HSICPValuesPermutationPolicy(const Collection<Indices> & indicesCollection,
+                               const Point & HSICobs,
+                               const HSICEstimatorImplementation & hsic,
+                               Sample & output)
+    : indicesCollection_(indicesCollection)
+    , HSICobs_(HSICobs)
+    , p_hsic_(hsic.clone())
+    , output_(output)
+  {}
+
+  inline void operator()( const TBBImplementation::BlockedRange<UnsignedInteger> & r ) const
   {
-
-    const Sample xdim(inputSample_.getMarginal(dim));
-    const Scalar HSIC_obs = computeHSICIndex(xdim, outputSample_, covarianceModelCollection_[dim], covarianceModelCollection_[inputDimension_], Wobs);
-    UnsignedInteger count = 0;
-
-    for( UnsignedInteger b = 0; b < permutationSize_; ++b)
-    {
-      const Sample Yp(shuffleCollection[b]);
-      const SquareMatrix W(weightMatrixCollection[b]);
-      const Scalar HSIC_loc = computeHSICIndex(xdim, Yp, covarianceModelCollection_[dim], covarianceModelCollection_[inputDimension_], W);
-      if( HSIC_loc > HSIC_obs) count += 1;
-    }
-
-    /* p-value by permutation */
-    PValuesPermutation_[dim] = count * 1.0 / (permutationSize_ + 1) ;
+    const UnsignedInteger hsicDimension = HSICobs_.getDimension();
+    const UnsignedInteger covarianceDimension = p_hsic_->outputCovarianceMatrix_.getDimension();
+    Sample shuffledSample(p_hsic_->outputSample_.getSize(), p_hsic_->outputSample_.getDimension());
+    CovarianceMatrix shuffledCovariance(covarianceDimension);
+    SquareMatrix shuffledWeight;
+    for (UnsignedInteger b = r.begin(); b != r.end(); ++b)
+      {
+        const Indices indices(indicesCollection_[b]);
+        for (UnsignedInteger j = 0; j < covarianceDimension; ++j)
+          {
+            const UnsignedInteger newJ = indices[j];
+            shuffledSample[j] = p_hsic_->outputSample_[newJ];
+            for (UnsignedInteger i = j; i < covarianceDimension; ++i)
+              {
+                const UnsignedInteger newI = indices[i];
+                shuffledCovariance(i, j) = p_hsic_->outputCovarianceMatrix_(newI, newJ);
+              } // i
+          } // j
+        shuffledWeight = p_hsic_->computeWeightMatrix(shuffledSample);
+        for (UnsignedInteger dim = 0; dim < hsicDimension; ++dim)
+          {
+            const Scalar HSICloc = p_hsic_->computeHSICIndex(p_hsic_->inputCovarianceMatrixCollection_[dim], shuffledCovariance, shuffledWeight);
+            if (HSICloc > HSICobs_[dim]) ++output_(b, dim);
+          }
+      } // b
   }
+
+}; /* end struct HSICPValuesPermutationPolicy */
+
+
+
+/* Compute p-value with permutation */
+void HSICEstimatorImplementation::computePValuesPermutationParallel() const
+{
+  const SquareMatrix Wobs(computeWeightMatrix(outputSample_));
+  Point HSICobs(inputDimension_);
+  for (UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
+  {
+    HSICobs[dim] = computeHSICIndex(inputCovarianceMatrixCollection_[dim], outputCovarianceMatrix_, Wobs);
+  }
+  Collection<Indices> indicesCollection(permutationSize_);
+  for (UnsignedInteger b = 0; b < permutationSize_; ++b)
+  {
+    const Indices indices(shuffleIndices(outputSample_.getSize()));
+    indicesCollection[b] = indices;
+  }
+#ifdef WITH_FUNCTOR
+  HSICPValuesPermutationFunctor functor(indicesCollection,
+                                        HSICobs,
+                                        inputCovarianceMatrixCollection_,
+                                        outputSample_,
+                                        outputCovarianceMatrix_,
+                                        *this);
+  TBBImplementation::ParallelReduce( 0, permutationSize_, functor );
+  PValuesPermutation_ = functor.accumulator_ / (permutationSize_ + 1.0);
+#else
+  Sample result(permutationSize_, inputDimension_);
+  HSICPValuesPermutationPolicy policy(indicesCollection,
+                                      HSICobs,
+                                      *this,
+                                      result);
+  
+  TBBImplementation::ParallelFor( 0, permutationSize_, policy );
+  PValuesPermutation_ = result.computeMean() * (1.0 - 1.0 / (permutationSize_ + 1.0));
+#endif
   isAlreadyComputedPValuesPermutation_ = true;
 }
 
@@ -194,23 +366,20 @@ void HSICEstimatorImplementation::computePValuesAsymptotic() const
     H(j, j) += 1.0;
   }
 
-  const CovarianceMatrix Ky(covarianceModelCollection_[inputDimension_].discretize(outputSample_));
-  const Scalar traceKy = Ky.computeTrace();
-  const Scalar sumKy = Ky.computeSumElements();
+  const Scalar traceKy = outputCovarianceMatrix_.computeTrace();
+  const Scalar sumKy = outputCovarianceMatrix_.computeSumElements();
 
   const Scalar Ey = (sumKy - traceKy) / n_ / (n_ - 1 );
-  const Matrix By = H * Ky * H;
+  const Matrix By(H * outputCovarianceMatrix_ * H);
   const Point HSICobsPt(getHSICIndices());
 
   for(UnsignedInteger dim = 0; dim < inputDimension_; ++dim)
   {
-    const Sample Xi(inputSample_.getMarginal(dim));
-    const CovarianceMatrix Kx(covarianceModelCollection_[dim].discretize(Xi));
-    const Scalar traceKx = Kx.computeTrace();
-    const Scalar sumKx = Kx.computeSumElements();
+    const Scalar traceKx = inputCovarianceMatrixCollection_[dim].computeTrace();
+    const Scalar sumKx = inputCovarianceMatrixCollection_[dim].computeSumElements();
     const Scalar Ex = (sumKx - traceKx) / n_ / (n_ - 1);
 
-    const Matrix Bx = H * Kx * H;
+    const Matrix Bx(H * inputCovarianceMatrixCollection_[dim] * H);
 
     /* Hadamard product then square all elements */
     SquareMatrix B(Bx.computeHadamardProduct(By).getImplementation());
@@ -261,6 +430,17 @@ Point HSICEstimatorImplementation::getPValuesPermutation() const
   if( !(isAlreadyComputedPValuesPermutation_))
   {
     computePValuesPermutation();
+    isAlreadyComputedPValuesPermutation_ = true ;
+  }
+  return PValuesPermutation_;
+}
+
+/* Get the p-values by permutation */
+Point HSICEstimatorImplementation::getPValuesPermutationParallel() const
+{
+  if( !(isAlreadyComputedPValuesPermutation_))
+  {
+    computePValuesPermutationParallel();
     isAlreadyComputedPValuesPermutation_ = true ;
   }
   return PValuesPermutation_;
@@ -348,6 +528,7 @@ void HSICEstimatorImplementation::setCovarianceModelCollection(const CovarianceM
 {
   covarianceModelCollection_ = coll ;
   resetIndices();
+  computeCovarianceMatrices();
 }
 
 /* Get the input sample */
@@ -361,6 +542,7 @@ void HSICEstimatorImplementation::setInputSample(const Sample & inputSample)
 {
   inputSample_ = inputSample;
   resetIndices();
+  computeCovarianceMatrices();
 }
 
 /* Get the output sample */
@@ -379,6 +561,7 @@ void HSICEstimatorImplementation::setOutputSample(const Sample & outputSample)
 
   outputSample_ = outputSample;
   resetIndices();
+  computeCovarianceMatrices();
 }
 
 
@@ -413,20 +596,19 @@ HSICStat HSICEstimatorImplementation::getEstimator() const
 }
 
 /* Return a shuffled copy of a sample */
-Sample HSICEstimatorImplementation::shuffledCopy(const Sample & inSample) const
+Indices HSICEstimatorImplementation::shuffleIndices(const UnsignedInteger size) const
 {
   /* Shuffle an array a of n elements (indices 0..n-1)
     see https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
   */
-  Sample sampleOut(inSample);
-  for(UnsignedInteger i = sampleOut.getSize() - 1; i > 0; --i)
+  Indices output(size);
+  output.fill();
+  for(UnsignedInteger i = size - 1; i > 0; --i)
   {
     const UnsignedInteger j = RandomGenerator::IntegerGenerate(i + 1);
-    // swap i & j rows
-    for (UnsignedInteger d = 0; d < sampleOut.getDimension(); ++d)
-      std::swap(sampleOut(j, d), sampleOut(i, d));
+    std::swap(output[j], output[i]);
   }
-  return sampleOut;
+  return output;
 }
 
 /* Run all computations at once */
@@ -464,6 +646,8 @@ void HSICEstimatorImplementation::save(Advocate & adv) const
   adv.saveAttribute( "permutationSize_", permutationSize_ );
   adv.saveAttribute( "isAlreadyComputedIndices_", isAlreadyComputedIndices_ );
   adv.saveAttribute( "isAlreadyComputedPValuesPermutation_", isAlreadyComputedPValuesPermutation_ );
+  adv.saveAttribute( "inputCovarianceMatrixCollection_", inputCovarianceMatrixCollection_ );
+  adv.saveAttribute( "outputCovarianceMatrix_", outputCovarianceMatrix_ );
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -485,6 +669,8 @@ void HSICEstimatorImplementation::load(Advocate & adv)
   adv.loadAttribute( "permutationSize_", permutationSize_ );
   adv.loadAttribute( "isAlreadyComputedIndices_", isAlreadyComputedIndices_ );
   adv.loadAttribute( "isAlreadyComputedPValuesPermutation_", isAlreadyComputedPValuesPermutation_ );
+  adv.loadAttribute( "inputCovarianceMatrixCollection_", inputCovarianceMatrixCollection_ );
+  adv.loadAttribute( "outputCovarianceMatrix_", outputCovarianceMatrix_ );
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
@@ -178,7 +178,7 @@ void HSICEstimatorImplementation::computePValuesPermutationSequential() const
     for (UnsignedInteger j = 0; j < outputCovarianceMatrix_.getDimension(); ++j)
       {
         const UnsignedInteger newJ = indices[j];
-        shuffledSample[j] = outputSample_[newJ];
+        shuffledSample(j, 0) = outputSample_(newJ, 0);
         for (UnsignedInteger i = j; i < outputCovarianceMatrix_.getDimension(); ++i)
           {
             const UnsignedInteger newI = indices[i];
@@ -299,7 +299,7 @@ struct HSICPValuesPermutationPolicy
         for (UnsignedInteger j = 0; j < covarianceDimension; ++j)
           {
             const UnsignedInteger newJ = indices[j];
-            shuffledSample[j] = p_hsic_->outputSample_[newJ];
+            shuffledSample(j, 0) = p_hsic_->outputSample_(newJ, 0);
             for (UnsignedInteger i = j; i < covarianceDimension; ++i)
               {
                 const UnsignedInteger newI = indices[i];

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorImplementation.cxx
@@ -349,6 +349,8 @@ void HSICEstimatorImplementation::computePValuesPermutationParallel() const
                                       result);
   
   TBBImplementation::ParallelFor( 0, permutationSize_, policy );
+  // Here we want to divide the sum by (size+1) instead of size, so we multiply the mean by
+  // size/(size+1)=1-1/(size+1)
   PValuesPermutation_ = result.computeMean() * (1.0 - 1.0 / (permutationSize_ + 1.0));
   isAlreadyComputedPValuesPermutation_ = true;
 }

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
@@ -86,49 +86,16 @@ void HSICEstimatorTargetSensitivity::setFilterFunction(const Function & filterFu
   computeCovarianceMatrices();
 }
 
-/* Reset all indices to void */
-void HSICEstimatorTargetSensitivity::resetIndices()
-{
-  HSICEstimatorImplementation::resetIndices();
-  PValuesAsymptotic_ = Point();
-  isAlreadyComputedPValuesAsymptotic_ = false;
-}
-
 /* Draw the asymptotic p-values */
 Graph HSICEstimatorTargetSensitivity::drawPValuesAsymptotic() const
 {
   return drawValues(getPValuesAsymptotic(), "Asymptotic p-values");
 }
 
-/* Compute all indices at once */
-void HSICEstimatorTargetSensitivity::run() const
-{
-  /* Compute the HSIC and R2-HSIC indices */
-  if(!(isAlreadyComputedIndices_))
-  {
-    computeIndices();
-  }
-
-  /* Compute the p-values by permutation */
-  if(!(isAlreadyComputedPValuesPermutation_))
-  {
-    computePValuesPermutation();
-  }
-
-  /* Compute the p-values asymptotically */
-  if(!(isAlreadyComputedPValuesAsymptotic_))
-  {
-    computePValuesAsymptotic();
-  }
-
-}
-
 /* Method save() stores the object through the StorageManager */
 void HSICEstimatorTargetSensitivity::save(Advocate & adv) const
 {
   HSICEstimatorImplementation::save(adv);
-  adv.saveAttribute( "PValuesAsymptotic_", PValuesAsymptotic_ );
-  adv.saveAttribute( "isAlreadyComputedPValuesAsymptotic_", isAlreadyComputedPValuesAsymptotic_ );
   adv.saveAttribute( "filterFunction_", filterFunction_ );
 }
 
@@ -136,8 +103,6 @@ void HSICEstimatorTargetSensitivity::save(Advocate & adv) const
 void HSICEstimatorTargetSensitivity::load(Advocate & adv)
 {
   HSICEstimatorImplementation::load(adv);
-  adv.loadAttribute( "PValuesAsymptotic_", PValuesAsymptotic_ );
-  adv.loadAttribute( "isAlreadyComputedPValuesAsymptotic_", isAlreadyComputedPValuesAsymptotic_ );
   adv.loadAttribute( "filterFunction_", filterFunction_ );
 }
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
@@ -26,6 +26,8 @@ CLASSNAMEINIT(HSICEstimatorTargetSensitivity)
 /* Default */
 HSICEstimatorTargetSensitivity::HSICEstimatorTargetSensitivity()
   : HSICEstimatorImplementation()
+  , unfilteredSample_()
+
 {
   // Nothing to do
 }
@@ -40,8 +42,9 @@ HSICEstimatorTargetSensitivity::HSICEstimatorTargetSensitivity(
   : HSICEstimatorImplementation(covarianceModelCollection, X, Y, estimatorType)
 {
   filterFunction_ =  filterFunction;
+  unfilteredSample_ = outputSample_;
   /* apply filter */
-  outputSample_ = filterFunction_(outputSample_);
+  outputSample_ = filterFunction_(unfilteredSample_);
   computeCovarianceMatrices();
 }
 
@@ -81,9 +84,9 @@ void HSICEstimatorTargetSensitivity::setFilterFunction(const Function & filterFu
 {
   filterFunction_ =  filterFunction;
   /* apply filter */
-  outputSample_ = filterFunction_(outputSample_);
+  outputSample_ = filterFunction_(unfilteredSample_);
   resetIndices();
-  computeCovarianceMatrices();
+  outputCovarianceMatrix_ = covarianceModelCollection_[inputDimension_].discretize(outputSample_);
 }
 
 /* Draw the asymptotic p-values */
@@ -97,6 +100,7 @@ void HSICEstimatorTargetSensitivity::save(Advocate & adv) const
 {
   HSICEstimatorImplementation::save(adv);
   adv.saveAttribute( "filterFunction_", filterFunction_ );
+  adv.saveAttribute( "unfilteredSample_", unfilteredSample_);
 }
 
 /* Method load() reloads the object from the StorageManager */
@@ -104,6 +108,7 @@ void HSICEstimatorTargetSensitivity::load(Advocate & adv)
 {
   HSICEstimatorImplementation::load(adv);
   adv.loadAttribute( "filterFunction_", filterFunction_ );
+  adv.loadAttribute( "unfilteredSample_", unfilteredSample_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
@@ -42,6 +42,7 @@ HSICEstimatorTargetSensitivity::HSICEstimatorTargetSensitivity(
   filterFunction_ =  filterFunction;
   /* apply filter */
   outputSample_ = filterFunction_(outputSample_);
+  computeCovarianceMatrices();
 }
 
 /* Virtual constructor */
@@ -82,6 +83,7 @@ void HSICEstimatorTargetSensitivity::setFilterFunction(const Function & filterFu
   /* apply filter */
   outputSample_ = filterFunction_(outputSample_);
   resetIndices();
+  computeCovarianceMatrices();
 }
 
 /* Reset all indices to void */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
@@ -41,13 +41,11 @@ HSICStat::HSICStat(const HSICStatImplementation & implementation)
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICStat::computeHSICIndex(const Sample & inSample,
-                                  const Sample & outSample,
-                                  const CovarianceModel & inCovariance,
-                                  const CovarianceModel & outCovariance,
+Scalar HSICStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
+                                  const CovarianceMatrix & CovMat2,
                                   const SquareMatrix & weightMatrix) const
 {
-  return getImplementation()->computeHSICIndex(inSample, outSample, inCovariance, outCovariance, weightMatrix);
+  return getImplementation()->computeHSICIndex(CovMat1, CovMat2, weightMatrix);
 }
 
 /* Is compatible with a Conditional HSIC Estimator ? */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
@@ -41,11 +41,11 @@ HSICStat::HSICStat(const HSICStatImplementation & implementation)
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
-                                  const CovarianceMatrix & CovMat2,
+Scalar HSICStat::computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
+                                  const CovarianceMatrix & covarianceMatrix2,
                                   const SquareMatrix & weightMatrix) const
 {
-  return getImplementation()->computeHSICIndex(CovMat1, CovMat2, weightMatrix);
+  return getImplementation()->computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightMatrix);
 }
 
 /* Is compatible with a Conditional HSIC Estimator ? */
@@ -55,12 +55,12 @@ Bool HSICStat::isCompatibleWithConditionalAnalysis() const
 }
 
 /* Compute the asymptotic p-value */
-Scalar HSICStat::computePValue(const Gamma &dist,
+Scalar HSICStat::computePValue(const Gamma & distribution,
                                const UnsignedInteger n,
-                               const Scalar HSIC_obs,
+                               const Scalar HSICObs,
                                const Scalar mHSIC) const
 {
-  return getImplementation()->computePValue(dist, n, HSIC_obs, mHSIC);
+  return getImplementation()->computePValue(distribution, n, HSICObs, mHSIC);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
@@ -43,10 +43,8 @@ HSICStatImplementation * HSICStatImplementation::clone() const
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICStatImplementation::computeHSICIndex(const Sample&,
-    const Sample&,
-    const CovarianceModel&,
-    const CovarianceModel&,
+Scalar HSICStatImplementation::computeHSICIndex(const CovarianceMatrix&,
+    const CovarianceMatrix&,
     const SquareMatrix&) const
 {
   throw NotYetImplementedException(HERE) << "You must use a derived class such as HSICUStat or HSICVStat.";

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
@@ -1,7 +1,8 @@
 
 //                                               -*- C++ -*-
 /**
- * @brief HSICStatImplementation implements the HSIC sensivity index for one marginal.
+ * @brief HSICStatImplementation implements the HSIC sensivity index for
+ *        one marginal.
  *
  *  Copyright 2005-2023 Airbus-EDF-IMACS-ONERA-Phimeca
  *
@@ -43,9 +44,9 @@ HSICStatImplementation * HSICStatImplementation::clone() const
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICStatImplementation::computeHSICIndex(const CovarianceMatrix&,
-    const CovarianceMatrix&,
-    const SquareMatrix&) const
+Scalar HSICStatImplementation::computeHSICIndex(const CovarianceMatrix &,
+    const CovarianceMatrix &,
+    const SquareMatrix &) const
 {
   throw NotYetImplementedException(HERE) << "You must use a derived class such as HSICUStat or HSICVStat.";
 }
@@ -57,7 +58,7 @@ Bool HSICStatImplementation::isCompatibleWithConditionalAnalysis() const
 }
 
 /* Compute the asymptotic p-value */
-Scalar HSICStatImplementation::computePValue(const Gamma&,
+Scalar HSICStatImplementation::computePValue(const Gamma &,
     const UnsignedInteger,
     const Scalar,
     const Scalar) const

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
@@ -39,39 +39,30 @@ HSICUStat* HSICUStat::clone() const
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICUStat::computeHSICIndex(const Sample & inSample,
-                                   const Sample & outSample,
-                                   const CovarianceModel & inCovariance,
-                                   const CovarianceModel & outCovariance,
+Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
+                                   const CovarianceMatrix & CovMat2,
                                    const SquareMatrix & weightMatrix) const
 {
-  if(inSample.getDimension() != 1) throw InvalidDimensionException(HERE) << "Input Sample must be of dimension 1";
-  if(outSample.getDimension() != 1) throw InvalidDimensionException(HERE) << "Output Sample must be of dimension 1";
-  if(inCovariance.getInputDimension() != 1) throw InvalidDimensionException(HERE) << "Input covariance input dimension must be 1";
-  if(outCovariance.getInputDimension() != 1) throw InvalidDimensionException(HERE) << "Output covariance input dimension must be 1";
-  if(inCovariance.getOutputDimension() != 1) throw InvalidDimensionException(HERE) << "Input covariance output dimension must be 1";
-  if(outCovariance.getOutputDimension() != 1) throw InvalidDimensionException(HERE) << "Output covariance output dimension must be 1";
-  if(inSample.getSize() != outSample.getSize()) throw InvalidDimensionException(HERE) << "Input and Output Samples must have the same size";
 
   Scalar hsic = 0.0;
   const SignedInteger n = weightMatrix.getNbColumns();
 
-  CovarianceMatrix Kv1(inCovariance.discretize(inSample));
-  CovarianceMatrix Kv2(outCovariance.discretize(outSample));
-
   const Point nullDiag(n);
-  Kv1.setDiagonal(nullDiag, 0);
-  Kv2.setDiagonal(nullDiag, 0);
+  
+  CovarianceMatrix CovMat1cp(CovMat1);
+  CovarianceMatrix CovMat2cp(CovMat2);
+  CovMat1cp.setDiagonal(nullDiag, 0);
+  CovMat2cp.setDiagonal(nullDiag, 0);
 
 
-  const SquareMatrix Kv = Kv1 * Kv2;
+  const SquareMatrix Kv(CovMat1cp * CovMat2cp);
 
   const Scalar trace = Kv.computeTrace();
   const Scalar sumKv = Kv.computeSumElements();
-  const Scalar sumKv1 = Kv1.computeSumElements();
-  const Scalar sumKv2 = Kv2.computeSumElements();
+  const Scalar sumCov1 = CovMat1cp.computeSumElements();
+  const Scalar SumCov2 = CovMat2cp.computeSumElements();
 
-  hsic = trace - 2 * sumKv / (n - 2) + sumKv1 * sumKv2 / (n - 1) / (n - 2);
+  hsic = trace - 2 * sumKv / (n - 2) + sumCov1 * SumCov2 / (n - 1) / (n - 2);
   hsic /= n * (n - 3);
 
   return hsic;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
@@ -39,8 +39,8 @@ HSICUStat* HSICUStat::clone() const
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
-                                   const CovarianceMatrix & CovMat2,
+Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
+                                   const CovarianceMatrix & covarianceMatrix2,
                                    const SquareMatrix & weightMatrix) const
 {
 
@@ -49,18 +49,18 @@ Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
 
   const Point nullDiag(n);
   
-  CovarianceMatrix CovMat1cp(CovMat1);
-  CovarianceMatrix CovMat2cp(CovMat2);
-  CovMat1cp.setDiagonal(nullDiag, 0);
-  CovMat2cp.setDiagonal(nullDiag, 0);
+  CovarianceMatrix covarianceMatrix1Copy(covarianceMatrix1);
+  CovarianceMatrix covarianceMatrix2Copy(covarianceMatrix2);
+  covarianceMatrix1Copy.setDiagonal(nullDiag, 0);
+  covarianceMatrix2Copy.setDiagonal(nullDiag, 0);
 
 
-  const SquareMatrix Kv(CovMat1cp * CovMat2cp);
+  const SquareMatrix Kv(covarianceMatrix1Copy * covarianceMatrix2Copy);
 
   const Scalar trace = Kv.computeTrace();
   const Scalar sumKv = Kv.computeSumElements();
-  const Scalar sumCov1 = CovMat1cp.computeSumElements();
-  const Scalar SumCov2 = CovMat2cp.computeSumElements();
+  const Scalar sumCov1 = covarianceMatrix1Copy.computeSumElements();
+  const Scalar SumCov2 = covarianceMatrix2Copy.computeSumElements();
 
   hsic = trace - 2 * sumKv / (n - 2) + sumCov1 * SumCov2 / (n - 1) / (n - 2);
   hsic /= n * (n - 3);

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
@@ -44,32 +44,88 @@ Scalar HSICVStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
 {
 
   UnsignedInteger n = weightMatrix.getNbColumns();
+  // The interest is to provide the V stat, which is the trace of
+  // M = (W * Kx * W) * (H1 * Ky * H2)
+  // Left side involves only Kx, the second only Ky
+  // The first block is easy to compute
+  // (W * Kx * W)_[i,j] = W[i] * Kx[i,j] * W[j]
+  // However we will not "build" a full matrix, as we intend
+  // to perform computations without using blas/lapack
+  // The second block needs more computations.
+  // If we drop the 1/n factor (in H1 / H2), we get
+  // (H1 * Ky * H2) = (I - U * W/n) * Ky * (I - W * U/n)
+  //                = (Ky - Ky * W * U / n - U * W * Ky / n + U * W * Ky * W * U / n / n)
+  // Looking more closely,
+  // (Ky * W * U)[i,j] = \sum_k Ky[i,k] * W[k]
+  // (U * Ky * W)[i,j] = \sum_k Ky[k,j] * W[k]
+  // Thus summing the two provides :
+  // 1/n * (Ky * W * U + U * Ky * W)[i,j] = 1/n \sum_k (Ky[i,k] + Ky[k,j]) * W[k]
+  //                                      = 1/n \sum_k (Ky[i,k] + Ky[j,k]) * W[k]
+  // We define the weightedSumRows to compute these sums
+  // For the last part of the second block, we need to compute (U * W * Ky * W * U)
+  // W * K * W is an easy task (same as left block but replacing Kx with Ky).
+  // Multiplying the latter by U on left and right allows one to sum all the elements
+  // (U M U)[i,j] = sum_{k, l} M[k,l] for all i, j
+  // The result is a square matrix with values \sum_{k,l} Ky[k,k] * W[k] * W[l]
+  // We define weightedSumElements to compute this
+  // Finally we get for the right side block a matrix that writes as
+  // (H1 * Ky * H2)[i,j] = Ky[i,j] - \sum_k (Ky[i,k] + Ky[j,k]) * W[k] / n + \sum_{k,l} Ky[k,l] * W[k] * W[l] /n /n
+  //                     = Ky[i,j] -  (weightedSumElements[i] + weightedSumElements[j]) + weightedSumElements
+  // One has to note that both left & right side blocks are symmetric
+  // Finally the trace is computed manually. Indeed it is a O(n^2) algorithm
+  // whereas building matrices (left/right), computing left * right then the trace is O(n^3)
+  // trace(left * right) = \sum{i,j} left[i,j] right[j,i]
+  //                     = \sum{i,j} left[i,j] right[i,j]
+  // because of symmetry
 
-  /* U = ones((n, n)) */
-  const SquareMatrix U(n, Collection<Scalar>(n * n, 1.0 / n));
+  // Compute weighted sum \sum_k (Ky[i,k] + Ky[j,k]) * W[k]
+  Point weightedSumRows(CovMat2.getDimension());
+  Scalar weightedSumElements = 0.0;
+  for (UnsignedInteger j = 0; j < CovMat2.getDimension(); ++j)
+  {
+      const Scalar wjjCjj = weightMatrix(j, j) * CovMat2(j, j);
+      weightedSumRows[j] += wjjCjj;
+      weightedSumElements += wjjCjj * weightMatrix(j, j);
+      for (UnsignedInteger i = j + 1; i < CovMat2.getDimension(); ++i)
+      {
+        const Scalar wiiCij = CovMat2(i, j) * weightMatrix(i, i);
+        const Scalar wjjCij = CovMat2(i, j) * weightMatrix(j, j);
+        const Scalar wiCijwj = wjjCij * weightMatrix(i, i);
+        // Sum rows
+        weightedSumRows[j] += wiiCij;
+        weightedSumRows[i] += wjjCij;
+        // Sum all elements : because of symmetry using both lower and upper
+        weightedSumElements += 2.0 * wiCijwj;
+      }//i
+  }//j
 
-  SquareMatrix H1(n);
-  SquareMatrix H2(n);
-  const Point diag(n, 1.0 / n);
-  H1.setDiagonal(diag);
-  H2.setDiagonal(diag);
+  // weightedSumRows scaled by 1/n
+  weightedSumRows /= n;
 
-  H1 = H1 - U * weightMatrix / n ;
-  H2 = H2 - weightMatrix * U / n ;
+  // weighted sum elements scaled by 1/ n / n
+  weightedSumElements /= n * n;
 
-  const SquareMatrix M = weightMatrix * CovMat1 * weightMatrix * H1 * CovMat2 * H2;
-  const Scalar trace = M.computeTrace();
-
-  return trace;
+  // Compute the trace : the algorithm is O(n^2)
+  // If we compute left * right and then the trace, the algorithm is O(n^3)
+  Scalar trace = 0.0;
+  for (UnsignedInteger j = 0; j < CovMat2.getDimension(); ++j)
+  {
+    trace += (weightMatrix(j, j) * CovMat1(j, j) * weightMatrix(j, j)) * (CovMat2(j, j) + weightedSumElements - 2 * weightedSumRows[j]);
+    for (UnsignedInteger i = j + 1; i < CovMat2.getDimension(); ++i)
+    {
+      trace += 2.0 * (weightMatrix(i, i) * CovMat1(i, j) * weightMatrix(j, j)) * (CovMat2(i, j) + weightedSumElements - (weightedSumRows[i] + weightedSumRows[j]));
+    }
+  }
+  return trace / n /n;
 }
 
 /* Compute the asymptotic p-value */
-Scalar HSICVStat::computePValue(const Gamma &dist,
+Scalar HSICVStat::computePValue(const Gamma & distribution,
                                 const UnsignedInteger n,
-                                const Scalar HSIC_obs,
+                                const Scalar HSICObs,
                                 const Scalar) const
 {
-  return dist.computeComplementaryCDF(HSIC_obs * n);
+  return distribution.computeComplementaryCDF(HSICObs * n);
 }
 
 /* Is compatible with a Conditional HSIC Estimator ? Yes! */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
@@ -38,38 +38,26 @@ HSICVStat* HSICVStat::clone() const
 }
 
 /* Compute the HSIC index for one marginal*/
-Scalar HSICVStat::computeHSICIndex(const Sample & inSample,
-                                   const Sample & outSample,
-                                   const CovarianceModel & inCovariance,
-                                   const CovarianceModel & outCovariance,
+Scalar HSICVStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
+                                   const CovarianceMatrix & CovMat2,
                                    const SquareMatrix & weightMatrix) const
 {
-  if(inSample.getDimension() != 1) throw InvalidDimensionException(HERE) << "Input Sample must be of dimension 1";
-  if(outSample.getDimension() != 1) throw InvalidDimensionException(HERE) << "Output Sample must be of dimension 1";
-  if(inCovariance.getInputDimension() != 1) throw InvalidDimensionException(HERE) << "Input covariance input dimension must be 1";
-  if(outCovariance.getInputDimension() != 1) throw InvalidDimensionException(HERE) << "Output covariance input dimension must be 1";
-  if(inCovariance.getOutputDimension() != 1) throw InvalidDimensionException(HERE) << "Input covariance output dimension must be 1";
-  if(outCovariance.getOutputDimension() != 1) throw InvalidDimensionException(HERE) << "Output covariance output dimension must be 1";
-  if(inSample.getSize() != outSample.getSize()) throw InvalidDimensionException(HERE) << "Input and Output Samples must have the same size";
 
   UnsignedInteger n = weightMatrix.getNbColumns();
 
   /* U = ones((n, n)) */
-  const SquareMatrix U(n, Collection<Scalar>(n * n, 1.0));
+  const SquareMatrix U(n, Collection<Scalar>(n * n, 1.0 / n));
 
   SquareMatrix H1(n);
   SquareMatrix H2(n);
-  const Point diag(n, 1.0);
+  const Point diag(n, 1.0 / n);
   H1.setDiagonal(diag);
   H2.setDiagonal(diag);
 
   H1 = H1 - U * weightMatrix / n ;
   H2 = H2 - weightMatrix * U / n ;
 
-  const CovarianceMatrix Kv1(inCovariance.discretize(inSample));
-  const CovarianceMatrix Kv2(outCovariance.discretize(outSample));
-
-  const SquareMatrix M = weightMatrix * Kv1 * weightMatrix * H1 * Kv2 * H2 / n / n;
+  const SquareMatrix M = weightMatrix * CovMat1 * weightMatrix * H1 * CovMat2 * H2;
   const Scalar trace = M.computeTrace();
 
   return trace;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorConditionalSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorConditionalSensitivity.hxx
@@ -45,6 +45,7 @@ class OT_API HSICEstimatorConditionalSensitivity
 public:
 
   typedef Collection<CovarianceModel> CovarianceModelCollection;
+  typedef Collection <CovarianceMatrix>  CovarianceMatrixCollection;
 
 public:
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorGlobalSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorGlobalSensitivity.hxx
@@ -46,12 +46,16 @@ class OT_API HSICEstimatorGlobalSensitivity
 public:
 
   typedef Collection<CovarianceModel> CovarianceModelCollection;
+  typedef Collection <CovarianceMatrix>  CovarianceMatrixCollection;
 
   /** Default */
   HSICEstimatorGlobalSensitivity();
 
   /** Constructor */
-  HSICEstimatorGlobalSensitivity(const CovarianceModelCollection & covarianceModelCollection,  const Sample & X,  const Sample & Y, const HSICStat & estimatorType);
+  HSICEstimatorGlobalSensitivity(const CovarianceModelCollection & covarianceModelCollection,
+                                 const Sample & X,
+                                 const Sample & Y,
+                                 const HSICStat & estimatorType);
 
   /** Virtual constructor */
   HSICEstimatorGlobalSensitivity* clone() const override;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
@@ -45,7 +45,7 @@ class OT_API HSICEstimatorImplementation
 {
   // For parallelism using TBB. This struct is defined
   // in HSICEstimatorImplementation.cxx
-  friend struct HSICPValuesPermutationPolicy;
+  friend struct HSICPValuesPermutationFunctor;
   CLASSNAME
 
 public:

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
@@ -43,7 +43,8 @@ BEGIN_NAMESPACE_OPENTURNS
 class OT_API HSICEstimatorImplementation
   : public PersistentObject
 {
-  friend struct HSICPValuesPermutationFunctor;
+  // For parallelism using TBB. This struct is defined
+  // in HSICEstimatorImplementation.cxx
   friend struct HSICPValuesPermutationPolicy;
   CLASSNAME
 
@@ -108,9 +109,6 @@ public:
   /** Get the p-values by permutation */
   Point getPValuesPermutation() const;
 
-  /** Get the p-values by permutation */
-  Point getPValuesPermutationParallel() const;
-
   /** Compute all indices at once */
   virtual void run() const;
 
@@ -138,9 +136,9 @@ protected:
   virtual void computeCovarianceMatrices();
 
   /** Compute p-value with permutation */
-  virtual void computePValuesPermutation() const;
+  virtual void computePValuesPermutationSequential() const;
 
-  /** Compute p-value with permutation */
+  /** Compute p-value with permutation using TBB */
   virtual void computePValuesPermutationParallel() const;
 
   /** Compute the p-values with asymptotic formula */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
@@ -43,17 +43,23 @@ BEGIN_NAMESPACE_OPENTURNS
 class OT_API HSICEstimatorImplementation
   : public PersistentObject
 {
+  friend struct HSICPValuesPermutationFunctor;
+  friend struct HSICPValuesPermutationPolicy;
   CLASSNAME
 
 public:
 
   typedef Collection <CovarianceModel>  CovarianceModelCollection;
+  typedef Collection <CovarianceMatrix>  CovarianceMatrixCollection;
 
   /** Default constructor */
   HSICEstimatorImplementation();
 
   /** Constructor */
-  HSICEstimatorImplementation(const CovarianceModelCollection & covarianceModelCollection, const Sample & X, const Sample & Y, const HSICStat & estimatorType);
+  HSICEstimatorImplementation(const CovarianceModelCollection & covarianceModelCollection,
+                              const Sample & X,
+                              const Sample & Y,
+                              const HSICStat & estimatorType);
 
   /* Here is the interface that all derived class must implement */
 
@@ -102,6 +108,9 @@ public:
   /** Get the p-values by permutation */
   Point getPValuesPermutation() const;
 
+  /** Get the p-values by permutation */
+  Point getPValuesPermutationParallel() const;
+
   /** Compute all indices at once */
   virtual void run() const;
 
@@ -125,8 +134,14 @@ protected:
   /** Reset indices to void */
   virtual void resetIndices();
 
+  /* Compute the covariance matrices associated to the inputs and outputs */
+  virtual void computeCovarianceMatrices();
+
   /** Compute p-value with permutation */
   virtual void computePValuesPermutation() const;
+
+  /** Compute p-value with permutation */
+  virtual void computePValuesPermutationParallel() const;
 
   /** Compute the p-values with asymptotic formula */
   virtual void computePValuesAsymptotic() const;
@@ -135,7 +150,9 @@ protected:
   virtual SquareMatrix computeWeightMatrix(const Sample & Y) const;
 
   /** Compute a HSIC index (one marginal) by using the underlying estimator (biased or not) */
-  virtual Scalar computeHSICIndex( const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix & covMat1,
+                                  const CovarianceMatrix & covMat2,
+                                  const SquareMatrix & weightMatrix) const;
 
   /** Compute HSIC and R2-HSIC indices */
   virtual void computeIndices() const;
@@ -143,7 +160,7 @@ protected:
   /** Draw values stored in a point */
   Graph drawValues(const Point &values, const String &title) const;
 
-  Sample shuffledCopy(const Sample & inSample) const;
+  Indices shuffleIndices(const UnsignedInteger size) const;
 
   /** Data */
   PersistentCollection <CovarianceModel> covarianceModelCollection_ ;
@@ -159,6 +176,8 @@ protected:
   mutable Point R2HSICIndices_;
   mutable Point PValuesPermutation_ ;
   mutable Point PValuesAsymptotic_ ;
+  PersistentCollection <CovarianceMatrix> inputCovarianceMatrixCollection_;
+  CovarianceMatrix outputCovarianceMatrix_;
   UnsignedInteger permutationSize_ ;
   mutable Bool isAlreadyComputedIndices_ = false ;
   mutable Bool isAlreadyComputedPValuesPermutation_ = false ;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
@@ -88,6 +88,9 @@ private:
   /** Compute the weight matrix from the weight function */
   SquareMatrix computeWeightMatrix(const Sample & Y) const override;
 
+  // unfiltered sample
+  Sample unfilteredSample_;
+
 };
 
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
@@ -51,7 +51,11 @@ public:
   HSICEstimatorTargetSensitivity();
 
   /** Constructor */
-  HSICEstimatorTargetSensitivity(const CovarianceModelCollection & covarianceModelCollection, const Sample & X, const Sample & Y, const HSICStat & estimatorType, const Function & filterFunction);
+  HSICEstimatorTargetSensitivity(const CovarianceModelCollection & covarianceModelCollection,
+                                 const Sample & X,
+                                 const Sample & Y,
+                                 const HSICStat & estimatorType,
+                                 const Function & filterFunction);
 
   /** Virtual constructor */
   HSICEstimatorTargetSensitivity* clone() const override;
@@ -68,9 +72,6 @@ public:
   /** Get the filter function */
   void setFilterFunction(const Function & filterFunction);
 
-  /** Compute all indices at once */
-  void run() const override;
-
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 
@@ -81,9 +82,6 @@ protected:
 
   /* data */
   Function filterFunction_ ;
-
-  /** Reset all indices to void */
-  void resetIndices() override;
 
 private:
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
@@ -45,6 +45,7 @@ class OT_API HSICEstimatorTargetSensitivity
 public:
 
   typedef Collection<CovarianceModel> CovarianceModelCollection;
+  typedef Collection <CovarianceMatrix>  CovarianceMatrixCollection;
 
   /** Default */
   HSICEstimatorTargetSensitivity();

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
@@ -54,7 +54,7 @@ public:
 #endif
 
   /** Compute the HSIC index for one marginal*/
-  virtual Scalar computeHSICIndex(const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const;
 
   /** Compute the asymptotic p-value */
   virtual Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
@@ -54,10 +54,15 @@ public:
 #endif
 
   /** Compute the HSIC index for one marginal*/
-  virtual Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
+                                  const CovarianceMatrix & covarianceMatrix2,
+                                  const SquareMatrix & weightMatrix) const;
 
   /** Compute the asymptotic p-value */
-  virtual Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const;
+  virtual Scalar computePValue(const Gamma & distribution,
+                               const UnsignedInteger n,
+                               const Scalar HSICObs,
+                               const Scalar mHSIC) const;
 
   /** Is compatible with a Conditional HSIC Estimator ? */
   virtual Bool isCompatibleWithConditionalAnalysis() const;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
@@ -1,7 +1,8 @@
 
 //                                               -*- C++ -*-
 /**
- * @brief HSICStatImplementation implements the HSIC sensivity index for one marginal.
+ * @brief HSICStatImplementation implements the HSIC sensivity index for
+ *        one marginal.
  *
  *  Copyright 2005-2023 Airbus-EDF-IMACS-ONERA-Phimeca
  *
@@ -49,10 +50,15 @@ public:
   HSICStatImplementation * clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  virtual Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
+                                  const CovarianceMatrix & covarianceMatrix2,
+                                  const SquareMatrix & weightMatrix) const;
 
   /** Compute the asymptotic p-value */
-  virtual Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const;
+  virtual Scalar computePValue(const Gamma & distribution,
+                               const UnsignedInteger n,
+                               const Scalar HSICObs,
+                               const Scalar mHSIC) const;
 
   /** Is compatible with a Conditional HSIC Estimator ? */
   virtual Bool isCompatibleWithConditionalAnalysis() const;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
@@ -49,7 +49,7 @@ public:
   HSICStatImplementation * clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  virtual Scalar computeHSICIndex(const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const;
 
   /** Compute the asymptotic p-value */
   virtual Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
@@ -41,7 +41,9 @@ public:
   HSICUStat* clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const override;
+  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1,
+                          const CovarianceMatrix & CovMat2,
+                          const SquareMatrix & weightMatrix) const override;
 
   /** Compute the asymptotic p-value */
   Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const override;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
@@ -41,7 +41,7 @@ public:
   HSICUStat* clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  Scalar computeHSICIndex(const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const override;
+  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const override;
 
   /** Compute the asymptotic p-value */
   Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const override;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
@@ -41,10 +41,15 @@ public:
   HSICVStat* clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const override;
+  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1,
+                          const CovarianceMatrix & CovMat2,
+                          const SquareMatrix & weightMatrix) const override;
 
   /** Compute the asymptotic p-value */
-  Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const override;
+  Scalar computePValue(const Gamma & distribution,
+                       const UnsignedInteger n,
+                       const Scalar HSICObs,
+                       const Scalar mHSIC) const override;
 
   /** Is compatible with a Conditional HSIC Estimator ? */
   Bool isCompatibleWithConditionalAnalysis() const override;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
@@ -41,7 +41,7 @@ public:
   HSICVStat* clone() const override;
 
   /** Compute the HSIC index for one marginal*/
-  Scalar computeHSICIndex(const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const override;
+  Scalar computeHSICIndex(const CovarianceMatrix & CovMat1, const CovarianceMatrix & CovMat2, const SquareMatrix & weightMatrix) const override;
 
   /** Compute the asymptotic p-value */
   Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const override;

--- a/lib/test/t_HSICEstimatorTargetSensitivity_std.cxx
+++ b/lib/test/t_HSICEstimatorTargetSensitivity_std.cxx
@@ -141,11 +141,10 @@ int main(int, char *[])
     SymbolicFunction squaredExponential("x", "exp(-0.1 * x^2)");
     ComposedFunction alternateFilter(squaredExponential, g);
     TSA.setFilterFunction(alternateFilter);
-    assert_almost_equal(TSA.getR2HSICIndices(), {0.263026, 0.0041902, 0.00309598});
-    assert_almost_equal(TSA.getHSICIndices(), {1.54349e-05, 2.45066e-07, 1.88477e-07}, 1e-4, 0.0);
-    assert_almost_equal(TSA.getPValuesPermutation(), {0.0, 0.264735, 0.279720});
-    assert_almost_equal(TSA.getPValuesAsymptotic(), {0.0, 0.270278, 0.288026});
-
+    assert_almost_equal(TSA.getR2HSICIndices(), {0.373511, 0.0130156, 0.0153977});
+    assert_almost_equal(TSA.getHSICIndices(), {0.00118685, 4.12193e-05, 5.07577e-05}, 1e-4, 0.0);
+    assert_almost_equal(TSA.getPValuesPermutation(), {0, 0.137862, 0.112887});
+    assert_almost_equal(TSA.getPValuesAsymptotic(), {7.32022e-13, 0.143851, 0.128866});
   }
   catch (TestFailed & ex)
   {

--- a/lib/test/t_HSICStat_std.cxx
+++ b/lib/test/t_HSICStat_std.cxx
@@ -85,7 +85,9 @@ int main(int, char *[])
       Sample test = X.getMarginal(i);
       /* Set input covariance scale */
       Cov1.setScale(test.computeStandardDeviation());
-      Scalar hsicIndex = estimatorTypeV.computeHSICIndex(test, Y, Cov1, Cov2, W);
+          CovarianceMatrix CovMat1(Cov1.discretize(test));
+          CovarianceMatrix CovMat2(Cov2.discretize(Y));
+      Scalar hsicIndex = estimatorTypeV.computeHSICIndex(CovMat1, CovMat2, W);
       assert_almost_equal(hsicIndex, referenceV[i]);
     }
 
@@ -103,7 +105,9 @@ int main(int, char *[])
       Sample test = X.getMarginal(i);
       /* Set input covariance scale */
       Cov1.setScale(test.computeStandardDeviation());
-      Scalar hsicIndex = estimatorTypeU.computeHSICIndex(test, Y, Cov1, Cov2, W);
+          CovarianceMatrix CovMat1(Cov1.discretize(test));
+          CovarianceMatrix CovMat2(Cov2.discretize(Y));
+      Scalar hsicIndex = estimatorTypeU.computeHSICIndex(CovMat1, CovMat2, W);
       assert_almost_equal(hsicIndex, referenceU[i]);
     }
 

--- a/python/src/HSICStatImplementation_doc.i.in
+++ b/python/src/HSICStatImplementation_doc.i.in
@@ -4,7 +4,7 @@
 Notes
 -----
 This is a base class for the implementation of an HSIC statistic
-but cannot be used by itself. An HSIC statistic object can created by using the
+but cannot be used by itself. An HSIC statistic object can be created by using the
 derived classes: :class:`~openturns.HSICUStat` and :class:`~openturns.HSICVStat`.
 
 See also
@@ -21,17 +21,13 @@ OT_HSICStat_doc
 
 Parameters
 ----------
-inSample : 2-d sequence of float
-    Input sample.
 
-outSample : 2-d sequence of float
-    Output sample.
+covarianceMatrixX : :class:`~openturns.CovarianceMatrix`
+    The xi-covariance model discretized over the input marginal sample xi.
 
-inCovariance : :class:`~openturns.CovarianceModel`
-    The covariance model associated with the input sample.
-
-outCovariance : :class:`~openturns.CovarianceModel`
-    The covariance model associated with the output sample.
+covarianceMatrixY : :class:`~openturns.CovarianceMatrix`
+    The covariance model associated with the output sample, discretized
+    over the last one.
 
 weightMatrix : :class:`~openturns.Matrix`
     A weight matrix used for the statistic.

--- a/python/test/t_HSICEstimatorConditionalSensitivity_std.py
+++ b/python/test/t_HSICEstimatorConditionalSensitivity_std.py
@@ -2,19 +2,15 @@
 
 import openturns as ot
 import openturns.testing as ott
-import math as m
+from openturns.usecases import ishigami_function
 
 ot.TESTPREAMBLE()
 ot.RandomGenerator.SetSeed(0)
 
 
-# Definition of the marginals
-X1 = ot.Uniform(-m.pi, m.pi)
-X2 = ot.Uniform(-m.pi, m.pi)
-X3 = ot.Uniform(-m.pi, m.pi)
-
-# 3d distribution made with independent marginals
-distX = ot.ComposedDistribution([X1, X2, X3])
+# Ishigami use-case
+ishigami = ishigami_function.IshigamiModel()
+distX = ishigami.distributionX
 
 # Get a sample of it
 size = 100
@@ -22,9 +18,8 @@ X = distX.getSample(size)
 
 
 # The Ishigami model
-modelIshigami = ot.SymbolicFunction(
-    ["X1", "X2", "X3"], ["sin(X1) + 5.0 * (sin(X2))^2 + 0.1 * X3^4 * sin(X1)"]
-)
+modelIshigami = ishigami.model
+modelIshigami.setParameter([5, 0.1])
 
 # Apply model: Y = m(X)
 Y = modelIshigami(X)

--- a/python/test/t_HSICEstimatorGlobalSensitivity_std.py
+++ b/python/test/t_HSICEstimatorGlobalSensitivity_std.py
@@ -2,19 +2,15 @@
 
 import openturns as ot
 import openturns.testing as ott
-import math as m
+from openturns.usecases import ishigami_function
 
 ot.TESTPREAMBLE()
 ot.RandomGenerator.SetSeed(0)
 
 
-# Definition of the marginals
-X1 = ot.Uniform(-m.pi, m.pi)
-X2 = ot.Uniform(-m.pi, m.pi)
-X3 = ot.Uniform(-m.pi, m.pi)
-
-# 3d distribution made with independent marginals
-distX = ot.ComposedDistribution([X1, X2, X3])
+# Ishigami use-case
+ishigami = ishigami_function.IshigamiModel()
+distX = ishigami.distributionX
 
 # Get a sample of it
 size = 100
@@ -22,9 +18,8 @@ X = distX.getSample(size)
 
 
 # The Ishigami model
-modelIshigami = ot.SymbolicFunction(
-    ["X1", "X2", "X3"], ["sin(X1) + 5.0 * (sin(X2))^2 + 0.1 * X3^4 * sin(X1)"]
-)
+modelIshigami = ishigami.model
+modelIshigami.setParameter([5, 0.1])
 
 # Apply model: Y = m(X)
 Y = modelIshigami(X)

--- a/python/test/t_HSICEstimatorTargetSensitivity_std.py
+++ b/python/test/t_HSICEstimatorTargetSensitivity_std.py
@@ -88,9 +88,9 @@ ott.assert_almost_equal(pvaluesPerm, [0.00000000, 0.23376623, 0.26573427])
 squaredExponential = ot.SymbolicFunction("x", "exp(-0.1 * x^2)")
 alternateFilter = ot.ComposedFunction(squaredExponential, g)
 TSA.setFilterFunction(alternateFilter)
-ott.assert_almost_equal(TSA.getR2HSICIndices(), [0.263026, 0.0041902, 0.00309598])
+ott.assert_almost_equal(TSA.getR2HSICIndices(), [0.373511, 0.0130156, 0.0153977])
 ott.assert_almost_equal(
-    TSA.getHSICIndices(), [1.54349e-05, 2.45066e-07, 1.88477e-07], 1e-4, 0.0
+    TSA.getHSICIndices(), [0.00118685, 4.12193e-05, 5.07577e-05], 1e-4, 0.0
 )
-ott.assert_almost_equal(TSA.getPValuesPermutation(), [0.0, 0.264735, 0.279720])
-ott.assert_almost_equal(TSA.getPValuesAsymptotic(), [0.0, 0.270278, 0.288026])
+ott.assert_almost_equal(TSA.getPValuesPermutation(), [0, 0.137862, 0.112887])
+ott.assert_almost_equal(TSA.getPValuesAsymptotic(), [7.32022e-13, 0.143851, 0.128866])

--- a/python/test/t_HSICEstimatorTargetSensitivity_std.py
+++ b/python/test/t_HSICEstimatorTargetSensitivity_std.py
@@ -2,19 +2,14 @@
 
 import openturns as ot
 import openturns.testing as ott
-import math as m
+from openturns.usecases import ishigami_function
 
 ot.TESTPREAMBLE()
 ot.RandomGenerator.SetSeed(0)
 
-
-# Definition of the marginals
-X1 = ot.Uniform(-m.pi, m.pi)
-X2 = ot.Uniform(-m.pi, m.pi)
-X3 = ot.Uniform(-m.pi, m.pi)
-
-# 3d distribution made with independent marginals
-distX = ot.ComposedDistribution([X1, X2, X3])
+# Ishigami use-case
+ishigami = ishigami_function.IshigamiModel()
+distX = ishigami.distributionX
 
 # Get a sample of it
 size = 100
@@ -22,9 +17,8 @@ X = distX.getSample(size)
 
 
 # The Ishigami model
-modelIshigami = ot.SymbolicFunction(
-    ["X1", "X2", "X3"], ["sin(X1) + 5.0 * (sin(X2))^2 + 0.1 * X3^4 * sin(X1)"]
-)
+modelIshigami = ishigami.model
+modelIshigami.setParameter([5, 0.1])
 
 # Apply model: Y = m(X)
 Y = modelIshigami(X)


### PR DESCRIPTION
The aim of this PR is to speed up drastically `HSIC` implementations. It relies on the work started by @JPelamatti and @regislebrun (see for example  #2053 and 

 many axes were considered to boost the performances : 

 - Factorization of covariance matrices computations : many often we need to compute these matrices once! 
 - Parallelization of `PValues` evaluation (permutation) using TBB
 - Boosting low level methods (`computeSumElements`)
 - Rewriting `HSICVStat` :  don't use an inline product matrix (with 6 matrices) to get the trace but perform manually the computation of the trace!
 
With these changes, we can now perform easily a `getPValuesPermutation` in a reasonable CPU time.

For example, considering the following use-case (wing_weight) :

```python

import openturns as ot
from openturns.usecases.wingweight_function import WingWeightModel
import time

ot.Log.Show(ot.Log.NONE)
m = WingWeightModel()

inputNames = m.distributionX.getDescription()

# We then estimate the HSIC indices using a data-driven approach.
sizeHSIC = 1000
inputDesignHSIC = m.distributionX.getSample(sizeHSIC)
outputDesignHSIC = m.model(inputDesignHSIC)

covarianceModelCollection = []

for i in range(m.dim):
    Xi = inputDesignHSIC.getMarginal(i)
    inputCovariance = ot.SquaredExponential(1)
    inputCovariance.setScale(Xi.computeStandardDeviation())
    covarianceModelCollection.append(inputCovariance)

# We define a covariance kernel associated to the output variable.
outputCovariance = ot.SquaredExponential(1)
outputCovariance.setScale(outputDesignHSIC.computeStandardDeviation())
covarianceModelCollection.append(outputCovariance)

# the global HSIC estimator.
estimatorType = ot.HSICUStat()

print("\nGlobal HSIC analysis")
for estimatorType in [ot.HSICUStat(), ot.HSICVStat()]:
    # We now build the HSIC estimator:
    tic = time.time()
    globHSIC = ot.HSICEstimatorGlobalSensitivity(
        covarianceModelCollection, inputDesignHSIC, outputDesignHSIC, estimatorType
    )
    toc = time.time()
    print(estimatorType)
    print("Instanciation time = ", toc - tic)
    # We get the R2-HSIC indices:
    tic = time.time()
    R2HSICIndices = globHSIC.getR2HSICIndices()
    toc = time.time()
    print("R2-HSIC Indices: ", R2HSICIndices)
    print("Time for R2 estimate = ", toc - tic)

    # and the HSIC indices:
    tic = time.time()
    HSICIndices = globHSIC.getHSICIndices()
    toc = time.time()
    print("HSIC Indices: ", HSICIndices)
    print("Elapsed time : ", toc - tic)

    # The p-value by permutation.
    if sizeHSIC <= 2500:
        tic = time.time()
        pvperm = globHSIC.getPValuesPermutation()
        toc = time.time()
        print("p-value (permutation): ", pvperm)
        print("Elapsed time : ", toc - tic)

    # We have an asymptotic estimate of the value for this estimator.
    tic = time.time()
    pvas = globHSIC.getPValuesAsymptotic()
    toc = time.time()
    print("p-value (asymptotic): ", pvas)
    print("Elapsed time : ", toc - tic)
    print("\n   ")

```

we get the following outputs (on a standard laptop):

```
Global HSIC analysis
class=HSICUStat name=Unnamed
Instanciation time =  0.07935810089111328
R2-HSIC Indices:  [0.0709503,0.00103284,0.152332,-0.000338035,-0.00124628,-0.000575032,0.0724024,0.314949,0.043949,0.00727484]#10
Time for R2 estimate =  0.5985391139984131
HSIC Indices:  [0.00608393,8.85098e-05,0.0129163,-2.86095e-05,-0.000107061,-4.91412e-05,0.00617851,0.0268515,0.00379584,0.00062124]#10
Elapsed time :  1.1920928955078125e-05
p-value (permutation):  [0,0.138614,0,0.49505,0.920792,0.584158,0,0,0,0]#10
Elapsed time :  25.38448405265808
p-value (asymptotic):  [2.53485e-31,0.196364,5.84228e-64,0.512493,0.822696,0.590785,2.03882e-30,1.38724e-117,1.43837e-19,0.000902154]#10
Elapsed time :  0.11694788932800293


class=HSICVStat name=Unnamed
Instanciation time =  0.05374884605407715
R2-HSIC Indices:  [0.0729538,0.00319583,0.154156,0.0018792,0.000925932,0.00159457,0.0744594,0.316396,0.045997,0.00946931]#10
Time for R2 estimate =  0.4571058750152588
HSIC Indices:  [0.00625534,0.000273851,0.0130707,0.000159042,7.95361e-05,0.000136262,0.00635374,0.0269738,0.00397238,0.0008086]#10
Elapsed time :  8.106231689453125e-06
p-value (permutation):  [0,0.19802,0,0.514851,0.821782,0.60396,0,0,0,0]#10
Elapsed time :  5.759479761123657
p-value (asymptotic):  [3.01964e-31,0.197912,8.40198e-64,0.506229,0.820642,0.592799,2.30747e-30,2.64449e-117,1.61341e-19,0.000890518]#10
Elapsed time :  0.10218405723571777
```

If we set `sizeHSIC` to `5000`, we disable permuations and we get :

```
Global HSIC analysis
class=HSICUStat name=Unnamed
Instanciation time =  1.7497069835662842
R2-HSIC Indices:  [0.0791215,-0.000157705,0.145721,0.00018125,-0.000212411,0.000589517,0.0855008,0.324874,0.0508335,0.00253669]#10
Time for R2 estimate =  51.17399001121521
HSIC Indices:  [0.00694355,-1.38849e-05,0.0127322,1.57884e-05,-1.86616e-05,5.14695e-05,0.00748233,0.0287413,0.00446901,0.00022362]#10
Elapsed time :  1.3113021850585938e-05
p-value (asymptotic):  [1.84895e-177,0.661291,9.5065e-304,0.217087,0.757147,0.0417729,6.92914e-183,0,1.54431e-113,4.18437e-06]#10
Elapsed time :  2.7764899730682373


class=HSICVStat name=Unnamed
Instanciation time =  2.1400630474090576
R2-HSIC Indices:  [0.07951,0.000270026,0.146086,0.00061273,0.000217375,0.00102167,0.085894,0.325149,0.0512368,0.0029618]#10
Time for R2 estimate =  13.811235189437866
HSIC Indices:  [0.0069774,2.37732e-05,0.0127637,5.33723e-05,1.90971e-05,8.91966e-05,0.00751649,0.0287645,0.0045043,0.000261086]#10
Elapsed time :  9.059906005859375e-06
p-value (asymptotic):  [2.30791e-177,0.660383,1.33116e-303,0.216908,0.753928,0.0414665,8.40925e-183,0,1.76878e-113,4.21712e-06]#10
Elapsed time :  2.945770025253296
```
Less than 20 s to perform the use-case within the `v-stat`, on a standard (and not really powerful) aptop!