### PR TITLE
Improvements in HSIC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,8 @@
  * KrigingResult.getBasisCollection was removed in favor of KrigingResult.getBasis which returns a single Basis
  * GeneralLinearModelResult.getBasisCollection was removed in favor of GeneralLinearModelResult.getBasis which returns a single Basis
  * Deprecated EllipticalDistribution::getInverseCorrelation
+ * HSICStat arguments updated (covariance matrices instead of data + covariance models)
+ * Deprecated HSICStat relying on weight matrix
 
 === Documentation ===
  * Add API documentation to common use cases pages

--- a/TODO
+++ b/TODO
@@ -1,2 +1,3 @@
 Remove DomainIntersection|Union|DisjunctiveUnion(Domain, Domain) ctors
 Remove EllipticalDistribution::getInverseCorrelation
+Drop HSICStat::computeHSICIndex(cov, cov, squareMat)

--- a/lib/src/Base/Type/Matrix.cxx
+++ b/lib/src/Base/Type/Matrix.cxx
@@ -322,11 +322,31 @@ Matrix Matrix::getDiagonal(const SignedInteger k) const
   return getImplementation()->getDiagonal(k);
 }
 
+/** Extract diagonal */
+Point Matrix::getDiagonalAsPoint(const SignedInteger k) const
+{
+  return getImplementation()->getDiagonalAsPoint(k);
+}
+
 /** Fill a diagonal */
 void Matrix::setDiagonal(const Point &diag, const SignedInteger k)
 {
   copyOnWrite();
   getImplementation()->setDiagonal(diag, k);
+}
+
+/** Fill diagonal with the same value */
+void Matrix::setDiagonal(const Scalar value, const SignedInteger k)
+{
+  copyOnWrite();
+  getImplementation()->setDiagonal(value, k);
+}
+
+/** Fill diagonal with values */
+void Matrix::Matrix::setDiagonal(const Matrix &diag, const SignedInteger k)
+{
+  copyOnWrite();
+  getImplementation()->setDiagonal(*diag.getImplementation(), k);
 }
 
 /** Sum all coefficients */

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -1759,6 +1759,112 @@ MatrixImplementation MatrixImplementation::getDiagonal(const SignedInteger k) co
   return diag;
 }
 
+/** Extract diagonal */
+Point MatrixImplementation::getDiagonalAsPoint(const SignedInteger k) const
+{
+  SignedInteger m = nbRows_;
+  SignedInteger n = nbColumns_;
+  if (k >= n)
+    throw OutOfBoundException(HERE) << "One must have k < nbColumns";
+  if (-k > m)
+    throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
+
+  /* First step: the size of the diagonal */
+  UnsignedInteger nElt;
+  /* Extraction */
+  if (k >= 0)
+  {
+    nElt = std::min(m, n - k);
+  }
+  else
+  {
+    nElt = std::min(m + k, n);
+  }
+
+  /* Extraction */
+  Point diag(nElt);
+  if (k >= 0)
+  {
+    for (UnsignedInteger l = 0; l < nElt; ++l)
+    {
+      diag[l] = (*this)(l, l + k);
+    }
+  }
+  else
+  {
+    for (UnsignedInteger l = 0; l < nElt; ++l)
+    {
+      diag[l] = (*this)(l - k, l);
+    }
+  }
+  return diag;
+}
+
+/** Fill diagonal with values */
+void MatrixImplementation::setDiagonal(const MatrixImplementation &diag, const SignedInteger k)
+{
+  SignedInteger m = nbRows_;
+  SignedInteger n = nbColumns_;
+  if (k >= n)
+    throw OutOfBoundException(HERE) << "One must have k < nbColumns";
+  if (-k > m)
+    throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
+
+  /* First step: the size of the diagonal */
+  SignedInteger nElt;
+  if (k >= 0)
+  {
+    nElt = std::min(m, n - k);
+  }
+  else
+  {
+    nElt = std::min(m + k, n);
+  }
+
+  /* Extraction */
+  SignedInteger diagRows = diag.getNbRows();
+  SignedInteger diagColumns = diag.getNbColumns();
+
+  // Check dimension
+  // diag should be a (nElt, 1) or (1, nElt) matrix
+  if ((diagRows == nElt) && (diagColumns == 1))
+  {
+    if (k >= 0)
+    {
+      for (SignedInteger l = 0; l < nElt; ++l)
+      {
+        (*this)(l, l + k) = diag(l, 0);
+      }
+    }
+    else
+    {
+      for (SignedInteger l = 0; l < nElt; ++l)
+      {
+        (*this)(l - k, l) = diag(l, 0);
+      }
+    }
+  }
+  else if ((diagColumns == nElt) && (diagRows == 1))
+  {
+    if (k >= 0)
+    {
+      for (SignedInteger l = 0; l < nElt; ++l)
+      {
+        (*this)(l, l + k) = diag(0, l);
+      }
+    }
+    else
+    {
+      for (SignedInteger l = 0; l < nElt; ++l)
+      {
+        (*this)(l - k, l) = diag(0, l);
+      }
+    }
+  }
+  else
+      throw InvalidDimensionException(HERE) << "Dimension mismatch.";
+}
+
 /** Fill a diagonal with values */
 void MatrixImplementation::setDiagonal(const Point &diag, const SignedInteger k)
 {
@@ -1794,6 +1900,51 @@ void MatrixImplementation::setDiagonal(const Point &diag, const SignedInteger k)
     for(UnsignedInteger l = 0; l < nElt; ++l)
     {
       (*this)(l - k, l) = diag[l];
+    }
+  }
+}
+
+/** Fill diagonal with the same value */
+void MatrixImplementation::setDiagonal(const Scalar value, const SignedInteger k)
+{
+  SignedInteger m = nbRows_;
+  SignedInteger n = nbColumns_;
+  if (k >= n)
+    throw OutOfBoundException(HERE) << "One must have k < nbColumns";
+  if (-k > m)
+    throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
+
+  /* First step: the size of the diagonal */
+  UnsignedInteger nElt;
+  if (k >= 0)
+  {
+    nElt = std::min(m, n - k);
+  }
+  else
+  {
+    nElt = std::min(m + k, n);
+  }
+
+  /* Fill with values */
+  if (k == 0)
+  {
+    for (UnsignedInteger l = 0; l < nElt; ++l)
+    {
+      (*this).operator[](l + l * m) = value;
+    }
+  }
+  else if (k > 0)
+  {
+    for (UnsignedInteger l = 0; l < nElt; ++l)
+    {
+      (*this)(l, l + k) = value;
+    }
+  }
+  else
+  {
+    for (UnsignedInteger l = 0; l < nElt; ++l)
+    {
+      (*this)(l - k, l) = value;
     }
   }
 }

--- a/lib/src/Base/Type/MatrixImplementation.cxx
+++ b/lib/src/Base/Type/MatrixImplementation.cxx
@@ -1723,38 +1723,22 @@ UnsignedInteger MatrixImplementation::stride(const UnsignedInteger dim) const
 /** Diagonal extraction */
 MatrixImplementation MatrixImplementation::getDiagonal(const SignedInteger k) const
 {
-  SignedInteger m = nbRows_;
-  SignedInteger n = nbColumns_;
+  const SignedInteger m = nbRows_;
+  const SignedInteger n = nbColumns_;
   if (k >= n) throw OutOfBoundException(HERE) << "One must have k < nbColumns";
   if (-k > m) throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
 
   /* First step: the size of the diagonal */
-  UnsignedInteger nElt;
-  /* Extraction */
-  if(k >= 0)
-  {
-    nElt = std::min(m, n - k);
-  }
-  else
-  {
-    nElt = std::min(m + k, n);
-  }
-
+  const UnsignedInteger nElt = (k >= 0 ? std::min(m, n - k) : std::min(m + k, n));
+  
   /* Extraction */
   MatrixImplementation diag(nElt, 1);
-  if(k >= 0)
+  UnsignedInteger index = (k >= 0 ? k * m : -k);
+  const SignedInteger stride = m + 1;
+  for(UnsignedInteger l = 0; l < nElt; ++l)
   {
-    for(UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      diag(l, 0) = (*this)(l, l + k);
-    }
-  }
-  else
-  {
-    for(UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      diag(l, 0) = (*this)(l - k, l);
-    }
+    diag(l, 0) = (*this)[index];//(l, l + k);
+    index += stride;
   }
   return diag;
 }
@@ -1762,40 +1746,24 @@ MatrixImplementation MatrixImplementation::getDiagonal(const SignedInteger k) co
 /** Extract diagonal */
 Point MatrixImplementation::getDiagonalAsPoint(const SignedInteger k) const
 {
-  SignedInteger m = nbRows_;
-  SignedInteger n = nbColumns_;
+  const SignedInteger m = nbRows_;
+  const SignedInteger n = nbColumns_;
   if (k >= n)
     throw OutOfBoundException(HERE) << "One must have k < nbColumns";
   if (-k > m)
     throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
 
   /* First step: the size of the diagonal */
-  UnsignedInteger nElt;
-  /* Extraction */
-  if (k >= 0)
-  {
-    nElt = std::min(m, n - k);
-  }
-  else
-  {
-    nElt = std::min(m + k, n);
-  }
+  const UnsignedInteger nElt = (k >= 0 ? std::min(m, n - k) : std::min(m + k, n));
 
   /* Extraction */
   Point diag(nElt);
-  if (k >= 0)
+  UnsignedInteger index = (k >= 0 ? k * m : -k);
+  const SignedInteger stride = m + 1;
+  for (UnsignedInteger l = 0; l < nElt; ++l)
   {
-    for (UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      diag[l] = (*this)(l, l + k);
-    }
-  }
-  else
-  {
-    for (UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      diag[l] = (*this)(l - k, l);
-    }
+    diag[l] = (*this)[index]; //(l, l + k);
+    index += stride;
   }
   return diag;
 }
@@ -1803,149 +1771,70 @@ Point MatrixImplementation::getDiagonalAsPoint(const SignedInteger k) const
 /** Fill diagonal with values */
 void MatrixImplementation::setDiagonal(const MatrixImplementation &diag, const SignedInteger k)
 {
-  SignedInteger m = nbRows_;
-  SignedInteger n = nbColumns_;
+  const SignedInteger m = nbRows_;
+  const SignedInteger n = nbColumns_;
   if (k >= n)
     throw OutOfBoundException(HERE) << "One must have k < nbColumns";
   if (-k > m)
     throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
-
+  if ((diag.getNbRows() > 1) && (diag.getNbColumns() > 1))
+    throw InvalidDimensionException(HERE) << "Diag matrix must have one dimension equals to 1.";
   /* First step: the size of the diagonal */
-  SignedInteger nElt;
-  if (k >= 0)
-  {
-    nElt = std::min(m, n - k);
-  }
-  else
-  {
-    nElt = std::min(m + k, n);
-  }
+  const SignedInteger nElt = (k >= 0 ? std::min(m, n - k) : std::min(m + k, n));
 
   /* Extraction */
-  SignedInteger diagRows = diag.getNbRows();
-  SignedInteger diagColumns = diag.getNbColumns();
-
-  // Check dimension
-  // diag should be a (nElt, 1) or (1, nElt) matrix
-  if ((diagRows == nElt) && (diagColumns == 1))
+  const SignedInteger stride = m + 1;
+  UnsignedInteger index = (k >= 0 ? k * m : -k);
+  for (SignedInteger l = 0; l < nElt; ++l)
   {
-    if (k >= 0)
-    {
-      for (SignedInteger l = 0; l < nElt; ++l)
-      {
-        (*this)(l, l + k) = diag(l, 0);
-      }
-    }
-    else
-    {
-      for (SignedInteger l = 0; l < nElt; ++l)
-      {
-        (*this)(l - k, l) = diag(l, 0);
-      }
-    }
+    (*this)[index] = diag[l];
+    index += stride;
   }
-  else if ((diagColumns == nElt) && (diagRows == 1))
-  {
-    if (k >= 0)
-    {
-      for (SignedInteger l = 0; l < nElt; ++l)
-      {
-        (*this)(l, l + k) = diag(0, l);
-      }
-    }
-    else
-    {
-      for (SignedInteger l = 0; l < nElt; ++l)
-      {
-        (*this)(l - k, l) = diag(0, l);
-      }
-    }
-  }
-  else
-      throw InvalidDimensionException(HERE) << "Dimension mismatch.";
 }
 
 /** Fill a diagonal with values */
 void MatrixImplementation::setDiagonal(const Point &diag, const SignedInteger k)
 {
-  SignedInteger m = nbRows_;
-  SignedInteger n = nbColumns_;
-  if (k >= n) throw OutOfBoundException(HERE) << "One must have k < nbColumns";
-  if (-k > m) throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
-
+  const SignedInteger m = nbRows_;
+  const SignedInteger n = nbColumns_;
+  if (k >= n)
+    throw OutOfBoundException(HERE) << "One must have k < nbColumns";
+  if (-k > m)
+    throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
   /* First step: the size of the diagonal */
-  UnsignedInteger nElt;
-  if(k >= 0)
-  {
-    nElt = std::min(m, n - k);
-  }
-  else
-  {
-    nElt = std::min(m + k, n);
-  }
+  const UnsignedInteger nElt = (k >= 0 ? std::min(m, n - k) : std::min(m + k, n));
 
-  /* Check dimensions */
-  if (nElt != diag.getSize()) throw InvalidDimensionException(HERE) << "Dimension mismatch";
-
-  /* Fill with values */
-  if(k >= 0)
+  /* Extraction */
+  if (diag.getSize() != nElt)
+    throw InvalidDimensionException(HERE) << "Dimension mismatch.";
+  const SignedInteger stride = m + 1;
+  UnsignedInteger index = (k >= 0 ? k * m : -k);
+  for (UnsignedInteger l = 0; l < nElt; ++l)
   {
-    for(UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      (*this)(l, l + k) = diag[l];
-    }
-  }
-  else
-  {
-    for(UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      (*this)(l - k, l) = diag[l];
-    }
+    (*this)[index] = diag[l];
+    index += stride;
   }
 }
 
 /** Fill diagonal with the same value */
 void MatrixImplementation::setDiagonal(const Scalar value, const SignedInteger k)
 {
-  SignedInteger m = nbRows_;
-  SignedInteger n = nbColumns_;
+  const SignedInteger m = nbRows_;
+  const SignedInteger n = nbColumns_;
   if (k >= n)
     throw OutOfBoundException(HERE) << "One must have k < nbColumns";
   if (-k > m)
     throw OutOfBoundException(HERE) << "One must have -nbRows < k ";
-
   /* First step: the size of the diagonal */
-  UnsignedInteger nElt;
-  if (k >= 0)
-  {
-    nElt = std::min(m, n - k);
-  }
-  else
-  {
-    nElt = std::min(m + k, n);
-  }
+  const SignedInteger nElt = (k >= 0 ? std::min(m, n - k) : std::min(m + k, n));
 
-  /* Fill with values */
-  if (k == 0)
+  /* Extraction */
+  const SignedInteger stride = m + 1;
+  UnsignedInteger index = (k >= 0 ? k * m : -k);
+  for (SignedInteger l = 0; l < nElt; ++l)
   {
-    for (UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      (*this).operator[](l + l * m) = value;
-    }
-  }
-  else if (k > 0)
-  {
-    for (UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      (*this)(l, l + k) = value;
-    }
-  }
-  else
-  {
-    for (UnsignedInteger l = 0; l < nElt; ++l)
-    {
-      (*this)(l - k, l) = value;
-    }
+    (*this)[index] = value;
+    index += stride;
   }
 }
 

--- a/lib/src/Base/Type/openturns/Matrix.hxx
+++ b/lib/src/Base/Type/openturns/Matrix.hxx
@@ -187,8 +187,17 @@ public:
   /** Extract diagonal */
   Matrix getDiagonal(const SignedInteger k = 0) const;
 
+  /** Extract diagonal */
+  Point getDiagonalAsPoint(const SignedInteger k = 0) const;
+
   /** Fill diagonal with values */
   void setDiagonal(const Point &diag, const SignedInteger k = 0);
+
+  /** Fill diagonal with the same value */
+  void setDiagonal(const Scalar value, const SignedInteger k = 0);
+
+  /** Fill diagonal with values */
+  void setDiagonal(const Matrix &diag, const SignedInteger k = 0);
 
   /** Hadamard product aka elementwise product */
   Matrix computeHadamardProduct(const Matrix &other) const;

--- a/lib/src/Base/Type/openturns/MatrixImplementation.hxx
+++ b/lib/src/Base/Type/openturns/MatrixImplementation.hxx
@@ -332,8 +332,17 @@ public:
   /** Extract diagonal */
   MatrixImplementation getDiagonal(const SignedInteger k = 0) const;
 
+  /** Extract diagonal */
+  Point getDiagonalAsPoint(const SignedInteger k = 0) const;
+
+  /** Fill diagonal with values */
+  void setDiagonal(const MatrixImplementation &diag, const SignedInteger k = 0);
+
   /** Fill diagonal with values */
   void setDiagonal(const Point &diag, const SignedInteger k = 0);
+
+  /** Fill diagonal with the same value */
+  void setDiagonal(const Scalar value, const SignedInteger k = 0);
 
   /** Hadamard product aka elementwise product */
   MatrixImplementation computeHadamardProduct(const MatrixImplementation &other) const;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimator.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimator.cxx
@@ -66,6 +66,12 @@ Point HSICEstimator::getPValuesPermutation() const
   return getImplementation()->getPValuesPermutation();
 }
 
+/* Get the asymptotic p-values  */
+Point HSICEstimator::getPValuesAsymptotic() const
+{
+  return getImplementation()->getPValuesAsymptotic();
+}
+
 /* Draw the HSIC indices */
 Graph HSICEstimator::drawHSICIndices() const
 {
@@ -84,8 +90,20 @@ Graph HSICEstimator::drawPValuesPermutation() const
   return getImplementation()->drawPValuesPermutation();
 }
 
+/* Draw the p-values asymptotic with permutation */
+Graph HSICEstimator::drawPValuesAsymptotic() const
+{
+  return getImplementation()->drawPValuesAsymptotic();
+}
+
+// run all
+void HSICEstimator::run() const
+{
+  getImplementation()->run();
+}
+
 /* Get the covariance models */
-HSICEstimatorImplementation::CovarianceModelCollection HSICEstimator::getCovarianceModelCollection() const
+HSICEstimator::CovarianceModelCollection HSICEstimator::getCovarianceModelCollection() const
 {
   return getImplementation()->getCovarianceModelCollection();
 }

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorConditionalSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorConditionalSensitivity.cxx
@@ -39,8 +39,8 @@ HSICEstimatorConditionalSensitivity::HSICEstimatorConditionalSensitivity(
   , const Function & weightFunction)
   : HSICEstimatorImplementation(covarianceModelCollection, X, Y, HSICVStat())
 {
-  weightFunction_ = weightFunction;
   computeCovarianceMatrices();
+  setWeightFunction(weightFunction);
 }
 
 /* Virtual constructor */
@@ -55,16 +55,6 @@ void HSICEstimatorConditionalSensitivity::computePValuesAsymptotic() const
   throw NotYetImplementedException(HERE) << "HSICEstimatorConditionalSensitivity cannot compute asymptotic p-values.";
 }
 
-/* Compute the weight matrix from the weight function */
-SquareMatrix HSICEstimatorConditionalSensitivity::computeWeightMatrix(const Sample & Y) const
-{
-  const Sample wY(weightFunction_(Y));
-  const Scalar meanWY(wY.computeMean()[0]);
-  SquareMatrix mat(n_);
-  mat.setDiagonal(wY.asPoint() / meanWY);
-  return mat;
-}
-
 /* Get the weight function */
 Function HSICEstimatorConditionalSensitivity::getWeightFunction() const
 {
@@ -76,18 +66,15 @@ void HSICEstimatorConditionalSensitivity::setWeightFunction(const Function & wei
 {
   weightFunction_ = weightFunction;
   resetIndices();
+  computeWeights();
 }
 
-/* Method save() stores the object through the StorageManager */
-void HSICEstimatorConditionalSensitivity::save(Advocate & adv) const
+/** Compute the weights from the weight function */
+void HSICEstimatorConditionalSensitivity::computeWeights()
 {
-  HSICEstimatorImplementation::save(adv);
-}
-
-/* Method load() reloads the object from the StorageManager */
-void HSICEstimatorConditionalSensitivity::load(Advocate & adv)
-{
-  HSICEstimatorImplementation::load(adv);
+  const Sample wY(weightFunction_(outputSample_));
+  const Scalar meanWY(wY.computeMean()[0]);
+  weights_ = wY.asPoint() / meanWY;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorGlobalSensitivity.cxx
@@ -39,6 +39,7 @@ HSICEstimatorGlobalSensitivity::HSICEstimatorGlobalSensitivity(
   : HSICEstimatorImplementation(covarianceModelCollection, X, Y, estimatorType)
 {
   computeCovarianceMatrices();
+  computeWeights();
 }
 
 /* Virtual constructor */
@@ -47,75 +48,10 @@ HSICEstimatorGlobalSensitivity* HSICEstimatorGlobalSensitivity::clone() const
   return new HSICEstimatorGlobalSensitivity(*this);
 }
 
-/* Compute the weight matrix */
-SquareMatrix HSICEstimatorGlobalSensitivity::computeWeightMatrix(const Sample&) const
+/** Compute the weights from the weight function */
+void HSICEstimatorGlobalSensitivity::computeWeights()
 {
-  return IdentityMatrix(n_);
-}
-
-/* Get the asymptotic p-values */
-Point HSICEstimatorGlobalSensitivity::getPValuesAsymptotic() const
-{
-  if(!(isAlreadyComputedPValuesAsymptotic_))
-  {
-    computePValuesAsymptotic();
-    isAlreadyComputedPValuesAsymptotic_ = true ;
-  }
-  return PValuesAsymptotic_;
-}
-
-/* Reset all indices to void */
-void HSICEstimatorGlobalSensitivity::resetIndices()
-{
-  HSICEstimatorImplementation::resetIndices();
-  PValuesAsymptotic_ = Point();
-  isAlreadyComputedPValuesAsymptotic_ = false;
-}
-
-/* Draw the asymptotic p-values */
-Graph HSICEstimatorGlobalSensitivity::drawPValuesAsymptotic() const
-{
-  return drawValues(getPValuesAsymptotic(), "Asymptotic p-values");
-}
-
-/* Compute all indices at once */
-void HSICEstimatorGlobalSensitivity::run() const
-{
-  /* Compute the HSIC and R2-HSIC indices */
-  if(!(isAlreadyComputedIndices_))
-  {
-    computeIndices();
-  }
-
-  /* Compute the p-values by permutation */
-  if(!(isAlreadyComputedPValuesPermutation_))
-  {
-    // In order to avoid th
-    (void) getPValuesPermutation();
-  }
-
-  /* Compute the p-values asymptotically */
-  if(!(isAlreadyComputedPValuesAsymptotic_))
-  {
-    computePValuesAsymptotic();
-  }
-
-}
-
-/* Method save() stores the object through the StorageManager */
-void HSICEstimatorGlobalSensitivity::save(Advocate & adv) const
-{
-  HSICEstimatorImplementation::save(adv);
-  adv.saveAttribute( "PValuesAsymptotic_", PValuesAsymptotic_ );
-  adv.saveAttribute( "isAlreadyComputedPValuesAsymptotic_", isAlreadyComputedPValuesAsymptotic_ );
-}
-
-/* Method load() reloads the object from the StorageManager */
-void HSICEstimatorGlobalSensitivity::load(Advocate & adv)
-{
-  HSICEstimatorImplementation::load(adv);
-  adv.loadAttribute( "PValuesAsymptotic_", PValuesAsymptotic_ );
-  adv.loadAttribute( "isAlreadyComputedPValuesAsymptotic_", isAlreadyComputedPValuesAsymptotic_ );
+  weights_ = Point(n_, 1.0);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICEstimatorTargetSensitivity.cxx
@@ -46,31 +46,13 @@ HSICEstimatorTargetSensitivity::HSICEstimatorTargetSensitivity(
   /* apply filter */
   outputSample_ = filterFunction_(unfilteredSample_);
   computeCovarianceMatrices();
+  computeWeights();
 }
 
 /* Virtual constructor */
 HSICEstimatorTargetSensitivity* HSICEstimatorTargetSensitivity::clone() const
 {
   return new HSICEstimatorTargetSensitivity(*this);
-}
-
-/* Compute the weight matrix from a sample */
-SquareMatrix HSICEstimatorTargetSensitivity::computeWeightMatrix(const Sample&) const
-{
-  /* Identity matrix */
-  const IdentityMatrix mat(n_);
-  return mat;
-}
-
-/* Get the asymptotic p-values */
-Point HSICEstimatorTargetSensitivity::getPValuesAsymptotic() const
-{
-  if(!(isAlreadyComputedPValuesAsymptotic_))
-  {
-    computePValuesAsymptotic();
-    isAlreadyComputedPValuesAsymptotic_ = true ;
-  }
-  return PValuesAsymptotic_;
 }
 
 /* Get the filter function */
@@ -89,11 +71,12 @@ void HSICEstimatorTargetSensitivity::setFilterFunction(const Function & filterFu
   outputCovarianceMatrix_ = covarianceModelCollection_[inputDimension_].discretize(outputSample_);
 }
 
-/* Draw the asymptotic p-values */
-Graph HSICEstimatorTargetSensitivity::drawPValuesAsymptotic() const
+/** Compute the weights from the weight function */
+void HSICEstimatorTargetSensitivity::computeWeights()
 {
-  return drawValues(getPValuesAsymptotic(), "Asymptotic p-values");
+  weights_ = Point(n_, 1.0);
 }
+
 
 /* Method save() stores the object through the StorageManager */
 void HSICEstimatorTargetSensitivity::save(Advocate & adv) const

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStat.cxx
@@ -48,6 +48,14 @@ Scalar HSICStat::computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
   return getImplementation()->computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightMatrix);
 }
 
+/* Compute the HSIC index for one marginal*/
+Scalar HSICStat::computeHSICIndex(const CovarianceMatrix &covarianceMatrix1,
+                                  const CovarianceMatrix &covarianceMatrix2,
+                                  const Point &weights) const
+{
+  return getImplementation()->computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weights);
+}
+
 /* Is compatible with a Conditional HSIC Estimator ? */
 Bool HSICStat::isCompatibleWithConditionalAnalysis() const
 {

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICStatImplementation.cxx
@@ -45,8 +45,16 @@ HSICStatImplementation * HSICStatImplementation::clone() const
 
 /* Compute the HSIC index for one marginal*/
 Scalar HSICStatImplementation::computeHSICIndex(const CovarianceMatrix &,
-    const CovarianceMatrix &,
-    const SquareMatrix &) const
+                                                const CovarianceMatrix &,
+                                                const SquareMatrix &) const
+{
+  throw NotYetImplementedException(HERE) << "You must use a derived class such as HSICUStat or HSICVStat.";
+}
+
+/** Compute the HSIC index for one marginal*/
+Scalar HSICStatImplementation::computeHSICIndex(const CovarianceMatrix &,
+                                                const CovarianceMatrix &,
+                                                const Point & ) const
 {
   throw NotYetImplementedException(HERE) << "You must use a derived class such as HSICUStat or HSICVStat.";
 }

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICUStat.cxx
@@ -23,6 +23,8 @@
 #include "openturns/Exception.hxx"
 #include "openturns/Log.hxx"
 #include "openturns/HSICUStat.hxx"
+#include "openturns/Log.hxx"
+
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HSICUStat)
@@ -43,16 +45,14 @@ Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
                                    const CovarianceMatrix & covarianceMatrix2,
                                    const SquareMatrix & weightMatrix) const
 {
-
+  LOGWARN(OSS() << "computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightMatrix) is deprecated in favor of computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightPoint)");
   Scalar hsic = 0.0;
   const SignedInteger n = weightMatrix.getNbColumns();
-
-  const Point nullDiag(n);
   
   CovarianceMatrix covarianceMatrix1Copy(covarianceMatrix1);
+  covarianceMatrix1Copy.setDiagonal(0.0, 0);
   CovarianceMatrix covarianceMatrix2Copy(covarianceMatrix2);
-  covarianceMatrix1Copy.setDiagonal(nullDiag, 0);
-  covarianceMatrix2Copy.setDiagonal(nullDiag, 0);
+  covarianceMatrix2Copy.setDiagonal(0.0, 0);
 
 
   const SquareMatrix Kv(covarianceMatrix1Copy * covarianceMatrix2Copy);
@@ -60,11 +60,94 @@ Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
   const Scalar trace = Kv.computeTrace();
   const Scalar sumKv = Kv.computeSumElements();
   const Scalar sumCov1 = covarianceMatrix1Copy.computeSumElements();
-  const Scalar SumCov2 = covarianceMatrix2Copy.computeSumElements();
+  const Scalar sumCov2 = covarianceMatrix2Copy.computeSumElements();
 
-  hsic = trace - 2 * sumKv / (n - 2) + sumCov1 * SumCov2 / (n - 1) / (n - 2);
+  hsic = trace - 2 * sumKv / (n - 2) + sumCov1 * sumCov2 / (n - 1) / (n - 2);
   hsic /= n * (n - 3);
 
+  return hsic;
+}
+
+/* Compute the HSIC index for one marginal*/
+Scalar HSICUStat::computeHSICIndex(const CovarianceMatrix &covarianceMatrix1,
+                                   const CovarianceMatrix &covarianceMatrix2,
+                                   const Point &weights) const
+{
+  /*
+  The interest is to provide the U-stat, which is function of (Kx, Ky)
+  If we define M as
+    M = MKx * MKy
+  with MKx (resp MKy)  matrices equal to Kx (resp Ky) outside diagonal, and 0
+  on this last one
+  Then u-stat defines as :
+    hsic = trace(M) - 2 * sum(M) / (n - 2) + sum(MKx) * sum(MKy) / (n - 1) / (n - 2)
+  sum(.) refers to the sum of elements of the matrix.
+
+  If we create MKy and MKy as copies of Kx and Ky, we have some performance issues
+  when n becomes high.
+  Thus we propose an implementation where we only create small objects (vectors)
+  and use blas operations to avoiding copies
+  Indeed,
+     Mkx = Kx - Dx
+     MKy = Ky - Dy
+  where Dx (respectively Dy) is a diagonal matrix containing the diagonal values of Kx
+  (respectively Ky). Then
+    M = (Kx - Dx) * (Ky - Dy)
+      = Kx * Ky - Kx * Dy - Dx * Ky + Dx * Dy
+  Having an eye on the previous formula,
+    sum(MKx) = sum(Kx) - trace(Kx)
+    sum(MKy) = sum(Ky) - trace(Ky)
+  Now let us focus on trace(M), sum(M)
+    trace(M) = trace(Kx * Ky - Kx * Dy - Dx * Ky + Dx * Dy)
+    trace(M) = trace(Kx * Ky) - trace(Kx * Dy) - trace(Dx * Ky) + trace(Dx * Dy)
+
+  It is easy to notice that
+    (Kx * Dy)[i,j] = Kx[i,j] * Dy[j]
+    (Dx * Ky)[i,j] = Ky[i,j] * Dx[i]
+  Then
+    trace(Kx * Dy) = \sum_i Kx[i,i] * Dy[i]
+                   = \sum_i Kx[i,i] * Ky[i,i]
+  One could notice that :
+    trace(Dx * Ky) = \sum_i Kx[i,i] * Ky[i,i]
+                   = trace(Kx * Dy)
+                  =  trace(Dx * Dy)
+  Thus
+    trace(M) = trace(Kx * Ky) - trace(Dx * Dy)
+  Focusing on the sum of elements:
+    sum(Kx * Dy) = \sum_{i,j} Kx[i,j] * Dy[j]
+                 = \sum_{i} KxDy[i]
+  with KxDy = Kx * vect(Dy) (vect(.) is seeing . as a vector)
+  By similarity, we get sum(Dx * Ky) (using sum(M) = sum(M^t))
+  Finally
+    sum(M) = sum(Kx * Ky) - \sum_{i} KxDy[i] - \sum_{i} KyDx[i] + <Dx, Dy>
+  */
+
+  Scalar hsic = 0.0;
+  const SignedInteger n = weights.getDimension();
+  const Point ones(n, 1.0);
+
+  const SquareMatrix Kv(covarianceMatrix1 * covarianceMatrix2);
+
+  // Compute \sum Kx * Dy
+  const Point diagonalKy(covarianceMatrix2.getDiagonalAsPoint());
+  const Point KxDy(covarianceMatrix1 * diagonalKy);
+  const Scalar sumKxDy = KxDy.dot(ones);
+
+  // Compute Ky * Dx
+  const Point diagonalKx(covarianceMatrix1.getDiagonalAsPoint());
+  const Point KyDx(covarianceMatrix2 * diagonalKx);
+  const Scalar sumKyDx = KyDx.dot(ones);
+
+  const Scalar sumDxDy = diagonalKx.dot(diagonalKy);
+
+  const Scalar trace = Kv.computeTrace() - sumDxDy;
+  const Scalar sumKv = Kv.computeSumElements() - sumKyDx - sumKxDy + sumDxDy;
+
+  const Scalar sumCov1 = covarianceMatrix1.computeSumElements() - diagonalKx.dot(ones);
+  const Scalar sumCov2 = covarianceMatrix2.computeSumElements() - diagonalKy.dot(ones);
+
+  hsic = trace - 2 * sumKv / (n - 2) + sumCov1 * sumCov2 / (n - 1) / (n - 2);
+  hsic /= n * (n - 3);
   return hsic;
 }
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/HSICVStat.cxx
@@ -22,6 +22,8 @@
 #include "openturns/Exception.hxx"
 #include "openturns/Log.hxx"
 #include "openturns/HSICVStat.hxx"
+#include "openturns/Log.hxx"
+
 BEGIN_NAMESPACE_OPENTURNS
 
 CLASSNAMEINIT(HSICVStat)
@@ -42,7 +44,7 @@ Scalar HSICVStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
                                    const CovarianceMatrix & CovMat2,
                                    const SquareMatrix & weightMatrix) const
 {
-
+  LOGWARN(OSS() << "computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightMatrix) is deprecated in favor of computeHSICIndex(covarianceMatrix1, covarianceMatrix2, weightPoint)");
   UnsignedInteger n = weightMatrix.getNbColumns();
   // The interest is to provide the V stat, which is the trace of
   // M = (W * Kx * W) * (H1 * Ky * H2)
@@ -117,6 +119,87 @@ Scalar HSICVStat::computeHSICIndex(const CovarianceMatrix & CovMat1,
     }
   }
   return trace / n /n;
+}
+
+/* Compute the HSIC index for one marginal*/
+Scalar HSICVStat::computeHSICIndex(const CovarianceMatrix &CovMat1,
+                                   const CovarianceMatrix &CovMat2,
+                                   const Point &weights) const
+{
+  /*
+  The interest is to provide the V stat, which is the trace of
+  M = (W * Kx * W) * (H1 * Ky * H2)
+  Left side involves only Kx, the second only Ky
+  The first block is easy to compute
+  (W * Kx * W)_[i,j] = W[i] * Kx[i,j] * W[j]
+  However we will not "build" a full matrix, as we intend
+  to perform computations without using blas/lapack
+  The second block needs more computations.
+  If we drop the 1/n factor (in H1 / H2), we get
+  (H1 * Ky * H2) = (I - U * W/n) * Ky * (I - W * U/n)
+                 = (Ky - Ky * W * U / n - U * W * Ky / n + U * W * Ky * W * U / n / n)
+  Looking more closely,
+  (Ky * W * U)[i,j] = \sum_k Ky[i,k] * W[k]
+  (U * Ky * W)[i,j] = \sum_k Ky[k,j] * W[k]
+  Thus summing the two provides :
+  1/n * (Ky * W * U + U * Ky * W)[i,j] = 1/n \sum_k (Ky[i,k] + Ky[k,j]) * W[k]
+                                       = 1/n \sum_k (Ky[i,k] + Ky[j,k]) * W[k]
+  We define the weightedSumRows to compute these sums.
+  One could notice that:
+  weightedSumRows[l] = \sum{k} Ky[l,k] * W[k]
+  weightedSumRows[l] = Ky * W
+  It a standard matrix-vector product.
+  For the last part of the second block, we need to compute (U * W * Ky * W * U)
+  W * K * W is an easy task (same as left block but replacing Kx with Ky).
+  Multiplying the latter by U on left and right allows one to sum all the elements
+  (U M U)[i,j] = \sum_{k, l} M[k,l] for all i, j
+  The result is a square matrix with values \sum_{k,l} Ky[k,l] * W[k] * W[l]
+  We define weightedSumElements to compute this
+  weightedSumElements =  \sum_{k, l} M[k,l]
+                      =  \sum_{k, l} Ky[k,k] * W[k] * W[l]
+                      =  \sum_{k} W[k] * (Ky[k,l] * W[l])
+                      =  \sum_{k} W[k] * weightedSumRows[k]
+  weightedSumElements is an inner product between W and weightedSumRows
+  Finally we get for the right side block a matrix that writes as
+  (H1 * Ky * H2)[i,j] = Ky[i,j] - \sum_k (Ky[i,k] + Ky[j,k]) * W[k] / n + \sum_{k,l} Ky[k,l] * W[k] * W[l] /n /n
+                      = Ky[i,j] -  (weightedSumElements[i] + weightedSumElements[j]) + weightedSumElements
+  One has to note that both left & right side blocks are symmetric. 
+  Finally the trace is computed manually. Indeed it is a O(n^2) algorithm
+  whereas building matrices (left/right), computing left * right then the trace is O(n^3)
+  trace(left * right) = \sum{i,j} left[i,j] right[j,i]
+                      = \sum{i,j} left[i,j] right[i,j] (because of symmetry)
+  */
+  // Compute weighted sum \sum_k (Ky[i,k] + Ky[j,k]) * W[k]
+  const UnsignedInteger n = weights.getDimension();
+  Point weightedSumRows(CovMat2 * weights);
+  // weightedSumRows scaled by 1/n
+  weightedSumRows /= n;
+  // We compute the sum of the weighted matrix
+  Scalar weightedSumElements = weightedSumRows.dot(weights);
+  // weighted sum elements of K is to be scaled by 1/ n / n
+  // As weightedSumRows is already scaled, we scale with 1/n
+  weightedSumElements /= n;
+
+  // Compute the trace : the algorithm is O(n^2)
+  // If we compute left * right and then the trace, the algorithm is O(n^3)
+  Scalar trace = 0.0;
+  for (UnsignedInteger j = 0; j < n; ++j)
+  {
+    const Scalar wj = weights[j];
+    const Scalar wsrJ = weightedSumRows[j];
+    const Scalar cxJJ = CovMat1(j, j);
+    const Scalar cyJJ = CovMat2(j, j);
+    trace += (wj * cxJJ * wj) * (cyJJ + weightedSumElements - 2 * wsrJ);
+    for (UnsignedInteger i = j + 1; i < n; ++i)
+    {
+      const Scalar wi = weights[i];
+      const Scalar wsrI = weightedSumRows[i];
+      const Scalar cxIJ = CovMat1(i, j);
+      const Scalar cyIJ = CovMat2(i, j);
+      trace += 2.0 * (wi * cxIJ * wj) * (cyIJ + weightedSumElements - wsrI - wsrJ);
+    }
+  }
+  return trace / n / n;
 }
 
 /* Compute the asymptotic p-value */

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimator.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimator.hxx
@@ -76,6 +76,9 @@ public:
    * */
   Point getPValuesPermutation() const;
 
+  // Get the asymptotic p-values.
+  Point getPValuesAsymptotic() const;
+
   /** Graphic methods */
   Graph drawHSICIndices() const;
 
@@ -84,6 +87,12 @@ public:
 
   /** Graphic methods */
   Graph drawPValuesPermutation() const;
+
+  /** Graphic methods */
+  Graph drawPValuesAsymptotic() const;
+
+  // run all
+  void run() const;
 
   /** Set the number of permutation used */
   void setPermutationSize(const UnsignedInteger B);
@@ -117,23 +126,6 @@ public:
 
   /** Get the underlying estimator: biased or unbiased*/
   HSICStat getEstimator() const;
-
-protected:
-
-  /** Compute the weight matrix from the weight function */
-  SquareMatrix computeWeightMatrix(const Sample & Y) const;
-
-  /** Compute a HSIC index (one marginal) by using the underlying estimator (biased or not) */
-  Scalar computeHSICIndex( const Sample & inSample, const Sample & outSample, const CovarianceModel & inCovariance, const CovarianceModel & outCovariance, const SquareMatrix & weightMatrix) const;
-
-  /** Compute p-value with permutation */
-  void computePValuesPermutation() const;
-
-  /** Compute HSIC and R2-HSIC indices */
-  void computeIndices() const;
-
-  /** Reset indices to void */
-  void resetIndices();
 
 };
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorConditionalSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorConditionalSensitivity.hxx
@@ -67,19 +67,13 @@ public:
   /** Set the weight function */
   void setWeightFunction(const Function & weightFunction);
 
-  /** Method save() stores the object through the StorageManager */
-  void save(Advocate & adv) const override;
+  /** Compute the weights from the weight function */
+  void computeWeights() override;
 
-  /** Method load() reloads the object from the StorageManager */
-  void load(Advocate & adv) override;
-
-private:
+protected:
 
   /** Compute the p-values with asymptotic formula */
   void computePValuesAsymptotic() const override;
-
-  /** Compute the weight matrix from the weight function */
-  SquareMatrix computeWeightMatrix(const Sample & Y) const override;
 
 };
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorGlobalSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorGlobalSensitivity.hxx
@@ -60,30 +60,8 @@ public:
   /** Virtual constructor */
   HSICEstimatorGlobalSensitivity* clone() const override;
 
-  /** Get the asymptotic p-values */
-  Point getPValuesAsymptotic() const;
-
-  /** Draw the asymptotic p-values */
-  Graph drawPValuesAsymptotic() const;
-
-  /** Compute all indices at once */
-  void run() const override;
-
-  /** Method save() stores the object through the StorageManager */
-  void save(Advocate & adv) const override;
-
-  /** Method load() reloads the object from the StorageManager */
-  void load(Advocate & adv) override;
-
-protected:
-
-  /** Reset all indices to void */
-  void resetIndices() override;
-
-private:
-
-  /** Compute the weight matrix from the weight function */
-  SquareMatrix computeWeightMatrix(const Sample & Y) const override;
+  /** Compute the weights from the weight function */
+  void computeWeights() override;
 
 };
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
@@ -33,7 +33,8 @@
 #include "openturns/SymbolicFunction.hxx"
 #include "openturns/Function.hxx"
 #include "openturns/HSICStat.hxx"
-#include "openturns/RandomGenerator.hxx"
+#include "openturns/Point.hxx"
+
 BEGIN_NAMESPACE_OPENTURNS
 
 /**
@@ -109,6 +110,9 @@ public:
   /** Get the p-values by permutation */
   Point getPValuesPermutation() const;
 
+  /** Get the asymptotic p-values */
+  virtual Point getPValuesAsymptotic() const;
+
   /** Compute all indices at once */
   virtual void run() const;
 
@@ -120,6 +124,9 @@ public:
 
   /** Draw the p-values by permutation */
   Graph drawPValuesPermutation() const;
+
+  /** Draw the asymptotic p-values */
+  virtual Graph drawPValuesAsymptotic() const;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -144,13 +151,16 @@ protected:
   /** Compute the p-values with asymptotic formula */
   virtual void computePValuesAsymptotic() const;
 
-  /** Compute the weight matrix from the weight function */
-  virtual SquareMatrix computeWeightMatrix(const Sample & Y) const;
+  /** Compute the weights from the weight function */
+  virtual void computeWeights();
+
+  /** Get the weights function as Point */
+  virtual Point getWeights() const;
 
   /** Compute a HSIC index (one marginal) by using the underlying estimator (biased or not) */
-  virtual Scalar computeHSICIndex(const CovarianceMatrix & covMat1,
-                                  const CovarianceMatrix & covMat2,
-                                  const SquareMatrix & weightMatrix) const;
+  virtual Scalar computeHSICIndex(const CovarianceMatrix &covMat1,
+                                  const CovarianceMatrix &covMat2,
+                                  const Point &weights) const;
 
   /** Compute HSIC and R2-HSIC indices */
   virtual void computeIndices() const;
@@ -166,6 +176,7 @@ protected:
   Sample outputSample_ ;
   HSICStat estimatorType_;
   Function weightFunction_ ;
+  Point weights_;
   UnsignedInteger n_ ;
   UnsignedInteger inputDimension_ ;
   mutable Point HSIC_XY_ ;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorTargetSensitivity.hxx
@@ -60,17 +60,14 @@ public:
   /** Virtual constructor */
   HSICEstimatorTargetSensitivity* clone() const override;
 
-  /** Get the p-values with asymptotic formula */
-  Point getPValuesAsymptotic() const;
-
-  /** Draw the asymptotic p-values */
-  Graph drawPValuesAsymptotic() const;
-
   /** Get the filter function */
   Function getFilterFunction() const;
 
   /** Get the filter function */
   void setFilterFunction(const Function & filterFunction);
+
+  /** Compute the weights from the weight function */
+  void computeWeights() override;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -82,11 +79,6 @@ protected:
 
   /* data */
   Function filterFunction_ ;
-
-private:
-
-  /** Compute the weight matrix from the weight function */
-  SquareMatrix computeWeightMatrix(const Sample & Y) const override;
 
   // unfiltered sample
   Sample unfilteredSample_;

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStat.hxx
@@ -29,6 +29,8 @@
 #include "openturns/CovarianceModel.hxx"
 #include "openturns/Gamma.hxx"
 #include "openturns/HSICStatImplementation.hxx"
+#include "openturns/Point.hxx"
+
 BEGIN_NAMESPACE_OPENTURNS
 
 
@@ -57,6 +59,11 @@ public:
   virtual Scalar computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
                                   const CovarianceMatrix & covarianceMatrix2,
                                   const SquareMatrix & weightMatrix) const;
+
+  /** Compute the HSIC index for one marginal*/
+  virtual Scalar computeHSICIndex(const CovarianceMatrix &covarianceMatrix1,
+                                  const CovarianceMatrix &covarianceMatrix2,
+                                  const Point &weights) const;
 
   /** Compute the asymptotic p-value */
   virtual Scalar computePValue(const Gamma & distribution,

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICStatImplementation.hxx
@@ -30,6 +30,8 @@
 #include "openturns/ResourceMap.hxx"
 #include "openturns/CovarianceModel.hxx"
 #include "openturns/Gamma.hxx"
+#include "openturns/Point.hxx"
+
 BEGIN_NAMESPACE_OPENTURNS
 
 /**
@@ -53,6 +55,11 @@ public:
   virtual Scalar computeHSICIndex(const CovarianceMatrix & covarianceMatrix1,
                                   const CovarianceMatrix & covarianceMatrix2,
                                   const SquareMatrix & weightMatrix) const;
+
+  /** Compute the HSIC index for one marginal*/
+  virtual Scalar computeHSICIndex(const CovarianceMatrix &covarianceMatrix1,
+                                  const CovarianceMatrix &covarianceMatrix2,
+                                  const Point & weights) const;
 
   /** Compute the asymptotic p-value */
   virtual Scalar computePValue(const Gamma & distribution,

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICUStat.hxx
@@ -45,6 +45,11 @@ public:
                           const CovarianceMatrix & CovMat2,
                           const SquareMatrix & weightMatrix) const override;
 
+  /** Compute the HSIC index for one marginal*/
+  Scalar computeHSICIndex(const CovarianceMatrix &CovMat1,
+                          const CovarianceMatrix &CovMat2,
+                          const Point &weights) const override;
+
   /** Compute the asymptotic p-value */
   Scalar computePValue(const Gamma &dist, const UnsignedInteger n, const Scalar HSIC_obs, const Scalar mHSIC) const override;
 

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICVStat.hxx
@@ -45,6 +45,11 @@ public:
                           const CovarianceMatrix & CovMat2,
                           const SquareMatrix & weightMatrix) const override;
 
+  /** Compute the HSIC index for one marginal*/
+  Scalar computeHSICIndex(const CovarianceMatrix &CovMat1,
+                          const CovarianceMatrix &CovMat2,
+                          const Point &weights) const override;
+  
   /** Compute the asymptotic p-value */
   Scalar computePValue(const Gamma & distribution,
                        const UnsignedInteger n,

--- a/lib/test/t_HSICStat_std.cxx
+++ b/lib/test/t_HSICStat_std.cxx
@@ -65,11 +65,7 @@ int main(int, char *[])
     Cov2.setScale(Y.computeStandardDeviation());
 
     /* This is the GSA-type estimator: weight is 1. */
-    SquareMatrix W(size);
-    for(UnsignedInteger i = 0; i < size; ++i)
-    {
-      W(i, i) = 1.0;
-    }
+    Point W(size, 1.0);
 
     /* Using a biased estimator */
     HSICVStat estimatorTypeV;

--- a/python/src/HSICEstimatorConditionalSensitivity_doc.i.in
+++ b/python/src/HSICEstimatorConditionalSensitivity_doc.i.in
@@ -24,7 +24,9 @@ See also
 
 Notes
 -----
-Conditional sensitivity analysis relies on the :class:`~openturns.HSICVStat` estimator.
+Conditional sensitivity analysis relies on the :class:`~openturns.HSICVStat` estimator. Also it does not provides an
+asymptotic estimate of the p-values thus the generic methods `getPValuesAsymptotic` and `drawPValuesAsymptotic`
+throws an exception in that case.
 
 Examples
 --------

--- a/python/src/HSICEstimatorGlobalSensitivity_doc.i.in
+++ b/python/src/HSICEstimatorGlobalSensitivity_doc.i.in
@@ -62,23 +62,3 @@ Build and use the HSIC estimator for global sensitivity analysis.
 [0.404051,0.0206756,0.0846069]"
 
 // ---------------------------------------------------------------------
-
-%feature("docstring") OT::HSICEstimatorGlobalSensitivity::getPValuesAsymptotic
-"Get the p-values obtained with an asymptotic formula.
-
-Returns
--------
-pval : sequence of float
-    The p-values for all components."
-
-// ---------------------------------------------------------------------
-
-%feature("docstring") OT::HSICEstimatorGlobalSensitivity::drawPValuesAsymptotic
-"Draw the p-values obtained with an asymptotic formula.
-
-Returns
--------
-graph : :class:`~openturns.Graph`
-    The graph of all p-values estimated with an asymptotic formula."
-
-// ---------------------------------------------------------------------

--- a/python/src/HSICEstimatorImplementation_doc.i.in
+++ b/python/src/HSICEstimatorImplementation_doc.i.in
@@ -235,30 +235,32 @@ OT_HSICEstimator_drawPValuesPermutation_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_HSICEstimator_drawValues_doc
-"Draw values contained in a point.
-
-Parameters
-----------
-values : sequence of float
-    The values to be displayed as a Cloud.
-
-title : str
-    The title of the graph.
-
-Returns
--------
-graph : :class:`~openturns.Graph`
-    The desired graph."
-%enddef
-%feature("docstring") OT::HSICEstimatorImplementation::drawValues
-OT_HSICEstimator_drawValues_doc
-
-// ---------------------------------------------------------------------
-
 %define OT_HSICEstimator_run_doc
 "Compute all values at once."
 %enddef
 %feature("docstring") OT::HSICEstimatorImplementation::run
 OT_HSICEstimator_run_doc
+// ---------------------------------------------------------------------
+
+%define OT_HSICEstimator_getPValuesAsymptotic_doc
+"Get the p-values obtained with an asymptotic formula.
+
+Returns
+-------
+pval : sequence of float
+    The p-values for all components."
+%enddef
+%feature("docstring") OT::HSICEstimatorImplementation::getPValuesAsymptotic
+OT_HSICEstimator_getPValuesAsymptotic_doc
+// ---------------------------------------------------------------------
+%define OT_HSICEstimator_drawPValuesAsymptotic_doc
+"Draw the p-values obtained with an asymptotic formula.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph of all p-values estimated with an asymptotic formula."
+%enddef
+%feature("docstring") OT::HSICEstimatorImplementation::drawPValuesAsymptotic
+OT_HSICEstimator_drawPValuesAsymptotic_doc
 // ---------------------------------------------------------------------

--- a/python/src/HSICEstimatorTargetSensitivity_doc.i.in
+++ b/python/src/HSICEstimatorTargetSensitivity_doc.i.in
@@ -72,16 +72,6 @@ Build and use the HSIC estimator for target sensitivity analysis.
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::HSICEstimatorTargetSensitivity::getPValuesAsymptotic
-"Get the p-values estimated with an asymptotic formula.
-
-Returns
--------
-pval : :class:`~openturns.Point`
-    The p-values obtained with an asymptotic formula."
-
-// ---------------------------------------------------------------------
-
 %feature("docstring") OT::HSICEstimatorTargetSensitivity::getFilterFunction
 "Get the filter function used.
 
@@ -102,12 +92,3 @@ filterFunction : :class:`~openturns.Function`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::HSICEstimatorTargetSensitivity::drawPValuesAsymptotic
-"Draw the p-values obtained with an asymptotic formula.
-
-Returns
--------
-graph : :class:`~openturns.Graph`
-    The graph of all p-values obtained with an asymptotic formula."
-
-// ---------------------------------------------------------------------

--- a/python/src/HSICEstimator_doc.i.in
+++ b/python/src/HSICEstimator_doc.i.in
@@ -26,15 +26,17 @@ OT_HSICEstimator_getEstimator_doc
 OT_HSICEstimator_getHSICIndices_doc
 %feature("docstring") OT::HSICEstimator::getR2HSICIndices
 OT_HSICEstimator_getR2HSICIndices_doc
+%feature("docstring") OT::HSICEstimator::getPValuesAsymptotic
+OT_HSICEstimator_getPValuesAsymptotic_doc
 %feature("docstring") OT::HSICEstimator::getPValuesPermutation
 OT_HSICEstimator_getPValuesPermutation_doc
 %feature("docstring") OT::HSICEstimator::drawHSICIndices
 OT_HSICEstimator_drawHSICIndices_doc
 %feature("docstring") OT::HSICEstimator::drawR2HSICIndices
 OT_HSICEstimator_drawR2HSICIndices_doc
+%feature("docstring") OT::HSICEstimator::drawPValuesAsymptotic
+OT_HSICEstimator_drawPValuesAsymptotic_doc
 %feature("docstring") OT::HSICEstimator::drawPValuesPermutation
 OT_HSICEstimator_drawPValuesPermutation_doc
-%feature("docstring") OT::HSICEstimator::drawValues
-OT_HSICEstimator_drawValues_doc
 %feature("docstring") OT::HSICEstimator::run
 OT_HSICEstimator_run_doc

--- a/python/src/HSICStatImplementation_doc.i.in
+++ b/python/src/HSICStatImplementation_doc.i.in
@@ -29,12 +29,14 @@ covarianceMatrixY : :class:`~openturns.CovarianceMatrix`
     The covariance model associated with the output sample, discretized
     over the last one.
 
-weightMatrix : :class:`~openturns.Matrix`
-    A weight matrix used for the statistic.
+weights : :class:`~openturns.Point` or :class:`~openturns.Matrix` (deprecated)
+    The weight argument used for the statistic.
 
 Returns
 -------
-hsicIndex : the HSIC index of the two :class:`~openturns.Sample`."
+hsicIndex : the HSIC index of the two :class:`~openturns.Sample`.
+
+"
 %enddef
 %feature("docstring") OT::HSICStatImplementation::computeHSICIndex
 OT_HSICStat_computeHSICIndex_doc

--- a/python/src/Matrix_doc.i.in
+++ b/python/src/Matrix_doc.i.in
@@ -551,32 +551,61 @@ Examples
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::Matrix::getDiagonalAsPoint
+"Get the k-th diagonal of the matrix.
+
+Parameters
+----------
+k : int
+    The k-th diagonal to extract
+    Default value is 0
+
+Returns
+-------
+pt : :class:`~openturns.Point`
+    The k-th digonal.
+
+Examples
+--------
+>>> import openturns as ot
+>>> M = ot.Matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+>>> pt = M.getDiagonalAsPoint()
+>>> print(pt)
+[1,5,9]
+"
+
+// ---------------------------------------------------------------------
 
 %feature("docstring") OT::Matrix::setDiagonal
 "Set the k-th diagonal of the matrix.
 
 Parameters
 ----------
-diag : sequence of floats
-    Value to set
+diag : :class:`~openturns.Point` or :class:`~openturns.Matrix` or a float
+    Value(s) used to fill the diagonal of the matrix
 
 k : int
-    The k-th diagonal to extract
+    The k-th diagonal to fill
     Default value is 0
 
 Examples
 --------
 >>> import openturns as ot
 >>> M = ot.Matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
->>> diag = M.getDiagonal()
->>> print(diag)
-[[ 1 ]
- [ 5 ]
- [ 9 ]]
 >>> M.setDiagonal([-1, 23, 9])
 >>> print(M)
 [[ -1  2  3 ]
  [  4 23  6 ]
- [  7  8  9 ]]"
+ [  7  8  9 ]]
+>>> M.setDiagonal(1.0)
+>>> print(M)
+[[ 1 2 3 ]
+ [ 4 1 6 ]
+ [ 7 8 1 ]]
+>>> M.setDiagonal([2, 6, 9])
+>>> print(M)
+[[ 2 2 3 ]
+ [ 4 6 6 ]
+ [ 7 8 9 ]]"
 
 // ---------------------------------------------------------------------

--- a/python/src/Matrix_doc.i.in
+++ b/python/src/Matrix_doc.i.in
@@ -439,3 +439,144 @@ Examples
 >>> M = ot.Matrix([[]])
 >>> M.isEmpty()
 True"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Matrix::computeHadamardProduct
+"Compute the Hadamard product matrix.
+
+Parameters
+----------
+Mat : :class:`~openturns.Matrix`
+    The right hand matrix
+
+Returns
+-------
+C : :class:`~openturns.Matrix`
+    The Hadamard product matrix.
+
+Notes
+-----
+
+The matrix :math:`\cC` resulting from the Hadamard product of the matrices
+:math:`\cA` and :`\cB` is as follows:
+
+.. math::
+
+    \cC_{i,j} = \cA_{i,j} * \cB_{i,j}
+
+Examples
+--------
+>>> import openturns as ot
+>>> A = ot.Matrix([[1.0, 2.0], [3.0, 4.0]])
+>>> B = ot.Matrix([[1.0, 2.0], [3.0, 4.0]])
+>>> C = A.computeHadamardProduct(B)
+>>> print(C)
+[[  1  4 ]
+ [  9 16 ]]
+>>> print(B.computeHadamardProduct(A))
+[[  1  4 ]
+ [  9 16 ]]"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Matrix::computeSumElements
+"Compute the sum of the matrix elements.
+
+Returns
+-------
+sum : a float
+    The sum of the elements.
+
+Notes
+-----
+
+We compute here the sum of elements of the matrix :math:`\cM`, that defines as:
+
+.. math::
+
+    s = \sum_{i=1}^{nRows}\sum_{j=1}^{nColumns} \cM_{i,j}
+
+Examples
+--------
+>>> import openturns as ot
+>>> M = ot.Matrix([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+>>> s = M.computeSumElements()
+>>> print(s)
+21.0"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Matrix::squareElements
+"Square the Matrix, ie each element of the matrix is squared.
+
+Examples
+--------
+>>> import openturns as ot
+>>> M = ot.Matrix([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+>>> M.squareElements()
+>>> print(M)
+[[  1  4 ]
+ [  9 16 ]
+ [ 25 36 ]]"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::Matrix::getDiagonal
+"Get the k-th diagonal of the matrix.
+
+Parameters
+----------
+k : int
+    The k-th diagonal to extract
+    Default value is 0
+
+Returns
+-------
+D: :class:`~openturns.Matrix`
+    The k-th diagonal.
+
+Examples
+--------
+>>> import openturns as ot
+>>> M = ot.Matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+>>> diag = M.getDiagonal()
+>>> print(diag)
+[[ 1 ]
+ [ 5 ]
+ [ 9 ]]
+>>> print(M.getDiagonal(1))
+[[ 2 ]
+ [ 6 ]]"
+
+// ---------------------------------------------------------------------
+
+
+%feature("docstring") OT::Matrix::setDiagonal
+"Set the k-th diagonal of the matrix.
+
+Parameters
+----------
+diag : sequence of floats
+    Value to set
+
+k : int
+    The k-th diagonal to extract
+    Default value is 0
+
+Examples
+--------
+>>> import openturns as ot
+>>> M = ot.Matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+>>> diag = M.getDiagonal()
+>>> print(diag)
+[[ 1 ]
+ [ 5 ]
+ [ 9 ]]
+>>> M.setDiagonal([-1, 23, 9])
+>>> print(M)
+[[ -1  2  3 ]
+ [  4 23  6 ]
+ [  7  8  9 ]]"
+
+// ---------------------------------------------------------------------

--- a/python/test/t_HSICEstimatorConditionalSensitivity_std.py
+++ b/python/test/t_HSICEstimatorConditionalSensitivity_std.py
@@ -53,32 +53,39 @@ g2 = ot.ParametricFunction(foo, [1], [0.1 * stdDev])
 # The weight function
 weight = ot.ComposedFunction(g2, g)
 
-# We eventually build the HSIC object
-# HSICVStat event is already embedded as it is the only one available
-# for that kind of analysis
-CSA = ot.HSICEstimatorConditionalSensitivity(covarianceModelCollection, X, Y, weight)
+# random generator state
+# use the same state for parallel/sequential validation
+state = ot.RandomGenerator.GetState()
 
-# We get the R2-HSIC
-R2HSIC = CSA.getR2HSICIndices()
-ott.assert_almost_equal(R2HSIC, [0.03717355, 0.00524130, 0.23551919])
+for key in [True, False]:
+    ot.ResourceMap.SetAsBool("HSICEstimator-ParallelPValues", key)
+    ot.RandomGenerator.SetState(state)
 
+    # We eventually build the HSIC object
+    # HSICVStat event is already embedded as it is the only one available
+    # for that kind of analysis
+    CSA = ot.HSICEstimatorConditionalSensitivity(covarianceModelCollection, X, Y, weight)
 
-# and the HSIC indices
-HSICIndices = CSA.getHSICIndices()
-ott.assert_almost_equal(HSICIndices, [0.00064033, 0.00025769, 0.01105157])
+    # We get the R2-HSIC
+    R2HSIC = CSA.getR2HSICIndices()
+    ott.assert_almost_equal(R2HSIC, [0.03717355, 0.00524130, 0.23551919])
 
-# We set the number of permutations for the pvalue estimate
-b = 100
-CSA.setPermutationSize(b)
+    # and the HSIC indices
+    HSICIndices = CSA.getHSICIndices()
+    ott.assert_almost_equal(HSICIndices, [0.00064033, 0.00025769, 0.01105157])
 
-# We get the pvalue estimate by permutations
-pvaluesPerm = CSA.getPValuesPermutation()
-ott.assert_almost_equal(pvaluesPerm, [0.74257426, 0.94059406, 0.00000000])
+    # We set the number of permutations for the pvalue estimate
+    b = 100
+    CSA.setPermutationSize(b)
 
-# Change the weight function and recompute everything
-squaredExponential = ot.SymbolicFunction("x", "exp(-x^2)")
-alternateWeight = ot.ComposedFunction(squaredExponential, g)
-CSA.setWeightFunction(alternateWeight)
-ott.assert_almost_equal(CSA.getR2HSICIndices(), [0.0910527, 0.00738055, 0.166624])
-ott.assert_almost_equal(CSA.getHSICIndices(), [0.00218376, 0.000419288, 0.00898721])
-ott.assert_almost_equal(CSA.getPValuesPermutation(), [0.287129, 0.881188, 0.00000000])
+    # We get the pvalue estimate by permutations
+    pvaluesPerm = CSA.getPValuesPermutation()
+    ott.assert_almost_equal(pvaluesPerm, [0.74257426, 0.94059406, 0.00000000])
+
+    # Change the weight function and recompute everything
+    squaredExponential = ot.SymbolicFunction("x", "exp(-x^2)")
+    alternateWeight = ot.ComposedFunction(squaredExponential, g)
+    CSA.setWeightFunction(alternateWeight)
+    ott.assert_almost_equal(CSA.getR2HSICIndices(), [0.0910527, 0.00738055, 0.166624])
+    ott.assert_almost_equal(CSA.getHSICIndices(), [0.00218376, 0.000419288, 0.00898721])
+    ott.assert_almost_equal(CSA.getPValuesPermutation(), [0.287129, 0.881188, 0.00000000])

--- a/python/test/t_HSICEstimatorGlobalSensitivity_std.py
+++ b/python/test/t_HSICEstimatorGlobalSensitivity_std.py
@@ -46,24 +46,32 @@ covarianceModelCollection.add(Cov2)
 #
 estimatorType = ot.HSICUStat()
 
-# We eventually build the HSIC object!
-hsic = ot.HSICEstimatorGlobalSensitivity(covarianceModelCollection, X, Y, estimatorType)
+# random generator state
+# use the same state for parallel/sequential validation
+state = ot.RandomGenerator.GetState()
 
-# We get the HSIC indices
-HSICIndices = hsic.getHSICIndices()
-ott.assert_almost_equal(HSICIndices, [0.02228377, 0.00025668, 0.00599247])
+for key in [True, False]:
+    ot.ResourceMap.SetAsBool("HSICEstimator-ParallelPValues", key)
+    ot.RandomGenerator.SetState(state)
 
-# and the R2-HSIC
-R2HSIC = hsic.getR2HSICIndices()
-ott.assert_almost_equal(R2HSIC, [0.29807297, 0.00344498, 0.07726572])
+    # We eventually build the HSIC object!
+    hsic = ot.HSICEstimatorGlobalSensitivity(covarianceModelCollection, X, Y, estimatorType)
 
-# We set the bootstrap size for the pvalue estimate
-b = 1000
-hsic.setPermutationSize(b)
+    # We get the HSIC indices
+    HSICIndices = hsic.getHSICIndices()
+    ott.assert_almost_equal(HSICIndices, [0.02228377, 0.00025668, 0.00599247])
 
-# We get the pvalue estimate by permutations
-pvaluesPerm = hsic.getPValuesPermutation()
-ott.assert_almost_equal(pvaluesPerm, [0.00000000, 0.29670330, 0.00199800])
+    # and the R2-HSIC
+    R2HSIC = hsic.getR2HSICIndices()
+    ott.assert_almost_equal(R2HSIC, [0.29807297, 0.00344498, 0.07726572])
 
-pvaluesAs = hsic.getPValuesAsymptotic()
-ott.assert_almost_equal(pvaluesAs, [0.00000000, 0.33271992, 0.00165620])
+    # We set the bootstrap size for the pvalue estimate
+    b = 1000
+    hsic.setPermutationSize(b)
+
+    # We get the pvalue estimate by permutations
+    pvaluesPerm = hsic.getPValuesPermutation()
+    ott.assert_almost_equal(pvaluesPerm, [0.00000000, 0.29670330, 0.00199800])
+
+    pvaluesAs = hsic.getPValuesAsymptotic()
+    ott.assert_almost_equal(pvaluesAs, [0.00000000, 0.33271992, 0.00165620])

--- a/python/test/t_HSICEstimatorTargetSensitivity_std.py
+++ b/python/test/t_HSICEstimatorTargetSensitivity_std.py
@@ -58,39 +58,46 @@ g2 = ot.ParametricFunction(foo, [1], [0.1 * stdDev])
 # The filter function
 filterFunction = ot.ComposedFunction(g2, g)
 
+# random generator state
+# use the same state for parallel/sequential validation
+state = ot.RandomGenerator.GetState()
 
-# We eventually build the HSIC object!
-TSA = ot.HSICEstimatorTargetSensitivity(
-    covarianceModelCollection, X, Y, estimatorType, filterFunction
-)
+for key in [True, False]:
+    ot.ResourceMap.SetAsBool("HSICEstimator-ParallelPValues", key)
+    ot.RandomGenerator.SetState(state)
 
-# We get the R2-HSIC
-R2HSIC = TSA.getR2HSICIndices()
-ott.assert_almost_equal(R2HSIC, [0.26863688, 0.00468423, 0.00339962])
+    # We eventually build the HSIC object!
+    TSA = ot.HSICEstimatorTargetSensitivity(
+        covarianceModelCollection, X, Y, estimatorType, filterFunction
+    )
 
-# and the HSIC indices
-HSICIndices = TSA.getHSICIndices()
-ott.assert_almost_equal(HSICIndices, [0.00107494, 0.00001868, 0.00001411])
+    # We get the R2-HSIC
+    R2HSIC = TSA.getR2HSICIndices()
+    ott.assert_almost_equal(R2HSIC, [0.26863688, 0.00468423, 0.00339962])
 
-# We get the asymptotic pvalue
-pvaluesAs = TSA.getPValuesAsymptotic()
-ott.assert_almost_equal(pvaluesAs, [0.00000000, 0.26201467, 0.28227083])
+    # and the HSIC indices
+    HSICIndices = TSA.getHSICIndices()
+    ott.assert_almost_equal(HSICIndices, [0.00107494, 0.00001868, 0.00001411])
 
-# We set the number of permutations for the pvalue estimate
-b = 1000
-TSA.setPermutationSize(b)
+    # We get the asymptotic pvalue
+    pvaluesAs = TSA.getPValuesAsymptotic()
+    ott.assert_almost_equal(pvaluesAs, [0.00000000, 0.26201467, 0.28227083])
 
-# We get the pvalue estimate by permutations
-pvaluesPerm = TSA.getPValuesPermutation()
-ott.assert_almost_equal(pvaluesPerm, [0.00000000, 0.23376623, 0.26573427])
+    # We set the number of permutations for the pvalue estimate
+    b = 1000
+    TSA.setPermutationSize(b)
 
-# Change the filter function and recompute everything
-squaredExponential = ot.SymbolicFunction("x", "exp(-0.1 * x^2)")
-alternateFilter = ot.ComposedFunction(squaredExponential, g)
-TSA.setFilterFunction(alternateFilter)
-ott.assert_almost_equal(TSA.getR2HSICIndices(), [0.373511, 0.0130156, 0.0153977])
-ott.assert_almost_equal(
-    TSA.getHSICIndices(), [0.00118685, 4.12193e-05, 5.07577e-05], 1e-4, 0.0
-)
-ott.assert_almost_equal(TSA.getPValuesPermutation(), [0, 0.137862, 0.112887])
-ott.assert_almost_equal(TSA.getPValuesAsymptotic(), [7.32022e-13, 0.143851, 0.128866])
+    # We get the pvalue estimate by permutations
+    pvaluesPerm = TSA.getPValuesPermutation()
+    ott.assert_almost_equal(pvaluesPerm, [0.00000000, 0.23376623, 0.26573427])
+
+    # Change the filter function and recompute everything
+    squaredExponential = ot.SymbolicFunction("x", "exp(-0.1 * x^2)")
+    alternateFilter = ot.ComposedFunction(squaredExponential, g)
+    TSA.setFilterFunction(alternateFilter)
+    ott.assert_almost_equal(TSA.getR2HSICIndices(), [0.373511, 0.0130156, 0.0153977])
+    ott.assert_almost_equal(
+        TSA.getHSICIndices(), [0.00118685, 4.12193e-05, 5.07577e-05], 1e-4, 0.0
+    )
+    ott.assert_almost_equal(TSA.getPValuesPermutation(), [0, 0.137862, 0.112887])
+    ott.assert_almost_equal(TSA.getPValuesAsymptotic(), [7.32022e-13, 0.143851, 0.128866])

--- a/python/test/t_HSICStat_std.py
+++ b/python/test/t_HSICStat_std.py
@@ -33,7 +33,7 @@ Cov2 = ot.SquaredExponential(1)
 Cov2.setScale(Y.computeStandardDeviation())
 
 # This is the GSA-type estimator: weight is 1.
-W = ot.IdentityMatrix(size)
+W = ot.Point(size, 1.0)
 
 # Using a biased estimator
 estimatorTypeV = ot.HSICVStat()


### PR DESCRIPTION
The following PR improves a bit the current implementation of `HSIC`, particularly :

 - A new `Matrix::setWeight(scalar, index)` : set the same value in the `kth` diagonal
 - A new `HSICStat::computeIndex(CovarianceMatrix, CovarianceMatrix, Point)` : we deprecte oldest implementations
 - Drop useless redefinition of methods if not different from the parent class
 - Store the `weight` as a `Point` once and update it if necessary only. No need to generate `Matrix/Point` at each call. In case of permutation, we just shuffle the `Point` and we use `ParallelFor` instead of `ParallelForIf` as the `function` is called outside the loop
 - Minor changes in `U-Stat`, `V-Stat`
 
With these changes, we noticed some minor improvements. 

For example, within the `wing weight` use case (see [benchmark script](https://gist.github.com/sofianehaddad/986a2019ad73107ce99467c09e694e5e), I get the following results with my laptop for `U-stat`

|      |       init |  r2-hsic   |  pval-asy   |   pval-perm |
|-----:|-----------:|-----------:|------------:|------------:|
|  100 | 0.00612903 | 0.00293088 |  0.00074219 |    0.027756 |
|  200 | 0.00523901 | 0.0124397  |  0.00281286 |    0.17576  |
|  500 | 0.0222888  | 0.0822959  |  0.0266981  |    1.9466   |
| 1000 | 0.0951841  | 0.550445   |  0.0720642  |   16.0755   |
| 2000 | 0.359562   | 3.26645    |  0.28436    |  128.049    |
| 2500 | 0.578034   | 6.00155    |  0.447185   |  242.051    |
| 3000 | 0.667434   | 9.298      |  0.642244   |      -      |
| 3500 | 1.05192    | 15.2839    |  0.976287   |      -      |
| 4000 | 1.51048    | 23.001     |  1.17932    |      -      |
| 4500 | 2.12988    | 33.7298    |  1.61314    |      -      |
| 5000 | 2.38631    | 47.5674    |  1.8537     |      -      |
| 6000 | 4.25345    | 77.4235    |  2.60874    |      -      |

And the following results for `V-stat`:

|      |       init |    r2-hsic |    pval-asy |   pval-perm |
|-----:|-----------:|-----------:|------------:|------------:|
|  100 | 0.00592804 | 0.00171781 |  0.00107694 |   0.020597  |
|  200 | 0.00447893 | 0.00584197 |  0.00419688 |   0.0776269 |
|  500 | 0.0217521  | 0.0396409  |  0.0255439  |   0.483539  |
| 1000 | 0.0838301  | 0.154861   |  0.10017    |   2.01072   |
| 2000 | 0.300805   | 0.587466   |  0.41436    |   8.33378   |
| 2500 | 0.489612   | 1.02717    |  0.801108   |  13.5863    |
| 3000 | 0.723731   | 1.31411    |  0.981472   |  19.706     |
| 3500 | 1.07265    | 1.86581    |  1.45907    |  35.3829    |
| 4000 | 1.6513     | 2.51471    |  1.83635    |  38.8146    |
| 4500 | 1.94085    | 2.97615    |  2.54931    |  52.6599    |
| 5000 | 2.11758    | 3.61043    |  2.87732    |  59.9759    |
| 6000 | 3.87465    | 5.58295    |  4.60711    |  94.9558    |

Results are to be compared (partially) with #2251 (`size=1000, 5000`):

|      |      |       init |    r2-hsic  |   pval-asy |  pval-perm |
|-----:|-----:|-----------:|------------:|-----------:|-----------:|
|U-Stat| 1000 |  0.079358  |  0.5985     |   0.1169   |  25.384    |
|U-Stat| 5000 |  1.749707  | 51.1739     |   2.7764   |    -       | 
|V-Stat| 1000 |  0.0537    |  0.4571     |   0.1022   |   5.7595   |
|V-Stat| 5000 |  1.749707  | 51.1739     |   2.7764   |    -       | 

Evaluating p-value with permutation has become faster, when applicable ( size < 500) 

The global picture is :
 - With small data, both `V-stat` and `U-stat` perform "well"; there are probably ways of improving. 
   Also `permutation` is very     efficient with `V-stat` and more time consuming with `U-stat`
 - With more large dataset, we probably should prefer `V-stat`. 