### PR TITLE
Improve examples

### DIFF
--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend.py
@@ -1,12 +1,14 @@
 """
-Configuring an arbitrary trend in Kriging
-=========================================
+Kriging: choose an arbitrary trend
+==================================
 """
 # %%
 # The goal of this example is to show how to configure an arbitrary trend in a Kriging metamodel.
+# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_chose_trend` example,
+# we show how to configure a polynomial trend.
 #
 # In general, any collection of multivariate functions can be used as the
-# `basis` argument of a `KrigingAlgorithm`.
+# `basis` argument of a :class:`~openturns.KrigingAlgorithm`.
 # In practice, it might not be convenient to create a multivariate basis and
 # this is why we sometimes create it by tensorization of univariate functions.
 # In this example, we first use Legendre polynomials as our univariate functions,

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend.py
@@ -4,7 +4,8 @@ Kriging: choose an arbitrary trend
 """
 # %%
 # The goal of this example is to show how to configure an arbitrary trend in a Kriging metamodel.
-# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_chose_trend` example,
+# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_chose_trend`
+# and :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_beam_trend` examples,
 # we show how to configure a polynomial trend.
 #
 # In general, any collection of multivariate functions can be used as the

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
@@ -6,9 +6,9 @@ Choose the trend basis of a kriging metamodel
 # The goal of this example is to show how to configure the trend in a Kriging metamodel.
 # This is why this example focuses on the three available trends:
 #
-# * `ConstantBasisFactory`,
-# * `LinearBasisFactory`,
-# * `QuadraticBasisFactory`.
+# * :class:`~openturns.ConstantBasisFactory`,
+# * :class:`~openturns.LinearBasisFactory`,
+# * :class:`~openturns.QuadraticBasisFactory`.
 #
 # For this purpose, we use the :ref:`cantilever beam <use-case-cantilever-beam>` example.
 
@@ -43,7 +43,7 @@ myDistribution = cb.distribution
 
 # %%
 # We consider a simple Monte-Carlo sampling as a design of experiments.
-# This is why we generate an input sample using the `getSample` method of the distribution.
+# This is why we generate an input sample using the :meth:`~openturns.Distribution.getSample` method of the distribution.
 # Then we evaluate the output using the `model` function.
 
 # %%

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_beam_trend.py
@@ -1,14 +1,17 @@
 """
-Choose the trend basis of a kriging metamodel
-=============================================
+Kriging: choose a polynomial trend on the beam model
+====================================================
 """
 # %%
 # The goal of this example is to show how to configure the trend in a Kriging metamodel.
-# This is why this example focuses on the three available trends:
+# This example focuses on three polynomial trends:
 #
 # * :class:`~openturns.ConstantBasisFactory`,
 # * :class:`~openturns.LinearBasisFactory`,
 # * :class:`~openturns.QuadraticBasisFactory`.
+#
+# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_chose_trend` example,
+# we give another example of this procedure.
 #
 # For this purpose, we use the :ref:`cantilever beam <use-case-cantilever-beam>` example.
 

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
@@ -11,12 +11,14 @@ from matplotlib import pylab as plt
 # ------------
 #
 # In this example we present the polynomial trends which we may use in a kriging metamodel.
-# 
+# This example focuses on three polynomial trends:
 #
 # - :class:`~openturns.ConstantBasisFactory`;
 # - :class:`~openturns.LinearBasisFactory`;
 # - :class:`~openturns.QuadraticBasisFactory`.
 #
+# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_beam_trend` example,
+# we give another example of this method.
 # In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend` example,
 # we show how to configure an arbitrary trend.
 #

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_chose_trend.py
@@ -1,6 +1,6 @@
 """
-Kriging : choose a trend vector space
-=====================================
+Kriging: choose a polynomial trend
+==================================
 """
 import openturns as ot
 import openturns.viewer as otv
@@ -10,227 +10,283 @@ from matplotlib import pylab as plt
 # Introduction
 # ------------
 #
-# In this example we present the basic trends which we may use in the kriging metamodel procedure :
+# In this example we present the polynomial trends which we may use in a kriging metamodel.
+# 
 #
-#  - ConstantBasis ;
-#  - LinearBasis ;
-#  - QuadraticBasis ;
+# - :class:`~openturns.ConstantBasisFactory`;
+# - :class:`~openturns.LinearBasisFactory`;
+# - :class:`~openturns.QuadraticBasisFactory`.
 #
-# The model is the simple real function defined by
+# In the :doc:`/auto_meta_modeling/kriging_metamodel/plot_kriging_beam_arbitrary_trend` example,
+# we show how to configure an arbitrary trend.
+#
+# The model is the real function:
 #
 # .. math::
-#    f : x \mapsto x \left( \sin \frac{x}{2} \right)
+#    \model(x) = x \sin \left( \frac{x}{2} \right)
 #
-# which we study on the :math:`[0,10]` interval.
+# for any :math:`x \in [0,10]`.
+# We consider the :class:`~openturns.MaternModel` covariance kernel
+# where :math:`\vect{\theta} = (\sigma, \rho)` is the vector of hyperparameters.
+# The covariance model is fixed but its parameters must be calibrated
+# depending on the data.
+# The kriging metamodel is:
+#
+# .. math::
+#    \widehat{Y}(x) = m(x) + Z(x)
+#
+# where :math:`m(.)` is the trend and :math:`Z(.)` is a Gaussian process with zero mean and covariance model :math:`C_{\vect{\theta}}(s,t)`.
+# The trend is deterministic and the Gaussian process is probabilistic but they both contribute to the metamodel.
+# A special feature of the kriging is the interpolation property: the metamodel is exact at the
+# training data.
 
 # %%
-dimension = 1
-
-
-# %%
-# The focus being on the trend we assume a given squared exponential covariance kernel :
-#
-# .. math::
-#    C_{\theta}(s,t) = \sigma^2 e^{ - \frac{(t-s)^2}{2\rho^2} }
-#
-# where :math:`\theta = (\sigma, \rho)` is the hyperparameters vectors. The nature of the covariance
-# model is fixed but its parameters are calibrated during the kriging process. We want to choose them
-# so as to best fit our data.
-#
-# Eventually the kriging (meta)model :math:`\hat{Y}(x)` reads as
-#
-# .. math::
-#    \hat{Y}(x) = m(x) + Z(x)
-#
-# where :math:`m(.)` is the trend and :math:`Z(.)` is a gaussian process with zero-mean and its covariance matrix is :math:`C_{\theta}(s,t)`.
-# The trend is deterministic and the gaussian process is probabilistc but they both contribute to the metamodel.
-# A special feature of the kriging is the interpolation property : the metamodel is exact at the
-# trainig data.
 covarianceModel = ot.SquaredExponential([1.0], [1.0])
 
 # %%
-# We define our exact model with a `SymbolicFunction` :
-model = ot.SymbolicFunction(["x"], ["x*sin(0.5*x)"])
+# Define the model
+# ----------------
+
+# %%
+# First, we define the :class:`~openturns.MaternModel` covariance model.
+covarianceModel = ot.MaternModel([1.0], [1.0], 2.5)
+
+# %%
+# We define our exact model with a :class:`~openturns.SymbolicFunction`.
+model = ot.SymbolicFunction(["x"], ["x * sin(0.5 * x)"])
 
 
 # %%
-# We use the following sample to train our metamodel :
-nTrain = 5
-Xtrain = ot.Sample([[0.5], [1.3], [2.4], [5.6], [8.9]])
+# We use the following sample to train our metamodel.
+xmin = 0.0
+xmax = 10.0
+ot.RandomGenerator.SetSeed(0)
+nTrain = 8
+Xtrain = ot.Uniform(xmin, xmax).getSample(nTrain).sort()
+Xtrain
 
 # %%
-# The values of the exact model are also needed for training :
+# The values of the exact model are also needed for training.
 Ytrain = model(Xtrain)
+Ytrain
 
 # %%
-# We shall test the model on a set of points and use a regular grid for this matter.
-nTest = 101
-step = 0.1
-x_test = ot.RegularGrid(0, step, nTest).getVertices()
+# We shall test the model on a set of points based on a regular grid.
+nTest = 100
+step = (xmax - xmin) / (nTest - 1)
+x_test = ot.RegularGrid(xmin, step, nTest).getVertices()
 
 # %%
 # We draw the training points and the model at the testing points. We encapsulate it into a function to use it again later.
 
 
-def plot_exact_model():
+def plot_exact_model(color):
     graph = ot.Graph("", "x", "", True, "")
     y_test = model(x_test)
     curveModel = ot.Curve(x_test, y_test)
     curveModel.setLineStyle("solid")
-    curveModel.setColor("black")
+    curveModel.setColor(color)
+    curveModel.setLegend("Model")
     graph.add(curveModel)
     cloud = ot.Cloud(Xtrain, Ytrain)
-    cloud.setColor("black")
+    cloud.setColor(color)
     cloud.setPointStyle("fsquare")
+    cloud.setLegend("Data")
     graph.add(cloud)
+    graph.setLegendPosition("bottom")
     return graph
 
 
 # %%
-graph = plot_exact_model()
-graph.setLegends(["exact model", "training data"])
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging : exact model")
+palette = ot.Drawable.BuildDefaultPalette(5)
+graph = plot_exact_model(palette[0])
+graph.setTitle("1D Kriging: exact model")
 view = otv.View(graph)
 
+# %%
+# Scale the input training sample
+# -------------------------------
 
 # %%
-# A common pre-processing step is to apply a transform on the input data before performing the kriging.
-# To do so we write a linear transform of our input data : we make it unit centered at its mean.
-# Then we fix the mean and the standard deviation to their values with the `ParametricFunction`. We build the inverse transform as well.
+# We often have to apply a transform on the input data before performing the kriging.
+# This make the estimation of the hyperparameters of the kriging metamodel
+# easier for the optimization algorithm.
+# To do so we write a linear transform of our input data: we make it unit centered at its mean.
+# Then we fix the mean and the standard deviation to their values with the :class:`~openturns.ParametricFunction`.
+# We build the inverse transform as well.
 #
-# We first compute the mean and standard deviation of the input data :
+# We first compute the mean and standard deviation of the input data.
 mean = Xtrain.computeMean()[0]
 stdDev = Xtrain.computeStandardDeviation()[0]
-print("Xtrain, mean : %.3f" % mean)
-print("Xtrain, standard deviation : %.3f" % stdDev)
+print("Xtrain, mean: %.3f" % mean)
+print("Xtrain, standard deviation: %.3f" % stdDev)
 
 # %%
-tf = ot.SymbolicFunction(["mu", "sigma", "x"], ["(x-mu)/sigma"])
-itf = ot.SymbolicFunction(["mu", "sigma", "x"], ["sigma*x+mu"])
+tf = ot.SymbolicFunction(["mu", "sigma", "x"], ["(x - mu) / sigma"])
+itf = ot.SymbolicFunction(["mu", "sigma", "x"], ["sigma * x + mu"])
 myInverseTransform = ot.ParametricFunction(itf, [0, 1], [mean, stdDev])
 myTransform = ot.ParametricFunction(tf, [0, 1], [mean, stdDev])
 
+# %%
+# Scale the input training sample.
+scaledXtrain = myTransform(Xtrain)
+scaledXtrain
+
 
 # %%
-# A constant basis
-# ----------------
+# Constant basis
+# --------------
 #
-# In this paragraph we choose a basis constant for the kriging. There is only one unknown which is the
-# value of the constant. The basis is built with the :class:`~openturns.ConstantBasisFactory` class.
+# In this paragraph we choose a basis constant for the kriging.
+# This trend only has one parameter which is the
+# value of the constant.
+# The basis is built with the :class:`~openturns.ConstantBasisFactory` class.
+
+# %%
+dimension = 1
 basis = ot.ConstantBasisFactory(dimension).build()
 
 # %%
 # We build the kriging algorithm by giving it the transformed data, the output data, the covariance
 # model and the basis.
-algo = ot.KrigingAlgorithm(myTransform(Xtrain), Ytrain, covarianceModel, basis)
+algo = ot.KrigingAlgorithm(scaledXtrain, Ytrain, covarianceModel, basis)
 
 # %%
-# We can run the algorithm and store the result :
+# We can run the algorithm and store the result.
 algo.run()
 result = algo.getResult()
 
 # %%
-# The metamodel is the following :class:`~openturns.ComposedFunction` :
+# The metamodel is the following :class:`~openturns.ComposedFunction`.
 metamodel = ot.ComposedFunction(result.getMetaModel(), myTransform)
 
 # %%
+# Define a function to plot the metamodel
+
+
+def plotMetamodel(x_test, krigingResult, myTransform, color):
+    scaled_x_test = myTransform(x_test)
+    metamodel = result.getMetaModel()
+    y_test = metamodel(scaled_x_test)
+    curve = ot.Curve(x_test, y_test)
+    curve.setLineStyle("dashed")
+    curve.setColor(color)
+    curve.setLegend("Metamodel")
+    return curve
+
+
+# %%
 # We can draw the metamodel and the exact model on the same graph.
-graph = plot_exact_model()
-y_test = metamodel(x_test)
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dashed")
-curve.setColor("red")
-graph.add(curve)
-graph.setLegends(["exact model", "training data", "kriging metamodel"])
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging : exact model and metamodel")
+graph = plot_exact_model(palette[0])
+graph.add(plotMetamodel(x_test, result, myTransform, palette[1]))
+graph.setTitle("1D Kriging: exact model and metamodel")
 view = otv.View(graph)
 
 # %%
-# We can retrieve the calibrated trend coefficient :
+# We can retrieve the calibrated trend coefficient with :meth:`~openturns.KrigingResult.getTrendCoefficients`.
 c0 = result.getTrendCoefficients()
 print("The trend is the curve m(x) = %.6e" % c0[0])
 
 # %%
-# We also pay attention to the trained covariance model and observe the values
-# of the hyperparameters :
+# We also observe the values of the hyperparameters of the trained covariance model.
 rho = result.getCovarianceModel().getScale()[0]
-print("Scale parameter : %.3e" % rho)
+print("Scale parameter: %.3e" % rho)
 
 sigma = result.getCovarianceModel().getAmplitude()[0]
-print("Amplitude parameter : %.3e" % sigma)
+print("Amplitude parameter: %.3e" % sigma)
 
 # %%
-# We build the trend from the coefficient :
+# We build the trend from the coefficient.
 constantTrend = ot.SymbolicFunction(["a", "x"], ["a"])
 myTrend = ot.ParametricFunction(constantTrend, [0], [c0[0]])
 
 
 # %%
-# We draw the trend found by the kriging procedure :
-y_test = myTrend(myTransform(x_test))
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dotdash")
-curve.setColor("green")
-graph.add(curve)
-graph.setLegends(
-    ["exact model", "training data", "kriging metamodel", "constant trend"]
-)
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging with a constant trend")
-view = otv.View(graph)
+# Define a function to plot the trend
+
+
+def plotTrend(x_test, myTrend, myTransform, color):
+    scale_x_test = myTransform(x_test)
+    y_test = myTrend(scale_x_test)
+    curve = ot.Curve(x_test, y_test)
+    curve.setLineStyle("dotdash")
+    curve.setColor(color)
+    curve.setLegend("Trend")
+    return curve
 
 
 # %%
-# We create a small function returning bounds of the 68% confidence interval :math:`[-sigma,sigma]` :
-def plot_ICBounds(x_test, y_test, nTest, sigma):
-    vUp = [[x_test[i][0], y_test[i][0] + sigma] for i in range(nTest)]
-    vLow = [[x_test[i][0], y_test[i][0] - sigma] for i in range(nTest)]
-    polyData = [[vLow[i], vLow[i + 1], vUp[i + 1], vUp[i]] for i in range(nTest - 1)]
-    polygonList = [ot.Polygon(polyData[i], "grey", "grey") for i in range(nTest - 1)]
+# We draw the trend found by the kriging procedure.
+graph.add(plotTrend(x_test, myTrend, myTransform, palette[2]))
+graph.setTitle("1D Kriging with a constant trend")
+view = otv.View(graph)
+
+# %%
+# Create a function to plot confidence bounds.
+
+# %%
+
+
+def plotKrigingConfidenceBounds(krigingResult, x_test, myTransform, color, alpha=0.05):
+    bilateralCI = ot.Normal().computeBilateralConfidenceInterval(1.0 - alpha)
+    quantileAlpha = bilateralCI.getUpperBound()[0]
+    sqrt = ot.SymbolicFunction(["x"], ["sqrt(x)"])
+    n_test = x_test.getSize()
+    epsilon = ot.Sample(n_test, [1.0e-8])
+    scaled_x_test = myTransform(x_test)
+    conditionalVariance = (
+        krigingResult.getConditionalMarginalVariance(scaled_x_test) + epsilon
+    )
+    conditionalSigma = sqrt(conditionalVariance)
+    metamodel = krigingResult.getMetaModel()
+    y_test = metamodel(scaled_x_test)
+    dataLower = [
+        [y_test[i, 0] - quantileAlpha * conditionalSigma[i, 0]] for i in range(n_test)
+    ]
+    dataUpper = [
+        [y_test[i, 0] + quantileAlpha * conditionalSigma[i, 0]] for i in range(n_test)
+    ]
+    dataLower = ot.Sample(dataLower)
+    dataUpper = ot.Sample(dataUpper)
+    vLow = [[x_test[i, 0], dataLower[i, 0]] for i in range(n_test)]
+    vUp = [[x_test[i, 0], dataUpper[i, 0]] for i in range(n_test)]
+    polyData = [[vLow[i], vLow[i + 1], vUp[i + 1], vUp[i]] for i in range(n_test - 1)]
+    polygonList = [ot.Polygon(polyData[i], color, color) for i in range(n_test - 1)]
     boundsPoly = ot.PolygonArray(polygonList)
+    boundsPoly.setLegend("%d%% C.I." % ((1.0 - alpha) * 100))
     return boundsPoly
 
 
 # %%
-# We now draw it :
-boundsPoly = plot_ICBounds(x_test, y_test, nTest, sigma)
-graph.add(boundsPoly)
-graph.setLegends(
-    [
-        "exact model",
-        "training data",
-        "kriging metamodel",
-        "constant trend",
-        "68% - confidence interval",
-    ]
-)
-graph.setLegendPosition("bottom")
+# Plot a confidence interval.
+graph.add(plotKrigingConfidenceBounds(result, x_test, myTransform, palette[3]))
 graph.setTitle("1D Kriging with a constant trend")
-view = otv.View(graph)
+view = otv.View(
+    graph,
+    legend_kw={"bbox_to_anchor": (1.0, 1.0), "loc": "upper left"},
+    figure_kw={"figsize": (7.0, 3.0)},
+)
+
+plt.subplots_adjust(right=0.6)
 
 
 # %%
-# As expected with a constant basis, the trend obtained is an horizontal line amidst data points.
-# The main idea is that at any point :math:`x_0`, the gaussian term :math:`Z(x_0)` helps to find a
-# good value of :math:`\hat{Y}(x_0)` thanks to the high value of the amplitude :math:`\sigma`
-# (:math:`\sigma \approx 6.359`) far away from the mean :math:`m(x)`. As a consequence the 68%
-# confidence interval is wide.
+# As expected with a constant basis, the trend obtained is an horizontal line.
 
 
 # %%
 # Linear basis
 # ------------
 #
-# With a linear basis, the vector space is defined by the basis :math:`\{1, X\}` : that is
-# all the lines of the form :math:`y(X) = aX + b`.
+# With a linear basis, the vector space is defined by the basis :math:`\{1, z\}`: that is
+# all the lines of the form :math:`y(z) = az + b` where :math:`a` and :math:`b` are
+# real parameters.
 basis = ot.LinearBasisFactory(dimension).build()
 
 
 # %%
-# We run the kriging analysis and store the result :
-algo = ot.KrigingAlgorithm(myTransform(Xtrain), Ytrain, covarianceModel, basis)
+# We run the kriging analysis and store the result.
+algo = ot.KrigingAlgorithm(scaledXtrain, Ytrain, covarianceModel, basis)
 algo.run()
 result = algo.getResult()
 metamodel = ot.ComposedFunction(result.getMetaModel(), myTransform)
@@ -238,73 +294,43 @@ metamodel = ot.ComposedFunction(result.getMetaModel(), myTransform)
 
 # %%
 # We can draw the metamodel and the exact model on the same graph.
-graph = plot_exact_model()
-y_test = metamodel(x_test)
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dashed")
-curve.setColor("red")
-graph.add(curve)
-graph.setLegends(["exact model", "training data", "kriging metamodel"])
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging : exact model and metamodel")
-view = otv.View(graph)
+graph = plot_exact_model(palette[0])
+graph.add(plotMetamodel(x_test, result, myTransform, palette[1]))
 
 
 # %%
-# We can retrieve the calibrated trend coefficients with `getTrendCoefficients` :
+# We can retrieve the calibrated trend coefficients with :meth:`~openturns.KrigingResult.getTrendCoefficients`.
 c0 = result.getTrendCoefficients()
 print("Trend is the curve m(X) = %.6e X + %.6e" % (c0[1], c0[0]))
 
 
 # %%
-# We also pay attention to the trained covariance model and observe the values
-# of the hyperparameters :
+# We observe the values of the hyperparameters of the trained covariance model.
 rho = result.getCovarianceModel().getScale()[0]
-print("Scale parameter : %.3e" % rho)
+print("Scale parameter: %.3e" % rho)
 
 sigma = result.getCovarianceModel().getAmplitude()[0]
-print("Amplitude parameter : %.3e" % sigma)
+print("Amplitude parameter: %.3e" % sigma)
 
 
 # %%
 # We draw the linear trend that we are interested in.
-linearTrend = ot.SymbolicFunction(["a", "b", "x"], ["a*x+b"])
+linearTrend = ot.SymbolicFunction(["a", "b", "z"], ["a * z + b"])
 myTrend = ot.ParametricFunction(linearTrend, [0, 1], [c0[1], c0[0]])
-y_test = myTrend(myTransform(x_test))
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dotdash")
-curve.setColor("green")
-graph.add(curve)
-graph.setLegends(["exact model", "training data", "kriging metamodel", "linear trend"])
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging with a linear trend")
-view = otv.View(graph)
+graph.add(plotTrend(x_test, myTrend, myTransform, palette[2]))
 
 
 # %%
-# The same graphic with the 68% confidence interval :
-boundsPoly = plot_ICBounds(x_test, y_test, nTest, sigma)
-graph.add(boundsPoly)
-graph.setLegends(
-    [
-        "exact model",
-        "training data",
-        "kriging metamodel",
-        "linear trend",
-        "68% - confidence interval",
-    ]
+# Add the 95% confidence interval.
+graph.add(plotKrigingConfidenceBounds(result, x_test, myTransform, palette[3]))
+graph.setTitle("1D Kriging with a linear trend")
+view = otv.View(
+    graph,
+    legend_kw={"bbox_to_anchor": (1.0, 1.0), "loc": "upper left"},
+    figure_kw={"figsize": (7.0, 3.0)},
 )
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging with a linear trend")
-view = otv.View(graph)
 
-# %%
-# The trend obtained is decreasing on the interval of study : that is the general trend we observe
-# from the exact model. It is still nowhere close to the exact model but as in the constant case the
-# gaussian part will do the job of building a correct (visually at least) metamodel.
-# We note that the values of the amplitude and the scale parameters are similar to the previous constant case.
-# As it can be seen on the previous figure the metamodel is interpolating (see the last data point).
-
+plt.subplots_adjust(right=0.6)
 
 # %%
 # Quadratic basis
@@ -315,105 +341,59 @@ basis = ot.QuadraticBasisFactory(dimension).build()
 
 
 # %%
-# We run the kriging analysis and store the result :
-algo = ot.KrigingAlgorithm(myTransform(Xtrain), Ytrain, covarianceModel, basis)
+# We run the kriging analysis and store the result.
+algo = ot.KrigingAlgorithm(scaledXtrain, Ytrain, covarianceModel, basis)
 algo.run()
 result = algo.getResult()
 metamodel = ot.ComposedFunction(result.getMetaModel(), myTransform)
 
 # %%
 # We can draw the metamodel and the exact model on the same graph.
-graph = plot_exact_model()
-y_test = metamodel(x_test)
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dashed")
-curve.setColor("red")
-graph.add(curve)
-graph.setLegends(["exact model", "training data", "kriging metamodel"])
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging : exact model and metamodel")
-view = otv.View(graph)
+graph = plot_exact_model(palette[0])
+graph.add(plotMetamodel(x_test, result, myTransform, palette[1]))
 
 
 # %%
-#  We can retrieve the calibrated trend coefficients with `getTrendCoefficients` :
+#  We can retrieve the calibrated trend coefficients with :meth:`~openturns.KrigingResult.getTrendCoefficients`.
 c0 = result.getTrendCoefficients()
-print("Trend is the curve m(X) = %.6e X**2 + %.6e X + %.6e" % (c0[2], c0[1], c0[0]))
+print("Trend is the curve m(X) = %.6e Z**2 + %.6e Z + %.6e" % (c0[2], c0[1], c0[0]))
 
 
 # %%
-# We also pay attention to the trained covariance model and observe the values
-# of the hyperparameters :
+# We observe the values of the hyperparameters of the trained covariance model.
 rho = result.getCovarianceModel().getScale()[0]
-print("Scale parameter : %.3e" % rho)
+print("Scale parameter: %.3e" % rho)
 
 sigma = result.getCovarianceModel().getAmplitude()[0]
-print("Amplitude parameter : %.3e" % sigma)
+print("Amplitude parameter: %.3e" % sigma)
 
 # %%
-# The quadratic linear trend obtained is :
-quadraticTrend = ot.SymbolicFunction(["a", "b", "c", "x"], ["a*x^2 + b*x + c"])
+# The quadratic trend obtained.
+quadraticTrend = ot.SymbolicFunction(["a", "b", "c", "z"], ["a * z^2 + b * z + c"])
 myTrend = ot.ParametricFunction(quadraticTrend, [0, 1, 2], [c0[2], c0[1], c0[0]])
 
 
 # %%
-# In this case we restrict ourselves to the :math:`[0,6] \times [-2.5,4]` for visualization.
+# Add the quadratic trend
 y_test = myTrend(myTransform(x_test))
-curve = ot.Curve(x_test, y_test)
-curve.setLineStyle("dotdash")
-curve.setColor("green")
-graph.add(curve)
-graph.setLegends(
-    ["exact model", "training data", "kriging metamodel", "quadratic trend"]
-)
-graph.setLegendPosition("bottom")
+graph.add(plotTrend(x_test, myTrend, myTransform, palette[2]))
+
+
+# %%
+# Add the 95% confidence interval.
+
+# %%
+# sphinx_gallery_thumbnail_number = 6
+graph.add(plotKrigingConfidenceBounds(result, x_test, myTransform, palette[3]))
 graph.setTitle("1D Kriging with a quadratic trend")
-view = otv.View(graph)
-axes = view.getAxes()
-_ = axes[0].set_xlim(0.0, 6.0)
-_ = axes[0].set_ylim(-2.5, 4.0)
-
-
-# %%
-# sphinx_gallery_thumbnail_number = 10
-# The same graphic with the 68% confidence interval.
-boundsPoly = plot_ICBounds(x_test, y_test, nTest, sigma)
-graph.add(boundsPoly)
-graph.setLegends(
-    [
-        "exact model",
-        "training data",
-        "kriging metamodel",
-        "quadratic trend",
-        "68% - confidence interval",
-    ]
+view = otv.View(
+    graph,
+    legend_kw={"bbox_to_anchor": (1.0, 1.0), "loc": "upper left"},
+    figure_kw={"figsize": (7.0, 3.0)},
 )
-graph.setLegendPosition("bottom")
-graph.setTitle("1D Kriging with a quadratic trend")
-view = otv.View(graph)
-axes = view.getAxes()
-_ = axes[0].set_xlim(0.0, 6.0)
-_ = axes[0].set_ylim(-2.5, 4.0)
 
-
-# %%
-# In this case the analysis is interesting to understand the general behaviour of the kriging process.
-
-# %%
-# From the previous figure we feel that the metamodel is mostly characterized by the trend which is a
-# good approximate of the exact solution over the interval.
-# However, to a certain extent, we have lost flexibility by having a too good and rigid trend as we
-# still have to impose the interpolation property.
-#
-# We see that the gap between the trend and the exact model is small and the amplitude of the gaussian
-# process is small as well : :math:`\sigma \approx 0.684`. Then the confidence interval is more
-# narrow than before. The scale parameter is small, :math:`\rho \approx 0.010`, meaning that two
-# distant points are rapidly independent. The only way to set the interpolation property is to create
-# small peaks (see the figure). The sad conclusion is that the metamodel loses its smoothness.
-#
-# In that case one should use a constant or linear basis even if a quadratic trend seems right.
-
+plt.subplots_adjust(right=0.6)
 
 # %%
 # Display figures
-plt.show()
+otv.View.ShowAll()

--- a/python/doc/math_notations.sty
+++ b/python/doc/math_notations.sty
@@ -4,6 +4,9 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 
+% The physical model
+\newcommand{\model}{g}
+
 % For matrixes and vectors
 \newcommand{\vect}[1]{{\mathbf{\boldsymbol{{#1}}}}}
 \newcommand{\mat}[1]{{\vect{\vect{#1}}}}

--- a/python/src/EnumerateFunctionImplementation_doc.i.in
+++ b/python/src/EnumerateFunctionImplementation_doc.i.in
@@ -3,30 +3,28 @@
 
 Notes
 -----
-*EnumerateFunction* represents a bijection :math:`\tau`  from :math:`\Nset` to
-:math:`\Nset^{dim}`. This bijection is based on a particular enumeration rule
+*EnumerateFunction* is a bijection :math:`\vect{\alpha}`  from :math:`\Nset` to
+:math:`\Nset^{n_X}`. This bijection is based on a particular enumeration rule
 of the set of multi-indices.
-
-For every integer :math:`i \in \Nset`, we associate a multi-index
-
-.. math::
-
-    \boldsymbol{\tau}(i) = (\alpha_1,\dots, \alpha_{n_X}) \in {\Nset}^{n_X}.
-
-The first multi-index is
+For any integer :math:`i \in \Nset`, the value of the enumerate function is:
 
 .. math::
 
-    \boldsymbol{\alpha}(0) = (0, 0, \dots, 0).
+    \vect{\alpha}(i) = (\alpha_1(i),\dots, \alpha_{n_X}(i)) \in {\Nset}^{n_X}.
 
-Let :math:`i, j \in \Nset` be any pair of indices. If :math:`|i - j|\leq 1` then
+The first multi-index is:
+
+.. math::
+
+    \vect{\alpha}(0) = (0, 0, \dots, 0).
+
+Let :math:`i, j \in \Nset` be any pair of indices. If :math:`|i - j|\leq 1` then:
 
 .. math::
 
     \left|\sum_{k=1}^{n_X} \left[ \alpha_k(i) - \alpha_k(j) \right]\right| \leq 1
 
-where :math:`\alpha_k(i)` represents the k-th component of the multi-index :math:`\boldsymbol{\alpha}(i)`.
-    
+where :math:`\alpha_k(i)` is the k-th component of the multi-index :math:`\vect{\alpha}(i)`.
 This provides a necessary but insufficient condition 
 for the construction of the bijection: 
 a supplementary hypothesis must be made. 
@@ -36,24 +34,44 @@ The following mapping is an enumerate function:
 
 .. math::
 
-    \phi(0) &= (0, \; 0) \\
-    \phi(1) &= (1, \; 0) \\
-    \phi(2) &= (0, \; 1) \\
-    \phi(3) &= (2, \; 0) \\
-    \phi(4) &= (1, \; 1) \\
-    \phi(5) &= (0, \; 2) \\
-    \phi(6) &= (3, \; 0)
+    \vect{\alpha}(0) &= (0, \; 0) \\
+    \vect{\alpha}(1) &= (1, \; 0) \\
+    \vect{\alpha}(2) &= (0, \; 1) \\
+    \vect{\alpha}(3) &= (2, \; 0) \\
+    \vect{\alpha}(4) &= (1, \; 1) \\
+    \vect{\alpha}(5) &= (0, \; 2) \\
+    \vect{\alpha}(6) &= (3, \; 0)
 
 For the functional expansion (respectively polynomial chaos expansion), the
-multi-index :math:`\vect{i_p}` represents the collection of degrees of the
+multi-index :math:`\vect{\alpha}` is the collection of marginal degrees of the
 selected orthogonal functions (respectively orthogonal polynomials). 
 More precisely, after the selection of the type of orthogonal functions (respectively
 orthogonal polynomials) for the construction of the orthogonal basis, the
-*EnumerateFunction* characterizes the term of the basis by providing the
-degrees of the univariate functions (respectively univariate polynomials).
+*EnumerateFunction* defines the
+marginal degrees of the univariate functions (respectively univariate polynomials).
+The multivariate tensor product function
+is based on the product of marginal univariate functions:
 
-The total degree of the :math:`k^{th}` polynomial of the
-multivariate basis is equal to the sum of all the integers given in the list.
+.. math::
+
+    \psi_{\vect{\alpha}}(\vect{x}) = \prod_{i = 1}^{n_X} \pi_{\alpha_i}^{(i)}(x_i)
+
+for any point :math:`\vect{x}` where :math:`\pi_{\alpha_i}^{(i)}` is the
+polynomial of degree :math:`\alpha_i` for the i-th marginal.
+The total degree of the polynomial is equal to the sum of the integers 
+in the multi-index:
+
+.. math::
+
+    \operatorname{degree} \left(\psi_{\vect{\alpha}} \right) 
+    = \sum_{i = 1}^{n_X} \alpha_i = \|\vect{\alpha}\|_1.
+
+For example, consider the multi-index :math:`\vect{\alpha} = (2, 0, 3)`. 
+This multi-index defines a multivariate polynomial which has a input
+vector of dimension 3.
+The marginal degree of the polynomial of the first dimension is equal to 2, 
+the marginal degree of the polynomial of the second dimension is equal to 0 
+and the marginal degree of the polynomial of the third dimension is equal to 3.
 
 Examples
 --------

--- a/python/src/SmolyakExperiment_doc.i.in
+++ b/python/src/SmolyakExperiment_doc.i.in
@@ -34,15 +34,15 @@ The Smolyak experiment produces an approximation of the integral:
 
 .. math::
 
-    \int_{\mathcal{X}} g(\boldsymbol{x}) f(\boldsymbol{x}) d\boldsymbol{x}
-    \approx \sum_{i = 1}^{s_t} w_i g\left(\boldsymbol{x}_i\right)
+    \int_{\mathcal{X}} g(\vect{x}) f(\vect{x}) d\vect{x}
+    \approx \sum_{i = 1}^{s_t} w_i g\left(\vect{x}_i\right)
 
 where :math:`s_t \in \mathbb{N}` is the size of the Smolyak
 design of experiments, :math:`w_1, ..., w_{s_t} \in \mathbb{R}` are the
-weights and :math:`\boldsymbol{x}_1, ..., \boldsymbol{x}_{s_t} \in \mathbb{R}^{d_x}`
+weights and :math:`\vect{x}_1, ..., \vect{x}_{s_t} \in \mathbb{R}^{d_x}`
 are the nodes. 
 
-Let :math:`\boldsymbol{k} = (k_1, ..., k_{d_x}) \in (\mathbb{N}^\star)^{d_x}` 
+Let :math:`\vect{k} = (k_1, ..., k_{d_x}) \in (\mathbb{N}^\star)^{d_x}` 
 be the multi-index where
 
 .. math::
@@ -54,10 +54,10 @@ Consider the 1 and the infinity norms ([lemaitre2010]_ page 57, eq. 3.28):
 
 .. math::
 
-    \|\boldsymbol{k}\|_1 = \sum_{i = 1}^{d_x} k_i \qquad
-    \|\boldsymbol{k}\|_\infty = \max_{i = 1, ..., d_x} k_i.
+    \|\vect{k}\|_1 = \sum_{i = 1}^{d_x} k_i \qquad
+    \|\vect{k}\|_\infty = \max_{i = 1, ..., d_x} k_i.
 
-for any :math:`\boldsymbol{k} \in (\mathbb{N}^\star)^{d_x}`.
+for any :math:`\vect{k} \in (\mathbb{N}^\star)^{d_x}`.
 
 Let :math:`\ell` be an integer representing the level of the quadrature.
 Let :math:`Q_{\ell}^{(1)}` be a marginal quadrature of level :math:`\ell`.
@@ -100,15 +100,15 @@ quadrature ([lemaitre2010]_ page 57, eq. 3.30):
 
 .. math::
 
-    T_\ell^{(d_x)} = \sum_{\|\boldsymbol{k}\|_\infty \leq \ell}
+    T_\ell^{(d_x)} = \sum_{\|\vect{k}\|_\infty \leq \ell}
     \Delta_{k_1}^{(1)} \otimes \cdots \otimes \Delta_{k_{d_x}}^{(1)}.
 
 The significant part of the previous equation is the set of multi-indices
-:math:`\|\boldsymbol{k}\|_\infty \leq \ell`, which may be very large
+:math:`\|\vect{k}\|_\infty \leq \ell`, which may be very large
 depending on the dimension of the problem.
 
 One of the ways to reduce the size of this set is to consider the smaller set
-of multi-indices such that :math:`\|\boldsymbol{k}\|_1 \leq \ell + {d_x} - 1`. The sparse
+of multi-indices such that :math:`\|\vect{k}\|_1 \leq \ell + {d_x} - 1`. The sparse
 quadrature ([lemaitre2010]_ page 57, eq. 3.29, [gerstner1998]_  page 214)
 is introduced in the following definition.
 
@@ -116,12 +116,12 @@ The Smolyak sparse quadrature formula at level :math:`\ell` is:
 
 .. math::
 
-    S_\ell^{(d_x)} = \sum_{\|\boldsymbol{k}\|_1 \leq \ell + d_x - 1} 
+    S_\ell^{(d_x)} = \sum_{\|\vect{k}\|_1 \leq \ell + d_x - 1} 
     \Delta_{k_1}^{(1)} \otimes \cdots \otimes \Delta_{k_{d_x}}^{(1)}
 
 for any :math:`\ell \geq 1`. 
 
-As shown by the previous equation, for a given multi-index :math:`\boldsymbol{k}`
+As shown by the previous equation, for a given multi-index :math:`\vect{k}`
 the Smolyak quadrature requires to set the level of each marginal experiment to
 an integer which depends on the multi-index.
 This is done using the :meth:`~openturns.experimental.SmolyakExperiment.setLevel` method of the marginal quadrature.
@@ -134,9 +134,9 @@ The sparse quadrature formula at level :math:`\ell` is:
 
 .. math::
 
-    S_\ell^{(d_x)} = \sum_{\ell \leq \|\boldsymbol{k}\|_1 \leq \ell + d_x - 1} 
-    (-1)^{\ell + d_x - \|\boldsymbol{k}\|_1 - 1} 
-    {d_x - 1 \choose \|\boldsymbol{k}\|_1 - \ell} 
+    S_\ell^{(d_x)} = \sum_{\ell \leq \|\vect{k}\|_1 \leq \ell + d_x - 1} 
+    (-1)^{\ell + d_x - \|\vect{k}\|_1 - 1} 
+    {d_x - 1 \choose \|\vect{k}\|_1 - \ell} 
     Q_{k_1}^{(1)} \otimes \cdots \otimes Q_{k_{d_x}}^{(1)}
 
 for any :math:`\ell \geq 1` where the binomial coefficient is:
@@ -158,13 +158,13 @@ This can reduce the number of nodes, which may be particularly efficient when th
 marginal quadrature rule is nested such as, for example, with Fejér or Clenshaw-Curtis
 quadrature rule.
 
-If two candidate nodes :math:`\boldsymbol{x}_1, \boldsymbol{x}_2 \in \mathbb{R}^{d_x}`,
+If two candidate nodes :math:`\vect{x}_1, \vect{x}_2 \in \mathbb{R}^{d_x}`,
 associated with the two weights :math:`w_1, w_2 \in \mathbb{R}`, are to be merged,
 then the merged node is
 
 .. math::
 
-    \boldsymbol{x}_1' = \boldsymbol{x}_1
+    \vect{x}_1' = \vect{x}_1
 
 and the merged weight is:
 
@@ -181,7 +181,7 @@ Let :math:`\epsilon_r, \epsilon_a > 0` be the relative and absolute tolerances.
 These parameters can be set using the :class:`~openturns.ResourceMap` keys
 `SmolyakExperiment-MergeRelativeEpsilon` and `SmolyakExperiment-MergeAbsoluteEpsilon`.
 The criterion is based on a mixed absolute and relative tolerance.
-Two candidate nodes :math:`\boldsymbol{x}_1, \boldsymbol{x}_2 \in \mathbb{R}^{d_x}`
+Two candidate nodes :math:`\vect{x}_1, \vect{x}_2 \in \mathbb{R}^{d_x}`
 are close to each other and are to be merged if:
 
 .. math::
@@ -211,7 +211,7 @@ Therefore,
 
 .. math::
 
-    \left|\int_{[0, 1]^{d_x}} g(\boldsymbol{x}) d\boldsymbol{x} 
+    \left|\int_{[0, 1]^{d_x}} g(\vect{x}) d\vect{x} 
     - S_\ell(g)\right|
     = O \left(n_\ell^{-r} (\log(n_\ell))^{(d_x - 1)(r + 1)}\right).
 

--- a/python/src/TensorProductExperiment_doc.i.in
+++ b/python/src/TensorProductExperiment_doc.i.in
@@ -28,12 +28,12 @@ integral :
 
 .. math::
 
-    \int_{\mathcal{X}} g(\boldsymbol{x}) f(\boldsymbol{x}) d\boldsymbol{x} 
-    \approx \sum_{i = 1}^{s_t} w_i g\left(\boldsymbol{x}_i\right)
+    \int_{\mathcal{X}} g(\vect{x}) f(\vect{x}) d\vect{x} 
+    \approx \sum_{i = 1}^{s_t} w_i g\left(\vect{x}_i\right)
 
 where :math:`s_t \in \mathbb{N}` is the size of the tensor product 
 design of experiments, :math:`w_1, ..., w_{s_t} \in \mathbb{R}` are the 
-weights and :math:`\boldsymbol{x}_1, ..., \boldsymbol{x}_{s_t} \in \mathbb{R}^{d_x}` 
+weights and :math:`\vect{x}_1, ..., \vect{x}_{s_t} \in \mathbb{R}^{d_x}` 
 are the nodes. 
 
 Let :math:`n_e \in \mathbb{N}` be the number of marginal DOEs. 
@@ -58,11 +58,11 @@ marginal DOE sizes:
 
     s_t = \prod_{j = 1}^{n_e} s_j.
 
-Let :math:`\boldsymbol{k} = \left(k_1, ..., k_{n_e}\right) \in (\mathbb{N}^\star)^{n_e}`  
+Let :math:`\vect{k} = \left(k_1, ..., k_{n_e}\right) \in (\mathbb{N}^\star)^{n_e}`  
 be a multi-index where :math:`\mathbb{N}^\star = \{1, 2, ..., \}` is 
 the set of positive integers. For any marginal DOE :math:`j = 1,..., n_e`, 
 let :math:`\left\{w_{s_j, k_j} \right\}_{k_j = 1, ..., s_j}` be its 
-weights and let :math:`\left\{ \boldsymbol{x}_{s_j, k_j} \in \mathbb{R}^{d_j} \right\}_{k_j = 1, ..., s_j}` 
+weights and let :math:`\left\{ \vect{x}_{s_j, k_j} \in \mathbb{R}^{d_j} \right\}_{k_j = 1, ..., s_j}` 
 be its nodes. 
 
 The tensor product quadrature is ([gerstner1998]_ page 214):
@@ -78,19 +78,19 @@ where:
     Q_{s_1}^{(d_1)} \otimes \cdots \otimes Q_{s_{n_e}}^{(d_{n_e})} (g) 
     = \sum_{k_1 = 1}^{s_1} \cdots \sum_{k_{n_e} = 1}^{s_{n_e}} 
     w_{s_1, k_1} \cdots w_{s_{n_e}, k_{n_e}}  
-    g\left(\boldsymbol{x}_{s_1, k_1}, \ldots, \boldsymbol{x}_{s_{n_e}, k_{n_e}}\right).
+    g\left(\vect{x}_{s_1, k_1}, \ldots, \vect{x}_{s_{n_e}, k_{n_e}}\right).
 
-For any multi-index :math:`\boldsymbol{k} = (k_1, ..., k_{n_e}) \in (\mathbb{N}^\star)^{n_e}`, 
+For any multi-index :math:`\vect{k} = (k_1, ..., k_{n_e}) \in (\mathbb{N}^\star)^{n_e}`, 
 we write 
 
 .. math::
 
-    \boldsymbol{k} \leq \left(s_1, ..., s_{n_e}\right)
+    \vect{k} \leq \left(s_1, ..., s_{n_e}\right)
 
 if and only if :math:`k_j \leq s_j` for :math:`j = 1, ..., n_e`. 
 This means that each component of the multi-index is less than or equal to its 
 corresponding marginal size.
-The set of multi-indices such that :math:`\boldsymbol{k} \leq \left(s_1, ..., s_{n_e}\right)` 
+The set of multi-indices such that :math:`\vect{k} \leq \left(s_1, ..., s_{n_e}\right)` 
 is produced using all possible combinations of the indices with 
 the :class:`~openturns.Tuples` class.
 
@@ -99,21 +99,21 @@ The tensor product experiment is:
 .. math::
 
     Q_{s_1}^{(d_1)} \otimes \cdots \otimes Q_{s_{n_e}}^{(d_{n_e})} (g) 
-    = \sum_{\boldsymbol{k} \leq \left(s_1, ..., s_{n_e}\right)}  
-    w_{\boldsymbol{k}} g\left(\boldsymbol{x}_{\boldsymbol{k}}\right),
+    = \sum_{\vect{k} \leq \left(s_1, ..., s_{n_e}\right)}  
+    w_{\vect{k}} g\left(\vect{x}_{\vect{k}}\right),
 
 where each weight is equal to the product of the marginal elementary weights:
 
 .. math::
 
-    w_{\boldsymbol{k}} = \prod_{j = 1}^{n_e} w_{s_j, k_j} \in \mathbb{R}
+    w_{\vect{k}} = \prod_{j = 1}^{n_e} w_{s_j, k_j} \in \mathbb{R}
 
 and each node is equal to the agregation of the marginal elementary nodes:
 
 .. math::
 
-    \boldsymbol{x}_{\boldsymbol{k}}
-    = \left(\boldsymbol{x}_{s_1, k_1}, \ldots, \boldsymbol{x}_{s_{n_e}, k_{n_e}}\right) \in \mathbb{R}^{d_x}.
+    \vect{x}_{\vect{k}}
+    = \left(\vect{x}_{s_1, k_1}, \ldots, \vect{x}_{s_{n_e}, k_{n_e}}\right) \in \mathbb{R}^{d_x}.
 
 
 See also


### PR DESCRIPTION
This PR improves several examples.

- The [plot-kriging-chose-trend-py](http://openturns.github.io/openturns/master/auto_meta_modeling/kriging_metamodel/plot_kriging_chose_trend.html#sphx-glr-auto-meta-modeling-kriging-metamodel-plot-kriging-chose-trend-py) has issues :

![image](https://user-images.githubusercontent.com/31351465/236313226-6d06de37-aff8-490d-84da-0494f22ccb45.png)

- The [EnumerateFunction](http://openturns.github.io/openturns/master/user_manual/_generated/openturns.EnumerateFunction.html#openturns.EnumerateFunction) is unclear.
- The `vect` macro is not always used.