### PR TITLE
added permutation-based estimation of CI

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -351,6 +351,8 @@
   <!-- OT::HSICEstimator parameters -->
   <HSICEstimator-ParallelPValues value_bool="true" />
   <HSICEstimator-PermutationSize value_int="100" />
+  <HSICEstimator-DefaultBootstrapSize value_int="100" />
+  <HSICEstimator-DefaultBootstrapConfidenceLevel  value_float="0.95"          />
 
   <!-- OT::RandomGenerator parameters -->
   <RandomGenerator-InitialSeed value_int="0" />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -979,6 +979,8 @@ void ResourceMap::loadDefaultConfiguration()
   // HSIC parameters //
   addAsBool("HSICEstimator-ParallelPValues", true);
   addAsUnsignedInteger("HSICEstimator-PermutationSize", 100);
+  addAsUnsignedInteger("HSICEstimator-DefaultBootstrapSize", 100);
+  addAsScalar("HSICEstimator-DefaultBootstrapConfidenceLevel", 0.95);
 
   // RandomGenerator parameters //
   addAsUnsignedInteger("RandomGenerator-InitialSeed", 0);

--- a/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/Sensitivity/openturns/HSICEstimatorImplementation.hxx
@@ -34,6 +34,7 @@
 #include "openturns/Function.hxx"
 #include "openturns/HSICStat.hxx"
 #include "openturns/RandomGenerator.hxx"
+#include "openturns/Distribution.hxx"
 BEGIN_NAMESPACE_OPENTURNS
 
 /**
@@ -52,6 +53,7 @@ public:
 
   typedef Collection <CovarianceModel>  CovarianceModelCollection;
   typedef Collection <CovarianceMatrix>  CovarianceMatrixCollection;
+  typedef Collection <Distribution>  DistributionCollection;
 
   /** Default constructor */
   HSICEstimatorImplementation();
@@ -112,6 +114,15 @@ public:
   /** Compute all indices at once */
   virtual void run() const;
 
+  /** Compute the HSIC indices estimator intervals */
+  Interval getHSICIndicesInterval() const;
+
+  /** Compute the R2-HSIC indices estimator intervals */
+  Interval getR2HSICIndicesInterval() const;
+
+  /** Compute the permutation p-values estimator intervals */
+  Interval getPermutationPValuesInterval() const;
+
   /** Draw the HSIC indices */
   Graph drawHSICIndices() const;
 
@@ -127,6 +138,7 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+
 protected:
 
   /** Reset indices to void */
@@ -136,10 +148,10 @@ protected:
   virtual void computeCovarianceMatrices();
 
   /** Compute p-value with permutation */
-  virtual void computePValuesPermutationSequential() const;
+  virtual Point computePValuesPermutationSequential(const Sample & sample, const CovarianceMatrixCollection & coll, const CovarianceMatrix & covMat) const;
 
   /** Compute p-value with permutation using TBB */
-  virtual void computePValuesPermutationParallel() const;
+  virtual Point computePValuesPermutationParallel(const Sample & sample, const CovarianceMatrixCollection & coll, const CovarianceMatrix & covMat) const;
 
   /** Compute the p-values with asymptotic formula */
   virtual void computePValuesAsymptotic() const;
@@ -154,6 +166,12 @@ protected:
 
   /** Compute HSIC and R2-HSIC indices */
   virtual void computeIndices() const;
+
+  /** Compute the bootstrap HSIC indices sample */
+  void computeBootstrapIndices() const;
+
+  /** Compute the bootstrap asymptotic pvalues sample */
+  void computeBootstrapPValuesPermutation() const;
 
   /** Draw values stored in a point */
   Graph drawValues(const Point &values, const String &title) const;
@@ -176,10 +194,19 @@ protected:
   mutable Point PValuesAsymptotic_ ;
   PersistentCollection <CovarianceMatrix> inputCovarianceMatrixCollection_;
   CovarianceMatrix outputCovarianceMatrix_;
+  mutable Sample hsicBootstratSample_;
+  mutable Sample hsicR2BootstratSample_;
+  mutable Sample pValuesPermutationBootstratSample_;
+  mutable Sample pValuesAsymptoticBootstratSample_;
   UnsignedInteger permutationSize_ ;
   mutable Bool isAlreadyComputedIndices_ = false ;
   mutable Bool isAlreadyComputedPValuesPermutation_ = false ;
   mutable Bool isAlreadyComputedPValuesAsymptotic_ = false ;
+  mutable Bool isAlreadyComputedIndicesBootstrap_ = false ;
+  mutable Bool isAlreadyComputedPValuesAsymptoticBootstrap_ = false ;
+  mutable Bool isAlreadyComputedPValuesPermutationBootstrap_ = false ;
+  Scalar confidenceLevel_;
+  UnsignedInteger bootstrapSize_;
 };
 
 END_NAMESPACE_OPENTURNS


### PR DESCRIPTION
Here's a draft of new functionalities allowing to compute the bootstrap confidence intervals for HSIC indices.
The draw functionalities are still missing.

The main issue that I am trying to tackle is a segmentation fault that occurs when computing the U-stat indices through parallel calls. I tried running a Valgrind diagnostic and I get the following message, which I have not been able to use in order to find the memory leak.

==461== Memcheck, a memory error detector
==461== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==461== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==461== Command: ./t_HSICEstimatorGlobalSensitivity_std --leak-check=full
==461== 
==461== Thread 2:
==461== Invalid read of size 8
==461==    at 0x5C47D1E: OT::SymmetricMatrix::SymmetricMatrix(OT::SymmetricMatrix const&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x620FB43: OT::HSICPValuesPermutationFunctor::operator()(OT::TBBImplementation::BlockedRange<unsigned long> const&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x62109BC: void tbb::interface9::internal::dynamic_grainsize_mode<tbb::interface9::internal::adaptive_mode<tbb::interface9::internal::auto_partition_type> >::work_balance<tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>, tbb::blocked_range<unsigned long> >(tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>&, tbb::blocked_range<unsigned long>&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x6210CDD: tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>::execute() (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x7D14494: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D147CA: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D0E266: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D0C8EF: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D08E5B: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D090B8: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7123EA6: start_thread (pthread_create.c:477)
==461==    by 0x7041A2E: clone (clone.S:95)
==461==  Address 0x8 is not stack'd, malloc'd or (recently) free'd
==461== 
==461== 
==461== Process terminating with default action of signal 11 (SIGSEGV)
==461==  Access not within mapped region at address 0x8
==461==    at 0x5C47D1E: OT::SymmetricMatrix::SymmetricMatrix(OT::SymmetricMatrix const&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x620FB43: OT::HSICPValuesPermutationFunctor::operator()(OT::TBBImplementation::BlockedRange<unsigned long> const&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x62109BC: void tbb::interface9::internal::dynamic_grainsize_mode<tbb::interface9::internal::adaptive_mode<tbb::interface9::internal::auto_partition_type> >::work_balance<tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>, tbb::blocked_range<unsigned long> >(tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>&, tbb::blocked_range<unsigned long>&) (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x6210CDD: tbb::interface9::internal::start_reduce<tbb::blocked_range<unsigned long>, OT::HSICPValuesPermutationFunctor, tbb::auto_partitioner const>::execute() (in /home/devel/GIT/openturns/build_CI/lib/src/libOT.so.0.22.0)
==461==    by 0x7D14494: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D147CA: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D0E266: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D0C8EF: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D08E5B: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7D090B8: ??? (in /usr/lib/x86_64-linux-gnu/libtbb.so.2)
==461==    by 0x7123EA6: start_thread (pthread_create.c:477)
==461==    by 0x7041A2E: clone (clone.S:95)
==461==  If you believe this happened as a result of a stack
==461==  overflow in your program's main thread (unlikely but
==461==  possible), you can try to increase the size of the
==461==  main thread stack using the --main-stacksize= flag.
==461==  The main thread stack size used in this run was 8388608.
==461== 
==461== HEAP SUMMARY:
==461==     in use at exit: 3,859,812 bytes in 6,822 blocks
==461==   total heap usage: 23,091 allocs, 16,269 frees, 74,965,081 bytes allocated
==461== 
==461== LEAK SUMMARY:
==461==    definitely lost: 0 bytes in 0 blocks
==461==    indirectly lost: 0 bytes in 0 blocks
==461==      possibly lost: 1,536 bytes in 4 blocks
==461==    still reachable: 3,858,276 bytes in 6,818 blocks
==461==                       of which reachable via heuristic:
==461==                         newarray           : 3,096 bytes in 3 blocks
==461==         suppressed: 0 bytes in 0 blocks
==461== Rerun with --leak-check=full to see details of leaked memory
==461== 
==461== For lists of detected and suppressed errors, rerun with: -s

Does anyone have a better understanding of what the issue is?

Cheers