### PR TITLE
Update NAIS_doc.i.in

### DIFF
--- a/python/src/NAIS_doc.i.in
+++ b/python/src/NAIS_doc.i.in
@@ -3,7 +3,7 @@
 
 Parameters
 ----------
-event : :class:`~openturns.RandomVector`
+event : :class:`~openturns.ThresholdEvent`
     Event we are computing the probability of.
 
 rhoQuantile : float  :math:`0<\rho<1`


### PR DESCRIPTION
There is a typo in the documentation page of NAIS. The first attribute was indicated as RandomVector. This should be ThresholdEvent.