### PR TITLE
Modification of NAIS API

### DIFF
--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1315,7 +1315,7 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("SubsetSampling-DefaultMaximumOuterSampling", 10000);
 
   // NAIS parameters //
-  addAsScalar("NAIS-DefaultRhoQuantile", 0.25);
+  addAsScalar("NAIS-DefaultQuantileLevel", 0.25);
 
   // DirectionalSampling parameters //
   addAsUnsignedInteger("DirectionalSampling-MeanContributionIntegrationNodesNumber", 255);

--- a/lib/src/Uncertainty/Algorithm/Simulation/NAIS.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/NAIS.cxx
@@ -41,7 +41,7 @@ NAIS::NAIS()
 
 // Default constructor
 NAIS::NAIS(const RandomVector & event,
-           const Scalar rhoQuantile)
+           const Scalar quantileLevel)
   : EventSimulation(event)
   , initialDistribution_(getEvent().getAntecedent().getDistribution())
 {
@@ -50,7 +50,7 @@ NAIS::NAIS(const RandomVector & event,
   const Interval::BoolCollection rangeLower(range.getFiniteLowerBound());
   for (UnsignedInteger i = 0; i < rangeUpper.getSize(); ++i)
     if (rangeUpper[i] || rangeLower[i]) throw InvalidArgumentException(HERE) << "Current version of NAIS is only adapted to unbounded distribution" ;
-  rhoQuantile_ = (getEvent().getOperator()(0, 1) ? rhoQuantile : 1.0 - rhoQuantile);
+  quantileLevel_ = (getEvent().getOperator()(0, 1) ? quantileLevel : 1.0 - quantileLevel);
 }
 
 /* Virtual constructor */
@@ -59,16 +59,16 @@ NAIS * NAIS::clone() const
   return new NAIS(*this);
 }
 
-// Get rhoQuantile
-Scalar NAIS::getRhoQuantile() const
+// Get quantileLevel
+Scalar NAIS::getQuantileLevel() const
 {
-  return rhoQuantile_;
+  return quantileLevel_;
 }
 
-// Set rhoQuantile
-void NAIS::setRhoQuantile(const Scalar & rhoQuantile)
+// Set quantileLevel
+void NAIS::setQuantileLevel(const Scalar & quantileLevel)
 {
-  rhoQuantile_ = rhoQuantile;
+  quantileLevel_ = quantileLevel;
 }
 
 // Function computing the auxiliary distribution as a function of current sample and associated weights
@@ -146,7 +146,7 @@ void NAIS::run()
   Sample auxiliaryOutputSample(getEvent().getFunction()(auxiliaryInputSample));
 
   // Computation of current quantile
-  Scalar currentQuantile = auxiliaryOutputSample.computeQuantile(rhoQuantile_)[0];
+  Scalar currentQuantile = auxiliaryOutputSample.computeQuantile(quantileLevel_)[0];
   Distribution auxiliaryDistribution;
   if (getEvent().getOperator()(currentQuantile, getEvent().getThreshold()))
   {
@@ -183,7 +183,7 @@ void NAIS::run()
     }
 
     // Computation of current quantile
-    currentQuantile = auxiliaryOutputSample.computeQuantile(rhoQuantile_)[0];
+    currentQuantile = auxiliaryOutputSample.computeQuantile(quantileLevel_)[0];
 
     // If failure probability reached, stop the adaptation
     if (getEvent().getOperator()(currentQuantile, getEvent().getThreshold()))

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/NAIS.hxx
@@ -45,16 +45,16 @@ public:
 
   /** Default constructor */
   explicit  NAIS(const RandomVector & event,
-                 const Scalar rhoQuantile = ResourceMap::GetAsScalar("NAIS-DefaultRhoQuantile"));
+                 const Scalar quantileLevel = ResourceMap::GetAsScalar("NAIS-DefaultQuantileLevel"));
 
   /** Virtual constructor */
   NAIS * clone() const override;
 
-  /** Get rhoQuantile */
-  Scalar getRhoQuantile() const;
+  /** Get quantileLevel */
+  Scalar getQuantileLevel() const;
 
-  /** Set rhoQuantile */
-  void setRhoQuantile(const Scalar & rhoQuantile);
+  /** Set quantileLevel */
+  void setQuantileLevel(const Scalar & quantileLevel);
 
   /** Main function that computes the failure probability */
   void run() override;
@@ -78,7 +78,7 @@ private:
   Distribution initialDistribution_;
 
   // Quantile
-  Scalar rhoQuantile_ = 0.0;
+  Scalar quantileLevel_ = 0.0;
 
   // Result of NAIS algorithm
   NAISResult naisResult_;

--- a/lib/test/t_NAIS_std.cxx
+++ b/lib/test/t_NAIS_std.cxx
@@ -78,10 +78,10 @@ int main()
   const UnsignedInteger blockSize = 1 ;
 
   // Quantile determining the percentage of failure samples in the current population
-  const Scalar rhoQuantile = 0.25 ;
+  const Scalar quantileLevel = 0.25 ;
 
   // Definition of the algorithm
-  NAIS algoNais(event, rhoQuantile);
+  NAIS algoNais(event, quantileLevel);
   algoNais.setMaximumOuterSampling(numberSamples);
   algoNais.setBlockSize(blockSize);
 

--- a/python/doc/examples/reliability_sensitivity/reliability/plot_nais.py
+++ b/python/doc/examples/reliability_sensitivity/reliability/plot_nais.py
@@ -105,8 +105,8 @@ myEvent = ot.ThresholdEvent(Y, ot.Less(), threshold)
 # ------------------------------------------------
 
 # %%
-rhoQuantile = 0.1
-algo = ot.NAIS(myEvent, rhoQuantile)
+quantileLevel = 0.1
+algo = ot.NAIS(myEvent, quantileLevel)
 
 # %%
 # Now you can run the algorithm.
@@ -181,7 +181,7 @@ for i in range(Ns):
 # %%
 levels = ot.Point()
 for i in range(Ns - 1):
-    levels.add(listOutputNAISSamples[i].computeQuantile(rhoQuantile)[0])
+    levels.add(listOutputNAISSamples[i].computeQuantile(quantileLevel)[0])
 levels.add(threshold)
 
 # %%
@@ -214,6 +214,8 @@ for i in range(levels.getSize()):
     dr.setLineWidth(3)
     dr.setColor(col[i])
     graph.add(dr)
+
+# sphinx_gallery_thumbnail_number = 2
 view = View(graph)
 
 # %%

--- a/python/src/NAIS_doc.i.in
+++ b/python/src/NAIS_doc.i.in
@@ -6,7 +6,7 @@ Parameters
 event : :class:`~openturns.RandomVector`
     Event we are computing the probability of.
 
-rhoQuantile : float  :math:`0<\rho<1`
+quantileLevel : float  :math:`0<quantileLevel<1`
     Intermediate quantile level.
 
 Notes
@@ -22,7 +22,7 @@ The Importance Sampling (IS) probability estimate :math:`\widehat{P}^\text{IS}` 
     \widehat{P}^\text{IS}=\frac{1}{N} \sum_{i=1}^{N} {\mathbf{1}}_{g(\mathbf{x}_i)<T} \frac{h_0(\mathbf{x}_i)}{h(\mathbf{x}_i)},
 
 with :math:`h_0 = f_\mathbf{X}` the PDF of :math:`\mathbf{X}`, :math:`h` the auxiliary PDF of Importance Sampling, 
-:math:`N`the number of independent samples generated with :math:`h` and :math:`{\mathbf{1}}_{g(\mathbf{x}_i)<T}` the 
+:math:`N` the number of independent samples generated with :math:`h` and :math:`{\mathbf{1}}_{g(\mathbf{x}_i)<T}` the 
 indicator function of the failure domain. 
 
 The optimal density minimizing the variance of the estimator :math:`h_{opt}` is defined as:
@@ -39,12 +39,12 @@ the IS optimal auxiliary density :math:`h_{opt}` from the preceding equation
 with a kernel density function (e.g. Gaussian kernel). 
 Its iterative principle is described by the following steps.
 
-1. :math:`k=1` and set :math:`\rho \in [0,1]`
+1. :math:`k=1` and set the quantile level :math:`\rho \in [0,1]`
 
 2. Generate the population :math:`\mathbf{x}_1^{(k)},...,\mathbf{x}_N^{(k)}` according to the PDF :math:`h_{k-1}`, apply the 
    function :math:`g` in order to have :math:`y_1^{(k)}=g(\mathbf{x}_1^{(k)}),...,y_N^{(k)} = g(\mathbf{x}_N^{(k)})`
 
-3. Compute the empirical :math:`\rho`-quantile :math:`q_k=\max(T,y^{(k)}_{\left \lfloor \rho N \right\rfloor})`
+3. Compute the empirical quantile of level :math:`\rho` :math:`q_k=\max(T,y^{(k)}_{\left \lfloor \rho N \right\rfloor})`
 
 4. Estimate :math:`I_k= \frac{1}{kN} \displaystyle \sum_{j=1}^{k}\sum_{i=1}^{N} {\mathbf{1}}_{g(\mathbf{x}_i^{(j)}) \leq q_k} \frac{h_0(\mathbf{x}_i^{(j)})}{h_{j-1}(\mathbf{x}_i^{(j)})}` 
 
@@ -101,22 +101,22 @@ outputSample : :class:`~openturns.Sample`
 
 // ---------------------------------------------------------------------------
 
-%feature("docstring") OT::NAIS::getRhoQuantile
+%feature("docstring") OT::NAIS::getQuantileLevel
 "Accessor to the intermediate quantile level.
 
 Returns
 -------
-rhoQuantile : : float
+quantileLevel : float
     Intermediate quantile level."
 
 // ---------------------------------------------------------------------------
 
-%feature("docstring") OT::NAIS::setRhoQuantile
+%feature("docstring") OT::NAIS::setQuantileLevel
 "Accessor to the intermediate quantile level.
 
 Parameters
 ----------
-rhoQuantile : : float  :math:`0<\rho<1`
+quantileLevel : float  :math:`0<quantileLevel<1`
     Intermediate quantile level."
     
 // ---------------------------------------------------------------------------

--- a/python/test/t_NAIS_std.py
+++ b/python/test/t_NAIS_std.py
@@ -1,5 +1,4 @@
-
-#!/usr/bin/env python
+#! /usr/bin/env python
 
 import math
 import openturns as ot

--- a/python/test/t_NAIS_std.py
+++ b/python/test/t_NAIS_std.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 
 import math
@@ -61,10 +62,10 @@ assert_almost_equal(probability, 0.0023828813801648916)
 numberSamples = 10000  # Number of samples at each iteration
 blockSize = 1
 # Quantile determining the percentage of failure samples in the current population
-rhoQuantile = 0.25
+quantileLevel = 0.25
 
 # Definition of the algorithm
-Nais_algo = ot.NAIS(event, rhoQuantile)
+Nais_algo = ot.NAIS(event, quantileLevel)
 Nais_algo.setMaximumOuterSampling(numberSamples)
 Nais_algo.setBlockSize(blockSize)
 


### PR DESCRIPTION
Hello,

In the PR #2272 about Importance Sampling by Cross Entropy, it was agreed that the name of the attribute "rhoQuantile" is not meaningful for the user. So, it has been changed by "quantileLevel".

This PR proposes to propagate this change to the NAIS algorithm, as NAIS and Cross Entropy Importance Sampling have similar API.

Furthermore, the sphinx gallery thumbnail picture of the NAIS example has been changed to set a graph that is more representative of the algorithm behavior.