### PR TITLE
Chaos selection history

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@
 
 === Miscellaneous ===
  * Added IterativeThresholdExceedance::getRatio
+ * Added FunctionalChaosResult::drawSelectionHistory to plot LARS coefs paths
 
 
 == 1.21 release (2023-06-20) == #release-1.21

--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
@@ -238,5 +238,9 @@ void ApproximationAlgorithmImplementation::load(Advocate & adv)
   setWeight(weight);
 }
 
+Collection<Indices> ApproximationAlgorithmImplementation::getSelectionHistory(Collection<Point> & /*coefficientsHistory*/) const
+{
+  throw NotYetImplementedException(HERE) << "in ApproximationAlgorithmImplementation::getSelectionHistory";
+}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
@@ -209,5 +209,9 @@ void LeastSquaresMetaModelSelection::load(Advocate & adv)
   adv.loadAttribute( "fittingAlgorithm_", fittingAlgorithm_ );
 }
 
+Collection<Indices> LeastSquaresMetaModelSelection::getSelectionHistory(Collection<Point> & coefficientsHistory) const
+{
+  return basisSequenceFactory_.getImplementation()->getSelectionHistory(coefficientsHistory);
+}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -281,4 +281,10 @@ void PenalizedLeastSquaresAlgorithm::load(Advocate & adv)
   adv.loadAttribute( "penalizationMatrix_", penalizationMatrix_ );
 }
 
+Collection<Indices> PenalizedLeastSquaresAlgorithm::getSelectionHistory(Collection<Point> & coefficientsHistory) const
+{
+  coefficientsHistory = Collection<Point>(1, coefficients_);
+  return Collection<Indices>(1, currentIndices_);
+}
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
@@ -22,7 +22,7 @@
 #define OPENTURNS_APPROXIMATIONALGORITHMIMPLEMENTATION_HXX
 
 #include "openturns/PersistentObject.hxx"
-#include "openturns/Point.hxx"
+#include "openturns/IndicesCollection.hxx"
 #include "openturns/Sample.hxx"
 #include "openturns/DesignProxy.hxx"
 #include "openturns/PersistentCollection.hxx"
@@ -43,7 +43,6 @@ class OT_API ApproximationAlgorithmImplementation
 public:
   typedef Collection<Function> FunctionCollection;
   typedef PersistentCollection<Function> FunctionPersistentCollection;
-
 
   /** Default constructor */
   ApproximationAlgorithmImplementation();
@@ -105,6 +104,9 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** Selection history accessor */
+  virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
+
 protected:
 
   void setCoefficients(const Point & coefficients);
@@ -131,10 +133,10 @@ protected:
 
   mutable Bool isAlreadyComputedCoefficients_;
 
-private:
   /** Regression coefficients */
   Point coefficients_;
 
+private:
   /** Residual */
   Scalar residual_;
 

--- a/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
@@ -40,6 +40,7 @@ class OT_API LeastSquaresMetaModelSelection
   CLASSNAME
 
 public:
+
   /** Default constructor */
   LeastSquaresMetaModelSelection();
 
@@ -84,6 +85,8 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
+
 protected:
 
   /** Algorithm that builds the BasisSequence */
@@ -91,7 +94,6 @@ protected:
 
   /** Basis selection algorithm */
   FittingAlgorithm fittingAlgorithm_;
-
 
 }; /* class LeastSquaresMetaModelSelection */
 

--- a/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
+++ b/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
@@ -89,6 +89,9 @@ public:
   void run(const DesignProxy & proxy) override;
 #endif
 
+  /** Selection history accessor */
+  Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
+
 protected:
 
 private:

--- a/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
+++ b/lib/src/Base/Func/BasisSequenceFactoryImplementation.cxx
@@ -146,4 +146,9 @@ void BasisSequenceFactoryImplementation::load(Advocate & adv)
 }
 
 
+Collection<Indices> BasisSequenceFactoryImplementation::getSelectionHistory(Collection<Point> & /*coefficientsHistory*/) const
+{
+  throw NotYetImplementedException(HERE) << "in BasisSequenceFactoryImplementation::getSelectionHistory";
+}
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Func/openturns/BasisSequenceFactoryImplementation.hxx
+++ b/lib/src/Base/Func/openturns/BasisSequenceFactoryImplementation.hxx
@@ -89,6 +89,9 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** Selection history accessor */
+  virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
+
 protected:
   /** Verbosity flag */
   Bool verbose_;

--- a/lib/src/Base/Func/openturns/LARS.hxx
+++ b/lib/src/Base/Func/openturns/LARS.hxx
@@ -68,6 +68,9 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** Selection history accessor */
+  Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
+
 private:
   Scalar relativeConvergence_;
 
@@ -80,6 +83,11 @@ private:
   Indices inPredictors_;
 
   mutable Matrix mPsiX_;
+
+  /** Selection history */
+  Collection<Indices> indicesHistory_;
+  PersistentCollection<Point> coefficientsHistory_;
+
 }; /* class LARS */
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -339,6 +339,11 @@ void FunctionalChaosAlgorithm::run()
   }
   // Build the result
   result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis, I_k, alpha_k, Psi_k, residuals, relativeErrors);
+
+  // set selection history
+  Collection<Point> coefficientsHistory;
+  Collection<Indices> indicesHistory(projectionStrategy_.getImplementation()->getSelectionHistory(coefficientsHistory));
+  result_.setSelectionHistory(indicesHistory, coefficientsHistory);
 }
 
 /* Marginal computation */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
@@ -202,6 +202,12 @@ void IntegrationStrategy::load(Advocate & adv)
   ProjectionStrategyImplementation::load(adv);
 }
 
+/* Selection history accessor */
+Collection<Indices> IntegrationStrategy::getSelectionHistory(Collection<Point> & coefficientsHistory) const
+{
+  coefficientsHistory = Collection<Point>();
+  return Collection<Indices>();
+}
 
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
@@ -145,6 +145,7 @@ void LeastSquaresStrategy::computeCoefficients(const Function & function,
   alpha_k_p_ = approximationAlgorithm.getCoefficients();
   residual_p_ = approximationAlgorithm.getResidual();
   relativeError_p_ = approximationAlgorithm.getRelativeError();
+  indicesHistory_ = approximationAlgorithm.getImplementation()->getSelectionHistory(coefficientsHistory_);
 }
 
 
@@ -155,7 +156,6 @@ void LeastSquaresStrategy::save(Advocate & adv) const
   adv.saveAttribute( "p_approximationAlgorithmImplementationFactory_", *p_approximationAlgorithmImplementationFactory_ );
 }
 
-
 /* Method load() reloads the object from the StorageManager */
 void LeastSquaresStrategy::load(Advocate & adv)
 {
@@ -165,5 +165,11 @@ void LeastSquaresStrategy::load(Advocate & adv)
   p_approximationAlgorithmImplementationFactory_ = approximationAlgorithmImplementationFactory.clone();
 }
 
+/* Selection history accessor */
+Collection<Indices> LeastSquaresStrategy::getSelectionHistory(Collection<Point> & coefficientsHistory) const
+{
+  coefficientsHistory = coefficientsHistory_;
+  return indicesHistory_;
+}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -245,4 +245,9 @@ void ProjectionStrategyImplementation::load(Advocate & adv)
   PersistentObject::load(adv);
 }
 
+Collection<Indices> ProjectionStrategyImplementation::getSelectionHistory(Collection<Point> & /*coefficientsHistory*/) const
+{
+  throw NotYetImplementedException(HERE) << "in ProjectionStrategyImplementation::getSelectionHistory";
+}
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
@@ -106,6 +106,11 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** Selection history accessor */
+  IndicesCollection getIndicesHistory() const;
+  Collection<Point> getCoefficientsHistory() const;
+  void setSelectionHistory(Collection<Indices> & indicesHistory, Collection<Point> & coefficientsHistory);
+  Graph drawSelectionHistory() const;
 
 protected:
 
@@ -133,6 +138,10 @@ private:
 
   /** Composed meta model */
   Function composedMetaModel_;
+
+  /** Selection history */
+  Collection<Indices> indicesHistory_;
+  PersistentCollection<Point> coefficientsHistory_;
 
 } ; /* class FunctionalChaosResult */
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
@@ -75,7 +75,8 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
-
+  /** Selection history accessor */
+  Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
   void computeCoefficients(const Function & function,
@@ -86,7 +87,8 @@ protected:
                            const Indices & removedRanks,
                            const UnsignedInteger marginalIndex = 0) override;
 private:
-
+  Collection<Indices> indicesHistory_;
+  PersistentCollection<Point> coefficientsHistory_;
 } ; /* class IntegrationStrategy */
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
@@ -81,6 +81,9 @@ public:
 
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
+  
+  /** Selection history accessor */
+  Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
 
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
@@ -94,6 +97,10 @@ protected:
 private:
   /** Factory to build an ApproximationAlgorithmImplementation */
   ApproximationAlgorithmImplementationFactoryImplementation p_approximationAlgorithmImplementationFactory_;
+
+  /** Selection history */
+  Collection<Indices> indicesHistory_;
+  PersistentCollection<Point> coefficientsHistory_;
 
 } ; /* class LeastSquaresStrategy */
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
@@ -115,6 +115,8 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
+
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
   virtual void computeCoefficients(const Function & function,

--- a/python/doc/pyplots/LARS.py
+++ b/python/doc/pyplots/LARS.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import openturns as ot
+from openturns.usecases import ishigami_function
+from openturns.viewer import View
+
+# data
+ot.RandomGenerator.SetSeed(0)
+im = ishigami_function.IshigamiModel()
+N = 1000
+g = im.model
+x = im.distributionX.getSample(N)
+P = x.getDimension()
+marginals = [im.distributionX.getMarginal(i) for i in range(P)]
+y = g(x)
+
+# polynomial chaos
+q, totalDegree = 0.4, 5
+enumerateFunction = ot.HyperbolicAnisotropicEnumerateFunction(P, q)
+productBasis = ot.OrthogonalProductPolynomialFactory(marginals, enumerateFunction)
+approximationAlgorithm = ot.LeastSquaresMetaModelSelectionFactory(
+    ot.LARS(), ot.CorrectedLeaveOneOut())
+adaptiveStrategy = ot.FixedStrategy(
+    productBasis, enumerateFunction.getStrataCumulatedCardinal(totalDegree))
+projectionStrategy = ot.LeastSquaresStrategy(approximationAlgorithm)
+algo = ot.FunctionalChaosAlgorithm(
+    x, y, im.distributionX, adaptiveStrategy, projectionStrategy)
+algo.run()
+result = algo.getResult()
+graph = result.drawSelectionHistory()
+View(graph)

--- a/python/doc/user_manual/response_surface/functional_chaos_expansion.rst
+++ b/python/doc/user_manual/response_surface/functional_chaos_expansion.rst
@@ -42,7 +42,11 @@ Computation of the polynomial chaos coefficients
     LeastSquaresMetaModelSelectionFactory
     LeastSquaresMetaModelSelection
     BasisSequenceFactory
+
+    :template: classWithPlot.rst_t
     LARS
+
+    :template: class.rst_t
     FittingAlgorithm
     CorrectedLeaveOneOut
     KFold

--- a/python/src/ApproximationAlgorithmImplementation.i
+++ b/python/src/ApproximationAlgorithmImplementation.i
@@ -6,5 +6,7 @@
 
 %include ApproximationAlgorithmImplementation_doc.i
 
+%ignore OT::ApproximationAlgorithmImplementation::getSelectionHistory;
+
 %include openturns/ApproximationAlgorithmImplementation.hxx
 namespace OT { %extend ApproximationAlgorithmImplementation { ApproximationAlgorithmImplementation(const ApproximationAlgorithmImplementation & other) { return new OT::ApproximationAlgorithmImplementation(other); } } }

--- a/python/src/BasisSequenceFactoryImplementation.i
+++ b/python/src/BasisSequenceFactoryImplementation.i
@@ -6,5 +6,7 @@
 
 %include BasisSequenceFactoryImplementation_doc.i
 
+%ignore OT::BasisSequenceFactoryImplementation::getSelectionHistory;
+
 %include openturns/BasisSequenceFactoryImplementation.hxx
 namespace OT { %extend BasisSequenceFactoryImplementation { BasisSequenceFactoryImplementation(const BasisSequenceFactoryImplementation & other) { return new OT::BasisSequenceFactoryImplementation(other); } } }

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -160,3 +160,55 @@ Returns
 -------
 transformation : :class:`~openturns.Function`
     Transformation :math:`T` such that :math:`T(\vect{X}) = \vect{Z}`."
+    
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::drawSelectionHistory
+"Draw the basis selection history.
+
+This is only available with :class:`~openturns.LARS`, and when the output dimension is 1.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The evolution of the basis coefficients at each selection iteration"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::getCoefficientsHistory
+"The coefficients values selection history accessor.
+
+This is only available with :class:`~openturns.LARS`, and when the output dimension is 1.
+
+Returns
+-------
+coefficientsHistory : 2-d sequence of float
+    The coefficients values selection history, for each iteration.
+    Each inner list gives the coefficients values of the basis terms at i-th iteration."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::getIndicesHistory
+"The basis indices selection history accessor.
+
+This is only available with :class:`~openturns.LARS`, and when the output dimension is 1.
+
+Returns
+-------
+indicesHistory : 2-d sequence of int
+    The basis indices selection history, for each iteration.
+    Each inner list gives the indices of the basis terms at i-th iteration."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::setSelectionHistory
+"The basis coefficients and indices accessor.
+
+Parameters
+----------
+indicesHistory : 2-d sequence of int
+    The basis indices selection history
+coefficientsHistory : 2-d sequence of float
+    The coefficients values selection history
+    Must be of same size as indicesHistory."
+

--- a/python/src/ProjectionStrategyImplementation.i
+++ b/python/src/ProjectionStrategyImplementation.i
@@ -6,5 +6,7 @@
 
 %include ProjectionStrategyImplementation_doc.i
 
+%ignore OT::ProjectionStrategyImplementation::getSelectionHistory;
+
 %include openturns/ProjectionStrategyImplementation.hxx
 namespace OT{ %extend ProjectionStrategyImplementation { ProjectionStrategyImplementation(const ProjectionStrategyImplementation & other) { return new OT::ProjectionStrategyImplementation(other); } } }

--- a/python/test/t_FunctionalChaos_mixed.py
+++ b/python/test/t_FunctionalChaos_mixed.py
@@ -41,3 +41,12 @@ assert result.getRelativeErrors()[0] < 1e-10, "relative error too high"
 assert (
     algo.getResult().getMetaModel().getOutputDescription() == y.getDescription()
 ), "wrong output description"
+
+# selection history
+indices = result.getIndicesHistory()
+coefs = result.getCoefficientsHistory()
+assert indices.getSize() > 0, "no indices selection"
+assert indices.getSize() == coefs.getSize(), "not same size"
+print(indices)
+print(coefs)
+graph = result.drawSelectionHistory()


### PR DESCRIPTION
Adds new methods to retrieve selection history from a FCE result
```
result = algo.getResult()

print(result.getIndicesHistory())
print(result.getCoefficientsHistory())
graph = result.drawSelectionHistory()
```

![lars](https://user-images.githubusercontent.com/3832365/234207335-22aa8c46-be75-4215-9d7d-afdb05839618.png)

notes:
- sofiane script does not account that LARS eventually works in a local selection of the basis
- might want to add Q2 history too
- only returns the last selection history & marginal

see also:
https://gist.github.com/sofianehaddad/0011686ed5eb917f1201383ee5069cbf
https://gist.github.com/sofianehaddad/a6f94bf992f8bde3810f9013bb1f3665
