### PR TITLE
tail dependence

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -885,7 +885,8 @@
 
   <!-- OT::VisualTest parameters -->
   <VisualTest-KendallPlot-MonteCarloSize value_int="100" />
-  
+  <VisualTest-DependenceConfidenceLevel value_float="0.95" />
+
   <!--  OT::RandomWalkMetropolisHastings parameters -->
   <RandomWalkMetropolisHastings-DefaultAdaptationExpansionFactor   value_float="1.2" />
   <RandomWalkMetropolisHastings-DefaultAdaptationLowerBound        value_float="0.117" /> <!-- = 0.5 * 0.234 -->

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1504,6 +1504,7 @@ void ResourceMap::loadDefaultConfiguration()
 
   // VisualTest parameters //
   addAsUnsignedInteger("VisualTest-KendallPlot-MonteCarloSize", 100);
+  addAsScalar("VisualTest-DependenceConfidenceLevel", 0.95);
 
   // RandomWalkMetropolisHastings parameters //
   addAsScalar("RandomWalkMetropolisHastings-DefaultAdaptationExpansionFactor", 1.2);

--- a/lib/src/Uncertainty/Model/Distribution.cxx
+++ b/lib/src/Uncertainty/Model/Distribution.cxx
@@ -1180,6 +1180,27 @@ Graph Distribution::drawQuantile(const Scalar qMin,
   return getImplementation()->drawQuantile(qMin, qMax, pointNumber, logScale);
 }
 
+/* Draw dependence functions */
+Graph Distribution::drawUpperTailDependenceFunction() const
+{
+  return getImplementation()->drawUpperTailDependenceFunction();
+}
+
+Graph Distribution::drawUpperExtremalDependenceFunction() const
+{
+  return getImplementation()->drawUpperExtremalDependenceFunction();
+}
+
+Graph Distribution::drawLowerTailDependenceFunction() const
+{
+  return getImplementation()->drawLowerTailDependenceFunction();
+}
+
+Graph Distribution::drawLowerExtremalDependenceFunction() const
+{
+  return getImplementation()->drawLowerExtremalDependenceFunction();
+}
+
 /* Parameters value and description accessor */
 Distribution::PointWithDescriptionCollection Distribution::getParametersCollection() const
 {

--- a/lib/src/Uncertainty/Model/openturns/Distribution.hxx
+++ b/lib/src/Uncertainty/Model/openturns/Distribution.hxx
@@ -572,6 +572,12 @@ public:
                              const UnsignedInteger pointNumber = ResourceMap::GetAsUnsignedInteger("Distribution-DefaultPointNumber"),
                              const Bool logScale = false) const;
 
+  /** Draw dependence functions */
+  virtual Graph drawUpperTailDependenceFunction() const;
+  virtual Graph drawUpperExtremalDependenceFunction() const;
+  virtual Graph drawLowerTailDependenceFunction() const;
+  virtual Graph drawLowerExtremalDependenceFunction() const;
+
   /** Parameters value and description accessor */
   PointWithDescriptionCollection getParametersCollection() const;
   void setParametersCollection(const PointWithDescriptionCollection & parametersCollection);

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -719,7 +719,14 @@ protected:
                                const UnsignedInteger pointNumber = ResourceMap::GetAsUnsignedInteger("Distribution-DefaultPointNumber"),
                                const Bool logScaleX = false,
                                const Bool logScaleY = false) const;
+
+  virtual Graph drawDependenceFunction(const Function & transfer, const String & legend, const Bool tail = false) const;
 public:
+  /** Draw dependence functions */
+  virtual Graph drawUpperTailDependenceFunction() const;
+  virtual Graph drawUpperExtremalDependenceFunction() const;
+  virtual Graph drawLowerTailDependenceFunction() const;
+  virtual Graph drawLowerExtremalDependenceFunction() const;
 
   /** Parameters value and description accessor */
   virtual PointWithDescriptionCollection getParametersCollection() const;

--- a/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
@@ -101,6 +101,12 @@ OT_API Graph DrawKendallPlot(const Sample & data,
 OT_API Graph DrawKendallPlot(const Sample & firstSample,
                              const Sample & secondSample);
 
+/** Draw dependence functions */
+OT_API Graph DrawUpperTailDependenceFunction(const Sample & data);
+OT_API Graph DrawUpperExtremalDependenceFunction(const Sample & data);
+OT_API Graph DrawLowerTailDependenceFunction(const Sample & data);
+OT_API Graph DrawLowerExtremalDependenceFunction(const Sample & data);
+
 } /* VisualTest */
 
 END_NAMESPACE_OPENTURNS

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -25,6 +25,8 @@ Bibliography
     *OpenTURNS: An Industrial Software for Uncertainty Quantification in Simulation.*
     In: Ghanem R., Higdon D., Owhadi H. (eds) Handbook of Uncertainty Quantification. Springer
     `pdf <https://arxiv.org/pdf/1501.05242>`__
+.. [beirlant2004] Beirlant J., Goegebeur Y., Teugels J., Segers J.,
+    *Statistics of extremes: theory and applications*, Wiley, 2004
 .. [bhattacharyya1997] Bhattacharyya G.K., and R.A. Johnson, *Statistical
     Concepts and Methods*, John Wiley and Sons, New York, 1997.
 .. [blatman2009] Blatman, G. *Adaptive sparse polynomial chaos expansions for

--- a/python/doc/pyplots/DrawLowerExtremalDependenceFunction.py
+++ b/python/doc/pyplots/DrawLowerExtremalDependenceFunction.py
@@ -1,0 +1,8 @@
+import openturns as ot
+from openturns.viewer import View
+
+ot.RandomGenerator.SetSeed(0)
+data = ot.FrankCopula().getSample(1000)
+graph = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)
+
+View(graph, figure_kw={"figsize": (4.5, 4.5)})

--- a/python/doc/pyplots/DrawLowerTailDependenceFunction.py
+++ b/python/doc/pyplots/DrawLowerTailDependenceFunction.py
@@ -1,0 +1,8 @@
+import openturns as ot
+from openturns.viewer import View
+
+ot.RandomGenerator.SetSeed(0)
+data = ot.FrankCopula().getSample(1000)
+graph = ot.VisualTest.DrawLowerTailDependenceFunction(data)
+
+View(graph, figure_kw={"figsize": (4.5, 4.5)})

--- a/python/doc/pyplots/DrawUpperExtremalDependenceFunction.py
+++ b/python/doc/pyplots/DrawUpperExtremalDependenceFunction.py
@@ -1,0 +1,8 @@
+import openturns as ot
+from openturns.viewer import View
+
+ot.RandomGenerator.SetSeed(0)
+data = ot.FrankCopula().getSample(1000)
+graph = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
+
+View(graph, figure_kw={"figsize": (4.5, 4.5)})

--- a/python/doc/pyplots/DrawUpperTailDependenceFunction.py
+++ b/python/doc/pyplots/DrawUpperTailDependenceFunction.py
@@ -1,0 +1,8 @@
+import openturns as ot
+from openturns.viewer import View
+
+ot.RandomGenerator.SetSeed(0)
+data = ot.FrankCopula().getSample(1000)
+graph = ot.VisualTest.DrawUpperTailDependenceFunction(data)
+
+View(graph, figure_kw={"figsize": (4.5, 4.5)})

--- a/python/doc/theory/data_analysis/data_analysis.rst
+++ b/python/doc/theory/data_analysis/data_analysis.rst
@@ -62,6 +62,7 @@ Detection and quantification of dependencies
     spearman_test
     chi2_independence_test
     linear_regression
+    tail_dependence
 
 Estimating a quantile
 ---------------------

--- a/python/doc/theory/data_analysis/tail_dependence.rst
+++ b/python/doc/theory/data_analysis/tail_dependence.rst
@@ -4,6 +4,7 @@ Tail dependence coefficients
 ----------------------------
 
 The tail dependence coefficients helps to assess the asymptotic dependency of a bivariate random variables.
+
 Let :math:`X` a bivariate random variable which components :math:`X_i` follow the
 cumulative distribution fonctions :math:`F_i` and copula :math:`C`.
 
@@ -44,6 +45,17 @@ which proves:
 The :math:`\chi(u)` function also gives information on the dependence structure between the variables
 at quantiles levels less than :math:`1`.
 
+.. plot::
+
+    import openturns as ot
+    from openturns.viewer import View
+
+    ot.RandomGenerator.SetSeed(0)
+    copula = ot.FrankCopula()
+    data = copula.getSample(1000)
+    graph1 = ot.VisualTest.DrawUpperTailDependenceFunction(data)
+    View(graph1)
+
 **Upper extremal dependence coefficient**
 
 Let the function :math:`\chi(u)` defined by:
@@ -69,10 +81,50 @@ The variables :math:`(X_1,X_2)` are:
 - asymptotically dependent if :math:`\bar{\chi}=1`
 - asymptotically independent if :math:`-1 \leq \bar{\chi} \leq 1`
 
+.. plot::
+
+    import openturns as ot
+    from openturns.viewer import View
+
+    ot.RandomGenerator.SetSeed(0)
+    copula = ot.FrankCopula()
+    data = copula.getSample(1000)
+    graph2 = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
+    View(graph2)
 
 **Lower tail dependence coefficient**
 
-**Lower extremal dependence coefficient**
+The lower tail dependence coefficient is defined by:
+
+.. math::
+
+    \lambda_L = \lim_{u \to 0} [F_2(X_2) < u, F1(X_1) < u]
+
+The :math:`\lambda_L` coefficient gives the tendency for one variable to take extreme low values
+knowing the other one is extreme low.
+
+The variables :math:`(X_1,X_2)` are:
+
+- asymptotically independent if :math:`\lambda_L=0`
+- asymptotically dependent if :math:`0 < \lambda_L \leq 1`
+
+Similarly to what is proposed for the upper tail coefficient we can define:
+
+.. math::
+
+    \chi_L(u) = \frac{\log 1-C(u,u)}{\log (1-u)}, \forall u \in [0,1]
+
+When :math:`u` is close to :math:`0` then:
+
+.. math::
+
+    \chi_L(u) = \frac{C(u,u)}{u} + o(1) = \Pset[F_2(X_2) < u | F1(X_1) < u] + o(1)
+
+which proves:
+
+.. math::
+
+    \lim_{u \to 0} \chi_L(u) = \lambda_L
 
 .. plot::
 
@@ -80,14 +132,49 @@ The variables :math:`(X_1,X_2)` are:
     from openturns.viewer import View
 
     ot.RandomGenerator.SetSeed(0)
-    data = ot.FrankCopula().getSample(1000)
-    graph1 = ot.VisualTest.DrawUpperTailDependenceFunction(data)
-    graph2 = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
+    copula = ot.FrankCopula()
+    data = copula.getSample(1000)
     graph3 = ot.VisualTest.DrawLowerTailDependenceFunction(data)
-    graph4 = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)
-    View(graph1)
-    View(graph2)
     View(graph3)
+
+**Lower extremal dependence coefficient**
+
+Similarly we can introduce another function based on the comparison between the survival function
+of the copula :math:`C` and the one assuming independence, defined by:
+
+.. math::
+    \begin{array}{lcl}
+      \bar{\chi}_L(u) & = & \frac{\log (\Pset [F_1(X_1) > u] \Pset [F2(X_2) > u])}{\log \Pset [F_1(X_1) > u, F2(X_2) > u]} - 1\\
+      & = & \frac{\log u^2}{\log \bar{C}(u,u)} - 1\\
+      & = & \frac{2 \log u}{\log \bar{C}(u,u)} - 1
+    \end{array}
+
+We define the lower extremal coefficient :math:`\bar{\chi}_L` by:
+
+.. math::
+
+    \bar{\chi}_L = \lim_{u \to 0} \bar{\chi}_L(u)
+
+We have :math:`-1 \leq \bar{\chi}_L \leq 1`.
+We show that :math:`\lambda_L \neq 0` only if :math:`\bar{\chi}_L = 1`.
+For asymptotically independent variables (:math:`\chi_L = 0`), :math:`\bar{\chi}_L` gives the strength of the vanishing dependency.
+
+We define the following rules:
+
+- if :math:`\lambda_L > 0` (and :math:`\bar{\chi}_L = 1`): the variables are asymptotically dependent in the low values
+  and :math:`\bar{\chi}_L` gives a measure of the strength of the dependence.
+- if :math:`\lambda_L = 0`: the variables are asymptotically independent in the low values
+  and :math:`\bar{\chi}_L` gives the strength of the vanishing dependency.
+
+.. plot::
+
+    import openturns as ot
+    from openturns.viewer import View
+
+    ot.RandomGenerator.SetSeed(0)
+    copula = ot.FrankCopula()
+    data = copula.getSample(1000)
+    graph4 = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)
     View(graph4)
 
 .. topic:: API:
@@ -96,6 +183,10 @@ The variables :math:`(X_1,X_2)` are:
     - See :py:func:`~openturns.VisualTest.DrawUpperExtremalDependenceFunction`
     - See :py:func:`~openturns.VisualTest.DrawLowerTailDependenceFunction`
     - See :py:func:`~openturns.VisualTest.DrawLowerExtremalDependenceFunction`
+    - See :py:func:`~openturns.Distribution.drawUpperTailDependenceFunction`
+    - See :py:func:`~openturns.Distribution.drawUpperExtremalDependenceFunction`
+    - See :py:func:`~openturns.Distribution.drawLowerTailDependenceFunction`
+    - See :py:func:`~openturns.Distribution.drawLowerExtremalDependenceFunction`
 
 .. topic:: References:
 

--- a/python/doc/theory/data_analysis/tail_dependence.rst
+++ b/python/doc/theory/data_analysis/tail_dependence.rst
@@ -1,0 +1,102 @@
+.. _tail_dependence:
+
+Tail dependence coefficients
+----------------------------
+
+The tail dependence coefficients helps to assess the asymptotic dependency of a bivariate random variables.
+Let :math:`X` a bivariate random variable which components :math:`X_i` follow the
+cumulative distribution fonctions :math:`F_i` and copula :math:`C`.
+
+**Upper tail dependence coefficient**
+
+We note :math:`\chi` the upper tail dependence coefficient:
+
+.. math::
+
+    \lambda_U = \chi = \lim_{u \to 1} \Pset[F_2(X_2) > u | F1(X_1) > u]
+
+The :math:`\chi` coefficient represents the tendency for one variable to take extreme high values
+knowing the other variable is extremely high.
+
+The variables :math:`(X_1,X_2)` are:
+
+- asymptotically independent if :math:`\chi=0`
+- asymptotically dependent if :math:`0 \leq \chi \leq 1`
+
+Let the function :math:`\chi(u)` defined by:
+
+.. math::
+
+    \chi(u) = 2 - \frac{\log C(u,u)}{\log u}, \forall u \in [0,1]
+
+When :math:`u` is close to :math:`1` then:
+
+.. math::
+
+    \chi(u) = 2 - \frac{1-C(u,u)}{1-u} + o(1) = \Pset[F_2(X_2) > u | F1(X_1) > u] + o(1)
+
+which proves:
+
+.. math::
+
+    \lim_{u \to 1} \chi(u) = \lambda_U = \chi
+
+The :math:`\chi(u)` function also gives information on the dependence structure between the variables
+at quantiles levels less than :math:`1`.
+
+**Upper extremal dependence coefficient**
+
+Let the function :math:`\chi(u)` defined by:
+
+.. math::
+
+    \bar{\chi}(u) = \frac{\log (\Pset [F_1(X_1) > u] \Pset [F2(X_2) > u])}{\log [F_1(X_1) > u, F2(X_2) > u]}, \forall u \in [0,1]
+
+We show that:
+
+.. math::
+
+    \bar{\chi}(u) = \frac{2 \log 1-u}{\log C(u,u)} - 1, \forall u \in [0,1]
+
+And we define the asymtotic independence coefficient
+
+.. math::
+
+    \bar{\chi} = \lim_{u \to 1} \bar{\chi}(u)
+
+The variables :math:`(X_1,X_2)` are:
+
+- asymptotically dependent if :math:`\bar{\chi}=1`
+- asymptotically independent if :math:`-1 \leq \bar{\chi} \leq 1`
+
+
+**Lower tail dependence coefficient**
+
+**Lower extremal dependence coefficient**
+
+.. plot::
+
+    import openturns as ot
+    from openturns.viewer import View
+
+    ot.RandomGenerator.SetSeed(0)
+    data = ot.FrankCopula().getSample(1000)
+    graph1 = ot.VisualTest.DrawUpperTailDependenceFunction(data)
+    graph2 = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
+    graph3 = ot.VisualTest.DrawLowerTailDependenceFunction(data)
+    graph4 = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)
+    View(graph1)
+    View(graph2)
+    View(graph3)
+    View(graph4)
+
+.. topic:: API:
+
+    - See :py:func:`~openturns.VisualTest.DrawUpperTailDependenceFunction`
+    - See :py:func:`~openturns.VisualTest.DrawUpperExtremalDependenceFunction`
+    - See :py:func:`~openturns.VisualTest.DrawLowerTailDependenceFunction`
+    - See :py:func:`~openturns.VisualTest.DrawLowerExtremalDependenceFunction`
+
+.. topic:: References:
+
+    - [beirlant2004]_

--- a/python/doc/user_manual/statistics_on_sample.rst
+++ b/python/doc/user_manual/statistics_on_sample.rst
@@ -222,6 +222,10 @@ Graphical tests
     VisualTest.DrawLinearModelResidual
     VisualTest.DrawQQplot
     VisualTest.DrawCDFplot
+    VisualTest.DrawUpperTailDependenceFunction
+    VisualTest.DrawUpperExtremalDependenceFunction
+    VisualTest.DrawLowerTailDependenceFunction
+    VisualTest.DrawLowerExtremalDependenceFunction
 
 Hypothesis tests
 ----------------

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -3236,3 +3236,86 @@ Examples
 %feature("docstring") OT::DistributionImplementation::drawMarginal2DSurvivalFunction
 OT_Distribution_drawMarginal2DSurvivalFunction_doc
 
+// ---------------------------------------------------------------------
+
+%define OT_Distribution_drawUpperTailDependenceFunction_doc
+"Draw upper tail dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> copula = ot.FrankCopula()
+>>> graph = copula.drawUpperTailDependenceFunction()"
+%enddef
+%feature("docstring") OT::DistributionImplementation::drawUpperTailDependenceFunction
+OT_Distribution_drawUpperTailDependenceFunction_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_Distribution_drawUpperExtremalDependenceFunction_doc
+"Draw upper extremal dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> copula = ot.FrankCopula()
+>>> graph = copula.drawUpperExtremalDependenceFunction()"
+%enddef
+%feature("docstring") OT::DistributionImplementation::drawUpperExtremalDependenceFunction
+OT_Distribution_drawUpperExtremalDependenceFunction_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_Distribution_drawLowerTailDependenceFunction_doc
+"Draw lower tail dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> copula = ot.FrankCopula()
+>>> graph = copula.drawLowerTailDependenceFunction()"
+%enddef
+%feature("docstring") OT::DistributionImplementation::drawLowerTailDependenceFunction
+OT_Distribution_drawLowerTailDependenceFunction_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_Distribution_drawLowerExtremalDependenceFunction_doc
+"Draw lower extremal dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> copula = ot.FrankCopula()
+>>> graph = copula.drawLowerExtremalDependenceFunction()"
+%enddef
+%feature("docstring") OT::DistributionImplementation::drawLowerExtremalDependenceFunction
+OT_Distribution_drawLowerExtremalDependenceFunction_doc

--- a/python/src/Distribution_doc.i.in
+++ b/python/src/Distribution_doc.i.in
@@ -106,6 +106,14 @@ OT_Distribution_drawSurvivalFunction_doc
 OT_Distribution_drawMarginal1DSurvivalFunction_doc
 %feature("docstring") OT::Distribution::drawMarginal1DPDF
 OT_Distribution_drawMarginal1DPDF_doc
+%feature("docstring") OT::Distribution::drawUpperTailDependenceFunction
+OT_Distribution_drawUpperTailDependenceFunction_doc
+%feature("docstring") OT::Distribution::drawUpperExtremalDependenceFunction
+OT_Distribution_drawUpperExtremalDependenceFunction_doc
+%feature("docstring") OT::Distribution::drawLowerTailDependenceFunction
+OT_Distribution_drawLowerTailDependenceFunction_doc
+%feature("docstring") OT::Distribution::drawLowerExtremalDependenceFunction
+OT_Distribution_drawLowerExtremalDependenceFunction_doc
 %feature("docstring") OT::Distribution::getCDFEpsilon
 OT_Distribution_getCDFEpsilon_doc
 %feature("docstring") OT::Distribution::getCentralMoment

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -502,3 +502,94 @@ Examples
 >>> clouds = ot.VisualTest.DrawPairsMarginals(sample, distribution)
 >>> View(clouds).show()"
 
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::VisualTest::DrawUpperTailDependenceFunction
+"Draw upper tail dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Parameters
+----------
+sample : 2-d sequence of float
+    Bivariate sample
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> sample = ot.FrankCopula().getSample(100)
+>>> graph = ot.VisualTest.DrawUpperTailDependenceFunction(sample)"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::VisualTest::DrawUpperExtremalDependenceFunction
+"Draw upper extremal dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Parameters
+----------
+sample : 2-d sequence of float
+    Bivariate sample
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> sample = ot.FrankCopula().getSample(100)
+>>> graph = ot.VisualTest.DrawUpperExtremalDependenceFunction(sample)"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::VisualTest::DrawLowerTailDependenceFunction
+"Draw lower tail dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Parameters
+----------
+sample : 2-d sequence of float
+    Bivariate sample
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> sample = ot.FrankCopula().getSample(100)
+>>> graph = ot.VisualTest.DrawLowerTailDependenceFunction(sample)"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::VisualTest::DrawLowerExtremalDependenceFunction
+"Draw lower extremal dependence.
+
+Refer to :ref:`tail_dependence`.
+
+Parameters
+----------
+sample : 2-d sequence of float
+    Bivariate sample
+
+Returns
+-------
+graph : :class:`~openturns.Graph`
+    The graph object
+
+Examples
+--------
+>>> import openturns as ot
+>>> sample = ot.FrankCopula().getSample(100)
+>>> graph = ot.VisualTest.DrawLowerExtremalDependenceFunction(sample)"

--- a/python/test/t_Distribution_draw.py
+++ b/python/test/t_Distribution_draw.py
@@ -54,3 +54,10 @@ graphCDF = distND.drawMarginal2DCDF(2, 3, [-4.0, -4.0], [4.0, 4.0], [101, 101])
 # Quantile
 graphQuantile = dist1D.drawQuantile()
 graphQuantile = dist2D.drawQuantile()
+
+# dependence functions
+copula = ot.FrankCopula()
+graph1 = copula.drawUpperTailDependenceFunction()
+graph2 = copula.drawUpperExtremalDependenceFunction()
+graph3 = copula.drawLowerTailDependenceFunction()
+graph4 = copula.drawLowerExtremalDependenceFunction()

--- a/python/test/t_VisualTest_std.py
+++ b/python/test/t_VisualTest_std.py
@@ -93,3 +93,10 @@ distribution = ot.ComposedDistribution(
 )
 cloudsMarginals = ot.VisualTest.DrawPairsMarginals(sample, distribution)
 print("CloudsMarginals = ", cloudsMarginals)
+
+# dependence functions
+data = ot.FrankCopula().getSample(100)
+graph1 = ot.VisualTest.DrawUpperTailDependenceFunction(data)
+graph2 = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
+graph3 = ot.VisualTest.DrawLowerTailDependenceFunction(data)
+graph4 = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)


### PR DESCRIPTION
Add methods to draw the dependence functions

![tail1](https://user-images.githubusercontent.com/3832365/234534908-08fe187a-17c3-4811-ae21-9d9b84ef1978.png)


- 1 in VisualTest:
```
# dependence functions
data = ot.GumbelCopula().getSample(1000)
graph1 = ot.VisualTest.DrawUpperTailDependenceFunction(data)
graph2 = ot.VisualTest.DrawUpperExtremalDependenceFunction(data)
graph3 = ot.VisualTest.DrawLowerTailDependenceFunction(data)
graph4 = ot.VisualTest.DrawLowerExtremalDependenceFunction(data)
```

![tail2](https://user-images.githubusercontent.com/3832365/234535016-4712d8d0-db58-4021-880a-ec11b581139b.png)

- 2 in Distribution:
```
copula = ot.FrankCopula()
graph1 = copula.drawUpperTailDependenceFunction()
graph2 = copula.drawUpperExtremalDependenceFunction()
graph3 = copula.drawLowerTailDependenceFunction()
graph4 = copula.drawLowerExtremalDependenceFunction()
```

![tail3](https://user-images.githubusercontent.com/3832365/234580048-b02a6173-3d04-4fcd-a8ba-22953cccd5cb.png)

- validation on the wavesurge example:

![tail5](https://user-images.githubusercontent.com/3832365/234865093-ea26b014-db6c-4317-891d-1eb6acc13fe1.png)


![tail4](https://user-images.githubusercontent.com/3832365/234864783-99efebba-9151-41fb-b01b-35a702530580.png)

