### PR TITLE
BoxCoxFactory: Split build method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,7 @@
  * Removed burn-in from Gibbs and all MetropolisHastings classes except RandomWalkMetropolisHastings
  * RandomWalkMetropolisHastings::getRealization|Sample no longer remove states reached during burn-in
  * RandomWalkMetropolisHastings default adaptation parameters were changed to enable adaptation
+ * Split BoxCoxFactory::build into buildWithGraph, buildWithLM, buildWithGLM
 
 === Documentation ===
  * Add API documentation to common use cases pages

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/BoxCoxFactory.cxx
@@ -358,11 +358,11 @@ BoxCoxTransform BoxCoxFactory::build(const Field & timeSeries,
   return build(timeSeries.getValues(), shift);
 }
 
-BoxCoxTransform BoxCoxFactory::build(const Field & timeSeries,
+BoxCoxTransform BoxCoxFactory::buildWithGraph(const Field & timeSeries,
                                      const Point & shift,
                                      Graph & graph) const
 {
-  return build(timeSeries.getValues(), shift, graph);
+  return buildWithGraph(timeSeries.getValues(), shift, graph);
 }
 
 BoxCoxTransform BoxCoxFactory::build(const Sample & sample) const
@@ -374,10 +374,10 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & sample,
                                      const Point & shift) const
 {
   Graph tmp;
-  return build(sample, shift, tmp);
+  return buildWithGraph(sample, shift, tmp);
 }
 
-BoxCoxTransform BoxCoxFactory::build(const Sample & sample,
+BoxCoxTransform BoxCoxFactory::buildWithGraph(const Sample & sample,
                                      const Point & shift,
                                      Graph & graph) const
 {
@@ -457,7 +457,7 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & sample,
 }
 
 /** Build the factory from data by estimating the best generalized linear model */
-BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
+BoxCoxTransform BoxCoxFactory::buildWithGLM(const Sample & inputSample,
                                      const Sample & outputSample,
                                      const CovarianceModel & covarianceModel,
                                      const Basis & basis,
@@ -516,17 +516,17 @@ BoxCoxTransform BoxCoxFactory::build(const Sample & inputSample,
   return BoxCoxTransform(optpoint, shift);
 }
 
-BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+BoxCoxTransform BoxCoxFactory::buildWithGLM(const Sample &inputSample,
                                      const Sample &outputSample,
                                      const CovarianceModel &covarianceModel,
                                      const Point &shift,
                                      GeneralLinearModelResult &generalLinearModelResult)
 {
-  return build(inputSample, outputSample, covarianceModel, Basis(), shift, generalLinearModelResult);
+  return buildWithGLM(inputSample, outputSample, covarianceModel, Basis(), shift, generalLinearModelResult);
 }
 
 /** Build the factory from data by estimating the best generalized linear model */
-BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+BoxCoxTransform BoxCoxFactory::buildWithLM(const Sample &inputSample,
                                      const Sample &outputSample,
                                      const Basis &basis,
                                      const Point &shift,
@@ -576,13 +576,13 @@ BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
   return BoxCoxTransform(optpoint, shift);
 }
 
-BoxCoxTransform BoxCoxFactory::build(const Sample &inputSample,
+BoxCoxTransform BoxCoxFactory::buildWithLM(const Sample &inputSample,
                                      const Sample &outputSample,
                                      const Point &shift,
                                      LinearModelResult &linearModelResult)
 {
   const Basis basis(LinearBasisFactory(inputSample.getDimension()).build());
-  return build(inputSample, outputSample, basis, shift, linearModelResult);
+  return buildWithLM(inputSample, outputSample, basis, shift, linearModelResult);
 }
 
 /* String converter */

--- a/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
+++ b/lib/src/Uncertainty/Algorithm/Transformation/ProcessTransformation/openturns/BoxCoxFactory.hxx
@@ -65,7 +65,7 @@ public:
   BoxCoxTransform build(const Field & timeSeries,
                         const Point & shift) const;
 
-  BoxCoxTransform build(const Field & timeSeries,
+  BoxCoxTransform buildWithGraph(const Field & timeSeries,
                         const Point & shift,
                         Graph & graph) const;
 
@@ -74,31 +74,31 @@ public:
   BoxCoxTransform build(const Sample & sample,
                         const Point & shift) const;
 
-  BoxCoxTransform build(const Sample & sample,
+  BoxCoxTransform buildWithGraph(const Sample & sample,
                         const Point & shift,
                         Graph & graph) const;
 
   /** Build the factory from data by estimating the best generalized linear model */
-  BoxCoxTransform build(const Sample &inputSample,
+  BoxCoxTransform buildWithGLM(const Sample &inputSample,
                         const Sample &outputSample,
                         const CovarianceModel &covarianceModel,
                         const Basis &basis,
                         const Point &shift,
                         GeneralLinearModelResult &generalLinearModelResult);
 
-  BoxCoxTransform build(const Sample & inputSample,
+  BoxCoxTransform buildWithGLM(const Sample & inputSample,
                         const Sample & outputSample,
                         const CovarianceModel & covarianceModel,
                         const Point & shift,
                         GeneralLinearModelResult & generalLinearModelResult);
 
-  BoxCoxTransform build(const Sample &inputSample,
+  BoxCoxTransform buildWithLM(const Sample &inputSample,
                         const Sample &outputSample,
                         const Basis &basis,
                         const Point &shift,
                         LinearModelResult &linearModelResult);
 
-  BoxCoxTransform build(const Sample &inputSample,
+  BoxCoxTransform buildWithLM(const Sample &inputSample,
                         const Sample &outputSample,
                         const Point &shift,
                         LinearModelResult &linearModelResult);

--- a/lib/test/t_BoxCoxFactory_glm.cxx
+++ b/lib/test/t_BoxCoxFactory_glm.cxx
@@ -65,7 +65,7 @@ int main(int, char *[])
     const Basis basis = LinearBasisFactory(1).build();
     const DiracCovarianceModel covarianceModel;
     const Point shift = {1e-10};
-    BoxCoxTransform myBoxCox = factory.build(inputSample, outputSample, covarianceModel, basis, shift, result);
+    BoxCoxTransform myBoxCox = factory.buildWithGLM(inputSample, outputSample, covarianceModel, basis, shift, result);
 
     fullprint << "myBoxCox (GLM)=" << myBoxCox.__str__() << std::endl;
     fullprint << "GLM result=" << result.__str__() << std::endl;

--- a/lib/test/t_BoxCoxFactory_lm.cxx
+++ b/lib/test/t_BoxCoxFactory_lm.cxx
@@ -63,7 +63,7 @@ int main(int, char *[])
     // Creation of the BoxCoxTransform
     LinearModelResult result;
     const Point shift = {1e-10};
-    BoxCoxTransform myBoxCox = factory.build(inputSample, outputSample, shift, result);
+    BoxCoxTransform myBoxCox = factory.buildWithLM(inputSample, outputSample, shift, result);
     // estimated lambda =  1.99098;
     // beta = [9.90054,2.95995]
     assert_almost_equal(myBoxCox.getLambda(), lambda, 1e-2, 1e-2);

--- a/lib/test/t_BoxCoxFactory_std.cxx
+++ b/lib/test/t_BoxCoxFactory_std.cxx
@@ -65,7 +65,7 @@ int main(int, char *[])
 
     // Creation of the BoxCoxTransform using shift with graph
     Graph graph;
-    BoxCoxTransform myBoxCoxShiftGraph(factory.build(timeSeries, shift, graph));
+    BoxCoxTransform myBoxCoxShiftGraph(factory.buildWithGraph(timeSeries, shift, graph));
 
     fullprint << "BoxCox graph (time-series)=" << graph << std::endl;
 

--- a/python/doc/pyplots/BoxCoxFactory.py
+++ b/python/doc/pyplots/BoxCoxFactory.py
@@ -43,7 +43,7 @@ shift = [0.0]
 
 # We estimate the lambda parameter from the field myField
 # All values of the field are positive
-myModelTransform, graph = myBoxCoxFactory.build(myField, shift)
+myModelTransform, graph = myBoxCoxFactory.buildWithGraph(myField, shift)
 graphMarginal2 = (
     ot.KernelSmoothing().build(myModelTransform(myField).getValues()).drawPDF()
 )

--- a/python/src/BoxCoxFactory_doc.i.in
+++ b/python/src/BoxCoxFactory_doc.i.in
@@ -29,61 +29,139 @@ The objective is to estimate the most likely surrogate model (general linear mod
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::BoxCoxFactory::build
-"Estimate the Box Cox transformation.
-
-Available usages with time series & fields:
-    build(*myField*) -> myBoxCoxTransform
-
-    build(*myField, shift*) -> Tuple[myBoxCoxTransform, myGraph]
-
-Available usages with data only:
-
-    build(*mySample*) -> myBoxCoxTransform
-
-    build(*mySample, shift*) -> Tuple[myBoxCoxTransform, myGraph]
-
-Available usages with a general linear model:
-
-    build(*inputSample, outputSample, covarianceModel, basis, shift*) -> Tuple[myBoxCoxTransform, myGeneralLinearModelResult]
-
-    build(*inputSample, outputSample, covarianceModel, shift*) -> Tuple[myBoxCoxTransform, myGeneralLinearModelResult]
-
-Available usages with a linear model:
-
-    build(*inputSample, outputSample, basis, shift*) -> Tuple[myBoxCoxTransform, myLinearModelResult]
-
-    build(*inputSample, outputSample, shift*) -> Tuple[myBoxCoxTransform, myLinearModelResult]
+%feature("docstring") OT::BoxCoxFactory::buildWithGraph
+"Estimate the Box Cox transformation with graph output.
 
 Parameters
 ----------
-myField : :class:`~openturns.Field`
-    One realization of a  process.
-mySample : 2-d sequence of float
-    A set of *iid* values.
+data : :class:`~openturns.Field` or 2-d sequence of float
+    One realization of a process.
 shift : :class:`~openturns.Point`
     It ensures that when shifted, the data are all positive.
     By default the opposite of the min vector of the data is used if some data are negative.
-inputSample, outputSample : :class:`~openturns.Sample` or 2d-array
-    The input and output samples of a model evaluated apart.
-basis : :class:`~openturns.Basis`
-    Functional basis to estimate the trend: :math:`(\varphi_j)_{1 \leq j \leq n_1}: \Rset^n \rightarrow \Rset`.
-    If :math:`d>1`, the same basis is used for each marginal output.
-covarianceModel : :class:`~openturns.CovarianceModel`
-    Covariance model.
-    Should have input dimension equal to input sample's dimension and dimension equal to output sample's dimension.
-    See note for some particular applications.
 
 Returns
 -------
 myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
     The estimated Box Cox transformation.
-myGraph : :class:`~openturns.Graph`
-    A graph that is fulfilled with the log-likelihood of the mapped variables with respect to the :math:`lambda` parameter for each component.
-myGeneralLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
-    The structure that contains results of general linear model algorithm.
+graph : :class:`~openturns.Graph`
+    The graph plots the evolution of the likelihood with respect to the value of :math:`\lambda` for each component *i*.
+    It enables to graphically detect the optimal values."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::BoxCoxFactory::buildWithLM
+"Estimate the Box Cox transformation with linear model.
+
+Refer to :meth:`build` for details.
+
+Parameters
+----------
+inputSample, outputSample : :class:`~openturns.Sample` or 2d-array
+    The input and output samples of a model evaluated apart.
+covarianceModel : :class:`~openturns.CovarianceModel`
+    Covariance model.
+    Should have input dimension equal to input sample's dimension and dimension equal to output sample's dimension.
+    See note for some particular applications.
+basis : :class:`~openturns.Basis`, optional
+    Functional basis to estimate the trend: :math:`(\varphi_j)_{1 \leq j \leq n_1}: \Rset^n \rightarrow \Rset`.
+    If :math:`d>1`, the same basis is used for each marginal output.
+shift : :class:`~openturns.Point`
+    It ensures that when shifted, the data are all positive.
+    By default the opposite of the min vector of the data is used if some data are negative.
+
+Returns
+-------
+myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
+    The estimated Box Cox transformation.
 myLinearModelResult : :class:`~openturns.LinearModelResult`
     The structure that contains results of linear model algorithm.
+
+Examples
+--------
+Estimation of a linear model:
+
+>>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
+>>> x = ot.Uniform(-1.0, 1.0).getSample(20)
+>>> y = ot.Sample(x)
+>>> # Evaluation of y = ax + b (a: scale, b: translate)
+>>> y = y * [3] + [3.1]
+>>> # inverse transformation
+>>> inv_transformation = ot.SymbolicFunction('x', 'exp(x)')
+>>> y = inv_transformation(y) + ot.Normal(0, 1.0e-4).getSample(20)
+>>> # Estimation
+>>> shift = [1.0e-1]
+>>> myBoxCox, result = ot.BoxCoxFactory().buildWithLM(x, y, shift)
+"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::BoxCoxFactory::buildWithGLM
+"Estimate the Box Cox transformation with general linear model.
+
+Refer to :meth:`build` for details.
+
+Parameters
+----------
+inputSample, outputSample : :class:`~openturns.Sample` or 2d-array
+    The input and output samples of a model evaluated apart.
+covarianceModel : :class:`~openturns.CovarianceModel`
+    Covariance model.
+    Should have input dimension equal to input sample's dimension and dimension equal to output sample's dimension.
+    See note for some particular applications.
+basis : :class:`~openturns.Basis`, optional
+    Functional basis to estimate the trend: :math:`(\varphi_j)_{1 \leq j \leq n_1}: \Rset^n \rightarrow \Rset`.
+    If :math:`d>1`, the same basis is used for each marginal output.
+shift : :class:`~openturns.Point`
+    It ensures that when shifted, the data are all positive.
+    By default the opposite of the min vector of the data is used if some data are negative.
+
+Returns
+-------
+myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
+    The estimated Box Cox transformation.
+myGeneralLinearModelResult : :class:`~openturns.GeneralLinearModelResult`
+    The structure that contains results of general linear model algorithm.
+
+Examples
+--------
+Estimation of a general linear model:
+
+>>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
+>>> inputSample = ot.Uniform(-1.0, 1.0).getSample(20)
+>>> outputSample = ot.Sample(inputSample)
+>>> # Evaluation of y = ax + b (a: scale, b: translate)
+>>> outputSample = outputSample * [3] + [3.1]
+>>> # inverse transfo + small noise
+>>> def f(x): import math; return [math.exp(x[0])]
+>>> inv_transfo = ot.PythonFunction(1, 1, f)
+>>> outputSample = inv_transfo(outputSample) + ot.Normal(0, 1.0e-2).getSample(20)
+>>> # Estimation
+>>> basis = ot.LinearBasisFactory(1).build()
+>>> covarianceModel = ot.DiracCovarianceModel()
+>>> shift = [1.0e-1]
+>>> myBoxCox, result = ot.BoxCoxFactory().buildWithGLM(inputSample, outputSample, covarianceModel, basis, shift)
+"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::BoxCoxFactory::build
+"Estimate the Box Cox transformation.
+
+Parameters
+----------
+data : :class:`~openturns.Field` or 2-d sequence of float
+    One realization of a process.
+shift : :class:`~openturns.Point`, optional
+    It ensures that when shifted, the data are all positive.
+    By default the opposite of the min vector of the data is used if some data are negative.
+
+Returns
+-------
+myBoxCoxTransform : :class:`~openturns.BoxCoxTransform`
+    The estimated Box Cox transformation.
 
 Notes
 -----
@@ -161,10 +239,6 @@ Substituting these expressions in the likelihood equation and taking the :math:`
 
 The parameter :math:`\hat{\lambda}` is the one maximising :math:`\ell(\lambda)`.
 
-When the empty graph *likelihoodGraph* is precised, it is fulfilled with the evolution of the likelihood with respect to the value of :math:`\lambda` for each component  *i*. It enables to graphically detect the optimal values.
-
-|
-
 In the case of surrogate model estimate, we note :math:`(x_0, \dots, x_{N-1})` the input sample of :math:`X`, :math:`(y_0, \dots, y_{N-1})` the input sample of :math:`Y`.
 We suppose the general linear model link :math:`h_\lambda(Y) = \vect{F}^t(\vect{x}) \vect{\beta} + \vect{Z}` with :math:`\mat{F} \in \mathcal{M}_{np, M}(\Rset)`:
 
@@ -220,35 +294,4 @@ Estimate the Box Cox transformation from a field:
 
 >>> myField = myXtProcess.getRealization()
 >>> myModelTransform = ot.BoxCoxFactory().build(myField)
-
-Estimation of a general linear model:
-
->>> ot.RandomGenerator.SetSeed(0)
->>> inputSample = ot.Uniform(-1.0, 1.0).getSample(20)
->>> outputSample = ot.Sample(inputSample)
->>> # Evaluation of y = ax + b (a: scale, b: translate)
->>> outputSample = outputSample * [3] + [3.1]
->>> # inverse transfo + small noise
->>> def f(x): import math; return [math.exp(x[0])]
->>> inv_transfo = ot.PythonFunction(1,1, f)
->>> outputSample = inv_transfo(outputSample) + ot.Normal(0, 1.0e-2).getSample(20)
->>> # Estimation
->>> basis = ot.LinearBasisFactory(1).build()
->>> covarianceModel = ot.DiracCovarianceModel()
->>> shift = [1.0e-1]
->>> myBoxCox, result = ot.BoxCoxFactory().build(inputSample, outputSample, covarianceModel, basis, shift)
-
-Estimation of a linear model:
-
->>> ot.RandomGenerator.SetSeed(0)
->>> x = ot.Uniform(-1.0, 1.0).getSample(20)
->>> y = ot.Sample(x)
->>> # Evaluation of y = ax + b (a: scale, b: translate)
->>> y = y * [3] + [3.1]
->>> # inverse transformation
->>> inv_transformation = ot.SymbolicFunction('x', 'exp(x)')
->>> y = inv_transformation(y) + ot.Normal(0, 1.0e-4).getSample(20)
->>> # Estimation
->>> shift = [1.0e-1]
->>> myBoxCox, result = ot.BoxCoxFactory().build(x, y, shift)
 "

--- a/python/test/t_BoxCoxFactory_glm.py
+++ b/python/test/t_BoxCoxFactory_glm.py
@@ -38,7 +38,7 @@ factory = ot.BoxCoxFactory()
 basis = ot.LinearBasisFactory(1).build()
 covarianceModel = ot.DiracCovarianceModel()
 shift = [1.0e-10]
-myBoxCox, result = factory.build(
+myBoxCox, result = factory.buildWithGLM(
     inputSample, outputSample, covarianceModel, basis, shift
 )
 

--- a/python/test/t_BoxCoxFactory_lm.py
+++ b/python/test/t_BoxCoxFactory_lm.py
@@ -38,10 +38,9 @@ outputSample += epsilon
 factory = ot.BoxCoxFactory()
 
 # Creation of the BoxCoxTransform
-result = ot.LinearModelResult()
 basis = ot.LinearBasisFactory(1).build()
 shift = [1.0e-10]
-myBoxCox, result = factory.build(inputSample, outputSample, shift)
+myBoxCox, result = factory.buildWithLM(inputSample, outputSample, shift)
 
 # estimated lambda =  1.99098,  beta = [9.90054,2.95995]
 beta = [9.90054, 2.95995]

--- a/python/test/t_BoxCoxFactory_std.py
+++ b/python/test/t_BoxCoxFactory_std.py
@@ -33,8 +33,11 @@ print("myBoxCox (sample)     =", factory.build(sample))
 
 # Creation of the BoxCoxTransform using shift
 shift = ot.Point(1, 1.0)
-myBoxCoxShift, graph = factory.build(timeSeries, shift)
+myBoxCoxShift, graph = factory.buildWithGraph(timeSeries, shift)
 
 print("myBoxCox with shift (time-series)=", myBoxCoxShift)
 print("myBoxCox with shift (sample)     =", factory.build(sample, shift))
 print("BoxCox graph (time-series)=", graph)
+
+# with sample
+myBoxCoxShift, graph = factory.buildWithGraph(sample, shift)


### PR DESCRIPTION
Since https://github.com/openturns/openturns/pull/2244 it seems BoxCoxFactory::build(Sample, Point) does not return a Graph anymore
This is because SWIG does not know which variant to call, with or without graph return argument.

To disambiguate the API, I propose to introduce new signatures depending on the result type:
```
  BoxCoxTransform build(const Field & timeSeries) const;

  BoxCoxTransform build(const Field & timeSeries,
                        const Point & shift) const;

  BoxCoxTransform buildWithGraph(const Field & timeSeries,
                        const Point & shift,
                        Graph & graph) const;

  BoxCoxTransform build(const Sample & sample) const;

  BoxCoxTransform build(const Sample & sample,
                        const Point & shift) const;

  BoxCoxTransform buildWithGraph(const Sample & sample,
                        const Point & shift,
                        Graph & graph) const;

  /** Build the factory from data by estimating the best generalized linear model */
  BoxCoxTransform buildWithGLM(const Sample &inputSample,
                        const Sample &outputSample,
                        const CovarianceModel &covarianceModel,
                        const Basis &basis,
                        const Point &shift,
                        GeneralLinearModelResult &generalLinearModelResult);

  BoxCoxTransform buildWithGLM(const Sample & inputSample,
                        const Sample & outputSample,
                        const CovarianceModel & covarianceModel,
                        const Point & shift,
                        GeneralLinearModelResult & generalLinearModelResult);

  BoxCoxTransform buildWithLM(const Sample &inputSample,
                        const Sample &outputSample,
                        const Basis &basis,
                        const Point &shift,
                        LinearModelResult &linearModelResult);

  BoxCoxTransform buildWithLM(const Sample &inputSample,
                        const Sample &outputSample,
                        const Point &shift,
                        LinearModelResult &linearModelResult);
```

This also clarifies a lot the docstrings with regards to the parameters, return values, and examples.

Since it solves a bug this targets the 1.21 branch even if it breaks the API

cc @sofianehaddad 