### PR TITLE
Fixed DiracCovarianceModel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -84,6 +84,7 @@
  * #2281 (The marginal of FireSatelliteModel can fail)
  * #2285 (The input and output descriptions does not go down to the metamodel)
  * #2287 (DesignProxy.computeDesign() can produce a segmentation fault)
+ * #2296 (DiracCovarianceModel.discretize() is buggy)
  * #2297 (Legend location with grid layout)
  * #2299 (Allow openturns as subproject)
  * #2306 (Dirichlet::computeConditionalPDF can produce NaNs and Infs)

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -361,6 +361,9 @@
   <CovarianceModel-DefaultTMin         value_float="-5.0"          />
   <CovarianceModel-DefaultPointNumber  value_int="129" />
 
+  <!-- OT::DiracCovarianceModel parameters -->
+  <DiracCovarianceModel-CheckUnique value_bool="true"         />
+
   <!-- OT::SpectralModelImplementation parameters -->
   <SpectralModel-DefaultMaximumFrequency value_float="5.0"           />
   <SpectralModel-DefaultMinimumFrequency value_float="-5.0"          />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -986,6 +986,9 @@ void ResourceMap::loadDefaultConfiguration()
   addAsScalar("CovarianceModel-DefaultTMin", -5.0);
   addAsUnsignedInteger("CovarianceModel-DefaultPointNumber",  129);
 
+  // DiracCovarianceModel parameters //
+  addAsBool("DiracCovarianceModel-CheckUnique", true);
+
   // SpectralModel parameters //
   addAsScalar("SpectralModel-DefaultMaximumFrequency",  5.0);
   addAsScalar("SpectralModel-DefaultMinimumFrequency", -5.0);

--- a/lib/src/Base/Stat/DiracCovarianceModel.cxx
+++ b/lib/src/Base/Stat/DiracCovarianceModel.cxx
@@ -234,6 +234,11 @@ struct DiracCovarianceModelDiscretizePolicy
 
 CovarianceMatrix DiracCovarianceModel::discretize(const Sample & vertices) const
 {
+  // If we have to check for repeated points and there are repeated points, use the generic discretization method
+  if (ResourceMap::GetAsBool("DiracCovarianceModel-CheckUnique") && (vertices.sortUnique().getSize() != vertices.getSize()))
+    return CovarianceModelImplementation::discretize(vertices);
+
+  // Here is the opimized discretization method, correct if no repeated points
   if (vertices.getDimension() != inputDimension_)
     throw InvalidArgumentException(HERE) << "In DiracCovarianceModel::discretize, the given sample has a dimension=" << vertices.getDimension()
                                          << " different from the input dimension=" << inputDimension_;
@@ -283,6 +288,11 @@ struct DiracCovarianceModelDiscretizeAndFactorizePolicy
 
 TriangularMatrix DiracCovarianceModel::discretizeAndFactorize(const Sample & vertices) const
 {
+  // If we have to check for repeated points and there are repeated points, use the generic discretization method
+  if (ResourceMap::GetAsBool("DiracCovarianceModel-CheckUnique") && (vertices.sortUnique().getSize() != vertices.getSize()))
+    return CovarianceModelImplementation::discretizeAndFactorize(vertices);
+
+  // Here is the opimized discretization method, correct if no repeated points
   if (vertices.getDimension() != inputDimension_)
     throw InvalidArgumentException(HERE) << "In DiracCovarianceModel::discretize, the given sample has a dimension=" << vertices.getDimension()
                                          << " different from the input dimension=" << inputDimension_;


### PR DESCRIPTION
Now the sample given to the discretize() and discretizeAndFactorize() methods is checked against repeated points. This behavior is controlled by the "DiracCovarianceModel-CheckUnique" boolean entry.

With this PR, the script given in #2296 produces:
```
    [ v0 ]
0 : [ 1  ]
1 : [ 2  ]
2 : [ 3  ]
3 : [ 1  ]
4 : [ 1  ]
5 : [ 3  ]
6 : [ 3  ]
7 : [ 3  ]
8 : [ 1  ]
9 : [ 1  ]
0.0
1.0
10x10
[[ 1 0 0 1 1 0 0 0 1 1 ]
 [ 0 1 0 0 0 0 0 0 0 0 ]
 [ 0 0 1 0 0 1 1 1 0 0 ]
 [ 1 0 0 1 1 0 0 0 1 1 ]
 [ 1 0 0 1 1 0 0 0 1 1 ]
 [ 0 0 1 0 0 1 1 1 0 0 ]
 [ 0 0 1 0 0 1 1 1 0 0 ]
 [ 0 0 1 0 0 1 1 1 0 0 ]
 [ 1 0 0 1 1 0 0 0 1 1 ]
 [ 1 0 0 1 1 0 0 0 1 1 ]]
```
as expected.

The impact on the performance is not large as soon as the sample size is of order 500:
```
import openturns as ot
from time import time

dimIn = 5
dimOut = 4
cov = ot.DiracCovarianceModel(dimIn, [1.0]*dimOut, ot.IdentityMatrix(dimOut))

all_sizes = [20, 50, 100, 200, 500, 1000, 2000, 5000]
results = ot.Sample(len(all_sizes), 4)
results.setDescription(["size", "w/o check", "w check", "ratio w / (w/o)"])
for i, size in enumerate(all_sizes):
    results[i, 0] = size
    ot.RandomGenerator.SetSeed(1)
    vertices = ot.Normal(dimIn).getSample(size)
    ot.ResourceMap.SetAsBool("DiracCovarianceModel-CheckUnique", False)
    t0 = time()
    n = 0
    t1 = t0
    while t1 - t0 < 2:
        n += 1
        res = cov.discretize(vertices)
        t1 = time()
    results[i, 1] = (t1 - t0) / n
    ot.ResourceMap.SetAsBool("DiracCovarianceModel-CheckUnique", True)
    t0 = time()
    n = 0
    t1 = t0
    while t1 - t0 < 2:
        n += 1
        res = cov.discretize(vertices)
        t1 = time()
    results[i, 2] = (t1 - t0) / n
    results[i, 3] = results[i, 2] / results[i, 1]

print(results)
```
gives:
```
    [ size            w/o check       w check         ratio w / (w/o) ]
0 : [   20               1.67183e-05     2.09704e-05     1.25434      ]
1 : [   50               3.36316e-05     4.52429e-05     1.34525      ]
2 : [  100               7.62806e-05     9.8879e-05      1.29625      ]
3 : [  200               0.000209386     0.000240857     1.1503       ]
4 : [  500               0.00133009      0.00140705      1.05786      ]
5 : [ 1000               0.0327142       0.032448        0.991863     ]
6 : [ 2000               0.124486        0.125248        1.00613      ]
7 : [ 5000               0.732411        0.754569        1.03025      ]
```