### PR TITLE
Reset auxiliary distribution of Cross Entropy Importance Sampling before use

### DIFF
--- a/lib/src/Uncertainty/Algorithm/Simulation/CrossEntropyImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/CrossEntropyImportanceSampling.cxx
@@ -92,9 +92,19 @@ Point CrossEntropyImportanceSampling::optimizeAuxiliaryDistributionParameters(co
 }
 
 
+// Reset auxiliary distribution parameters
+void CrossEntropyImportanceSampling::resetAuxiliaryDistribution() 
+{
+  throw NotYetImplementedException(HERE) << "In CrossEntropyImportanceSampling::resetAuxiliaryDistribution()";
+}
+
 // Main function that computes the failure probability
 void CrossEntropyImportanceSampling::run()
 {
+
+  // Initialization of auxiliary distribution (in case of multiple runs of algorithms)
+  resetAuxiliaryDistribution();
+  
   const UnsignedInteger sampleSize = getMaximumOuterSampling() * getBlockSize();
 
   // Drawing of samples using initial density
@@ -106,7 +116,7 @@ void CrossEntropyImportanceSampling::run()
   // Computation of current quantile
   Scalar currentQuantile = auxiliaryOutputSample.computeQuantile(quantileLevel_)[0];
 
-  Point  auxiliaryDistributionParameters;
+  Point auxiliaryDistributionParameters;
 
 
   const ComparisonOperator comparator(getEvent().getOperator());

--- a/lib/src/Uncertainty/Algorithm/Simulation/PhysicalSpaceCrossEntropyImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/PhysicalSpaceCrossEntropyImportanceSampling.cxx
@@ -56,6 +56,7 @@ PhysicalSpaceCrossEntropyImportanceSampling::PhysicalSpaceCrossEntropyImportance
   auxiliaryDistribution_ = auxiliaryDistribution;
   quantileLevel_ = (event.getOperator()(0, 1) ? quantileLevel : 1.0 - quantileLevel);
   bounds_ = bounds;
+  initialAuxiliaryDistributionParameters_ = initialAuxiliaryDistributionParameters;
 
   Point parameters(auxiliaryDistribution_.getParameter());
 
@@ -186,6 +187,20 @@ void PhysicalSpaceCrossEntropyImportanceSampling::updateAuxiliaryDistribution(co
   }
   auxiliaryDistribution_.setParameter(parameters);
 }
+
+
+// Reset auxiliary distribution
+void PhysicalSpaceCrossEntropyImportanceSampling::resetAuxiliaryDistribution()
+{
+  Point parameters(auxiliaryDistribution_.getParameter());
+  for (UnsignedInteger i = 0; i < activeParameters_.getSize(); ++i)
+  {
+    parameters[activeParameters_[i]] = initialAuxiliaryDistributionParameters_[i];
+  }
+  auxiliaryDistribution_.setParameter(parameters);
+}
+
+
 
 // Optimize auxiliary distribution parameters
 Point PhysicalSpaceCrossEntropyImportanceSampling::optimizeAuxiliaryDistributionParameters(const Sample & auxiliaryCriticInputSamples) const

--- a/lib/src/Uncertainty/Algorithm/Simulation/StandardSpaceCrossEntropyImportanceSampling.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/StandardSpaceCrossEntropyImportanceSampling.cxx
@@ -77,6 +77,12 @@ void StandardSpaceCrossEntropyImportanceSampling::updateAuxiliaryDistribution(co
   auxiliaryDistribution_.setParameter(temporaryParameters);
 }
 
+// Reset auxiliary distribution
+void StandardSpaceCrossEntropyImportanceSampling::resetAuxiliaryDistribution()
+{
+  auxiliaryDistribution_ = Normal(initialDistribution_.getDimension());
+}
+
 // Optimize auxiliary distribution parameters
 Point StandardSpaceCrossEntropyImportanceSampling::optimizeAuxiliaryDistributionParameters(const Sample & auxiliaryCriticInputSamples) const
 {

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/CrossEntropyImportanceSampling.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/CrossEntropyImportanceSampling.hxx
@@ -72,6 +72,9 @@ protected:
   /** Function optimizing the auxiliary distribution parameters*/
   virtual Point optimizeAuxiliaryDistributionParameters(const Sample & auxiliaryCriticInputSamples) const;
 
+  /** Function updating the auxiliary distribution with initial parameters (in case of multiple runs of algorithm) */
+  virtual void resetAuxiliaryDistribution();
+  
   // Initial distribution
   Distribution initialDistribution_;
 

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/PhysicalSpaceCrossEntropyImportanceSampling.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/PhysicalSpaceCrossEntropyImportanceSampling.hxx
@@ -68,6 +68,9 @@ protected:
   /** Function updating the auxiliary distribution as a function of auxiliary distribution parameters */
   void updateAuxiliaryDistribution(const Point & auxiliaryDistributionParameters) override;
 
+  /** Function updating the auxiliary distribution with initial parameters (in case of multiple runs of algorithm) */
+  void resetAuxiliaryDistribution() override;
+  
   Point optimizeAuxiliaryDistributionParameters(const Sample &  auxiliaryCriticInputSamples) const override;
 
 private:
@@ -75,6 +78,9 @@ private:
   // active parameters
   Indices activeParameters_;
 
+  // Initial auxiliary distribution parameters
+  Point initialAuxiliaryDistributionParameters_;
+  
   // bounds for optimization algorithm
   Interval bounds_;
 

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/StandardSpaceCrossEntropyImportanceSampling.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/StandardSpaceCrossEntropyImportanceSampling.hxx
@@ -56,6 +56,8 @@ protected:
   /** Function updating the auxiliary distribution as a function of auxiliary distribution parameters */
   void updateAuxiliaryDistribution(const Point & auxiliaryDistributionParameters) override;
 
+  /** Function updating the auxiliary distribution with initial parameters (in case of multiple runs of algorithm) */
+  void resetAuxiliaryDistribution() override;
 
   Point optimizeAuxiliaryDistributionParameters(const Sample &  auxiliaryCriticInputSamples) const override;
 }; /* class StandardSpaceCrossEntropyImportanceSampling */


### PR DESCRIPTION
As discussed in the previous meeting, after a run, current versions of Cross Entropy algorithms (StandardSpace and PhysicalSpace) keep in memory the auxiliary density as default auxiliary distribution. This may have impact in case of multiple runs. Furthermore, this behavior is not the same as Subset Sampling. 

This PR proposes to automatically reset the auxiliary distribution with default values in case of multiple runs of StandardSpaceCrossEntropyImportanceSampling and PhysicalSpaceCrossEntropyImportanceSampling. 

To do so, a new method  `resetAuxiliaryDistribution` has been created in order to reinitialize the auxiliary distribution to the default one in case of multiple runs of Importance Sampling.