### PR TITLE
Update plot_functional_chaos_exploitation.py

### DIFF
--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_exploitation.py
@@ -70,22 +70,6 @@ and the metamodel is:
 The three previous mathematical functions are implemented as instances of the
 :class:`~openturns.Function` class.
 """
-# %%
-# In this example we are going to create a global approximation of a model response using functional chaos and expose the associated results:
-#
-# - the composed model: :math:`h`: :math:`\underline{Z}^{\strut} \longrightarrow \underline{Y} = g \circ T^{-1}(\underline{Z})`,
-#   which is the model of the reduced variables :math:`\underline{Z}`.
-#   We have  :math:`\displaystyle h =  \sum_{k \in \mathbb N} \underline{\alpha}_k \Psi_k`,
-# - the coefficients of the polynomial approximation : :math:`(\underline{\alpha}_k)_{k \in K}`,
-# - the composed meta model: :math:`\hat{h}`, which is the model of the reduced variables reduced to the truncated multivariate basis :math:`(\Psi_k)_{k \in K}`.
-#   We have :math:`\displaystyle  \hat{h} = \sum_{k \in K} \underline{\alpha}_k \Psi_k`,
-# - the meta model: :math:`\displaystyle \hat{g} : \underline{X} \longrightarrow Y = \hat{h} \circ T(\underline{X})` which is the polynomial chaos approximation as a Function.
-#   We have :math:`\displaystyle \hat{g} = \sum_{k \in K} \underline{\alpha}_k \Psi_k \circ T`,
-# - the truncated multivariate basis : :math:`(\Psi_k)_{k \in K}`,
-# - the indices :math:`K`,
-# - the composition of each polynomial of the truncated multivariate basis :math:`\Psi_k`,
-# - the distribution :math:`\mu` of the transformed variables :math:`\underline{Z}`.
-#
 
 # %%
 import openturns as ot


### PR DESCRIPTION
This fixes the wrong merge at PR#2236, where the second part of the introduction of this example was meant to be removed, but stayed. The goal of this PR is to actually remove the second text.