### PR TITLE
Fixes doc issues

### DIFF
--- a/python/doc/examples/calibration/bayesian_calibration/plot_bayesian_calibration.py
+++ b/python/doc/examples/calibration/bayesian_calibration/plot_bayesian_calibration.py
@@ -19,7 +19,9 @@ Bayesian calibration of a computer code
 #
 # The posterior distribution is given by Bayes theorem:
 #
-# .. math::\pi(\vect\theta | \vect y) \quad \propto \quad L\left(\vect y | \vect\theta\right) \times \pi(\vect\theta):math:``
+# .. math::
+#
+#     \pi(\vect\theta | \vect y) \quad \propto \quad L\left(\vect y | \vect\theta\right) \times \pi(\vect\theta)
 #
 # where :math:`\propto` means "proportional to", regarded as a function of :math:`\vect\theta`.
 #
@@ -74,7 +76,7 @@ Bayesian calibration of a computer code
 # The following objects need to be defined in order to perform Bayesian calibration:
 #
 # - The conditional density :math:`p(y|\vect z)` must be defined as a probability distribution.
-# - The computer model must be implemented thanks to the ParametricFunction class.
+# - The computer model must be implemented thanks to the :class:`~openturns.ParametricFunction` class.
 #   This takes a value of :math:`\vect\theta` as input, and outputs the vector of model predictions :math:`\vect z`,
 #   as defined above (the vector of covariates :math:`\vect x = (x_1, \ldots, x_n)` is treated as a known constant).
 #   When doing that, we have to keep in mind that :math:`\vect z` will be used as the vector of parameters corresponding
@@ -86,6 +88,11 @@ Bayesian calibration of a computer code
 #   Again, this is implemented as a probability distribution.
 # - Metropolis-Hastings algorithm(s), possibly used in tandem with a Gibbs algorithm
 #   in order to sample from the posterior distribution of the calibration parameters.
+#
+# This example uses the :class:`~openturns.ParametricFunction` class.
+# Please read its documentation and
+# :doc:`/auto_functional_modeling/vectorial_functions/plot_parametric_function`
+# for a detailed example.
 
 # %%
 import openturns as ot

--- a/python/doc/examples/data_analysis/manage_data_and_samples/plot_quick_start_point_and_sample.py
+++ b/python/doc/examples/data_analysis/manage_data_and_samples/plot_quick_start_point_and_sample.py
@@ -17,8 +17,8 @@ A quick start guide to the `Point` and `Sample` classes
 #
 # Two fundamental objects in the library are:
 #
-# * `Point`: a multidimensional point in :math:`D` dimensions (:math:`\in \mathbb{R}^D`) ;
-# * `Sample`: a multivariate sample made of :math:`N` points in :math:`D` dimensions.
+# * `Point`: a multidimensional point in :math:`d` dimensions (:math:`\in \mathbb{R}^d`) ;
+# * `Sample`: a multivariate sample made of :math:`n` points in :math:`d` dimensions.
 #
 
 # %%
@@ -66,18 +66,18 @@ p.getDimension()
 # The `Sample` class
 # ------------------
 #
-# The `Sample` class represents a multivariate sample made of :math:`N` points in :math:`\mathbb{R}^D`.
+# The `Sample` class represents a multivariate sample made of :math:`n` points in :math:`\mathbb{R}^d`.
 #
-# * :math:`D` is the *dimension* of the sample,
-# * :math:`N` is the *size* of the sample.
+# * :math:`d` is the *dimension* of the sample,
+# * :math:`n` is the *size* of the sample.
 #
 #
-# A `Sample` can be seen as an array of with :math:`N` rows and :math:`D` columns.
+# A `Sample` can be seen as an array of with :math:`n` rows and :math:`d` columns.
 #
 # *Remark.* The :class:`~openturns.ProcessSample` class can be used to manage a sample of stochastic processes.
 
 # %%
-# The script below creates a `Sample` with size :math:`N=5` and dimension :math:`D=3`.
+# The script below creates a `Sample` with size :math:`n=5` and dimension :math:`d=3`.
 
 # %%
 data = ot.Sample(5, 3)
@@ -133,7 +133,7 @@ print(type(column))
 # * the `row` is a `Point`,
 # * the `column` is a `Sample`.
 #
-# This is consistent with the fact that, in a dimension :math:`D` `Sample`, a row is a :math:`D`-dimensional `Point`.
+# This is consistent with the fact that, in a dimension :math:`d` `Sample`, a row is a :math:`d`-dimensional `Point`.
 
 # %%
 # The following statement extracts several columns (with indices 0 and 2) and creates a new `Sample`.
@@ -142,17 +142,34 @@ print(type(column))
 data.getMarginal([0, 2])
 
 # %%
+# Set a row or a column of a `Sample`
+# -----------------------------------
+
+# %%
 # Slicing can also be used to set a `Sample` row or column.
 
 # %%
 sample = ot.Sample([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+sample
+
+# %%
+# Set the third row: this must be a `Point` or must be convertible to.
 p = [8.0, 10.0]
 sample[2, :] = p
 sample
 
 # %%
+# Set the second column: this must be a `Sample` or must be convertible to.
 sample = ot.Sample([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
 s = ot.Sample([[3.0], [5.0], [7.0]])
+sample[:, 1] = s
+sample
+
+# %%
+# Sometimes, we want to set a column with a list of floats.
+# This can be done using the :meth:`~openturns.Sample.BuildFromPoint` static method.
+sample = ot.Sample([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+s = ot.Sample.BuildFromPoint([3.0, 5.0, 7.0])
 sample[:, 1] = s
 sample
 
@@ -231,7 +248,7 @@ array = np.array(sample)
 array
 
 # %%
-type(array)
+print(type(array))
 
 # %%
 # Conversely, the following script creates a Numpy `array`, then converts it into a :class:`~openturns.Sample`.
@@ -278,13 +295,27 @@ sample = ot.Sample([u[i: i + 5] for i in range(len(u) // 5)])
 sample
 
 # %%
-# If we do not set the optional `size` parameter, the library cannot solve the
-# case and an `InvalidArgumentException` is generated.
-# More precisely, the code::
+# When there is an ambiguous case, the library cannot solve the
+# issue and an `InvalidArgumentException` is generated.
+
+# %%
+# More precisely, the code:
+#
+# .. code-block::
 #
 #     sample = ot.Sample(u)
 #
-# produces the exception::
+
+# %%
+# produces the exception:
+#
+# .. code-block::
 #
 #     TypeError: InvalidArgumentException : Invalid array dimension: 1
 #
+
+# %%
+# In order to solve that problem, we can use the :meth:`~openturns.Sample.BuildFromPoint`
+# static method.
+sample = ot.Sample.BuildFromPoint([ui for ui in u])
+sample

--- a/python/doc/examples/functional_modeling/vectorial_functions/plot_parametric_function.py
+++ b/python/doc/examples/functional_modeling/vectorial_functions/plot_parametric_function.py
@@ -3,21 +3,32 @@ Create a parametric function
 ============================
 """
 # %%
-# In this example we are going to create a parametric function:
+# In this example, we show how to use the :class:`~openturns.ParametricFunction` class.
+# This is a tool which is very convenient when we perform
+# calibration, e.g. with :class:`~openturns.NonLinearLeastSquaresCalibration`
+# or :class:`~openturns.RandomWalkMetropolisHastings`.
+
+# %%
+# In this example we create a parametric function:
 #
 # .. math::
-#    d_{L,I}(E, F):  \mathbb{R}^2  \rightarrow \mathbb{R}
+#    d_{L,I}(E, F):  \Rset^2  \rightarrow \Rset
 #
 # function from an existing "full" function:
 #
 # .. math::
-#  d(E, F, L, I):  \mathbb{R}^4  \rightarrow \mathbb{R}
+#  d(E, F, L, I):  \Rset^4  \rightarrow \Rset.
 #
 
 # %%
 import openturns as ot
 
 ot.Log.Show(ot.Log.NONE)
+
+
+# %%
+# Define the function
+# ~~~~~~~~~~~~~~~~~~~
 
 
 # %%
@@ -29,11 +40,74 @@ def d_func(X):
 
 
 beam = ot.PythonFunction(4, 1, d_func)
+beam.setInputDescription(["E", "F", "L", "I"])
 
 # %%
 # Evaluate d
 x = [50.0, 1.0, 10.0, 5.0]
 beam(x)
+
+# %%
+# In the physical model, the inputs and parameters are ordered as
+# presented in the next table.
+# Notice that there are no parameters in the physical model.
+#
+# +-------+----------------+
+# | Index | Input variable |
+# +=======+================+
+# | 0     | E              |
+# +-------+----------------+
+# | 1     | F              |
+# +-------+----------------+
+# | 2     | L              |
+# +-------+----------------+
+# | 3     | I              |
+# +-------+----------------+
+#
+# +-------+-----------+
+# | Index | Parameter |
+# +=======+===========+
+# | ∅     | ∅         |
+# +-------+-----------+
+#
+# **Table 1.** Indices and names of the inputs and parameters of the physical model.
+#
+
+# %%
+# The next cell presents the description of the input variables
+# and the description of the parameters of the physical model.
+# We see that there is no parameter at this stage in this function.
+print("Physical Model Inputs:", beam.getInputDescription())
+print("Physical Model Parameters:", beam.getParameterDescription())
+
+
+# %%
+# Define the parametric function
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# We create a :class:`~openturns.ParametricFunction`
+# where the parameters are `L` and `I` which have the indices 2 and
+# and 3 in the physical model.
+#
+# +-------+----------------+
+# | Index | Input variable |
+# +=======+================+
+# | 0     | E              |
+# +-------+----------------+
+# | 1     | F              |
+# +-------+----------------+
+#
+# +-------+-----------+
+# | Index | Parameter |
+# +=======+===========+
+# | 0     | L         |
+# +-------+-----------+
+# | 1     | I         |
+# +-------+-----------+
+#
+# **Table 2.** Indices and names of the inputs and parameters of the parametric model.
+#
 
 # %%
 # Create the indices of the frozen parameters (L,I) from the full parameter list
@@ -46,6 +120,13 @@ referencePoint = [10.0, 5.0]
 # %%
 # Create the parametric function
 beam_LI = ot.ParametricFunction(beam, indices, referencePoint)
+
+# %%
+# The next cell presents the description of the input variables
+# and the description of the parameters of the parametric function.
+# We see that the parametric function has 2 parameters: L and I.
+print("Physical Model Inputs:", beam_LI.getInputDescription())
+print("Physical Model Parameters:", beam_LI.getParameterDescription())
 
 # %%
 # Evaluate d on (E,F) with fixed parameters (L,I)

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_hyperparameters_optimization.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_hyperparameters_optimization.py
@@ -1,5 +1,5 @@
 """
-Kriging :configure the optimization solver
+Kriging: configure the optimization solver
 ==========================================
 """
 # %%
@@ -25,7 +25,7 @@ Kriging :configure the optimization solver
 #   Often, the parameter :math:`{\bf \theta}` is a scale parameter.
 #   This step involves an optimization algorithm.
 #
-# All these parameters are estimated with the `GeneralLinearModelAlgorithm` class.
+# All these parameters are estimated with the :class:`~openturns.GeneralLinearModelAlgorithm` class.
 #
 # The estimation of the :math:`{\bf \theta}` parameters is the step which has the highest CPU cost.
 # Moreover, the maximization of likelihood may be associated with difficulties e.g. many local maximums or even the non convergence of the optimization algorithm.
@@ -75,7 +75,7 @@ II = ot.Beta(2.5, 1.5, 310, 450)  # in cm^4
 II.setDescription("I")
 
 # %%
-# Finally, we define the dependency using a `NormalCopula`.
+# Finally, we define the dependency using a :class:`~openturns.NormalCopula`.
 
 # %%
 dim = 4  # number of inputs
@@ -89,7 +89,8 @@ myDistribution = ot.JointDistribution([E, F, L, II], myCopula)
 # --------------------------------
 
 # %%
-# We consider a simple Monte-Carlo sampling as a design of experiments. This is why we generate an input sample using the `getSample` method of the distribution.
+# We consider a simple Monte-Carlo sampling as a design of experiments.
+# This is why we generate an input sample using the `getSample` method of the distribution.
 # Then we evaluate the output using the `model` function.
 
 # %%
@@ -102,9 +103,9 @@ Y_train = model(X_train)
 # --------------------
 
 # %%
-# In order to create the kriging metamodel, we first select a constant trend with the `ConstantBasisFactory` class.
+# In order to create the kriging metamodel, we first select a constant trend with the :class:`~openturns.ConstantBasisFactory` class.
 # Then we use a squared exponential covariance model.
-# Finally, we use the `KrigingAlgorithm` class to create the kriging metamodel,
+# Finally, we use the :class:`~openturns.KrigingAlgorithm` class to create the kriging metamodel,
 # taking the training sample, the covariance model and the trend basis as input arguments.
 
 # %%
@@ -132,9 +133,10 @@ result = algo.getResult()
 krigingMetamodel = result.getMetaModel()
 
 # %%
-# The `run` method has optimized the hyperparameters of the metamodel.
+# The :meth:`~openturns.KrigingAlgorithm.run` method has optimized the hyperparameters of the metamodel.
 #
-# We can then print the constant trend of the metamodel, which have been estimated using the least squares method.
+# We can then print the constant trend of the metamodel, which have been
+# estimated using the least squares method.
 
 # %%
 result.getTrendCoefficients()
@@ -151,7 +153,10 @@ print(basic_covariance_model)
 # ---------------------------
 
 # %%
-# The `getOptimizationAlgorithm` method returns the optimization algorithm used to optimize the :math:`{\bf \theta}` parameters of the `SquaredExponential` covariance model.
+# The :meth:`~openturns.KrigingAlgorithm.getOptimizationAlgorithm` method
+# returns the optimization algorithm used to optimize the
+# :math:`{\bf \theta}` parameters of the
+# :class:`~openturns.SquaredExponential` covariance model.
 
 # %%
 solver = algo.getOptimizationAlgorithm()
@@ -164,7 +169,10 @@ solverImplementation = solver.getImplementation()
 solverImplementation.getClassName()
 
 # %%
-# The `getOptimizationBounds` method returns the bounds. The dimension of these bounds correspond to the spatial dimension of the covariance model.
+# The :meth:`~openturns.KrigingAlgorithm.getOptimizationBounds` method
+# returns the bounds.
+# The dimension of these bounds correspond to the spatial dimension of
+# the covariance model.
 # In the metamodeling context, this correspond to the input dimension of the model.
 
 # %%
@@ -182,7 +190,7 @@ print("ubounds")
 print(ubounds)
 
 # %%
-# The `getOptimizeParameters` method returns `True` if these parameters are to be optimized.
+# The :meth:`~openturns.KrigingAlgorithm.getOptimizeParameters` method returns `True` if these parameters are to be optimized.
 
 # %%
 isOptimize = algo.getOptimizeParameters()
@@ -195,7 +203,8 @@ print(isOptimize)
 
 # %%
 # The starting point of the optimization is based on the parameters of the covariance model.
-# In the following example, we configure the parameters of the covariance model to the arbitrary values `[12.,34.,56.,78.]`.
+# In the following example, we configure the parameters of the covariance model to
+# the arbitrary values `[12.0, 34.0, 56.0, 78.0]`.
 
 # %%
 covarianceModel = ot.SquaredExponential([12.0, 34.0, 56.0, 78.0], [1.0])
@@ -226,15 +235,16 @@ print(basic_covariance_model)
 
 # %%
 # It is sometimes useful to completely disable the optimization of the parameters.
-# In order to see the effect of this, we first initialize the parameters of the covariance model with the arbitrary values `[12.,34.,56.,78.]`.
+# In order to see the effect of this, we first initialize the parameters of
+# the covariance model with the arbitrary values `[12.0, 34.0, 56.0, 78.0]`.
 
 # %%
 covarianceModel = ot.SquaredExponential([12.0, 34.0, 56.0, 78.0], [91.0])
 algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)
-algo.setOptimizationBounds(scaleOptimizationBounds)  # Trick B
 
 # %%
-# The `setOptimizeParameters` method can be used to disable the optimization of the parameters.
+# The :meth:`~openturns.KrigingAlgorithm.setOptimizeParameters` method can be
+# used to disable the optimization of the parameters.
 
 # %%
 algo.setOptimizeParameters(False)
@@ -361,10 +371,13 @@ printCovarianceParameterChange(finetune_covariance_model, basic_covariance_model
 # ----------------------------------------
 
 # %%
-# The following example checks the robustness of the optimization of the kriging algorithm with respect to
-# the optimization of the likelihood function in the covariance model parameters estimation.
-# We use a `MultiStart` algorithm in order to avoid to be trapped by a local minimum.
-# Furthermore, we generate the design of experiments using a `LHSExperiments`, which guarantees that the points will fill the space.
+# The following example checks the robustness of the optimization of the
+# kriging algorithm with respect to the optimization of the likelihood
+# function in the covariance model parameters estimation.
+# We use a :class:`~openturns.MultiStart` algorithm in order to avoid to be trapped by a local minimum.
+# Furthermore, we generate the design of experiments using a
+# :class:`~openturns.LHSExperiments`, which guarantees that the points
+# will fill the space.
 
 # %%
 sampleSize_train = 10
@@ -372,14 +385,17 @@ X_train = myDistribution.getSample(sampleSize_train)
 Y_train = model(X_train)
 
 # %%
-# First, we create a multivariate distribution, based on independent `Uniform` marginals which have the bounds required by the covariance model.
+# First, we create a multivariate distribution, based on independent
+# :class:`~openturns.Uniform` marginals which have the bounds required
+# by the covariance model.
 
 # %%
 distributions = [ot.Uniform(lbounds[i], ubounds[i]) for i in range(dim)]
 boundedDistribution = ot.JointDistribution(distributions)
 
 # %%
-# We first generate a Latin Hypercube Sampling (LHS) design made of 25 points in the sample space. This LHS is optimized so as to fill the space.
+# We first generate a Latin Hypercube Sampling (LHS) design made of 25 points in the sample space.
+# This LHS is optimized so as to fill the space.
 
 # %%
 K = 25  # design size
@@ -393,7 +409,8 @@ starting_points = LHS_design.getOptimalDesign()
 starting_points.getSize()
 
 # %%
-# We can check that the minimum and maximum in the sample correspond to the bounds of the design of experiment.
+# We can check that the minimum and maximum in the sample correspond to the
+# bounds of the design of experiment.
 
 # %%
 print(lbounds, ubounds)
@@ -402,14 +419,14 @@ print(lbounds, ubounds)
 starting_points.getMin(), starting_points.getMax()
 
 # %%
-# Then we create a `MultiStart` algorithm based on the LHS starting points.
+# Then we create a :class:`~openturns.MultiStart` algorithm based on the LHS starting points.
 
 # %%
 solver.setMaximumIterationNumber(10000)
 multiStartSolver = ot.MultiStart(solver, starting_points)
 
 # %%
-# Finally, we configure the optimization algorithm so as to use the `MultiStart` algorithm.
+# Finally, we configure the optimization algorithm so as to use the :class:`~openturns.MultiStart` algorithm.
 
 # %%
 algo = ot.KrigingAlgorithm(X_train, Y_train, covarianceModel, basis)

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_build_distribution.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_build_distribution.py
@@ -75,7 +75,7 @@ distribution = ot.FunctionalChaosAlgorithm.BuildDistribution(inputSample)
 distribution
 
 # %%
-# We can also analyse its properties in more detail.
+# We can also analyse its properties in more details.
 
 # %%
 for i in range(dimension):

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_ishigami_grouped_indices.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_ishigami_grouped_indices.py
@@ -57,7 +57,7 @@ metamodel = result.getMetaModel()
 
 # %%
 chaosSI = ot.FunctionalChaosSobolIndices(result)
-print(chaosSI)
+chaosSI
 
 # %%
 # We compute the first order indice of the group [0,1].

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos.py
@@ -1,9 +1,17 @@
 """
-Create a polynomial chaos metamodel
-===================================
+Create a polynomial chaos metamodel from a data set
+===================================================
 """
 # %%
-# In this example we are going to create a global approximation of a model response using functional chaos.
+# In this example, we create a polynomial chaos expansion (PCE) using
+# a data set.
+# More precisely, given a pair of input and output samples,
+# we create a PCE without the knowledge of the input distribution.
+# In this example, we use a relatively small sample size equal to 80.
+
+# %%
+# In this example we create a global approximation of a model response using
+# polynomial chaos expansion.
 #
 # Let :math:`h` be the function defined by:
 #
@@ -21,7 +29,12 @@ Create a polynomial chaos metamodel
 # and that :math:`X_1` and :math:`X_2` are independent.
 #
 # An interesting point in this example is that the output is multivariate.
-# This is why we are going to use the `getMarginal` method in the script in order to select the output marginal that we want to manage.
+# This is why we are going to use the `getMarginal` method in the script
+# in order to select the output marginal that we want to manage.
+
+# %%
+# Simulate input and output samples
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # %%
 import openturns as ot
@@ -34,14 +47,15 @@ ot.Log.Show(ot.Log.NONE)
 # We first create the function `model`.
 
 # %%
-ot.RandomGenerator.SetSeed(0)
+ot.RandomGenerator.SetSeed(2)
 dimension = 2
 input_names = ["x1", "x2"]
 formulas = ["cos(x1 + x2)", "(x2 + 1) * exp(x1)"]
 model = ot.SymbolicFunction(input_names, formulas)
 
 # %%
-# Then we create a sample `inputSample` and compute the corresponding output sample `outputSample`.
+# Then we create a sample `inputSample` and compute the corresponding output
+# sample `outputSample`.
 
 # %%
 distribution = ot.Normal(dimension)
@@ -50,16 +64,42 @@ inputSample = distribution.getSample(samplesize)
 outputSample = model(inputSample)
 
 # %%
+# Create the PCE
+# ~~~~~~~~~~~~~~
+
+# %%
 # Create a functional chaos model.
-# First, we need to fit a distribution on the input sample. We can do this automatically with the Lilliefors test.
+# The algorithm needs to fit a distribution on the input sample.
+# To do this, the algorithm in :class:`~openturns.FunctionalChaosAlgorithm`
+# uses the :class:`~openturns.FunctionalChaosAlgorithm.BuildDistribution`
+# static method to fit the distribution to the input sample.
+# Please read :doc:`Fit a distribution from an input sample </auto_meta_modeling/polynomial_chaos_metamodel/plot_chaos_build_distribution>`
+# for an example of this method.
+# The algorithm does this automatically using the Lilliefors test.
+# In order to make the algorithm a little faster, we reduce the
+# value of the sample size used in the Lilliefors test.
 
 # %%
-ot.ResourceMap.SetAsUnsignedInteger("FittingTest-LillieforsMaximumSamplingSize", 100)
+ot.ResourceMap.SetAsUnsignedInteger("FittingTest-LillieforsMaximumSamplingSize", 50)
 
 # %%
+# The main topic of this example is to introduce the next constructor of
+# :class:`~openturns.FunctionalChaosAlgorithm`.
+# Notice that the only input arguments are the input and output sample.
 algo = ot.FunctionalChaosAlgorithm(inputSample, outputSample)
 algo.run()
 result = algo.getResult()
+result
+
+# %%
+# Not all coefficients are selected in this PCE.
+# Indeed, the default constructor of :class:`~openturns.FunctionalChaosAlgorithm`
+# creates a sparse PCE.
+# Please read :doc:`Create a full or sparse polynomial chaos expansion </auto_meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_database>`
+# for more details on this topic.
+
+# %%
+# Get the metamodel.
 metamodel = result.getMetaModel()
 
 # %%
@@ -87,8 +127,10 @@ graph.setTitle("Metamodel Validation, output #%d" % (outputIndex))
 view = viewer.View(graph)
 
 # %%
-# We see that the metamodel fits approximately to the model, except perhaps for extreme values of :math:`x_2`.
-# However, there is a better way of globally validating the metamodel, using the `MetaModelValidation` on a validation design of experiment.
+# We see that the metamodel fits approximately to the model, except
+# perhaps for extreme values of :math:`x_2`.
+# However, there is a better way of globally validating the metamodel,
+# using the :class:`~openturns.MetaModelValidation` on a validation design of experiment.
 
 # %%
 n_valid = 100
@@ -107,23 +149,28 @@ graph.setTitle("Metamodel validation Q2=" + str(Q2))
 view = viewer.View(graph)
 
 # %%
-# The coefficient of predictivity is not extremely satisfactory for the first output, but is would be sufficient for a central dispersion study.
-# The second output has a much more satisfactory Q2: only one single extreme point is far from the diagonal of the graphics.
+# The coefficient of predictivity is not extremely satisfactory for the
+# first output, but is would be sufficient for a central dispersion study.
+# The second output has a much more satisfactory Q2: only one single
+# extreme point is far from the diagonal of the graphics.
 
 # %%
 # Compute and print Sobol' indices
-# --------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # %%
 chaosSI = ot.FunctionalChaosSobolIndices(result)
-print(chaosSI)
+chaosSI
 
 # %%
 # Let us analyse the results of this global sensitivity analysis.
 #
-# * We see that the first output involves significant multi-indices with total degree 4. The contribution of the interactions are very significant in this model.
-# * The second output involves multi-indices with total degrees from 1 to 7, with a significant contribution of multi-indices with total degress 5 and 7.
-#   The first variable is especially significant, with a significant contribution of the interactions.
+# * We see that the first output involves significant multi-indices with
+#   higher marginal degree.
+# * For the second output, the first variable is especially significant,
+#   with a significant contribution of the interactions.
+#   The contribution of the interactions are very
+#   significant in this model.
 
 # %%
 # Draw Sobol' indices.
@@ -141,15 +188,20 @@ view = viewer.View(graph)
 
 # %%
 # Testing the sensitivity to the degree
-# -------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# With the specific constructor of `FunctionalChaosAlgorithm` that we use, the `FunctionalChaosAlgorithm-MaximumTotalDegree`
-# in the `ResourceMap` configure the maximum degree explored by the algorithm. This degree is a trade-off.
+# With the specific constructor of `FunctionalChaosAlgorithm` that
+# we use, the `FunctionalChaosAlgorithm-MaximumTotalDegree`
+# in the `ResourceMap` configure the maximum degree explored by
+# the algorithm. This degree is a trade-off.
 #
-# * If the maximum degree is too low, the polynomial may miss some coefficients so that the quality is lower than possible.
-# * If the maximum degree is too large, the number of coefficients to explore is too large, so that the coefficients might be poorly estimated.
+# * If the maximum degree is too low, the polynomial may miss some
+#   coefficients so that the quality is lower than possible.
+# * If the maximum degree is too large, the number of coefficients
+#   to explore is too large, so that the coefficients might be poorly estimated.
 #
-# This is why the following `for` loop explores various degrees to see the sensitivity of the metamodel predictivity depending on the degree.
+# This is why the following `for` loop explores various degrees to see
+# the sensitivity of the metamodel predictivity depending on the degree.
 
 # %%
 # The default value of this parameter is 10.
@@ -158,10 +210,10 @@ view = viewer.View(graph)
 ot.ResourceMap.GetAsUnsignedInteger("FunctionalChaosAlgorithm-MaximumTotalDegree")
 
 # %%
-# This is why we explore the values from 5 to 15.
+# This is why we explore the values from 1 to 15.
 
 # %%
-degrees = range(5, 12)
+degrees = range(1, 12)
 q2 = ot.Sample(len(degrees), 2)
 for maximumDegree in degrees:
     ot.ResourceMap.SetAsUnsignedInteger(
@@ -176,7 +228,8 @@ for maximumDegree in degrees:
         val = ot.MetaModelValidation(
             inputTest, outputTest[:, outputIndex], metamodel.getMarginal(outputIndex)
         )
-        q2[maximumDegree - degrees[0], outputIndex] = val.computePredictivityFactor()[0]
+        q2Value = min(1.0, max(0.0, val.computePredictivityFactor()[0]))  # Get lucky.
+        q2[maximumDegree - degrees[0], outputIndex] = q2Value
 
 # %%
 graph = ot.Graph("Predictivity", "Total degree", "Q2", True)
@@ -190,22 +243,35 @@ cloud.setColor("red")
 cloud.setPointStyle("bullet")
 graph.add(cloud)
 graph.setLegendPosition("upper right")
-view = viewer.View(graph)
+view = viewer.View(graph, legend_kw={"bbox_to_anchor": (1.0, 1.0), "loc": "upper left"})
+plt.subplots_adjust(right=0.7)
+
 plt.show()
 
 # %%
-# We see that a total degree lower than 9 is not sufficient to describe the first output with good predictivity.
-# However, the coefficient of predictivity drops when the total degree gets greater than 12.
-# The predictivity of the second output seems to be much less satisfactory: a little more work would be required to improve the metamodel.
+# We see that the R2 score increases then gets constant or decreases.
+# A low total polynomial degree is not sufficient to describe
+# the first output with good predictivity.
+# However, the coefficient of predictivity can decrease when the total degree
+# gets greater.
+# The predictivity of the second output seems to be much less
+# satisfactory: a little more work would be required to improve the metamodel.
 #
 # In this situation, the following methods may be used.
 #
-# * Since the distribution of the input is known, we may want to give this information to the `FunctionalChaosAlgorithm`.
-#   This prevents the algorithm from trying to fit the distribution which best fit to the data.
-# * We may want to customize the `adaptiveStrategy` by selecting an enumerate function which best fit to this particular situation.
-#   In this specific example, the interactions plays a great role so that the linear enumerate function may provide better results than the hyperbolic rule.
-# * We may want to customize the `projectionStrategy` by selecting an method to compute the coefficient which improves the estimation.
-#   Given that the function is symbolic and fast, it might be interesting to try an integration rule instead of the least squares method.
+# * Since the distribution of the input is known, we may want to give
+#   this information to the `FunctionalChaosAlgorithm`.
+#   This prevents the algorithm from trying to fit the input distribution
+#   which best fit to the data.
+# * We may want to customize the `adaptiveStrategy` by selecting an enumerate
+#   function which best fit to this particular example.
+#   In this specific example, however, the interactions plays a great role so that the
+#   linear enumerate function may provide better results than the hyperbolic rule.
+# * We may want to customize the `projectionStrategy` by selecting a method
+#   to compute the coefficient which improves the estimation.
+#   For example, it might be interesting to
+#   try an integration rule instead of the least squares method.
+#   Notice that a specific design of experiment is required in this case.
 
 # %%
 # Reset default settings

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_database.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_functional_chaos_database.py
@@ -1,12 +1,18 @@
 """
-Polynomial chaos over database
-==============================
+Create a full or sparse polynomial chaos expansion
+==================================================
 """
 # %%
-# In this example we are going to create a global approximation of a model response using functional chaos over a design of experiment.
-#
-# You will need to specify the distribution of the input parameters.
-# If not known, statistical inference can be used to select a possible candidate, and fitting tests can validate such an hypothesis.
+# In this example we create a global approximation of a model using
+# polynomial chaos expansion based on a design of experiment.
+# The goal of this example is to show how we can create a full or
+# sparse polynomial chaos expansion depending on our needs
+# and depending on the number of observations we have.
+# In general, we should have more observations than parameters to estimate.
+# This is why a sparse polynomial chaos may be interesting:
+# by carefully selecting the coefficients we estimate,
+# we may reduce overfitting and increase the predictions of the
+# metamodel.
 
 # %%
 import openturns as ot
@@ -14,49 +20,156 @@ import openturns as ot
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# Create a function R^n --> R^p
-# For example R^4 --> R
-myModel = ot.SymbolicFunction(["x1", "x2", "x3", "x4"], ["1+x1*x2 + 2*x3^2+x4^4"])
+# Define the model
+# ~~~~~~~~~~~~~~~~
 
-# Create a distribution of dimension n
-# for example n=3 with independent components
+# %%
+# Create the function.
+myModel = ot.SymbolicFunction(
+    ["x1", "x2", "x3", "x4"], ["1 + x1 * x2 + 2 * x3^2 + x4^4"]
+)
+
+# %%
+# Create a multivariate distribution.
 distribution = ot.JointDistribution(
     [ot.Normal(), ot.Uniform(), ot.Gamma(2.75, 1.0), ot.Beta(2.5, 1.0, -1.0, 2.0)]
 )
 
 # %%
-# Prepare the input/output samples
-sampleSize = 250
-X = distribution.getSample(sampleSize)
-Y = myModel(X)
-dimension = X.getDimension()
+# In order to create the PCE, we can specify the distribution of the
+# input parameters.
+# If not known, statistical inference can be used to select a possible
+# candidate, and fitting tests can validate such an hypothesis.
+# Please read :doc:`Fit a distribution from an input sample </auto_meta_modeling/polynomial_chaos_metamodel/plot_chaos_build_distribution>`
+# for an example of this method.
 
 # %%
-# build the orthogonal basis
+# Create a training sample
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# Create a pair of input and output samples.
+sampleSize = 250
+inputSample = distribution.getSample(sampleSize)
+outputSample = myModel(inputSample)
+
+# %%
+# Build the orthogonal basis
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# In the next cell, we create the univariate orthogonal polynomial basis
+# for each marginal.
+inputDimension = inputSample.getDimension()
 coll = [
     ot.StandardDistributionPolynomialFactory(distribution.getMarginal(i))
-    for i in range(dimension)
+    for i in range(inputDimension)
 ]
-enumerateFunction = ot.LinearEnumerateFunction(dimension)
+enumerateFunction = ot.LinearEnumerateFunction(inputDimension)
 productBasis = ot.OrthogonalProductPolynomialFactory(coll, enumerateFunction)
 
 # %%
-# create the algorithm
-degree = 6
-adaptiveStrategy = ot.FixedStrategy(
-    productBasis, enumerateFunction.getStrataCumulatedCardinal(degree)
+# We can achieve the same result using :class:`~OrthogonalProductPolynomialFactory`.
+marginalDistributionCollection = [
+    distribution.getMarginal(i) for i in range(inputDimension)
+]
+multivariateBasis = ot.OrthogonalProductPolynomialFactory(
+    marginalDistributionCollection
 )
-projectionStrategy = ot.LeastSquaresStrategy()
-algo = ot.FunctionalChaosAlgorithm(
-    X, Y, distribution, adaptiveStrategy, projectionStrategy
-)
-algo.run()
+multivariateBasis
 
 # %%
-# get the metamodel function
+# Create a full PCE
+# ~~~~~~~~~~~~~~~~~
+
+# %%
+# Create the algorithm.
+# We compute the basis size from the total degree.
+# The next lines use the :class:`~openturns.LeastSquaresStrategy` class
+# with default parameters (the default is the
+# :class:`~openturns.PenalizedLeastSquaresAlgorithmFactory` class).
+# This creates a full polynomial chaos expansion, i.e.
+# we keep all the candidate coefficients produced by the enumeration
+# rule.
+# In order to create a sparse polynomial chaos expansion, we
+# must use the :class:`~openturns.LeastSquaresMetaModelSelectionFactory`
+# class instead.
+#
+totalDegree = 3
+candidateBasisSize = enumerateFunction.getBasisSizeFromTotalDegree(totalDegree)
+print("Candidate basis size = ", candidateBasisSize)
+adaptiveStrategy = ot.FixedStrategy(productBasis, candidateBasisSize)
+projectionStrategy = ot.LeastSquaresStrategy()
+algo = ot.FunctionalChaosAlgorithm(
+    inputSample, outputSample, distribution, adaptiveStrategy, projectionStrategy
+)
+algo.run()
 result = algo.getResult()
+result
+
+# %%
+# Get the number of coefficients in the PCE.
+selectedBasisSizeFull = result.getIndices().getSize()
+print("Selected basis size = ", selectedBasisSizeFull)
+
+# %%
+# We see that the number of coefficients in the selected basis is
+# equal to the number of coefficients in the candidate basis.
+# This is, indeed, a *full* PCE.
+
+# %%
+# Use the PCE
+# ~~~~~~~~~~~
+
+# %%
+# Get the metamodel function.
 metamodel = result.getMetaModel()
 
 # %%
-# Print residuals
+# In order to evaluate the metamodel on a single point, we just
+# use it as any other :class:`openturns.Function`.
+xPoint = distribution.getMean()
+yPoint = metamodel(xPoint)
+print("Value at ", xPoint, " is ", yPoint)
+
+# %%
+# Print residuals.
 result.getResiduals()
+
+# %%
+# Based on these results, we may want to validate our metamodel.
+# More details on this topic are presented in
+# :doc:`Validate a polynomial chaos </auto_meta_modeling/polynomial_chaos_metamodel/plot_chaos_draw_validation>`.
+
+# %%
+# Create a sparse PCE
+# ~~~~~~~~~~~~~~~~~~~
+
+# %%
+# In order to create a sparse polynomial chaos expansion, we
+# use the :class:`~openturns.LeastSquaresMetaModelSelectionFactory`
+# class instead.
+#
+totalDegree = 6
+candidateBasisSize = enumerateFunction.getBasisSizeFromTotalDegree(totalDegree)
+print("Candidate basis size = ", candidateBasisSize)
+adaptiveStrategy = ot.FixedStrategy(productBasis, candidateBasisSize)
+selectionAlgorithm = ot.LeastSquaresMetaModelSelectionFactory()
+projectionStrategy = ot.LeastSquaresStrategy(selectionAlgorithm)
+algo = ot.FunctionalChaosAlgorithm(
+    inputSample, outputSample, distribution, adaptiveStrategy, projectionStrategy
+)
+algo.run()
+result = algo.getResult()
+result
+
+# %%
+# Get the number of coefficients in the PCE.
+selectedBasisSizeSparse = result.getIndices().getSize()
+print("Selected basis size = ", selectedBasisSizeSparse)
+
+# %%
+# We see that the number of selected coefficients is lower than
+# the number of candidate coefficients.
+# This may reduce overfitting and can produce a PCE with more
+# accurate predictions.

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_functional_chaos_sensitivity.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_functional_chaos_sensitivity.py
@@ -78,7 +78,7 @@ print(result.getRelativeErrors())
 # %%
 # Quick summary of sensitivity analysis
 sensitivityAnalysis = ot.FunctionalChaosSobolIndices(result)
-print(sensitivityAnalysis)
+sensitivityAnalysis
 
 # %%
 # draw Sobol' indices
@@ -92,10 +92,7 @@ view = viewer.View(graph)
 # so the higher order indices must be all quite close to 0
 for i in range(dimension):
     for j in range(i):
-        print(
-            input_names[i] + " & " + input_names[j],
-            ":",
-            sensitivityAnalysis.getSobolIndex([i, j]),
-        )
+        sij = sensitivityAnalysis.getSobolIndex([i, j])
+        print(f"{input_names[i]} & {input_names[j]}: {sij:.4f}")
 
 plt.show()

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_ancova.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_ancova.py
@@ -70,7 +70,7 @@ X = experiment.generate()
 Y = model(X)
 algo = ot.FunctionalChaosAlgorithm(X, Y, distribution, adaptiveStrategy)
 algo.run()
-result = ot.FunctionalChaosResult(algo.getResult())
+result = algo.getResult()
 
 # %%
 # Create the input sample taking account the correlation

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_wingweight.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_wingweight.py
@@ -357,7 +357,9 @@ print(result.getRelativeErrors())
 # The relative errors are low : this indicates that the PCE model has good accuracy.
 # Then, we exploit the surrogate model to compute the Sobol' indices.
 sensitivityAnalysis = ot.FunctionalChaosSobolIndices(result)
-print(sensitivityAnalysis)
+sensitivityAnalysis
+
+# %%
 firstOrder = [sensitivityAnalysis.getSobolIndex(i) for i in range(m.dim)]
 totalOrder = [sensitivityAnalysis.getSobolTotalIndex(i) for i in range(m.dim)]
 graph = ot.SobolIndicesAlgorithm.DrawSobolIndices(inputNames, firstOrder, totalOrder)

--- a/python/src/KrigingAlgorithm_doc.i.in
+++ b/python/src/KrigingAlgorithm_doc.i.in
@@ -95,7 +95,7 @@ Get the resulting meta model:
 
 Returns
 -------
-algorithm : :class:`~openturns.OptimizationAlgorithm`
+solver : :class:`~openturns.OptimizationAlgorithm`
     Solver used to optimize the covariance model parameters."
 
 // ---------------------------------------------------------------------
@@ -105,7 +105,7 @@ algorithm : :class:`~openturns.OptimizationAlgorithm`
 
 Parameters
 ----------
-algorithm : :class:`~openturns.OptimizationAlgorithm`
+solver : :class:`~openturns.OptimizationAlgorithm`
     Solver used to optimize the covariance model parameters.
 
 Examples
@@ -134,7 +134,7 @@ Create the Kriging algorithm with the optimizer option:
 
 Parameters
 ----------
-bounds : :class:`~openturns.Interval`
+optimizationBounds : :class:`~openturns.Interval`
     The bounds used for numerical optimization of the likelihood.
 
 Notes
@@ -148,7 +148,7 @@ particularly :meth:`~openturns.GeneralLinearModelAlgorithm.setOptimizationBounds
 
 Returns
 -------
-problem : :class:`~openturns.Interval`
+optimizationBounds : :class:`~openturns.Interval`
     The bounds used for numerical optimization of the likelihood."
 
 // ---------------------------------------------------------------------

--- a/python/src/OptimizationAlgorithmImplementation_doc.i.in
+++ b/python/src/OptimizationAlgorithmImplementation_doc.i.in
@@ -104,7 +104,7 @@ OT_OptimizationAlgorithm_getMaximumConstraintError_doc
 
 Returns
 -------
-N : int
+maximumIterationNumber : int
     Maximum allowed number of iterations."
 %enddef
 %feature("docstring") OT::OptimizationAlgorithmImplementation::getMaximumIterationNumber
@@ -117,7 +117,7 @@ OT_OptimizationAlgorithm_getMaximumIterationNumber_doc
 
 Returns
 -------
-N : int
+maximumEvaluationNumber : int
     Maximum allowed number of direct objective function calls through the `()` operator.
     Does not take into account eventual indirect calls through finite difference gradient calls."
 %enddef
@@ -181,7 +181,7 @@ OT_OptimizationAlgorithm_run_doc
 
 Parameters
 ----------
-N : int
+maximumIterationNumber : int
     Maximum allowed number of iterations."
 %enddef
 %feature("docstring") OT::OptimizationAlgorithmImplementation::setMaximumIterationNumber
@@ -194,7 +194,7 @@ OT_OptimizationAlgorithm_setMaximumIterationNumber_doc
 
 Parameters
 ----------
-N : int
+maximumEvaluationNumber : int
     Maximum allowed number of direct objective function calls through the `()` operator.
     Does not take into account eventual indirect calls through finite difference gradient calls."
 %enddef

--- a/python/src/OrthogonalFunctionFactory_doc.i.in
+++ b/python/src/OrthogonalFunctionFactory_doc.i.in
@@ -17,7 +17,7 @@ Examples
 >>> import openturns as ot
 >>> # Create an orthogonal basis
 >>> polynomialCollection = [ot.LegendreFactory(), ot.LaguerreFactory(), ot.HermiteFactory()]
->>> productBasis = ot.OrthogonalBasis(ot.OrthogonalProductPolynomialFactory(polynomialCollection))"
+>>> productBasis = ot.OrthogonalProductPolynomialFactory(polynomialCollection)"
 %enddef
 %feature("docstring") OT::OrthogonalFunctionFactory
 OT_OrthogonalBasis_doc
@@ -51,14 +51,14 @@ Examples
 >>> import openturns as ot
 >>> # Create an orthogonal basis
 >>> polynomialCollection = [ot.LegendreFactory(), ot.LaguerreFactory(), ot.HermiteFactory()]
->>> productBasis = ot.OrthogonalBasis(ot.OrthogonalProductPolynomialFactory(polynomialCollection))
+>>> productBasis =  ot.OrthogonalProductPolynomialFactory(polynomialCollection)
 >>> termBasis = productBasis.build(4)
 >>> print(termBasis.getEvaluation())
 -1.11803 + 3.3541 * x0^2
 >>> termBasis = productBasis.build(5)
 >>> print(termBasis.getEvaluation())
 1.73205 * x0 * (-1 + x1)
->>> termBasis2 = productBasis.build([1,1,0])
+>>> termBasis2 = productBasis.build([1, 1, 0])
 >>> print(termBasis2.getEvaluation())
 1.73205 * x0 * (-1 + x1)"
 %enddef
@@ -94,7 +94,7 @@ Examples
 >>> import openturns as ot
 >>> # Create an orthogonal basis
 >>> polynomialCollection = [ot.LegendreFactory(), ot.LaguerreFactory(), ot.HermiteFactory()]
->>> productBasis = ot.OrthogonalBasis(ot.OrthogonalProductPolynomialFactory(polynomialCollection))
+>>> productBasis = ot.OrthogonalProductPolynomialFactory(polynomialCollection)
 >>> measure = productBasis.getMeasure()
 >>> print(measure.getMarginal(0))
 Uniform(a = -1, b = 1)

--- a/python/src/OrthogonalProductPolynomialFactory_doc.i.in
+++ b/python/src/OrthogonalProductPolynomialFactory_doc.i.in
@@ -43,12 +43,12 @@ Examples
 >>> myModel = ot.SymbolicFunction(['x1','x2','x3'], ['1+x1*x2 + 2*x3^2'])
 >>> # Create a distribution of dimension 3
 >>> Xdist = ot.JointDistribution([ot.Normal(), ot.Uniform(), ot.Gamma(2.75, 1.0)])
->>> # Construct the multivariate orthonormal basis
+>>> # Create the multivariate orthonormal basis
 >>> polyColl = [ot.HermiteFactory(), ot.LegendreFactory(), ot.LaguerreFactory(2.75)]
 >>> enumerateFunction = ot.LinearEnumerateFunction(3)
 >>> productBasis = ot.OrthogonalProductPolynomialFactory(polyColl, enumerateFunction)
 
->>> # Easier way to construct the same multivariate orthonormal basis
+>>> # Easier way to create the same multivariate orthonormal basis
 >>> marginals = [Xdist.getMarginal(i) for i in range(Xdist.getDimension())]
 >>> productBasis = ot.OrthogonalProductPolynomialFactory(marginals)"
 
@@ -69,7 +69,7 @@ polynomialFamily : list of :class:`~openturns.OrthogonalUniVariatePolynomialFami
 
 Parameters
 ----------
-degrees : list of positiv int (:math:`k_1, \dots, k_n`)
+degrees : list of positive int (:math:`k_1, \dots, k_n`)
     List of :math:`n` polynomial orders associated with the :math:`n`
     univariate polynomials of the basis.
 

--- a/python/src/ParametricFunction_doc.i.in
+++ b/python/src/ParametricFunction_doc.i.in
@@ -7,6 +7,9 @@ Available constructor:
 It defines a parametric function from *function* by freezing the variables
 marked by the *indices* set to the values of *referencePoint*.
 
+Please read the example below and :doc:`/auto_functional_modeling/vectorial_functions/plot_parametric_function` 
+for a detailed example of this class.
+
 Parameters
 ----------
 function : :class:`~openturns.Function`
@@ -26,20 +29,20 @@ parametersSet : bool
 Examples
 --------
 >>> import openturns as ot
->>> f = ot.SymbolicFunction(['x', 'y', 'z'], ['x+y', 'x*z+y'])
+>>> f = ot.SymbolicFunction(['x', 'y', 'z'], ['x + y', 'x * z + y'])
 >>> print(f)
-[x,y,z]->[x+y,x*z+y]
+[x,y,z]->[x + y,x * z + y]
 
 Then create another function by setting x=2 and y=3:
 
->>> g=ot.ParametricFunction(f, [0,1], [2,3])
+>>> g=ot.ParametricFunction(f, [0,1], [2.0, 3.0])
 >>> print(g)
-ParametricEvaluation([x,y,z]->[x+y,x*z+y], parameters positions=[0,1], parameters=[x : 2, y : 3], input positions=[2])
+ParametricEvaluation([x,y,z]->[x + y,x * z + y], parameters positions=[0,1], parameters=[x : 2, y : 3], input positions=[2])
 
 Or by setting z=4 using the complementary set flag:
 
->>> g = ot.ParametricFunction(f, [0,1], [4], False)
+>>> g = ot.ParametricFunction(f, [0, 1], [4.0], False)
 >>> print(g.getInputDescription())
 [x,y]
 >>> print(g)
-ParametricEvaluation([x,y,z]->[x+y,x*z+y], parameters positions=[2], parameters=[z : 4], input positions=[0,1])"
+ParametricEvaluation([x,y,z]->[x + y,x * z + y], parameters positions=[2], parameters=[z : 4], input positions=[0,1])"


### PR DESCRIPTION
This PR fixes two bugs:
- the first kriging example mentioned by @mdelozzo in #2364
- the bugs mentioned in the API doc of  `KrigingAlgorithm` by @mdelozzo in #2361 
- the bugs mentioned on `Sample` example in #2359

This PR also fixes other doc bugs.
- This PR also fixes bugs in the Bayesian calibration doc:

![image](https://github.com/openturns/openturns/assets/31351465/9c289a2c-5804-461a-964f-fd11e1c7c9db)

- This PR provides more detailed explanations on the `ParametricFunction` class.
- It provides an improved example to set a column or a row of a `Sample`.
- It removes unnecessary casts (i.e. class conversions) in some examples.

To do this, I used `docfast.py` with the following parameters:
```bash
$ git add . && cd build && make -j8 && make install && cd .. && python3 utils/docfast.py build-sphinxonly response_surface.rst kriging.rst KrigingAlgorithm.rst GeneralLinearModelAlgorithm.rst glm.rst plot_kriging_hyperparameters_optimization.py
```
When I updated the example with `docfast`, I also added the `KrigingAlgorithm` so that I could made the links active (otherwise, they are just in bold face). But the kriging is in the "Response surface" section of the API help page, so I had to add this section. 