### PR TITLE
Convert a FunctionalChaosResult into a LinearModelResult

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
@@ -30,6 +30,7 @@
 #include "openturns/Function.hxx"
 #include "openturns/Distribution.hxx"
 #include "openturns/OrthogonalBasis.hxx"
+#include "openturns/LinearModelResult.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -114,6 +115,9 @@ public:
 
   /** involvesModelSelection accessor */
   virtual void setInvolvesModelSelection(const Bool involvesModelSelection);
+
+  /** Linear model accessor */
+  virtual LinearModelResult getLinearModelResult(const UnsignedInteger & marginalOutputIndex = 0) const;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/lib/test/t_FunctionalChaos_ishigami.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami.cxx
@@ -219,7 +219,6 @@ int main(int, char *[])
           const Function transformation(result.getTransformation());
           const Sample Ztest(transformation(Xtest));
           const Sample YtestLM(metamodelLM(Ztest));
-          const Sample YDiff(YtestPCE - YtestLM);
           assert_almost_equal(YtestPCE, YtestLM, rtol);
           
         }

--- a/lib/test/t_FunctionalChaos_ishigami.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami.cxx
@@ -203,6 +203,25 @@ int main(int, char *[])
           // Print summary
           fullprint << "Summary" << std::endl;
           fullprint << sensitivity.__str__() << std::endl;
+
+          // Convert to LinearModelResult
+          const LinearModelResult lmResult(result.getLinearModelResult());
+          // Check the coefficients
+          const Point coefficientsPCE(result.getCoefficients().getMarginal(0).asPoint());
+          const Point coefficientsLM(lmResult.getCoefficients());
+          const Scalar rtol = 1.e-15;
+          assert_almost_equal(coefficientsPCE, coefficientsLM, rtol);
+          // Check the metamodel
+          const Function metamodelPCE(result.getMetaModel());
+          const Sample Xtest(experiment.generate());
+          const Sample YtestPCE(metamodelPCE(Xtest));
+          const Function metamodelLM(lmResult.getMetaModel());
+          const Function transformation(result.getTransformation());
+          const Sample Ztest(transformation(Xtest));
+          const Sample YtestLM(metamodelLM(Ztest));
+          const Sample YDiff(YtestPCE - YtestLM);
+          assert_almost_equal(YtestPCE, YtestLM, rtol);
+          
         }
       }
     }

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_regression_analysis.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_regression_analysis.py
@@ -1,0 +1,156 @@
+"""
+Regression analysis of a PCE
+============================
+"""
+
+# %%
+# In this example, we create a polynomial chaos expansion from regression
+# and use regression analysis on the result.
+
+# %%
+import openturns as ot
+import openturns.viewer as otv
+from openturns.usecases import ishigami_function
+
+
+# %%
+def ComputeSparseLeastSquaresFunctionalChaos(
+    inputTrain,
+    outputTrain,
+    multivariateBasis,
+    basisSize,
+    distribution,
+    sparse=True,
+):
+    """
+    Create a sparse polynomial chaos based on least squares.
+
+    * Uses the enumerate rule in multivariateBasis.
+    * Uses the LeastSquaresStrategy to compute the coefficients based on
+      least squares.
+    * Uses LeastSquaresMetaModelSelectionFactory to use the LARS selection method.
+    * Uses FixedStrategy in order to keep all the coefficients that the
+      LARS method selected.
+
+    Parameters
+    ----------
+    inputTrain : ot.Sample
+        The input design of experiments.
+    outputTrain : ot.Sample
+        The output design of experiments.
+    multivariateBasis : ot.Basis
+        The multivariate chaos basis.
+    basisSize : int
+        The size of the function basis.
+    distribution : ot.Distribution.
+        The distribution of the input variable.
+    sparse: bool
+        If True, create a sparse PCE.
+
+    Returns
+    -------
+    result : ot.PolynomialChaosResult
+        The estimated polynomial chaos.
+    """
+    if sparse:
+        selectionAlgorithm = ot.LeastSquaresMetaModelSelectionFactory()
+    else:
+        selectionAlgorithm = ot.PenalizedLeastSquaresAlgorithmFactory()
+    projectionStrategy = ot.LeastSquaresStrategy(
+        inputTrain, outputTrain, selectionAlgorithm
+    )
+    adaptiveStrategy = ot.FixedStrategy(multivariateBasis, basisSize)
+    chaosAlgorithm = ot.FunctionalChaosAlgorithm(
+        inputTrain, outputTrain, distribution, adaptiveStrategy, projectionStrategy
+    )
+    chaosAlgorithm.run()
+    chaosResult = chaosAlgorithm.getResult()
+    return chaosResult
+
+
+# %%
+# Create a polynomial chaos expansion
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+ot.Log.Show(ot.Log.NONE)
+ot.RandomGenerator.SetSeed(0)
+im = ishigami_function.IshigamiModel()
+input_names = im.distributionX.getDescription()
+sampleSize = 1000
+inputSample = im.distributionX.getSample(sampleSize)
+outputSample = im.model(inputSample)
+
+# %%
+multivariateBasis = ot.OrthogonalProductPolynomialFactory([im.X1, im.X2, im.X3])
+totalDegree = 12
+enumerateFunction = multivariateBasis.getEnumerateFunction()
+basisSize = enumerateFunction.getBasisSizeFromTotalDegree(totalDegree)
+print("Basis size = ", basisSize)
+
+# %%
+chaosResult = ComputeSparseLeastSquaresFunctionalChaos(
+    inputSample,
+    outputSample,
+    multivariateBasis,
+    basisSize,
+    im.distributionX,
+)
+print("Selected basis size = ", chaosResult.getIndices().getSize())
+chaosResult
+
+# %%
+# Validate the metamodel
+metamodel = chaosResult.getMetaModel()
+n_valid = 1000
+inputTest = im.distributionX.getSample(n_valid)
+outputTest = im.model(inputTest)
+val = ot.MetaModelValidation(inputTest, outputTest, metamodel)
+Q2 = val.computePredictivityFactor()[0]
+graph = val.drawValidation()
+graph.setTitle("Q2=%.2f%%" % (Q2 * 100))
+view = otv.View(graph)
+
+# %%
+# Convert into a regression result
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# %%
+# Convert the PCE into a regression result.
+lmResult = chaosResult.getLinearModelResult()
+lmResult
+
+# %%
+# We can then perform the analysis of the linear model, as
+# is classical in regression analysis.
+analysis = ot.LinearModelAnalysis(lmResult)
+analysis
+
+# %%
+graph = analysis.drawModelVsFitted()
+view = otv.View(graph)
+
+# %%
+graph = analysis.drawResidualsVsFitted()
+view = otv.View(graph)
+
+# %%
+graph = analysis.drawScaleLocation()
+view = otv.View(graph)
+
+# %%
+# sphinx_gallery_thumbnail_number = 5
+graph = analysis.drawQQplot()
+view = otv.View(graph)
+
+# %%
+graph = analysis.drawCookDistance()
+view = otv.View(graph)
+
+# %%
+graph = analysis.drawResidualsVsLeverages()
+view = otv.View(graph)
+
+# %%
+graph = analysis.drawCookVsLeverages()
+view = otv.View(graph)

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -302,3 +302,17 @@ Returns
 residualsSample : :class:`~openturns.Sample`
     The sample of residuals :math:`r_{ji} = y_{ji} - \metamodel_i(\vect{x^{(j)}})`
     for :math:`i = 1, ..., n_Y` and :math:`j = 1, ..., n`."
+
+%feature("docstring") OT::FunctionalChaosResult::getLinearModelResult
+"Get the linear model result.
+
+Parameters
+----------
+marginalOutputIndex: int
+    The index of the marginal output.
+    The default value is `marginalOutputIndex = 0`.
+
+Returns
+-------
+lmResult : :class:`~openturns.LinearModelResult`
+    The linear model."

--- a/python/test/t_FunctionalChaos_ishigami.py
+++ b/python/test/t_FunctionalChaos_ishigami.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 import math as m
 
 ot.TESTPREAMBLE()
@@ -220,3 +221,10 @@ for adaptiveStrategyIndex in range(len(listAdaptiveStrategy)):
                 )
         # Print summary
         print(sensitivity)
+
+        # Convert to LinearModelResult
+        lmResult = result.getLinearModelResult()
+        coefficientsPCE = result.getCoefficients().getMarginal(0).asPoint()
+        coefficientsLM = lmResult.getCoefficients()
+        rtol = 1.0e-15
+        ott.assert_almost_equal(coefficientsPCE, coefficientsLM, rtol)


### PR DESCRIPTION
The goal of this PR is to convert a PCE into a linear model. 

## The problem
In the current implementation, when we create a polynomial chaos expansion based on linear regression, we get a `FunctionalChaosResult`. Mathematically, this is the result of a linear regression. However, the Python object is not the `LinearModelResult` that is needed to perform the `LinearModelAnalysis` that actually implements the regression analysis in the library. The goal of this PR is to be able to create a `LinearModelResult` from a `FunctionalChaosResult`.

## Features
- `LinearModelAnalysis`:
  - Creates a new `LinearModelAnalysis::getResidualsStandardError()` method.
  - New HTML Python pretty-print.
- Creates a new `FunctionalChaosResult::getLinearModelResult()` method.
- `LinearModelResult`
  - Creates new `LinearModelResult.getDesign()` and `LinearModelResult.getSigma2()` methods. These are attributes of the class which had no corresponding `get` methods.
  - Creates a new `LinearModelResult::__repr_markdown__()` method.

## Doc
- A new example of a `PythonRandomVector` is created: `plot_distribution_linear_regression.py`. It plots the distribution of the estimators of the variance and standard deviation of linear regression. This example uses the `LinearFunction` class.
- A new theory help page of linear regression is created.
- The help page of the `LinearFunction` class is improved.

## Fixed bugs
- In the ASCII-art pretty-print, the standard deviation is estimated using a code which is only available in the pretty-print source code ([see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L137)). This is wrong by design, because it prevents from implementing a unit test. Implement the new `LinearModelAnalysis.getResidualsStandardError()` method instead.
- In the normality test for the residuals, the Kolmogorov-Smirnov uses a biased estimator of the standard deviation ([see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L325)). Uses the new `LinearModelAnalysis.getResidualsStandardError()` method instead.

## Questions
- [ ] The standard deviation estimator looks suspicious to me: [see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L137). I cannot find a reference for this estimator. I cannot understand why we should not use the square root of the variance. I admit, however, that the distribution of this estimator is correct, as shown in `plot_distribution_linear_regression.py`.
- [ ] Wait for the merge of #2330 for the `isRegression_` attribute of `FunctionalChaosResult`. Then, if regression is false, generate an exception.

