### PR TITLE
Update KarhunenLoeveSVDAlgorithm_doc.i.in

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -139,9 +139,15 @@ Bibliography
     *Latin Hypercube sampling and the propagation of uncertainty analyses of complex systems*,
     Reliability Engineering and System Safety 81, 23-69.
     `pdf <https://web.archive.org/web/20141222122431id_/http://www.stat.unm.edu:80/~storlie/st579/articles/RESS_2003_LHS.pdf>`__
+.. [hotelling1933] Hotelling, H. (1933).
+    *Analysis of a complex of statistical variables into principal components.*
+    Journal of educational psychology, 24(6):417.
 .. [iooss2015] Iooss B., Lemaître P. (2015) *A review on global sensitivity
     analysis methods.* In: Meloni C., Dellino G. (eds) Uncertainty management in Simulation-Optimization of Complex Systems: Algorithms and Applications, Springer.
     `pdf <https://arxiv.org/pdf/1404.2405>`__
+.. [jackson1991] Jackson, J. E. (1991).
+    *A user’s guide to principal components.*
+    John Wiley & Sons.
 .. [janon2014] Janon A., Klein T., Lagnoux-Renaudie A., Prieur C., *Asymptotic
     normality and efficiency of two Sobol index estimators*,
     ESAIM: Probability and Statistics, EDP Sciences, 2014, 18, pp.342-364.
@@ -156,6 +162,9 @@ Bibliography
 .. [johnson1990] Johnson M, Moore L and Ylvisaker D (1990).
     *Minimax and maximin distance design.*
     Journal of Statistical Planning and Inference 26(2): 131-148.
+.. [jolliffe2002] Jolliffe, I. T. (2002).
+    *Principal component analysis.*
+    Springer.
 .. [jones1998] Donald R. Jones, Matthias Schonlau and William J Welch.
     *Global optimization of expensive black-box functions*,
     Journal of Global Optimization, 13(4), 455-492, 1998.
@@ -223,7 +232,10 @@ Bibliography
     Reliability Engineering & System Safety, 95(5), 550-564.
 .. [loader2000] Loader C. *Fast and Accurate Computation of Binomial Probabilities*,
     `pdf <http://octave.1599824.n4.nabble.com/attachment/3829107/0/loader2000Fast.pdf>`__
-.. [luke] https://www.luke-g.com/math/spearman/index.html
+.. [luke] Luke Gustafson. The Spearman Rho null distribution. https://www.luke-g.com/math/spearman/index.html
+.. [luo2018] Zhendong Luo, Goong Chen
+    *Proper Orthogonal Decomposition Methods for Partial Differential Equations.*
+    (2018) Academic Press.
 .. [marelli2018] S. Marelli, B. Sudret, *An active-learning algorithm that combines sparse
     polynomial chaos expansions and bootstrap for structural reliability analysis*, Structural Safety, 2018.
     `pdf <https://arxiv.org/pdf/1709.01589.pdf>`__
@@ -291,6 +303,10 @@ Bibliography
 .. [park1990] Byeong U. Park and J. S. Marron.
     *Comparison of data-driven bandwidth selectors.*
     Journal of the American Statistical Association, 85(409) :66–72, 1990.
+.. [pearson1907] Pearson, K. (1901).
+    *On lines and planes of closest fit to systems of points in space.*
+    The London, Edinburgh, and Dublin philosophical magazine and journal of
+    science, 2(11):559–572.
 .. [pelamatti2020] Pelamatti, J., Brevault, L., Balesdent, M., Talbi, E. G., & Guerin, Y. (2020).
     *Overview and comparison of gaussian process-based surrogate models for mixed continuous and discrete variables: Application on aerospace design problems.*
     High-Performance Simulation-Based Optimization, 189-224.

--- a/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
@@ -12,8 +12,8 @@ s : float, :math:`\geq0`
 Notes
 -----
 The Karhunen-Loeve decomposition enables to build some finite approximations
-of stochastic processes which are optimal with respect to the norm
-:math:`L^2` (see [sullivan2015]_ page 223).
+of stochastic processes which are optimal with respect to the :math:`L^2` norm
+(see [sullivan2015]_ page 223).
 
 We suppose that :math:`C:\cD \times \cD \rightarrow  \cS^+_d(\Rset)` is a covariance function defined on :math:`\cD \in \Rset^n`, continuous at :math:`\vect{0}`. 
 

--- a/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
@@ -15,9 +15,12 @@ The Karhunen-Loeve decomposition enables to build some finite approximations
 of stochastic processes which are optimal with respect to the :math:`L^2` norm
 (see [sullivan2015]_ page 223).
 
-We suppose that :math:`C:\cD \times \cD \rightarrow  \cS^+_d(\Rset)` is a covariance function defined on :math:`\cD \in \Rset^n`, continuous at :math:`\vect{0}`. 
+We suppose that :math:`C:\cD \times \cD \rightarrow  \cS^+_d(\Rset)` is a covariance
+function defined on :math:`\cD \in \Rset^n`, continuous at :math:`\vect{0}`. 
 
-The class :class:`~openturns.KarhunenLoeveAlgorithm` enables to determine the solutions of the second kind Fredholm equation associated to  :math:`C`, ie to find the :math:`(\lambda_k,  \vect{\varphi}_k)_{k \geq 1}` such that: 
+The class :class:`~openturns.KarhunenLoeveAlgorithm` enables to determine the solutions
+of the second kind Fredholm equation associated to  :math:`C`, ie to find the
+:math:`(\lambda_k,  \vect{\varphi}_k)_{k \geq 1}` such that: 
 
 .. math::
     :label: fredholm
@@ -25,10 +28,13 @@ The class :class:`~openturns.KarhunenLoeveAlgorithm` enables to determine the so
     \int_{\cD} \mat{C}(\vect{s},\vect{t}) \vect{\varphi}_k(\vect{t})\,  d\vect{t} = \lambda_k  \vect{\varphi}_k(\vect{s}) \quad \forall \vect{s} \in \cD
 
 
-where :math:`(\lambda_k)_{k \geq 1}` is a nonincreasing sequence of nonnegative values (the **eigenvalues**) and :math:`(\vect{\varphi}_k)_{k \geq 1}` the   associated sequence of **eigenfunctions**, normalized by :math:`\int_{\cD}\|\vect{\varphi}_k(\vect{s})\|^2\di{\vect{s}}=1`. They form an hilbertian basis of :math:`L^2(\cD, \Rset^d)`.
+where :math:`(\lambda_k)_{k \geq 1}` is a nonincreasing sequence of nonnegative values (the **eigenvalues**)
+and :math:`(\vect{\varphi}_k)_{k \geq 1}` the   associated sequence of **eigenfunctions**,
+normalized by :math:`\int_{\cD}\|\vect{\varphi}_k(\vect{s})\|^2\di{\vect{s}}=1`.
+They form an Hilbertian basis of :math:`L^2(\cD, \Rset^d)`.
 
 
-The Mercer theorem shows that the covariance function  :math:`C` writes:
+The Mercer theorem shows that the covariance function  :math:`C` is:
 
 .. math::
     :label: covFuncMercer
@@ -36,14 +42,17 @@ The Mercer theorem shows that the covariance function  :math:`C` writes:
     \mat{C}(\vect{s},\vect{t}) = \sum_{k=1}^{+\infty} \lambda_k \vect{\varphi}_k(\vect{s}) \Tr{\vect{\varphi}}_k(\vect{t}) \quad \forall (\vect{s}, \vect{t}) \in \cD \times \cD
 
 
-The threshold :math:`s` is used in order to select the most significant eigenvalues, ie all the eigenvalues such that (the infinite sum on the right being replaced by the sum of all computed eigenvalues in numerical algorithms): 
+The threshold :math:`s` is used in order to select the most significant eigenvalues, i.e. all
+the eigenvalues such that (the infinite sum on the right being replaced by the sum of all
+computed eigenvalues in numerical algorithms): 
 
 .. math::
     :label: thresholdK
 
     K_s = \min \left\{ k \in \Nset \, | \, \sum_{i=1}^{k}{\lambda_i} \geq (1-s) \times \sum_{i \geq 1}^{+\infty} \lambda_i \right\}
 
-The number of significant eigenvalues can also be specified directly by using :func:`setNbModes`. In this case, only :math:`n` eigenvalues will be computed, and the number of selected eigenvalues will be:
+The number of significant eigenvalues can also be specified directly by using :func:`setNbModes`.
+In this case, only :math:`n` eigenvalues will be computed, and the number of selected eigenvalues will be:
 
 .. math::
     :label: combinedK
@@ -52,9 +61,11 @@ The number of significant eigenvalues can also be specified directly by using :f
     
 with :math:`K_s` as defined in :eq:`thresholdK`.
 
-Thus if threshold is set to 0, the number of selected eigenvalues is set by :func:`setNbModes`.
+Thus if threshold :math:`s` is set to 0, the number of selected eigenvalues is set by :func:`setNbModes`.
     
-To solve :eq:`fredholm`, we use the functional basis :math:`(\theta_p)_{1 \leq p \leq P}` of :math:`L^2(\cD, \Rset)` with :math:`P` elements defined on :math:`\cD`. We search the solutions of type:
+To solve :eq:`fredholm`, we use the functional basis :math:`(\theta_p)_{1 \leq p \leq P}`
+of :math:`L^2(\cD, \Rset)` with :math:`P` elements defined on :math:`\cD`.
+We search the solutions of type:
 
 .. math::
 
@@ -75,9 +86,10 @@ where :math:`\vect{\phi}_{pk} \in \Rset^d`. We note:
         \right) \in \Rset^{Pd}
      \end{align*}
 
-and :math:`\mat{\vect{\Phi}} = (\vect{\Phi}_1\, |\, \dots \, | \vect{\Phi}_K)` the matrix of the :math:`K` first modes of the Karhunen-Loeve decomposition.
+and :math:`\mat{\vect{\Phi}} = (\vect{\Phi}_1\, |\, \dots \, | \vect{\Phi}_K)` the
+matrix of the :math:`K` first modes of the Karhunen-Loeve decomposition.
 
-The approximated Fredholm problem writes for all :math:`k \geq 1`:
+The approximated Fredholm problem is for all :math:`k \geq 1`:
 
 .. math::
 

--- a/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
+++ b/python/src/KarhunenLoeveAlgorithmImplementation_doc.i.in
@@ -11,7 +11,9 @@ s : float, :math:`\geq0`
 
 Notes
 -----
-The Karhunen-Loeve decomposition enables to build some finite approximations of stochastic processes which are optimal with respect to the norm :math:`L^2`.
+The Karhunen-Loeve decomposition enables to build some finite approximations
+of stochastic processes which are optimal with respect to the norm
+:math:`L^2` (see [sullivan2015]_ page 223).
 
 We suppose that :math:`C:\cD \times \cD \rightarrow  \cS^+_d(\Rset)` is a covariance function defined on :math:`\cD \in \Rset^n`, continuous at :math:`\vect{0}`. 
 

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -24,7 +24,7 @@ centeredSample : bool, default=False
     
 Notes
 -----
-The Karhunen-Loeve SVD algorithm solves the Fredholm problem  associated to the
+The Karhunen-Loeve SVD algorithm solves the Fredholm problem associated to the
 covariance function :math:`C`: see :class:`~openturns.KarhunenLoeveAlgorithm`
 to get the notations.
 If the mesh is regular, then this decomposition is equivalent to the principal

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -53,9 +53,9 @@ It consists in :
       otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
     - taking the :math:`L` vertices of the mesh of :math:`\vect{X}` as the :math:`L` quadrature points.
 
-We suppose now that :math:`K < dL`, and we note :math:`\mat{Y} = \sqrt{\mat{W}} \,\mat{X}`.
+We suppose now that :math:`K < Ld`, and we note :math:`\mat{Y} = \sqrt{\mat{W}} \,\mat{X}`.
 
-As the matrix :math:`\mat{\Theta} = \mat{C}` is invertible, the Galerkin and collocation
+As the matrix :math:`\mat{\Theta} = \mat{C}` is nonsingular, the Galerkin and collocation
 approaches are equivalent and both lead to the following singular value problem for :math:`\mat{Y}`:
 
 .. math::
@@ -69,12 +69,12 @@ The SVD decomposition of :math:`\mat{Y}\in \mathcal{M}_{dL,\tilde{K}}(\Rset)` wr
 
     \mat{Y} = \mat{U}\, \mat{\Sigma} \, \Tr{\mat{V}}
 
-where  we have :math:`\mat{U} \in \mathcal{M}_{dL,\tilde{K}}(\Rset)`, 
+where  we have :math:`\mat{U} \in \mathcal{M}_{Ld, \tilde{K}}(\Rset)`, 
 :math:`\mat{\Sigma}\in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)`, :math:`\mat{V} \in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)` such that :
 
     - :math:`\Tr{\mat{V}}\mat{V} =\mat{V}\Tr{\mat{V}}= \mat{I}_{\tilde{K}}`,  
     - :math:`\Tr{\mat{U}}\mat{U} = \mat{I}_{\tilde{K}}` ,
-    - :math:`\mat{\Sigma} = diag(\sigma_1, \dots, \sigma_{\tilde{K}})`.
+    - :math:`\mat{\Sigma} = \diag(\sigma_1, \dots, \sigma_{\tilde{K}})`.
 
 Then the columns of :math:`\mat{U}` are the eigenvectors of :math:`\mat{Y}\Tr{\mat{Y}}`
 associated to the eigenvalues :math:`\sigma_k^2`.

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -46,12 +46,13 @@ through :math:`K` fields of the associated stochastic process :math:`\vect{X}`: 
 
 It consists in :
 
-    - approximating :math:`\mat{C}` by its empirical estimator
-      :math:`\dfrac{1}{\tilde{K}} \tilde{\mat{X}}\, \Tr{\tilde{\mat{X}}}` where
-      :math:`\tilde{\mat{X}}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\tilde{K}=K`
-      if the process is centered and :math:`\tilde{\mat{X}}~=~(\vect{X}_1 - \vect{\mu} | \dots | \vect{X}_K - \vect{\mu})`:math:`\tilde{K}=K-1`
-      otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
-    - taking the :math:`L` vertices of the mesh of :math:`\vect{X}` as the :math:`L` quadrature points.
+- approximating :math:`\mat{C}` by its empirical estimator
+  :math:`\dfrac{1}{\widetilde{K}} \widetilde{\mat{X}}\, \Tr{\widetilde{\mat{X}}}` where
+  :math:`\widetilde{\mat{X}}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\widetilde{K}=K`
+  if the process is centered and :math:`\widetilde{\mat{X}}~=~(\vect{X}_1 - \vect{\mu} | \dots | \vect{X}_K - \vect{\mu})` 
+  and :math:`\widetilde{K}=K-1`
+  otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
+- taking the :math:`L` vertices of the mesh of :math:`\vect{X}` as the :math:`L` quadrature points.
 
 We suppose now that :math:`K < Ld`, and we note :math:`\mat{Y} = \sqrt{\mat{W}} \,\mat{X}`.
 
@@ -61,39 +62,39 @@ approaches are equivalent and both lead to the following singular value problem 
 .. math::
     :label: QuadCollDim1_ter
 
-     \mat{Y}\,\Tr{\mat{Y}}\,\mat{\Psi}_k  & = \tilde{K} \lambda_k \mat{\Psi}_k
+     \mat{Y}\,\Tr{\mat{Y}}\,\mat{\Psi}_k  & = \widetilde{K} \lambda_k \mat{\Psi}_k.
 
-The SVD decomposition of :math:`\mat{Y}\in \mathcal{M}_{dL,\tilde{K}}(\Rset)` writes:
+The SVD decomposition of :math:`\mat{Y}\in \mathcal{M}_{Ld,\widetilde{K}}(\Rset)` is:
 
 .. math::
 
     \mat{Y} = \mat{U}\, \mat{\Sigma} \, \Tr{\mat{V}}
 
-where  we have :math:`\mat{U} \in \mathcal{M}_{Ld, \tilde{K}}(\Rset)`, 
-:math:`\mat{\Sigma}\in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)`, :math:`\mat{V} \in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)` such that :
+where  the matrices :math:`\mat{U} \in \mathcal{M}_{Ld, \widetilde{K}}(\Rset)`, 
+:math:`\mat{\Sigma}\in \mathcal{M}_{\widetilde{K},\widetilde{K}}(\Rset)`, 
+:math:`\mat{V} \in \mathcal{M}_{\widetilde{K},\widetilde{K}}(\Rset)` are such that :
 
-    - :math:`\Tr{\mat{V}}\mat{V} =\mat{V}\Tr{\mat{V}}= \mat{I}_{\tilde{K}}`,  
-    - :math:`\Tr{\mat{U}}\mat{U} = \mat{I}_{\tilde{K}}` ,
-    - :math:`\mat{\Sigma} = \diag(\sigma_1, \dots, \sigma_{\tilde{K}})`.
+- :math:`\Tr{\mat{V}}\mat{V} =\mat{V}\Tr{\mat{V}}= \mat{I}_{\widetilde{K}}`,  
+- :math:`\Tr{\mat{U}}\mat{U} = \mat{I}_{\widetilde{K}}` ,
+- :math:`\mat{\Sigma} = \diag(\sigma_1, \dots, \sigma_{\widetilde{K}})`.
 
 Then the columns of :math:`\mat{U}` are the eigenvectors of :math:`\mat{Y}\Tr{\mat{Y}}`
 associated to the eigenvalues :math:`\sigma_k^2`.
 
-We deduce the modes and eigenvalues of the Fredholm problem for :math:`k \leq \tilde{K}`:
+We deduce the modes and eigenvalues of the Fredholm problem for :math:`k \leq \widetilde{K}`:
 
 .. math::
 
-    \begin{align*}
-      \mat{\Phi}_k = \dfrac{1}{\lambda_k} \sqrt{\mat{W}}\, \mat{U}_k
-      \lambda_k = \dfrac{\sigma_k^2}{\tilde{K}}
-    \end{align*}
+      \mat{\Phi}_k & = \dfrac{1}{\lambda_k} \sqrt{\mat{W}}\, \mat{U}_k \\
+      \lambda_k & = \dfrac{\sigma_k^2}{\widetilde{K}}.
 
 We have:
 
 .. math::
 
-    \tilde{\vect{\varphi}}_k(\vect{t})= \sum_{\ell=1}^L  C(\vect{t}, \vect{\xi}_\ell) \vect{\phi}_{\ell,k} \quad \mbox{pour} \quad k \leq \tilde{K}
+    \widetilde{\vect{\varphi}}_k(\vect{t})= \sum_{\ell=1}^L  C(\vect{t}, \vect{\xi}_\ell) \vect{\phi}_{\ell,k} 
 
+for :math:`k \leq \widetilde{K}`.
 The most computationally intensive part of the algorithm is the computation of the
 SVD decomposition. By default, it is done using LAPACK dgesdd routine. While being
 very accurate and reasonably fast for small to medium sized problems, it becomes
@@ -103,19 +104,19 @@ computed has to be fixed a priori.
 The following keys of :class:`~openturns.ResourceMap` allow one to select and tune
 these algorithms:
 
-    - 'KarhunenLoeveSVDAlgorithm-UseRandomSVD' which triggers the use of a random
-      algorithm. By default, it is set to *False* and LAPACK is used.
-    - 'KarhunenLoeveSVDAlgorithm-RandomSVDMaximumRank' which fixes the number of
-      singular values to compute. By default it is set to 1000.	
-    - 'KarhunenLoeveSVDAlgorithm-RandomSVDVariant' which can be equal to either
-      'halko2010' for [halko2010]_ (the default) or 'halko2011' for [halko2011]_.
-      These two algorithms have very similar structures, the first one being based
-      on a random compression of both the rows and columns of :math:`\mat{Y}`, the
-      second one being based on an iterative compressed sampling of the columns of
-      :math:`\mat{Y}`.
-    - 'KarhunenLoeveSVDAlgorithm-halko2011Margin' and
-      'KarhunenLoeveSVDAlgorithm-halko2011Iterations' to fix the parameters of the
-      'halko2011' variant. See [halko2011]_ for the details.
+- 'KarhunenLoeveSVDAlgorithm-UseRandomSVD' which triggers the use of a random
+  algorithm. By default, it is set to *False* and LAPACK is used.
+- 'KarhunenLoeveSVDAlgorithm-RandomSVDMaximumRank' which fixes the number of
+  singular values to compute. By default it is set to 1000.	
+- 'KarhunenLoeveSVDAlgorithm-RandomSVDVariant' which can be equal to either
+  'halko2010' for [halko2010]_ (the default) or 'halko2011' for [halko2011]_.
+  These two algorithms have very similar structures, the first one being based
+  on a random compression of both the rows and columns of :math:`\mat{Y}`, the
+  second one being based on an iterative compressed sampling of the columns of
+  :math:`\mat{Y}`.
+- 'KarhunenLoeveSVDAlgorithm-halko2011Margin' and
+  'KarhunenLoeveSVDAlgorithm-halko2011Iterations' to fix the parameters of the
+  'halko2011' variant. See [halko2011]_ for the details.
 
       
 Examples

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -28,7 +28,9 @@ The Karhunen-Loeve SVD algorithm solves the Fredholm problem  associated to the
 covariance function :math:`C`: see :class:`~openturns.KarhunenLoeveAlgorithm`
 to get the notations.
 If the mesh is regular, then this decomposition is equivalent to the principal
-component analysis (PCA).
+component analysis (PCA) (see [pearson1907]_, [hotelling1933]_, [jackson1991]_, [jolliffe2002]_).
+In other fields such as computational fluid dynamics for example,
+this is called the proper orthogonal decomposition (POD) (see [luo2018]_).
 
 The SVD approach is a particular case of the quadrature approach (see
 :class:`~openturns.KarhunenLoeveQuadratureAlgorithm`)  where we consider the

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -24,24 +24,37 @@ centeredSample : bool, default=False
     
 Notes
 -----
-The Karhunen-Loeve SVD algorithm solves the Fredholm problem  associated to the covariance function :math:`C`: see :class:`~openturns.KarhunenLoeveAlgorithm` to get the notations.
+The Karhunen-Loeve SVD algorithm solves the Fredholm problem  associated to the
+covariance function :math:`C`: see :class:`~openturns.KarhunenLoeveAlgorithm`
+to get the notations.
+If the mesh is regular, then this decomposition is equivalent to the principal
+component analysis (PCA).
 
-The SVD approach is a particular case of the quadrature approach (see :class:`~openturns.KarhunenLoeveQuadratureAlgorithm`)  where we consider the functional basis  :math:`((\vect{\theta}_p^j(\vect{s}))_{1 \leq j \leq d, 1 \leq p \leq P}` of :math:`L^2(\cD, \Rset^d)` defined on :math:`\cD` by:
+The SVD approach is a particular case of the quadrature approach (see
+:class:`~openturns.KarhunenLoeveQuadratureAlgorithm`)  where we consider the
+functional basis  :math:`((\vect{\theta}_p^j(\vect{s}))_{1 \leq j \leq d, 1 \leq p \leq P}` of
+:math:`L^2(\cD, \Rset^d)` defined on :math:`\cD` by:
 
 .. math:: 
 
     \vect{\theta}_p^j(\vect{s})= \left[\mat{C}(\vect{s}, \vect{s}_p) \right]_{:, j}
 
-The SVD approach is used when the covariance function is not explicitly known but only through :math:`K` fields of the associated stochastic process :math:`\vect{X}`: :math:`(\vect{X}_1, \dots, \vect{X}_K)`.
+The SVD approach is used when the covariance function is not explicitly known but only
+through :math:`K` fields of the associated stochastic process :math:`\vect{X}`: :math:`(\vect{X}_1, \dots, \vect{X}_K)`.
 
 It consists in :
 
-    - approximating :math:`\mat{C}` by its empirical estimator  :math:`\dfrac{1}{\tilde{K}} \tilde{\mat{X}}\, \Tr{\tilde{\mat{X}}}` where :math:`\tilde{\mat{X}}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\tilde{K}=K` if the process is centered and :math:`\tilde{\mat{X}}~=~(\vect{X}_1 - \vect{\mu} | \dots | \vect{X}_K - \vect{\mu})`:math:`\tilde{K}=K-1` otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
+    - approximating :math:`\mat{C}` by its empirical estimator
+      :math:`\dfrac{1}{\tilde{K}} \tilde{\mat{X}}\, \Tr{\tilde{\mat{X}}}` where
+      :math:`\tilde{\mat{X}}~=~(\vect{X}_1 | \dots | \vect{X}_K)` and :math:`\tilde{K}=K`
+      if the process is centered and :math:`\tilde{\mat{X}}~=~(\vect{X}_1 - \vect{\mu} | \dots | \vect{X}_K - \vect{\mu})`:math:`\tilde{K}=K-1`
+      otherwise, where :math:`\vect{\mu}=\dfrac{1}{K}\sum_{k=1}^K\vect{X}_k`;
     - taking the :math:`L` vertices of the mesh of :math:`\vect{X}` as the :math:`L` quadrature points.
 
 We suppose now that :math:`K < dL`, and we note :math:`\mat{Y} = \sqrt{\mat{W}} \,\mat{X}`.
 
-As the matrix :math:`\mat{\Theta} = \mat{C}` is invertible, the Galerkin and collocation approaches are equivalent and both lead to the following singular value problem for :math:`\mat{Y}`:
+As the matrix :math:`\mat{\Theta} = \mat{C}` is invertible, the Galerkin and collocation
+approaches are equivalent and both lead to the following singular value problem for :math:`\mat{Y}`:
 
 .. math::
     :label: QuadCollDim1_ter
@@ -54,13 +67,15 @@ The SVD decomposition of :math:`\mat{Y}\in \mathcal{M}_{dL,\tilde{K}}(\Rset)` wr
 
     \mat{Y} = \mat{U}\, \mat{\Sigma} \, \Tr{\mat{V}}
 
-where  we have :math:`\mat{U} \in \mathcal{M}_{dL,\tilde{K}}(\Rset)`, :math:`\mat{\Sigma}\in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)`, :math:`\mat{V} \in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)` such that :
+where  we have :math:`\mat{U} \in \mathcal{M}_{dL,\tilde{K}}(\Rset)`, 
+:math:`\mat{\Sigma}\in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)`, :math:`\mat{V} \in \mathcal{M}_{\tilde{K},\tilde{K}}(\Rset)` such that :
 
     - :math:`\Tr{\mat{V}}\mat{V} =\mat{V}\Tr{\mat{V}}= \mat{I}_{\tilde{K}}`,  
     - :math:`\Tr{\mat{U}}\mat{U} = \mat{I}_{\tilde{K}}` ,
     - :math:`\mat{\Sigma} = diag(\sigma_1, \dots, \sigma_{\tilde{K}})`.
 
-Then the columns of :math:`\mat{U}` are the eigenvectors of :math:`\mat{Y}\Tr{\mat{Y}}` associated to the eigenvalues :math:`\sigma_k^2`.
+Then the columns of :math:`\mat{U}` are the eigenvectors of :math:`\mat{Y}\Tr{\mat{Y}}`
+associated to the eigenvalues :math:`\sigma_k^2`.
 
 We deduce the modes and eigenvalues of the Fredholm problem for :math:`k \leq \tilde{K}`:
 

--- a/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
+++ b/python/src/KarhunenLoeveSVDAlgorithm_doc.i.in
@@ -30,7 +30,7 @@ to get the notations.
 If the mesh is regular, then this decomposition is equivalent to the principal
 component analysis (PCA) (see [pearson1907]_, [hotelling1933]_, [jackson1991]_, [jolliffe2002]_).
 In other fields such as computational fluid dynamics for example,
-this is called the proper orthogonal decomposition (POD) (see [luo2018]_).
+this is called proper orthogonal decomposition (POD) (see [luo2018]_).
 
 The SVD approach is a particular case of the quadrature approach (see
 :class:`~openturns.KarhunenLoeveQuadratureAlgorithm`)  where we consider the


### PR DESCRIPTION
One user searched for the principal component analysis in the library.
This PR mentions the equivalence of Karhunen-Loeve decomposition with principal component analysis (PCA) in the help page of `KarhunenLoeveSVDAlgorithm`.