### PR TITLE
KernelSmoothing: Fix doc.

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -249,6 +249,9 @@ Bibliography
     http://www.itl.nist.gov/div898/handbook/
 .. [nlopt2009] Steven G. Johnson, The NLopt nonlinear-optimization package,
     http://ab-initio.mit.edu/nlopt
+.. [park1990] Byeong U. Park and J. S. Marron.
+    *Comparison of data-driven bandwidth selectors.*
+    Journal of the American Statistical Association, 85(409) :66–72, 1990.
 .. [petras2003] Petras, K. (2003). *Smolyak cubature of given polynomial
     degree with few nodes for increasing dimension.* Numerische Mathematik,
     93 (4), 729-753.
@@ -259,6 +262,9 @@ Bibliography
     *Design of computer experiments: Space filling and beyond.*
     Statistics and Computing 22(3): 681-701.
     `pdf <https://hal.archives-ouvertes.fr/hal-00685876/document>`__
+.. [raykar2006] Vikas Chandrakant Raykar, Ramani Duraiswami
+    *Very Fast optimal bandwidth selection for univariate kernel density estimation.*
+    CS-TR-4774. University of Maryland, College Park, MD 20783, 2006
 .. [rawlings2001] Rawlings, J. O., Pantula, S. G., and Dickey, D. A.
     *Applied regression analysis: a research tool.*
     Springer Science and Business Media, 2001.
@@ -288,14 +294,27 @@ Bibliography
     Journal of Mechanical Design, 134(3):031008, 2012.
 .. [saporta1990] Saporta, G. (1990). *Probabilités, Analyse de données et
     Statistique*, Technip
-.. [scott1992] David W. Scott (1992). *Multivariate density estimation*,
+.. [scott1992] Scott, D. W. (1992). *Multivariate density estimation*,
     John Wiley & Sons, Inc.
+.. [scott2015] Scott, D. W. (2015).
+    *Multivariate density estimation: theory, practice, and visualization.*
+    John Wiley & Sons.
 .. [ScottStewart2011] W. F. Scott & B. Stewart.
     *Tables for the Lilliefors and Modified Cramer–von Mises Tests of Normality.*,
     Communications in Statistics - Theory and Methods. Volume 40, 2011 - Issue 4. Pages 726-730.
+.. [sheather1991] Sheather, S. J. and Jones, M. C. (1991).
+    *A reliable data-based bandwidth selection method for kernel density estimation.*
+    Journal of the Royal Statistical Society. Series B (Methodological),
+    53(3) :683–690.
 .. [simard2011] Simard, R. & L'Ecuyer, P. *Computing the Two-Sided Kolmogorov-
     Smirnov Distribution.* Journal of Statistical Software, 2011, 39(11), 1-18.
     `pdf <https://www.jstatsoft.org/article/view/v039i11/v39i11.pdf>`__
+.. [silverman1982] B. W. Silverman
+    *Algorithm AS 176: Kernel Density Estimation Using the Fast Fourier Transform.*
+    Journal of the Royal Statistical Society. Series C (Applied Statistics),
+    Vol. 31, No. 1 (1982), pp. 93-99 (7 pages)
+.. [silverman1986] Silverman, B. W. (1986).
+    *Density estimation.* (Chapman Hall, London).
 .. [sobol1993] Sobol, I. M. *Sensitivity analysis for non-linear mathematical
     model* Math. Modelling Comput. Exp., 1993, 1, 407-414.
     `pdf <https://openturns.github.io/openturns/papers/sobol1993.pdf>`__

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -47,6 +47,8 @@ Bibliography
     `pdf <https://tel.archives-ouvertes.fr/tel-00864175/document>`__
 .. [ceres2012] Sameer Agarwal and Keir Mierle and Others, *Ceres Solver*,
     http://ceres-solver.org
+.. [chacon2018] Chacón, J. E., & Duong, T. (2018).
+    *Multivariate kernel smoothing and its applications.* CRC Press.
 .. [cminpack2007] Devernay, F. *C/C++ Minpack*, 2007.
     http://devernay.free.fr/hacks/cminpack
 .. [coles2001] Coles, S. G., *An Introduction to Statistical Modelling of Extreme Values*.

--- a/python/doc/theory/data_analysis/kernel_smoothing.rst
+++ b/python/doc/theory/data_analysis/kernel_smoothing.rst
@@ -11,16 +11,16 @@ Introduction
 Let :math:`X` be a random variable with probability density function :math:`p`.
 Given a sample of independent observations :math:`x_1, ..., x_n` of :math:`X`
 and any point :math:`x \in \Rset`, the kernel smoothing estimator provides
-an approximation :math:`\hat{p}(x)` of :math:`p(x)`.
+an approximation :math:`\widehat{p}(x)` of :math:`p(x)`.
 
-In dimension 1, the kernel smoothed probability density function :math:`\hat{p}` has the following expression,
+In dimension 1, the kernel smoothed probability density function :math:`\widehat{p}` has the following expression,
 where *K* is the univariate kernel, *n* the sample size and :math:`(X_1, \cdots, X_n) \in \Rset^n`
 the univariate random sample with :math:`\forall i, \, \, X_i \in \Rset` ([wand1994]_ eq. 2.2 page 12):
 
 .. math::
   :label: kernelSmooth
 
-    \hat{p}(x) = \displaystyle \frac{1}{nh}\sum_{i=1}^{n} K\left(\frac{x-X_i}{h}\right)
+    \widehat{p}(x) = \frac{1}{nh}\sum_{i=1}^{n} K\left(\frac{x-X_i}{h}\right)
 
 The kernel *K* is a function satisfying:
 
@@ -28,38 +28,72 @@ The kernel *K* is a function satisfying:
 
     \int K(x)\, dx=1.
 
-Usually *K* is chosen to be a unimodal probability density function that is symmetric about 0.
+Usually, the kernel *K* is chosen to be a unimodal probability density function that is symmetric about 0.
 The parameter *h* is called the *bandwidth*.
 
+Multivariate kernels
+~~~~~~~~~~~~~~~~~~~~
 
 In dimension :math:`d>1`, the kernel may be defined as a product kernel :math:`K_d`,
-as follows where :math:`\vect{x} = (x_1, \cdots, x_d)\in \Rset^d` (([wand1994]_ eq. 2.2 page 12) page 91):
+as follows where :math:`\vect{x} = (x_1, \cdots, x_d)\in \Rset^d`
+([wand1994]_ eq. 2.2 page 91):
 
 .. math::
 
-    K_d(\vect{x}) = \displaystyle \prod_{j=1}^{d} K(x_j)
+    K_d(\vect{x}) = \prod_{j=1}^{d} K(x_j).
 
-which leads to the kernel smoothed probability density function in dimension *d*,
+The kernel smoothed probability density function in dimension *d* is:
+
+.. math::
+
+    \widehat{p}(\vect{x})
+    = \frac{1}{n \prod_{j=1}^{d}h_j} \sum_{i=1}^{n} K_d\left(\frac{x_1 - (X_{i})_1 }{h_1}, \dots, \frac{x_d - (X_{i})_d}{h_d}\right)
+
 where :math:`(\vect{X}_1, \cdots, \vect{X}_n)` is the d-variate random sample
-which components are denoted :math:`\vect{X}_i = (X_{i1}, \dots, X_{id})`:
+which components are denoted :math:`\vect{X}_i = (X_{i1}, \dots, X_{id})`.
+
+In the multivariate case, the bandwidth is the vector
+:math:`\vect{h} = (h_1, \cdots, h_d)`.
+
+Asymptotic error and asymptotically optimal bandwidth
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The quality of the approximation may be controlled by the AMISE (Asymptotic Mean Integrated Square error) criteria defined as follows.
+By definition, the mean squared error (MSE) at point :math:`\vect{x}` is
+(see [scott2015]_ eq. page 40, [wand1994]_ pages 14-21):
 
 .. math::
 
-    \hat{p}(\vect{x}) = \displaystyle \frac{1}{N \prod_{j=1}^{d}h_j} \sum_{i=1}^{N} K_d\left(\frac{x_1 - X_{i1} }{h_1}, \dots, \frac{x_d - X_{id}}{h_d}\right)
+    \operatorname{MSE}(\widehat{p}, \vect{x})
+    = \mathbb{E}_\vect{X}\left[\left(\widehat{p}(\vect{x}) - p(\vect{x})\right)^2 \right].
 
-Let's note that the bandwidth is the vector :math:`\vect{h} = (h_1, \cdots, h_d)`.
 
-The quality of the approximation may be controlled by the AMISE (Asymptotic Mean Integrated Square error) criteria defined as ([wand1994]_ pages 14-21):
+It can be proved that the mean squared error is the sum of the
+variance and the squared bias:
 
 .. math::
 
-  \left\{
-  \begin{array}{lcl}
-    AMISE(\hat{p}) & = & \mbox{two first terms in the series expansion with respect to $n$ in } MISE(\hat{p}) \\
-    MISE(\hat{p}) & = & \mathbb{E}_\vect{X}\left[||\hat{p} - p||^2_{L_2}\right]   =  \int \, MSE(\hat{p}, \vect{x}) \, d\vect{x}  \\
-    MSE(\hat{p}, \vect{x})&  =  & \left[ \mathbb{E}_\vect{X}\left[\hat{p}(\vect{x})\right] - p(\vect{x})\right]^2 + {\rm Var}_\vect{X}\left[\hat{p}(\vect{x})\right]
-  \end{array}
-  \right.
+    \operatorname{MSE}(\widehat{p}, \vect{x})
+    = \operatorname{Var}_\vect{X}\left[\widehat{p}(\vect{x})\right]
+    + \left(\operatorname{Bias}\left(\widehat{p}(\vect{x})\right)\right)^2
+
+where the bias is:
+
+.. math::
+    \operatorname{Bias}\left(\widehat{p}(\vect{x})\right)
+    = \mathbb{E}_\vect{X}\left[\widehat{p}(\vect{x})\right] - p(\vect{x}).
+
+The MSE depends on the point where the density is evaluated.
+The mean integrated squared error (MISE) is (see [scott2015]_ eq. page 41):
+
+.. math::
+    \operatorname{MISE}(\widehat{p})
+    = \mathbb{E}_\vect{X}\left[||\widehat{p} - p||^2_{L_2}\right]   = \int \, \operatorname{MSE}(\widehat{p}, \vect{x}) \, d\vect{x}  \\
+
+Finally, the asymptotic mean integrated squared error (AMISE),
+denoted :math:`\operatorname{AMISE}(\widehat{p})` is defined as the two first terms
+in the Taylor series expansion of :math:`\operatorname{MISE}(\widehat{p})` when :math:`n`
+tends to infinity.
 
 The quality of the estimation essentially depends on the value of the bandwidth *h*.
 In dimension 1, the bandwidth that minimizes the AMISE criteria is
@@ -68,7 +102,8 @@ In dimension 1, the bandwidth that minimizes the AMISE criteria is
 .. math::
   :label: AMISE1
 
-  h_{AMISE}(K) = \displaystyle \left[ \frac{R(K)}{\mu_2(K)^2 R(p^{(2)})}\right]^{\frac{1}{5}}n^{-\frac{1}{5}}
+  h_{\operatorname{AMISE}}(K)
+  = \left( \frac{R(K)}{\mu_2(K)^2 R\left(p^{(2)}\right)}\right)^{\frac{1}{5}}n^{-\frac{1}{5}}
 
 where the rugosity of the kernel is:
 
@@ -87,49 +122,154 @@ Since, by hypothesis, the true density :math:`p` is unknown, its
 second derivative is also unknown.
 Hence the equation :eq:`AMISE1` cannot be used directly to compute the bandwidth.
 
-If we note that :math:`R(p^{(r)}) = (-1)^r\Phi_{2r}` with :math:`\Phi_r = \int p^{(r)}p(x)\, dx = \mathbb{E}_\vect{X}\left[p^{(r)}\right]`,
-then relation writes:
+We have ([wand1994]_ page 67):
+
+.. math::
+    R\left(p^{(r)}\right) = (-1)^r\Psi_{2r}
+
+where:
+
+.. math::
+    \Psi_r(p)
+    = \int p^{(r)}p(x)\, dx = \mathbb{E}_\vect{X}\left[p^{(r)}\right].
+
+Therefore:
 
 .. math::
   :label: AMISE
 
-  h_{AMISE}(K) = \displaystyle \left[ \frac{R(K)}{\mu_2(K)^2\Phi_4}\right]^{\frac{1}{5}}n^{-\frac{1}{5}}
+  h_{\operatorname{AMISE}}(K)
+  = \left( \frac{R(K)}{\mu_2(K)^2\Psi_4(p)}\right)^{\frac{1}{5}}n^{-\frac{1}{5}}
 
-Several methods exist to  evaluate the optimal bandwidth :math:`h_{AMISE}(K)` based on different approximations of :math:`\Phi_4`:
+Several methods exist to  evaluate the optimal bandwidth :math:`h_{\operatorname{AMISE}}(K)` based on different approximations of :math:`\Psi_4`:
 
 - Silverman's rule in dimension 1,
 - the plug-in bandwidth selection,
 - Scott's rule in dimension d.
 
+Efficiency of a kernel
+~~~~~~~~~~~~~~~~~~~~~~
+
+Let :math:`K` be a kernel.
+We may be interested if a particular kernel may be able to reduce the
+estimation error.
+The efficiency of a kernel is (see [scott2015]_ page 151):
+
+.. math::
+    \operatorname{eff}(k)
+    = \frac{\sigma_k R(k)}{\sigma_{k_E} R(k_E)}
+
+where :math:`k_E` is Epanechnikov's kernel.
+The AMISE error is proportional to the efficiency (see [scott2015]_
+eq. 6.25 page 151):
+
+.. math::
+    \operatorname{AMISE} \propto \operatorname{eff}(k)
+
+The next table presents several kernels available in the
+library and their associated variance, rugosity and efficiency.
+We see that the best kernel is Epanechnikov's kernel.
+We also see that there is not much difference between the different
+kernels.
+This is one of the reasons why the normal kernel is often used.
+
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Kernel          | :math:`\operatorname{Var}(k)`   | :math:`R(k)`   | :math:`\sigma_k R(k)`    | :math:`\operatorname{eff}(k)`     |
++=================+=================================+================+==========================+===================================+
+| Epanechnikov    | 0.2000                          | 0.6000         | 0.2683                   | 100.00 \%                         |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Biweight        | 0.1429                          | 0.7143         | 0.2700                   | 99.39 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Quartic         | 0.1429                          | 0.7143         | 0.2700                   | 99.39 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Triweight       | 0.1111                          | 0.8159         | 0.2720                   | 98.67 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Triangular      | 0.1667                          | 0.6667         | 0.2722                   | 98.59 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Normal          | 1.0000                          | 0.2821         | 0.2821                   | 95.12 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Uniform         | 0.3333                          | 0.5000         | 0.2887                   | 92.95 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+| Logistic        | 3.2899                          | 0.1667         | 0.3023                   | 88.76 \%                          |
++-----------------+---------------------------------+----------------+--------------------------+-----------------------------------+
+
+**Table 1.** Efficiency of several order 2 kernels.
+
 Silverman's rule (dimension 1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the case where the density *p* is normal with standard deviation :math:`\sigma`,
-then the term :math:`\Phi_4` can be exactly evaluated.
-In that particular case,  the optimal bandwidth of relation :eq:`AMISE`
-with respect to the AMISE criteria writes as follows (see [silverman1986]_ page 45):
-
-.. math::
-  :label: pNormal
-
-    h^{p = normal}_{AMISE}(K) = \displaystyle \left[ \frac{8\sqrt{\pi} R(K)}{3\mu_2(K)^2}\right]^{\frac{1}{5}}\sigma n^{-\frac{1}{5}}
-
-An estimator of :math:`h^{p= normal}_{AMISE}(K)` is obtained by replacing :math:`\sigma` by its estimator :math:`\hat{\sigma}^n`,
-evaluated from the sample :math:`(X_1, \dots, X_n)`:
-
-.. math::
-  :label: Estimpnormal
-
-    \hat{h}^{p = normal}_{AMISE}(K) = \displaystyle \left[ \frac{8\sqrt{\pi} R(K)}{3\mu_2(K)^2}\right]^{\frac{1}{5}}\hat{\sigma}^n n^{-\frac{1}{5}}
-
-The Silverman rule consists in considering :math:`\hat{h}^{p = normal}_{AMISE}(K)` of relation :eq:`Estimpnormal` even if the density *p* is not normal:
+In this section, we consider a random variable i.e. :math:`d = 1`.
+If the density *p* is normal with standard deviation :math:`\sigma`,
+then the term :math:`\Psi_4` can be exactly evaluated.
+By definition, the Silverman rule for the bandwidth is
+the optimal bandwidth of the AMISE criteria when the true density *p* is normal
+(see [silverman1986]_ page 45):
 
 .. math::
   :label: Silverman
 
-    h^{Silver}(K) = \displaystyle \left[ \frac{8\sqrt{\pi} R(K)}{3\mu_2(K)^2}\right]^{\frac{1}{5}}\hat{\sigma}^n n^{-\frac{1}{5}}
+    h^{Silver}(K)
+    := h^{p = normal}_{\operatorname{AMISE}}(K)
+    = \left( \frac{8\sqrt{\pi} R(K)}{3\mu_2(K)^2}\right)^{\frac{1}{5}}
+    \sigma n^{-\frac{1}{5}}.
 
-Relation :eq:`Silverman` is empirical and gives good results when the density is not *far* from a normal one.
+The Silverman rule is based on the hypothesis that the true
+density *p* is close to the normal density,
+even if the density *p* is not necessarily normal.
+
+The equation :eq:`Silverman` is accurate when
+the density is not *far* from a normal one.
+In the special case where we use the normal kernel, the Silverman rule
+is (see [silverman1986]_ eq 3.28 page 45):
+
+.. math::
+  :label: SilvermanNormal
+
+    h^{Silver}(\mathcal{N})
+    = 1.06 \sigma n^{-\frac{1}{5}}.
+
+Choice for the standard deviation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We estimate the standard deviation :math:`\sigma` by its sample
+counterpart :math:`\hat{\sigma}`, evaluated from the sample
+:math:`(x_1, \dots, x_n)`:
+
+.. math::
+  :label: Estimpnormal
+
+    h^{Silver}(K)
+    = \left( \frac{8\sqrt{\pi} R(K)}{3\mu_2(K)^2}\right)^{\frac{1}{5}}
+    \hat{\sigma} n^{-\frac{1}{5}}
+
+The estimator :math:`\hat{\sigma}` of the true standard deviation can
+be estimated using the sample standard deviation based
+on the sample :math:`(x_1, \dots, x_n)`.
+This is:
+
+.. math::
+    \hat{\sigma}
+    = \sqrt{\frac{1}{n - 1} \sum_{i = 1}^n (x_i - \bar{x})^2 }
+
+where :math:`\bar{x}` is the sample mean:
+
+.. math::
+    \bar{x}
+    = \frac{1}{n} \sum_{i = 1}^n x_i.
+
+Another method is to use the standardized interquartile range
+([wand1994]_ page 60):
+
+.. math::
+    \widehat{\sigma}_{\operatorname{IQR}}
+    = \frac{\widehat{q}(3/4) - \widehat{q}(1/4)}{\Phi^{-1}(3/4) - \Phi^{-1}(1/4)}
+
+where :math:`\Phi^{-1}` is the quantile function of the
+standard normal distribution and
+:math:`\widehat{q}(3/4)` and :math:`\widehat{q}(1/4)` are the sample
+quartiles at levels 75% and 25% respectively.
+The previous estimator is robust against outliers that might be
+in the sample.
 
 Plug-in bandwidth selection method (dimension 1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,41 +282,50 @@ This method is due to [sheather1991]_ who used ideas from [park1990]_.
 The algorithm is presented in [wand1994]_, page 74 under the "Solve the equation rule" name.
 The implementation uses ideas from [raykar2006]_, but the fast selection is not implemented.
 
-The equation :eq:`AMISE` requires the evaluation of the quantity :math:`\Phi_4`.
-As a general rule, we use the estimator :math:`\hat{\Phi}_r` of :math:`\Phi_r` defined by:
+The equation :eq:`AMISE` requires the evaluation of the quantity :math:`\Psi_4`.
+We use the estimator :math:`\hat{\Psi}_r` of :math:`\Psi_r`, using a kernel
+density estimator of the :math:`r`-th derivative of the
+density.
+The estimator is (see [wand1994]_ page 64):
 
 .. math::
   :label: EstimPhir
 
-    \hat{\Phi}_r = \displaystyle \frac{1}{n}\sum_{i=1}^{n} \hat{p}^{(r)}(X_i)
+    \hat{\Psi}_r(K)
+    = \frac{1}{n}\sum_{i=1}^{n} \widehat{p}^{(r)}(X_i)
 
-Deriving relation :eq:`kernelSmooth` leads to:
+where :math:`\hat{\Psi}_r(K)` is the estimator based on the kernel
+*K*.
+Deriving equation :eq:`kernelSmooth` leads to:
 
 .. math::
   :label: kernelSmoothDerivative
 
-    \hat{p}^{(r)}(x) = \displaystyle \frac{1}{nh^{r+1}}\sum_{i=1}^{n} K^{(r)}\left(\frac{x-X_i}{h}\right)
+    \widehat{p}^{(r)}(x)
+    = \frac{1}{nh^{r+1}}\sum_{i=1}^{n} K^{(r)}\left(\frac{x-X_i}{h}\right)
 
-and then the estimator :math:`\hat{\Phi}_r(h)` is defined as:
+and then the estimator :math:`\hat{\Psi}_r(h)` is defined as:
 
 .. math::
   :label: EstimPhirFin
 
-    \hat{\Phi}_r(h) = \displaystyle \frac{1}{n^2h^{r+1}}\sum_{i=1}^{n}\sum_{j=1}^{n} K^{(r)}\left(\frac{X_i-X_j}{h}\right)
+    \hat{\Psi}_r(h)
+    = \frac{1}{n^2h^{r+1}}\sum_{i=1}^{n}\sum_{j=1}^{n} K^{(r)}\left(\frac{X_i-X_j}{h}\right)
 
-We note that :math:`\hat{\Phi}_r(h)` depends of the parameter *h* which can be
-taken in order to minimize the AMSE (Asymptotic Mean Square Error) criteria
-evaluated between :math:`\Phi_r` and :math:`\hat{\Phi}_r(h)`.
+We note that :math:`\hat{\Psi}_r(h)` depends of the parameter *h* which can be
+taken in order to minimize the Asymptotic Mean Square Error (AMSE) criteria
+evaluated between :math:`\Psi_r` and :math:`\hat{\Psi}_r(h)`.
 The optimal parameter *h* is:
 
 .. math::
   :label: optimHamse
 
-    h^{(r)}_{AMSE} = \displaystyle \left(\frac{-2K^{(r)}(0)}{\mu_2(K) \Phi_{r+2}}\right)^{\frac{1}{r+3}}n^{-\frac{1}{r+3}}
+    h^{(r)}_{\operatorname{AMSE}}
+    = \left(\frac{-2K^{(r)}(0)}{\mu_2(K) \Psi_{r+2}}\right)^{\frac{1}{r+3}}n^{-\frac{1}{r+3}}
 
 The previous equation states that the bandwidth :math:`h^{(r)}` required
-to compute :math:`\hat{p}^{(r)}` depends on :math:`\Phi_{r+2}`.
-But to compute :math:`\Phi_{r+2}`, we need :math:`h^{(r + 2)}`, etc.
+to compute :math:`\widehat{p}^{(r)}` depends on :math:`\Psi_{r+2}`.
+But to compute :math:`\Psi_{r+2}`, we need :math:`h^{(r + 2)}`, etc.
 The goal of the method is to break this infinite set of equations at some point
 by providing a *pilot* bandwidth.
 The :math:`\ell`-stage plug-in bandwidth method uses :math:`\ell` different
@@ -184,82 +333,81 @@ intermediate bandwidths before evaluating the final one.
 
 In this document, we present the two stage solve-the-equation plug-in method.
 
-- The equation :eq:`AMISE` defines :math:`h_{AMISE}(K)` as a function of :math:`\Phi_4`.
+- The equation :eq:`AMISE` defines :math:`h_{\operatorname{AMISE}}(K)` as a function of :math:`\Psi_4`.
   Let :math:`t` be the function defined by the equation:
 
   .. math::
     :label: rel1
 
-      h_{AMISE}(K) = t(\Phi_4).
+      h_{\operatorname{AMSE}}(K) = t(\Psi_4).
 
-- The term :math:`\Phi_4` is approximated by its estimator defined in
-  :eq:`EstimPhirFin` evaluated with its optimal parameter :math:`h^{(4)}_{AMSE}`
+- The term :math:`\Psi_4` is approximated by its estimator defined in
+  :eq:`EstimPhirFin` evaluated with its optimal parameter :math:`h^{(4)}_{\operatorname{AMSE}}`
   defined in :eq:`optimHamse`:
 
   .. math::
     :label: h4
 
-      h^{(4)}_{AMSE} = \displaystyle \left(\frac{-2K^{(4)}(0)}{\mu_2(K)\Phi_{6}}\right)^{\frac{1}{7}}n^{-\frac{1}{7}}
+      h^{(4)}_{\operatorname{AMSE}}
+      = \left(\frac{-2K^{(4)}(0)}{\mu_2(K)\Psi_{6}}\right)^{\frac{1}{7}}n^{-\frac{1}{7}}
 
-  which leads to a relation of type:
+  which leads to the approximation:
 
   .. math::
     :label: rel2
 
-      \Phi_4 \simeq  \hat{\Phi}_4(h^{(4)}_{AMSE})
+      \hat{\Psi}_4 \left(h^{(4)}_{\operatorname{AMSE}}\right) \approx  \Psi_4
 
 - The equation :eq:`AMISE` and :eq:`h4` lead to:
 
   .. math::
     :label: h4hAmise
 
-      h^{(4)}_{AMSE} = \displaystyle \left( \frac{-2K^{(4)}(0)\mu_2(K)\Phi_4}{R(K)\Phi_{6}}\right) ^{\frac{1}{7}}h_{AMISE}(K)^{\frac{5}{7}}.
+      h^{(4)}_{\operatorname{AMSE}}
+      = \left( \frac{-2K^{(4)}(0)\mu_2(K)\Psi_4}{R(K)\Psi_{6}}\right) ^{\frac{1}{7}}h_{\operatorname{AMISE}}(K)^{\frac{5}{7}}.
 
   Let :math:`\ell` be the function defined by the equation:
 
   .. math::
     :label: rel3
 
-      h^{(4)}_{AMSE} = \ell(h_{AMISE}(K)).
+      h^{(4)}_{\operatorname{AMSE}}
+      = \ell(h_{\operatorname{AMISE}}(K)).
 
-- The equation :eq:`h4hAmise` depends on both terms :math:`\Phi_4` and
-  :math:`\Phi_6` which are evaluated with their estimators defined in :eq:`EstimPhirFin`
+- The equation :eq:`h4hAmise` depends on both terms :math:`\Psi_4` and
+  :math:`\Psi_6` which are evaluated with their estimators defined in :eq:`EstimPhirFin`
   respectively with their AMSE optimal parameters :math:`g_1` and :math:`g_2`
   (see eq. :eq:`optimHamse`). It leads to the expressions:
 
   .. math::
     :label: g12
 
-      \left\{
-      \begin{array}{lcl}
-        g_1 & = & \displaystyle \left(\frac{-2K^{(4)}(0)}{\mu_2(K)\Phi_{6}}\right)^{\frac{1}{7}}n^{-\frac{1}{7}}\\
-        g_2 & = & \displaystyle \left(\frac{-2K^{(6)}(0)}{\mu_2(K)\Phi_{8}}\right)^{\frac{1}{7}}n^{-\frac{1}{9}}
-      \end{array}
-      \right.
+    g_1 & = \left(\frac{-2K^{(4)}(0)}{\mu_2(K)\Psi_{6}}\right)^{\frac{1}{7}}n^{-\frac{1}{7}}\\
+    g_2 & = \left(\frac{-2K^{(6)}(0)}{\mu_2(K)\Psi_{8}}\right)^{\frac{1}{7}}n^{-\frac{1}{9}}
 
-- In order to evaluate :math:`\Phi_6` and :math:`\Phi_8`,
-  we suppose that the density *p* is normal with a variance :math:`\sigma^2`
+- In order to evaluate :math:`\Psi_6` and :math:`\Psi_8`,
+  we assume that the density *p* is normal with a variance :math:`\sigma^2`
   which is approximated by the empirical variance of the sample, which leads to:
 
   .. math::
     :label: Phi68
 
-    \left\{
-    \begin{array}{lcl}
-      \hat{\Phi}_6 & = & \displaystyle \frac{-15}{16\sqrt{\pi}}\hat{\sigma}^{-7}\\
-      \hat{\Phi}_8 & = & \displaystyle \frac{105^{\strut}}{32\sqrt{\pi}}\hat{\sigma}^{-9}
-    \end{array}
-    \right.
+    \hat{\Psi}_6 & = \frac{-15}{16\sqrt{\pi}}\hat{\sigma}^{-7}\\
+    \hat{\Psi}_8 & = \frac{105^{\strut}}{32\sqrt{\pi}}\hat{\sigma}^{-9}
 
-Then, to summarize, thanks to the equations :eq:`rel1`, :eq:`rel2`, :eq:`rel3`, :eq:`g12` and :eq:`Phi68`,
-the optimal bandwidth :math:`h_{AMISE}` is solution of the equation:
+Finally, thanks to the equations :eq:`rel1`, :eq:`rel2`, :eq:`rel3`, :eq:`g12` and :eq:`Phi68`,
+the optimal bandwidth of the STE rule, :math:`h^{\operatorname{STE}}`, is solution of the equation:
 
 .. math::
   :label: equhAmise
 
-    h_{AMISE} = t \circ \hat{\Phi}_4 \circ \ell (h_{AMISE})
+    h^{\operatorname{STE}}
+    = t \circ \hat{\Psi}_4 \circ \ell (h^{\operatorname{STE}})
 
-A cut-off value can be used to define the function :math:`\hat{\psi_r}` in the equation :eq:`EstimPhirFin`.
+This equation does not necessarily have a close form expression and
+an numerical method must be used in general.
+
+A cut-off value can be used to define the function :math:`\widehat{\psi_r}` in the equation :eq:`EstimPhirFin`.
 Let :math:`\phi` be the probability density function of the standard Gaussian distribution.
 We have:
 
@@ -271,93 +419,199 @@ Let :math:`t> 0` the cut-off value.
 The evaluation is as follows:
 
 .. math::
-    \tilde{\phi}(x)= 
+    \widetilde{\phi}(x)=
     \begin{cases}
-    \phi(x) & \textrm{ si } |x| \leq t, \\
-    0 & \textrm{ sinon}.
+    \phi(x) & \textrm{ if } |x| \leq t, \\
+    0 & \textrm{ otherwise}.
     \end{cases}
 
 Hence, only the most significant values in the evaluation of :math:`\hat{\psi_r}`
 are taken into account, which improves the speed while slightly decreasing
 the accuracy.
 
+Rescaling a bandwidth
+~~~~~~~~~~~~~~~~~~~~~
+
+In this section, we show that, if the optimal bandwidth is known
+for the normal kernel, then it can be computed for any kernel
+*K* using a rescaling equation.
+
+Let :math:`K_1` and :math:`K_2` be two kernels.
+The equation :eq:`AMISE1` implies:
+
+.. math::
+  :label: ChangeBandwidth
+
+    \frac{h_{\operatorname{AMISE}}(K_1)}{h_{\operatorname{AMISE}}(K_2)}=\frac{\sigma_{K_2}}{\sigma_{K_1}}
+    \left(\frac{\sigma_{K_1}R(K_1)}{\sigma_{K_2}R(K_2)}\right)^{1/5}.
+
+Scott (see [scott2015]_ table 6.2 page 152) notices that:
+
+.. math::
+    \frac{\sigma_{K_1}R(K_1)}{\sigma_{K_2}R(K_2)} \in [1, 1.86]
+
+for many pairs of common kernels.
+Hence the equation :eq:`ChangeBandwidth` implies the *equivalent
+kernel rescaling equation* (see [scott2015]_ eq. 6.30 page 154):
+
+.. math::
+  :label: SimplifiedChangeBandwidth
+
+    h_{\operatorname{AMISE}}(K_1) \approx h_{\operatorname{AMISE}}(K_2)\frac{\sigma_{K_2}}{\sigma_{K_1}}
+
+Consider for example the normal kernel :math:`K_2 = \mathcal{N}(0,1)`.
+Since :math:`\sigma_{K_1} = \sigma_{\mathcal{N}(0,1)} = 1`,
+then equation :eq:`SimplifiedChangeBandwidth` implies:
+
+.. math::
+  :label: SimplifiedChangeBandwidthNormal
+
+    h_{\operatorname{AMISE}}(K) \approx h_{\operatorname{AMISE}}(\mathcal{N})\frac{1}{\sigma_{K}}
+
+We will use the previous equation in the derivation of the
+*mixed* rule presented in the next section.
+The previous equation applied to the Silverman rule implies:
+
+.. math::
+  :label: SimplifiedChangeBandwidthSilvNormal
+
+    h^{Silver}(K) \approx h^{Silver}(\mathcal{N})\frac{1}{\sigma_{K}}
+
+A mixed rule for a large sample
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the sample size :math:`n` is large, the *solve-the-equation* (STE)
+rule cannot be applied because of its CPU cost.
+In this case, we use a method which combines the STE rule
+and the Silverman rule, which is less costly.
+Moreover, we combine these rules using two different kernels, namely
+the kernel *K* given by the user and the normal kernel :math:`\mathcal{N}(0, 1)`.
+Finally, we combine two different samples, that is to say the
+large sample size :math:`n` and a smaller sample size for which the
+STE rule can be evaluated.
+
+The equation :eq:`AMISE` implies that:
+
+.. math::
+    \frac{h_{\operatorname{AMISE}}(K)}{h^{Silver}(K)}
+    = \left(\frac{\Psi_4(\mathcal{N})}{\Psi_4(p)}\right)^{1/5}
+
+where *K* is a given kernel and :math:`h_{\operatorname{AMISE}}(K)` is the
+optimal AMISE bandwidth for the kernel *K*.
+We notice that the previous ratio is independent from the sample
+size :math:`n`.
+Let :math:`n_t \ll n` be a small sample size.
+Hence, the ratio is the same if we consider the sample size :math:`n`
+or the sample size :math:`n_t`.
+We apply this equation to the normal kernel, approximate the
+AMISE optimal bandwidth by the STE rule and use the sample
+sizes :math:`n` and :math:`n_t`.
+We get:
+
+.. math::
+    \frac{h^{n, STE}(\mathcal{N})}{h^{n, Silver}(\mathcal{N})}
+    \approx \frac{h^{n_t, STE}(\mathcal{N})}{h^{n_t, Silver}(\mathcal{N})}
+
+which implies:
+
+.. math::
+    h^{n, STE}(\mathcal{N})
+    \approx \frac{h^{n_t, STE}(\mathcal{N})}{h^{n_t, Silver}(\mathcal{N})}
+    h^{n, Silver}(\mathcal{N})
+
+The equation :eq:`SimplifiedChangeBandwidthNormal` leads to the
+bandwidth of the STE rule for the kernel *K*:
+
+.. math::
+    h^{n, STE}(K)
+    \approx h^{n, STE}(\mathcal{N}) \frac{1}{\sigma_{K}}.
+
+We substitute the expression of :math:`h^{n, STE}` in the
+previous equation and get the *mixed* rule:
+
+.. math::
+    :label: MixedBandwidthRule
+
+    h^{n, STE}(K)
+    \approx \frac{h^{n_t, STE}(\mathcal{N})}{h^{n_t, Silver}(\mathcal{N})}
+    h^{n, Silver}(\mathcal{N}) \frac{1}{\sigma_{K}}.
+
 Scott rule (dimension d)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+In this section, we consider the general case where the
+random vector has dimension :math:`d`.
 The Scott rule is a simplification of the Silverman rule generalized to the
 dimension *d* which is optimal when the density *p* is normal with independent components.
 In all the other cases, it gives an empirical rule that gives good result when the density *p* is not *far* from the normal one.
 For examples, the Scott bandwidth may appear too large when *p* presents several maximum.
 
-The Silverman rule given in dimension 1 in relation :eq:`Silverman` can be generalized in dimension *d* as follows:
-if we suppose  that the density *p* is normal with independent components,
-in dimension *d* and that we use the normal kernel :math:`N(0,1)` to estimate it,
-then the optimal bandwidth vector :math:`\vect{h}` with respect to the AMISE criteria writes as follows:
+The Silverman rule given in dimension 1 in equation :eq:`Silverman` can be generalized in dimension *d* as follows.
+We make the assumption that the density *p* is normal with independent components,
+in dimension *d* and that we use the normal kernel :math:`\mathcal{N}(0,1)`
+to estimate it.
+Therefore the optimal bandwidth vector :math:`\vect{h}` with respect to the
+AMISE criteria is given by the *normal reference rule* (see [scott2015]_ eq.
+6.43 page 164):
 
 .. math::
   :label: SilvermanNormalKernel
 
-    \vect{h}^{Silver}(N) = \left(\left(\frac{4}{d+2}\right)^{1/(d+4)}\hat{\sigma}_i^n n^{-1/(d+4)}\right)_i
+    \vect{h}^{Silver}(\mathcal{N}) = \left(\left(\frac{4}{d+2}\right)^{1 / (d + 4)}\hat{\sigma}_i^n n^{-1 / (d + 4)}\right)_i
 
 where :math:`\hat{\sigma}_i^n` is the standard deviation of the *i*-th component of the sample
 :math:`(\vect{X}_1, \cdots, \vect{X}_n)`, and :math:`\sigma_K` the standard deviation of the 1D kernel *K*.
 
 Scott' method is  a simplification of Silverman's rule, based on the fact that the coefficient
-:math:`\left(\frac{4}{d+2}\right)^{1/(d+4)}` remains in :math:`[0.924, 1.059]` when the dimension *d* varies.
+:math:`\left(\frac{4}{d+2}\right)^{1 / (d + 4)}` remains in :math:`[0.924, 1.059]` when the dimension *d* varies (see [scott2015]_ page 164).
 Thus, Scott fixed it to *1*:
 
 .. math::
   :label: coefficientScott
 
-    \left(\frac{4}{d+2}\right)^{1/(d+4)} \simeq 1
+    \left(\frac{4}{d+2}\right)^{1 / (d + 4)} \approx 1.
 
-which leads to the simplified expression:
+This leads to Scott's rule (see [scott2015]_ eq. 6.44 page 164):
 
 .. math::
   :label: SilvermanNormalKernelSimplif
 
-    \vect{h}^{Silver}(N) \simeq \left( \hat{\sigma}_i^n n^{-1/(d+4)}\right)_i
+    \vect{h}^{Silver}(\mathcal{N}) \approx \left( \hat{\sigma}_i^n n^{-1 / (d + 4)}\right)_i
 
-Furthermore, in the general case, we have from relation (\ref{AMISE1}) :
-
-.. math::
-  :label: ChangeBandwidth
-
-    \frac{h_{AMISE}(K_1)}{h_{AMISE}(K_2)}=\frac{\sigma_{K_2}}{\sigma_{K_1}}\left[\frac{\sigma_{K_1}R(K_1)}{\sigma_{K_2}R(K_2)}\right]^{1/5}
-
-Considering that :math:`\sigma_{K}R(K) \simeq 1` whatever the kernel *K*, relation :eq:`ChangeBandwidth` simplifies in:
-
-.. math::
-  :label: SimplifiedChangeBandwidth
-
-    h_{AMISE}(K_1) \simeq h_{AMISE}(K_2)\frac{\sigma_{K_2}}{\sigma_{K_1}}
-
-If we consider the normal kernel :math:`N(0,1)` for :math:`K_2`, then relation :eq:`SimplifiedChangeBandwidth` writes in a more general notation:
-
-.. math::
-  :label: SimplifiedChangeBandwidthNormal
-
-    h_{AMISE}(K) \simeq h_{AMISE}(N)\frac{1}{\sigma_{K}}
-
-If :math:`h_{AMISE}(N)` is evaluated with the Silverman rule, :eq:`SimplifiedChangeBandwidthNormal` rewrites:
-
-.. math::
-  :label: SimplifiedChangeBandwidthSilvNormal
-
-    h^{Silver}(K) \simeq h^{Silver}(N)\frac{1}{\sigma_{K}}
-
-At last, from relation :eq:`SilvermanNormalKernelSimplif` and :eq:`SimplifiedChangeBandwidthSilvNormal`
-applied in each direction *i*, we deduce the Scott rule:
+Finally, the equations :eq:`SilvermanNormalKernelSimplif` and :eq:`SimplifiedChangeBandwidthSilvNormal`
+applied in each direction *i* imply:
 
 .. math::
   :label: ScottRule
 
-    \vect{h}^{Scott} = \left(\frac{\hat{\sigma}_i^n}{\sigma_K}n^{-1/(d+4)}\right)_i
+    \vect{h}^{Scott}
+    = \left(\frac{\hat{\sigma}_i^n}{\sigma_K}n^{-1 / (d + 4)}\right)_i
+
+for :math:`i = 1, ..., d`.
 
 Boundary treatment
 ~~~~~~~~~~~~~~~~~~
 
-In dimension 1, the boundary effects may be taken into account:
+In this section, we consider a random variable i.e. :math:`d = 1`.
+Assume that the domain of definition of the density is bounded.
+Then one of the problems of kernel smoothing is that it may
+produce a non zero density estimate even in the regions where
+we know it is zero.
+This is known as the *boundary bias problem* (see [silverman1986]_ page 29).
+The reason is that a subpart of the kernel windows does not contain
+any observation ([wand1994]_ page 127).
+In this case, for some observation :math:`x_i` near the boundary,
+the density may be underestimated if the kernel sets a positive weight
+outside the domain ([chacon2018]_ page 73).
+
+There are several methods to solve this problem.
+One of the methods is to apply a transformation to the data
+(see [chacon2018]_ page 73).
+Another method is to use boundary kernels (see [chacon2018]_ page 76,
+[scott2015]_ page 157).
+
+In dimension 1, the boundary effects may be taken into account using
+a *reflection* or *mirroring* method (see [silverman1982]_ page 31).
 the boundaries are automatically detected from the sample
 (with the *min* and *max* functions) and the kernel smoothed PDF
 is corrected in the boundary areas to remain within the boundaries,
@@ -375,6 +629,52 @@ according to the mirroring technique:
   the initial one and the two new ones, with the previous bandwidth *h*,
 
 - this last kernel smoothed PDF is truncated within the initial range :math:`[min, max]` (conditional PDF).
+
+Conclusion
+~~~~~~~~~~
+The next table presents a summary of histogram, kernel smoothing and
+parametric methods.
+It appears that the kernel density estimator has an AMISE error which is
+quite close to the parametric rate.
+
++------------------+-----------------------------------------+
+| Method           | Optimal :math:`\operatorname{AMISE}`    |
++==================+=========================================+
+| Histogram        | :math:`\propto n^{-\frac{2}{3}}`        |
++------------------+-----------------------------------------+
+| Kernel smoothing | :math:`\propto n^{-\frac{4}{5}}`        |
++------------------+-----------------------------------------+
+| Parametric       | :math:`\propto n^{-1}`                  |
++------------------+-----------------------------------------+
+
+**Table 2.** The AMISE error depending on the method to estimate the density,
+from the least to the most accurate.
+
+The next table compare the different estimators of the
+bandwidth that we have presented so far.
+The best method is the STE rule, but this can be
+costly to evaluate if the sample is large.
+In this case the *mixed* rule can be used.
+If this rule is still too large, then the Silverman rule can be
+used and might be satisfactory if the true density *p*
+is not too far away from the normal distribution (i.e.
+unimodal and symmetric).
+Otherwise, the Silverman rule may produce a too large bandwidth,
+leading to oversmoothing.
+
++--------------------------+----------------------+---------------+----------------------------+
+| Method                   | Assumption           | Cost          | Accuracy                   |
++==========================+======================+===============+============================+
+| Silverman                | Normal assumption    | Low           | If *p* not far from normal |
++--------------------------+----------------------+---------------+----------------------------+
+| Mixed                    | Normal assumption    | Moderate      | Intermediate               |
++--------------------------+----------------------+---------------+----------------------------+
+| Solve-the-equation (STE) | Normal assumption    | High          | Accurate                   |
++--------------------------+----------------------+---------------+----------------------------+
+
+**Table 3.** Different estimators of the bandwidth from the least to the
+most accurate.
+
 
 .. topic:: API:
 

--- a/python/doc/theory/data_analysis/kernel_smoothing.rst
+++ b/python/doc/theory/data_analysis/kernel_smoothing.rst
@@ -5,22 +5,35 @@ Kernel smoothing
 
 Kernel smoothing is a non parametric estimation method of the probability density function of a distribution.
 
+Introduction
+~~~~~~~~~~~~
+
+Let :math:`X` be a random variable with probability density function :math:`p`.
+Given a sample of independent observations :math:`x_1, ..., x_n` of :math:`X`
+and any point :math:`x \in \Rset`, the kernel smoothing estimator provides
+an approximation :math:`\hat{p}(x)` of :math:`p(x)`.
+
 In dimension 1, the kernel smoothed probability density function :math:`\hat{p}` has the following expression,
 where *K* is the univariate kernel, *n* the sample size and :math:`(X_1, \cdots, X_n) \in \Rset^n`
-the univariate random sample with :math:`\forall i, \, \, X_i \in \Rset`:
+the univariate random sample with :math:`\forall i, \, \, X_i \in \Rset` ([wand1994]_ eq. 2.2 page 12):
 
 .. math::
   :label: kernelSmooth
 
     \hat{p}(x) = \displaystyle \frac{1}{nh}\sum_{i=1}^{n} K\left(\frac{x-X_i}{h}\right)
 
-The kernel *K* is a function satisfying :math:`\int K(x)\, dx=1`.
+The kernel *K* is a function satisfying:
+
+.. math::
+
+    \int K(x)\, dx=1.
+
 Usually *K* is chosen to be a unimodal probability density function that is symmetric about 0.
 The parameter *h* is called the *bandwidth*.
 
 
 In dimension :math:`d>1`, the kernel may be defined as a product kernel :math:`K_d`,
-as follows where :math:`\vect{x} = (x_1, \cdots, x_d)\in \Rset^d`:
+as follows where :math:`\vect{x} = (x_1, \cdots, x_d)\in \Rset^d` (([wand1994]_ eq. 2.2 page 12) page 91):
 
 .. math::
 
@@ -36,7 +49,7 @@ which components are denoted :math:`\vect{X}_i = (X_{i1}, \dots, X_{id})`:
 
 Let's note that the bandwidth is the vector :math:`\vect{h} = (h_1, \cdots, h_d)`.
 
-The quality of the approximation may be controlled by the AMISE (Asymptotic Mean Integrated Square error) criteria defined as:
+The quality of the approximation may be controlled by the AMISE (Asymptotic Mean Integrated Square error) criteria defined as ([wand1994]_ pages 14-21):
 
 .. math::
 
@@ -49,14 +62,30 @@ The quality of the approximation may be controlled by the AMISE (Asymptotic Mean
   \right.
 
 The quality of the estimation essentially depends on the value of the bandwidth *h*.
-The bandwidth that minimizes the AMISE criteria  has the expression (given in dimension 1):
+In dimension 1, the bandwidth that minimizes the AMISE criteria is
+(see [wand1994]_ eq 2.13 page 22):
 
 .. math::
   :label: AMISE1
 
-  h_{AMISE}(K) = \displaystyle \left[ \frac{R(K)}{\mu_2(K)^2R(p^{(2)})}\right]^{\frac{1}{5}}n^{-\frac{1}{5}}
+  h_{AMISE}(K) = \displaystyle \left[ \frac{R(K)}{\mu_2(K)^2 R(p^{(2)})}\right]^{\frac{1}{5}}n^{-\frac{1}{5}}
 
-where :math:`R(K) = \int K(\vect{x})^2\, d\vect{x}` and :math:`\mu_2(K) = \int \vect{x}^2K(\vect{x})\, d\vect{x} = \sigma_K^2`.
+where the rugosity of the kernel is:
+
+.. math::
+    R(K) = \int K(\vect{x})^2\, d\vect{x}
+
+and the second raw moment of the kernel is:
+
+.. math::
+    \mu_2(K) = \int \vect{x}^2K(\vect{x})\, d\vect{x} = \sigma_K^2.
+
+In the equation :eq:`AMISE1`, the expression :math:`R\left(p^{(2)}\right)` is the rugosity of
+the second derivative of the density probability function :math:`p` that
+we wish to approximate.
+Since, by hypothesis, the true density :math:`p` is unknown, its
+second derivative is also unknown.
+Hence the equation :eq:`AMISE1` cannot be used directly to compute the bandwidth.
 
 If we note that :math:`R(p^{(r)}) = (-1)^r\Phi_{2r}` with :math:`\Phi_r = \int p^{(r)}p(x)\, dx = \mathbb{E}_\vect{X}\left[p^{(r)}\right]`,
 then relation writes:
@@ -77,7 +106,8 @@ Silverman's rule (dimension 1)
 
 In the case where the density *p* is normal with standard deviation :math:`\sigma`,
 then the term :math:`\Phi_4` can be exactly evaluated.
-In that particular case,  the optimal bandwidth of relation :eq:`AMISE` with respect to the AMISE criteria writes as follows:
+In that particular case,  the optimal bandwidth of relation :eq:`AMISE`
+with respect to the AMISE criteria writes as follows (see [silverman1986]_ page 45):
 
 .. math::
   :label: pNormal
@@ -109,7 +139,7 @@ derivative of the density.
 Instead of making the gaussian assumption, the method uses a kernel smoothing method
 in order to make an approximation of higher derivatives of the density.
 
-Relation :eq:`AMISE` requires the evaluation of the quantity :math:`\Phi_4`.
+The equation :eq:`AMISE` requires the evaluation of the quantity :math:`\Phi_4`.
 As a general rule, we use the estimator :math:`\hat{\Phi}_r` of :math:`\Phi_r` defined by:
 
 .. math::
@@ -143,12 +173,13 @@ The optimal parameter *h* is:
 
 Given that preliminary results, the solve-the-equation plug-in method  proceeds as follows:
 
-- Relation :eq:`AMISE` defines :math:`h_{AMISE}(K)` as a function of :math:`\Phi_4` we denote here as:
+- The equation :eq:`AMISE` defines :math:`h_{AMISE}(K)` as a function of :math:`\Phi_4`.
+  Let :math:`t` be the function defined by the equation:
 
   .. math::
     :label: rel1
 
-      h_{AMISE}(K) = t(\Phi_4)
+      h_{AMISE}(K) = t(\Phi_4).
 
 - The term :math:`\Phi_4` is approximated by its estimator defined in
   :eq:`EstimPhirFin` evaluated with its optimal parameter :math:`h^{(4)}_{AMSE}`
@@ -166,24 +197,24 @@ Given that preliminary results, the solve-the-equation plug-in method  proceeds 
 
       \Phi_4 \simeq  \hat{\Phi}_4(h^{(4)}_{AMSE})
 
-- Relations :eq:`AMISE` and :eq:`h4` lead to the new one:
+- The equation :eq:`AMISE` and :eq:`h4` lead to:
 
   .. math::
     :label: h4hAmise
 
-      h^{(4)}_{AMSE} = \displaystyle \left( \frac{-2K^{(4)}(0)\mu_2(K)\Phi_4}{R(K)\Phi_{6}}\right) ^{\frac{1}{7}}h_{AMISE}(K)^{\frac{5}{7}}
+      h^{(4)}_{AMSE} = \displaystyle \left( \frac{-2K^{(4)}(0)\mu_2(K)\Phi_4}{R(K)\Phi_{6}}\right) ^{\frac{1}{7}}h_{AMISE}(K)^{\frac{5}{7}}.
 
-  which rewrites:
+  Let :math:`\ell` be the function defined by the equation:
 
   .. math::
     :label: rel3
 
-      h^{(4)}_{AMSE} = l(h_{AMISE}(K))
+      h^{(4)}_{AMSE} = \ell(h_{AMISE}(K)).
 
-- Relation :eq:`h4hAmise` depends on both terms :math:`\Phi_4` and
+- The equation :eq:`h4hAmise` depends on both terms :math:`\Phi_4` and
   :math:`\Phi_6` which are evaluated with their estimators defined in :eq:`EstimPhirFin`
   respectively with their AMSE optimal parameters :math:`g_1` and :math:`g_2`
-  (see relation :eq:`optimHamse`). It leads to the expressions:
+  (see eq. :eq:`optimHamse`). It leads to the expressions:
 
   .. math::
     :label: g12
@@ -209,16 +240,16 @@ Given that preliminary results, the solve-the-equation plug-in method  proceeds 
     \end{array}
     \right.
 
-Then, to summarize, thanks to relations :eq:`rel1`, :eq:`rel2`, :eq:`rel3`, :eq:`g12` and :eq:`Phi68`, the optimal bandwidth is solution of the equation:
+Then, to summarize, thanks to the equations :eq:`rel1`, :eq:`rel2`, :eq:`rel3`, :eq:`g12` and :eq:`Phi68`, the optimal bandwidth is solution of the equation:
 
 .. math::
   :label: equhAmise
 
-    \boldsymbol{h_{AMISE}(K) = t \circ \hat{\Phi}_4 \circ l (h_{AMISE}(K))}
+    h_{AMISE}(K) = t \circ \hat{\Phi}_4 \circ \ell (h_{AMISE}(K))
 
-This method is due to (Sheather, Jones, 1991) who used ideas from (Park, Marron, 1990).
-The algorithm is presented in (Wand, Jones, 1994), page 74 under the "Solve the equation rule" name.
-The implementation uses ideas from (Raykar, Duraiswami, 2006), but the fast selection is not implemented.
+This method is due to [sheather1991]_ who used ideas from [park1990]_.
+The algorithm is presented in [wand1994]_, page 74 under the "Solve the equation rule" name.
+The implementation uses ideas from [raykar2006]_, but the fast selection is not implemented.
 
 Scott rule (dimension d)
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -325,8 +356,10 @@ according to the mirroring technique:
 
 .. topic:: References:
 
-     - *Kernel smoothing*, M.P. Wand and M.C. Jones, Chapman & Hall/CRC edition, ISNB 0-412-55270-1, 1994.
-     - *Multivariate Density Estimation, practice and Visualization, Theory*, David W. Scott, Wiley edition, 1992.
-     - *A reliable data-based bandwidth selection method for kernel density estimation.*, S. J. Sheather and M. C. Jones, Journal of the Royal Statistical Society. Series B (Methodological), 53(3) :683–690, 1991.
-     - "Comparison of data-driven bandwidth selectors.", Byeong U. Park and J. S. Marron. Journal of the American Statistical Association, 85(409) :66–72, 1990.
-     - "Very Fast optimal bandwidth selection for univariate kernel density estimation", Vikas Chandrakant Raykar, Ramani Duraiswami, CS-TR-4774. University of Maryland, CollegePark, MD 20783, 2006
+     - [silverman1986]_
+     - [wand1994]_
+     - [scott2015]_
+     - [sheather1991]_
+     - [park1990]_
+     - [raykar2006]_
+     - [silverman1982]_

--- a/python/src/HistogramFactory_doc.i.in
+++ b/python/src/HistogramFactory_doc.i.in
@@ -7,7 +7,7 @@ Available constructor:
 Notes
 -----
 
-The range is :math:`[min(data), max(data)]`. 
+The range is :math:`[\min(data), \max(data)]`. 
 
 See the `computeBandwidth` method for the bandwidth selection. 
 
@@ -118,26 +118,20 @@ sample:
 
 .. math::
 
-    \begin{aligned}
     Q_3 = q_n(0.75), \qquad Q_1 = q_n(0.25),
-    \end{aligned}
 
 and let :math:`IQR` be the inter-quartiles range:
 
 .. math::
 
-    \begin{aligned}
     IQR = Q_3 - Q_1.
-    \end{aligned}
 
 In this case, the bandwidth is the robust estimator of the AMISE-optimal bandwidth,
 known as Freedman and Diaconis rule [freedman1981]_:
 
 .. math::
 
-    \begin{aligned}
     h = \frac{IQR}{2\Phi^{-1}(0.75)} \left(\frac{24 \sqrt{\pi}}{n}\right)^{\frac{1}{3}}
-    \end{aligned}
 
 where :math:`\Phi^{-1}` is the quantile function of the gaussian standard 
 distribution. 
@@ -147,13 +141,11 @@ The normalized inter-quartile range is a robust estimator of the scale of the
 distribution (see [wand1994]_, page 60). 
 
 When `useQuantile` is `False`, the bandwidth is the AMISE-optimal one, 
-known as Scott's rule: 
+known as Scott's rule (see [scott2015]_ eq. 3.16 page 59): 
 
 .. math::
 
-    \begin{aligned}
     h = \sigma_n \left(\frac{24 \sqrt{\pi}}{n}\right)^{\frac{1}{3}}
-    \end{aligned}
 
 where :math:`\sigma_n^2` is the unbiaised variance of the data. 
 This estimator is optimal for the gaussian distribution (see [scott1992]_). 

--- a/python/src/KernelSmoothing_doc.i.in
+++ b/python/src/KernelSmoothing_doc.i.in
@@ -19,7 +19,7 @@ Notes
 -----
 The binning mechanism creates a regular grid of *binNumber* intervals in each
 dimension, then the unit weight of each point is linearly affected to the vertices
-of the bin containing the point. See [wand1994]_ for the details.
+of the bin containing the point (see [wand1994]_ appendix D, page 182).
 
 The boundary correction is available only in one dimension, and it is done using
 the mirroring technique. See the notes of the :meth:`setBoundingOption` method for
@@ -360,7 +360,7 @@ bandwidth : :class:`~openturns.Point`
 
 Notes
 -----
-This plug-in method is based on the solve-the-equation rule from (Sheather, Jones, 1991).
+This plug-in method is based on the solve-the-equation rule from [sheather1991]_.
 This method can take a lot of time for large samples, as the cost is  quadratic with the sample size.
 
 The `KernelSmoothing-CutOffPlugin` key of the :class:`~openturns.ResourceMap` controls

--- a/python/src/KernelSmoothing_doc.i.in
+++ b/python/src/KernelSmoothing_doc.i.in
@@ -348,7 +348,13 @@ automaticUpperBound : bool
 Returns
 -------
 bandwidth : :class:`~openturns.Point`
-    Bandwidth which components are evaluated according to the Silverman rule assuming a normal distribution. The bandwidth uses a robust estimate of the sample standard deviation, based on the interquartile range (rather than the standard deviation of the distribution and the sample). This method can manage a multivariate sample and produces a multivariate bandwidth.
+    Bandwidth which components are evaluated according to the Silverman rule
+    assuming a normal distribution.
+    The bandwidth uses a robust estimate of the
+    sample standard deviation, based on the interquartile range introduced
+    in :ref:`kernel_smoothing` (rather than the sample standard deviation).
+    This method can manage a multivariate sample and produces a
+    multivariate bandwidth.
 "
 
 // ---------------------------------------------------------------------
@@ -362,7 +368,7 @@ bandwidth : :class:`~openturns.Point`
 
 Notes
 -----
-This plug-in method is based on the solve-the-equation rule from [sheather1991]_.
+This plug-in method is based on the *solve-the-equation* rule from [sheather1991]_.
 This method can take a lot of time for large samples, as the cost is  quadratic with the sample size.
 
 Several keys of the :class:`~openturns.ResourceMap` are used by the [sheather1991]_ method.
@@ -389,7 +395,7 @@ More precisely, the `KernelSmoothing-CutOffPlugin` key of the :class:`~openturns
 the accuracy of the approximation used to estimate the rugosity of the
 second derivative of the distribution.
 The default value ensures that terms in the sum which weight are lower than
-4.e-6 are ignored, which can reduce the calculation in some situations.
+:math:`4 \times 10^{-6}` are ignored, which can reduce the calculation in some situations.
 The properties of the standard gaussian density are so that,
 in order to make the computation exact, the value of the
 `KernelSmoothing-CutOffPlugin` must be set to 39, but this may increase the
@@ -406,6 +412,18 @@ bandwidth : :class:`~openturns.Point`
     Bandwidth which components are evaluated according to a mixed rule.
 
 Notes
------ 
-Use the plugin rule for small sample, estimate the ratio between the plugin rule and the Silverman rule on this small sample, and finally scale the Silverman bandwidth computed on the full sample with this ratio. The size of the small sample is based on the `KernelSmoothing-SmallSize` key of the :class:`~openturns.ResourceMap`.
+-----
+This method uses the *mixed* rule introduced in :ref:`kernel_smoothing`.
+Its goal is to provide an accurate estimator of the bandwidth 
+when the sample size is large.
+
+Let :math:`n` be the sample size.
+The estimator depends on the threshold sample size :math:`n_t` defined in the
+`KernelSmoothing-SmallSize` key of the :class:`~openturns.ResourceMap`.
+
+
+- If :math:`n \leq n_t`, i.e. for a small sample, we use the plugin solve-the-equation
+  method.
+
+- Otherwise, the *mixed* rule is used.
 "

--- a/python/src/KernelSmoothing_doc.i.in
+++ b/python/src/KernelSmoothing_doc.i.in
@@ -20,6 +20,8 @@ Notes
 The binning mechanism creates a regular grid of *binNumber* intervals in each
 dimension, then the unit weight of each point is linearly affected to the vertices
 of the bin containing the point (see [wand1994]_ appendix D, page 182).
+The `KernelSmoothing-BinNumber` key defines the default value of the 
+number of bins used in the _binning_ algorithm to improve the evaluation speed.
 
 The boundary correction is available only in one dimension, and it is done using
 the mirroring technique. See the notes of the :meth:`setBoundingOption` method for
@@ -363,7 +365,27 @@ Notes
 This plug-in method is based on the solve-the-equation rule from [sheather1991]_.
 This method can take a lot of time for large samples, as the cost is  quadratic with the sample size.
 
-The `KernelSmoothing-CutOffPlugin` key of the :class:`~openturns.ResourceMap` controls
+Several keys of the :class:`~openturns.ResourceMap` are used by the [sheather1991]_ method.
+
+- The key `KernelSmoothing-AbsolutePrecision` is used in the Sheather-Jones algorithm
+  to estimate the bandwidth.
+  It defines the absolute tolerance used by the solver
+  to solve the nonlinear equation.
+
+- The `KernelSmoothing-MaximumIteration` key defines the maximum number of iterations
+  used by the solver.
+
+- The `KernelSmoothing-RelativePrecision` key defines the relative tolerance.
+
+- The `KernelSmoothing-AbsolutePrecision` key defines the absolute tolerance. 
+
+- The `KernelSmoothing-ResidualPrecision` key defines the absolute
+  tolerance on the residual.
+
+- The `KernelSmoothing-CutOffPlugin` key is the cut-off value
+  introduced in :ref:`kernel_smoothing`.
+
+More precisely, the `KernelSmoothing-CutOffPlugin` key of the :class:`~openturns.ResourceMap` controls
 the accuracy of the approximation used to estimate the rugosity of the
 second derivative of the distribution.
 The default value ensures that terms in the sum which weight are lower than
@@ -371,7 +393,8 @@ The default value ensures that terms in the sum which weight are lower than
 The properties of the standard gaussian density are so that,
 in order to make the computation exact, the value of the
 `KernelSmoothing-CutOffPlugin` must be set to 39, but this may increase the
-computation time."
+computation time.
+"
 
 // ---------------------------------------------------------------------
 %feature("docstring") OT::KernelSmoothing::computeMixedBandwidth
@@ -384,5 +407,5 @@ bandwidth : :class:`~openturns.Point`
 
 Notes
 ----- 
-Use the plugin rule for small sample, estimate the ratio between the plugin rule and the Silverman rule on this small sample, and finally scale the Silverman bandwidth computed on the full sample with this ratio. The size of the small sample is based on the `KernelSmoothing-SmallSize` key of the `ResourceMap`.
+Use the plugin rule for small sample, estimate the ratio between the plugin rule and the Silverman rule on this small sample, and finally scale the Silverman bandwidth computed on the full sample with this ratio. The size of the small sample is based on the `KernelSmoothing-SmallSize` key of the :class:`~openturns.ResourceMap`.
 "


### PR DESCRIPTION
This PR improves the kernel smoothing API and theory help pages.

This fixes #1979.

This PR improves two help pages:
- [KernelSmoothing](https://output.circle-artifacts.com/output/job/57a3c07f-4da4-43e8-a41c-a8ca276c48ef/artifacts/0/html/user_manual/_generated/openturns.KernelSmoothing.html#openturns.KernelSmoothing) API help page
- [kernel_smoothing](https://output.circle-artifacts.com/output/job/57a3c07f-4da4-43e8-a41c-a8ca276c48ef/artifacts/0/html/theory/data_analysis/kernel_smoothing.html) theory help page.

To do this, I had access to slides generously given by @adutfoy : thank you for this!

The theory help page had many bugs that are now fixed.

## Identified doc bugs

The Silverman rule of KDE does not make use of the estimated standard deviation. It uses the exact standard deviation. Then several rules can be used to estimate it.

![image](https://github.com/openturns/openturns/assets/31351465/0ccd25ea-7741-4538-afb1-dc417a9cb6d7)

The next equation should not be bold face. Furthermore, this is not h_AMISE, but h_STE.

![image](https://github.com/openturns/openturns/assets/31351465/e758751d-9f06-442f-8dab-2fed1917e963)

The next sentence is the most significant bug. We do not have sigma_K R(K) close to 1, but the ratio of this formula for two different kernels K1 and K2 is close to 1.

![image](https://github.com/openturns/openturns/assets/31351465/5f47e3da-9026-4f6c-a341-92abc88fe717)

## Improvements

- Fixed bibliographic references in KernelSmoothing.
- I created a table of several kernels to see the differences.

![image](https://github.com/openturns/openturns/assets/31351465/3f89f14c-c491-43a2-93d9-cd7de40ca01c)

- A new section documents the Mixed rule.
- A new conclusion sections summarizes the results.
