### PR TITLE
Update LinearModelAlgorithm_doc.i.in

### DIFF
--- a/python/src/LinearModelAlgorithm_doc.i.in
+++ b/python/src/LinearModelAlgorithm_doc.i.in
@@ -19,30 +19,70 @@ LinearModelResult
 
 Notes
 -----
-This class is used in order to create a linear model from data samples. The
-linear regression model between the scalar variable :math:`Y` and the :math:`n`
--dimensional vector :math:`\vect{X} = (X_i)_{i \leq n}` writes as follows:
+This class is used in order to create a linear model from an input sample
+and an output sample.
+Let :math:`n` be the sample size and let :math:`n_x` be the input
+sample dimension.
+This class considers the linear regression model between the scalar
+variable :math:`Y` and the :math:`n_x`-dimensional vector :math:`\vect{X} = (X_i)_{1 \leq i \leq n_x}`.
+The linear model can be estimated with or without a functional basis.
+
+If no basis is specified, the model is:
 
 .. math::
 
-    \tilde{Y} = \sum_{i=0}^p a_i \phi_i(X) + \epsilon
+    Y = a_0 + \sum_{i=1}^{n_x} a_i X_i + \epsilon
 
-where :math:`\epsilon` is the residual, supposed to follow the standard Normal
-distribution, :math:`\phi` a functional basis.
-The algorithm class enables to estimate the coefficients of the linear expansion.
+where :math:`a_0, a_1, ..., a_{n_x} \in \Rset`
+are unknown coefficients and :math:`\epsilon` is a random variable with zero mean and constant
+(unknown) variance :math:`\sigma^2` independent from
+the coefficients :math:`\{a_i\}_{i = 0, ..., n_x}`.
+The algorithm estimates the coefficients
+:math:`a_0, a_1, ..., a_{n_x}` of the linear model.
+Moreover, the method estimates the variance :math:`\sigma^2`.
 
-If basis is not specified, the underlying model is :
+If a functional basis is specified, let :math:`p \in \Nset` be the number of
+functions in the basis.
+For :math:`j \in \{1, ..., p\}`, let :math:`\phi_j : \Rset^{n_x} \rightarrow \Rset`
+be the :math:`i`-th basis function.
+The linear model is:
 
 .. math::
 
-    \tilde{Y} = a_0 + \sum_{i=1}^n a_i X_i + \epsilon
+    Y = \sum_{j=1}^p a_j \phi_j(\vect{X}) + \epsilon
 
-The coefficients :math:`a_i` are evaluated using a least squares method.
-Default method is `QR`. User might also choose `SVD` or `Cholesky` (useful
-if basis is orthogonal) and large dataset.
+where :math:`\epsilon` is a random variable with zero mean and constant
+(and unknown) variance :math:`\sigma^2` and :math:`a_1, ..., a_p \in \Rset`
+are unknown coefficients.
+The algorithm estimates the coefficients
+:math:`a_1, ..., a_p` of the linear model.
+Moreover, the method estimates the variance :math:`\sigma^2`.
 
-The evaluation of the coefficients is completed by some useful parameters that could
-help the diagnostic of the linearity.
+The coefficients :math:`a_i` are evaluated using a linear least squares method.
+Default method is `QR`. User might also choose `SVD` or `Cholesky` by
+setting the `LinearModelAlgorithm-DecompositionMethod` key of the :class:`~openturns.ResourceMap`.
+This choice can be based depending on the following parameters.
+
+- The Cholesky can be safely used if the functional basis is orthogonal
+  and the sample is drawn from the corresponding distribution,
+  because this ensures that the columns of the design matrix are
+  asymptotically orthogonal when the sample size increases.
+  In this case, evaluating the Gram matrix does not increase
+  the condition number.
+- Selecting the decomposition method can also be based on the sample size.
+
+Please read the :meth:`~openturns.LeastSquaresMethod.Build` help page
+for details on this topic.
+
+The :class:`~openturns.LinearModelAnalysis` class can be used for a detailed
+analysis of the linear model result.
+
+No scaling is involved in this method.
+The scaling of the data, if any, is the responsibility of the user of the algorithm.
+This may be useful if, for example, we use a linear model (without functional basis)
+with very different input magnitudes and use the Cholesky decomposition
+applied to the associated Gram matrix.
+In this case, the Cholesky method may fail to produce accurate results.
 
 Examples
 --------
@@ -55,7 +95,7 @@ Examples
 >>> output_sample = func(input_sample)
 >>> algo = ot.LinearModelAlgorithm(input_sample, output_sample)
 >>> algo.run()
->>> result = ot.LinearModelResult(algo.getResult())"
+>>> result = algo.getResult()"
 
 // ---------------------------------------------------------------------
 

--- a/python/src/LinearModelAlgorithm_doc.i.in
+++ b/python/src/LinearModelAlgorithm_doc.i.in
@@ -23,7 +23,7 @@ This class is used in order to create a linear model from an input sample
 and an output sample.
 Let :math:`n` be the sample size and let :math:`n_x` be the input
 sample dimension.
-This class considers the linear regression model between the scalar
+This class fits a linear regression model between the scalar
 variable :math:`Y` and the :math:`n_x`-dimensional vector :math:`\vect{X} = (X_i)_{1 \leq i \leq n_x}`.
 The linear model can be estimated with or without a functional basis.
 
@@ -58,10 +58,11 @@ The algorithm estimates the coefficients
 :math:`a_1, ..., a_p` of the linear model.
 Moreover, the method estimates the variance :math:`\sigma^2`.
 
-The coefficients :math:`a_i` are evaluated using a linear least squares method.
-Default method is `QR`. User might also choose `SVD` or `Cholesky` by
+The coefficients :math:`a_i` are evaluated using a linear least squares method,
+by default the `QR` method.
+User might also choose `SVD` or `Cholesky` by
 setting the `LinearModelAlgorithm-DecompositionMethod` key of the :class:`~openturns.ResourceMap`.
-This choice can be based depending on the following parameters.
+Here are a few guidelines to choose the appropriate decomposition method:
 
 - The Cholesky can be safely used if the functional basis is orthogonal
   and the sample is drawn from the corresponding distribution,


### PR DESCRIPTION
This PR improves the API doc of [LinearModelAlgorithm](http://openturns.github.io/openturns/1.21/user_manual/response_surface/_generated/openturns.LinearModelAlgorithm.html).

## Problems in the current doc

- There are different methods (SVD, QR and Cholesky) available in the algorithm. This requires to set a `ResourceMap` key, which is undocumented in the doc.

- The linear model with a functional basis is wrongly specified. 1) The Gauss-Markov theorem guarantees that the linear model regression has lowest possible variance, _whatever the distribution of the observation noise_. This is the opposite of the text, which states that the observation noise $\epsilon$ must have the Gaussian distribution. 2) The dimension of the input is denoted $n$, which is a poor letter choice. This is because the letter $n$ is usually chosen as the number of observations. 3) The number of functions is denoted by $p$, but $p$ is undefined in the text. 4) The input vector $\boldsymbol{X}$ should be in bold face in the input argument of the function $\phi_i$. 5) The same index letter $i$ is used in the index of the input vector $\boldsymbol{X}$ and the functional basis, which is wrong. 6) The index of $(X_i)$ is not "$i \leq n$" because a lower bound of $i$ must be specified.
 
![image](https://github.com/openturns/openturns/assets/31351465/5a058470-2ccc-48b1-8f62-a2a369165bec)

- The linear model without basis is wrongly specified. 1) There is no need of a tilde on the Y letter. In classical regression, this is the _exact_ noisy output. This is not the same in the approximation function setting (i.e. in the PCE setting), which is not the topic of this page. Otherwise, the link between $\tilde{Y}$ and $Y$ should be specified, which is not. 2) The coefficients are unspecified.

![image](https://github.com/openturns/openturns/assets/31351465/44fafc62-b107-401c-b34b-f358671a09b0)

- The "large dataset" statement does not seem to be related to the beginning of the sentence: its meaning is unclear.

![image](https://github.com/openturns/openturns/assets/31351465/27cd2ba9-5bcf-4b81-b726-d966289a7785)

## Result
The API help page of `LinearModelAlgorithm` is updated. The HTML is available at [this link](https://output.circle-artifacts.com/output/job/8aaf8e2c-9dd6-4f79-8c78-196714697afd/artifacts/0/html/user_manual/response_surface/_generated/openturns.LinearModelAlgorithm.html).
