### PR TITLE
Update ranking_src.rst

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -36,6 +36,10 @@ Bibliography
 .. [blatman2011] Blatman, G., and Sudret, B..
     *Adaptive sparse polynomial chaos expansion based on least angle regression.*
     Journal of Computational Physics 230 (2011) 2345–2367.
+.. [borgonovo2017] Borgonovo, E. (2017).
+    *Sensitivity analysis.*
+    *An Introduction for the Management Scientist.* International Series in
+    Operations Research and Management Science. Cham, Switzerland : Springer.
 .. [burnham2002] Burnham, K.P., and Anderson, D.R. *Model Selection and
     Multimodel Inference: A Practical Information Theoretic Approach*, Springer,
     2002.

--- a/python/doc/math_notations.sty
+++ b/python/doc/math_notations.sty
@@ -114,8 +114,8 @@
 \newcommand{\uz}{\vect{z}}
 \newcommand{\uZ}{\vect{Z}}
 \newcommand{\muX}{\vect{\mu}_{\:X}}
-\newcommand{\Var}[1]{{\rm Var}\left[ #1 \right]}
-\newcommand{\Cov}[1]{{\rm Cov}\left[ #1 \right]}
+\newcommand{\Var}[1]{{\rm Var}\left( #1 \right)}
+\newcommand{\Cov}[1]{{\rm Cov}\left( #1 \right)}
 \newcommand{\Expect}[1]{{\mathbb E}\left[ #1 \right]}
 \newcommand{\Econd}[2]{{\mathbb E}_{#1}\left[ #2 \right]}
 \newcommand{\Prob}[1]{{\mathbb P}\left( #1 \right)}

--- a/python/doc/theory/reliability_sensitivity/ranking_src.rst
+++ b/python/doc/theory/reliability_sensitivity/ranking_src.rst
@@ -5,9 +5,9 @@ Uncertainty ranking: SRC and SRRC
 
 Standard Regression Coefficients (SRC) deal with analyzing the influence the random vector
 :math:`\vect{X} = \left( X_1,\ldots,X_{n_X} \right)` has on a random
-variable :math:`Y` which is being studied for uncertainty. Here we
-attempt to measure linear relationships that exist between :math:`Y`
-and the different components :math:`X_i`.
+variable :math:`Y`.
+We measure linear relationships that exist between :math:`Y`
+and the different input variables :math:`X_i`.
 
 The principle of the multiple linear regression model consists in
 attempting to find the function that links the
@@ -18,71 +18,100 @@ variable :math:`Y` to the :math:`n_x` variables
 
     Y = a_0 + \sum_{i=1}^{n_X} a_i X_i + \varepsilon,
 
-where :math:`\varepsilon` describes a random variable with zero mean
+where :math:`(a_i)_{i = 0, 1, ..., n_X}` are constant parameters,
+:math:`\varepsilon` is a random variable with zero mean
 and standard deviation :math:`\sigma_{\varepsilon}` independent of the
 input variables :math:`X_i`. If the random variables
 :math:`X_1,\ldots,X_{n_X}` are independent and with finite variance
-:math:`\Var{X_k} = (\sigma_i)^2`, the variance of :math:`Y` can be
+:math:`\Var{X_i} = \sigma_i^2`, the variance of :math:`Y` can be
 estimated as follows:
 
 .. math::
 
-    \Var{Y} = \sum_{i=1}^n (a_i)^2 \Var{X_i} + (\sigma_{\varepsilon})^2 = (\sigma)^2.
+    \Var{Y} = \sum_{i=1}^n a_i^2 \Var{X_i} + \sigma_{\varepsilon}^2 = \sigma^2.
 
-From this we obtain the following coefficients:
+The SRC coefficient is defined by (see [borgonovo2017]_ page 131, eq. 14.3):
 
 .. math::
 
-    C_i = a_i \sqrt{\frac{\Var{X_k}}{\Var{Y}}}
+    \operatorname{SRC}_i = a_i \sqrt{\frac{\Var{X_i}}{\Var{Y}}}
 
+for :math:`i = 1, ..., n_X`.
 The estimators for the regression coefficients
 :math:`a_0,\ldots,a_{n_X}`, and the standard deviation
 :math:`\sigma` are obtained from a sample of
 :math:`(Y,X_1,\ldots,X_{n_X})`.
 The SRC coefficients are defined as the estimators :math:`\widehat{C}_i`
-of the coefficients :math:`C_i`:
+of the coefficients :math:`SRC_i`:
 
 .. math::
 
-    \widehat{C}_i = \frac{\displaystyle \widehat{a}_i \widehat{\sigma}_i}{\displaystyle \widehat{\sigma}},
+    \widehat{\operatorname{SRC}}_i = \widehat{a}_i \frac{\widehat{\sigma}_i}{\widehat{\sigma}},
 
-
-where :math:`\widehat{a}_i` denotes the estimate of the regression coefficient :math:`a_i`,
-:math:`\widehat{\sigma}_i` denotes the empirical standard
+for :math:`i = 1, ..., n_X`,
+where :math:`\widehat{a}_i` is the estimate of the regression coefficient :math:`a_i`,
+:math:`\widehat{\sigma}_i` is the sample standard
 deviation of the sample of the input variable :math:`X_i`
-and :math:`\widehat{\sigma}` denotes the empirical standard
+and :math:`\widehat{\sigma}` is the sample standard
 deviation of the sample of the output variable :math:`Y`.
 The absolute value of this estimated
 contribution is by definition between 0 and 1. The closer it is to 1,
-the greater the impact the variable :math:`X_i` has on the dispersion of
+the greater the impact the variable :math:`X_i` has on the variance of
 :math:`Y`.
+See the :class:`~openturns.CorrelationAnalysis.computeSRC` method to compute the SRC
+coefficients.
 
-The square :math:`(C_i)^2`, which is the contribution of :math:`X_i`
-to the variance of :math:`Y`,
-is sometimes described in
+Before estimating the SRC coefficients,
+we mush check the quality of the :ref:`linear regression <linear_regression>`:
+if the linear regression model
+is a poor fit to the data, then the SRC coefficients are useless.
+See e.g. the :class:`~openturns.MetaModelValidation` class to validate
+the linear model against a test data set.
+
+The :math:`\operatorname{SRC}_i^2` index, which is the contribution of :math:`X_i`
+to the variance of :math:`Y`, is sometimes described in
 the literature as the “importance factor”, because of the similarity
 between this approach to linear regression and the method of cumulative
 variance which uses the term importance factor.
+This importance factor is also named "squared SRC" coefficient
+(see [borgonovo2017]_ page 131, eq. 14.5):
 
-It is a good idea to check the quality of the :ref:`linear regression <linear_regression>`
-before estimating the SRC coefficients: if the linear regression model
-is a poor fit to the data, then the SRC coefficients are useless.
+.. math::
 
-Note that if there exists a map :math:`g` such that :math:`Y=g(X_1, ..., X_{n_X})`,
-then the squared SRC coefficients are equal to :ref:`Sobol' indices <sensitivity_sobol>`.
+    \operatorname{SRC}_i^2 = a_i^2 \frac{\Var{X_i}}{\Var{Y}}
+
+for :math:`i = 1, ..., n_X`.
+The squared SRC coefficients of a linear model are equal to its
+:ref:`Sobol' indices <sensitivity_sobol>`.
+If the model is linear, the first-order Sobol' index is equal
+to the total Sobol' index since there is no interaction.
+See the :class:`~openturns.CorrelationAnalysis.computeSquaredSRC` method to compute the squared SRC
+coefficients.
+
+If the input random variables :math:`(X_i)_{i = 1, ..., n_X}` are dependent,
+then the SRC is not a valid importance measure anymore (see [daveiga2022]_ remark 4
+page 33).
+In this case, the partial correlation coefficient (PCC) has been suggested, but
+this index is more a measure of the linear relationship between the input and the
+output.
+Other indices such as the Lindeman-Merenda-Gold (LMG) have been suggested in the
+dependent case (see [daveiga2022]_ page 33).
 
 Standard *Rank* Regression Coefficients (SRRC) are SRC coefficients
 computed on the ranked input variables
-:math:`r\vect{X} = \left( rX_1,\ldots,rX_{n_X} \right)`
-and the ranked output variable :math:`rY`.
+:math:`\operatorname{rank}(\vect{X}) = \left( \operatorname{rank}(X_1), \ldots, \operatorname{rank}(X_{n_X}) \right)`
+and the ranked output variable :math:`\operatorname{rank}(Y)`.
 They are useful when the relationship between :math:`Y`
 and :math:`\vect{X}` is not linear (so SRC cannot be used),
 but only monotonic.
+See the :class:`~openturns.CorrelationAnalysis.computeSRRC` method to compute the SRRC
+coefficients.
 
 .. topic:: API:
 
     - See :meth:`~openturns.CorrelationAnalysis.computeSRC`
     - See :meth:`~openturns.CorrelationAnalysis.computeSRRC`
+    - See :meth:`~openturns.CorrelationAnalysis.computeSquaredSRC`
 
 
 .. topic:: Examples:
@@ -95,3 +124,5 @@ but only monotonic.
     - [saltelli2000]_
     - [helton2003]_
     - [kleijnen1999]_
+    - [borgonovo2017]_
+    - [daveiga2022]_

--- a/python/doc/theory/reliability_sensitivity/ranking_src.rst
+++ b/python/doc/theory/reliability_sensitivity/ranking_src.rst
@@ -18,12 +18,12 @@ variable :math:`Y` to the :math:`n_x` variables
 
     Y = a_0 + \sum_{i=1}^{n_X} a_i X_i + \varepsilon,
 
-where :math:`(a_i)_{i = 0, 1, ..., n_X}` are constant parameters,
+where :math:`(a_i)_{i = 0, 1, ..., n_X}` are constant parameters and
 :math:`\varepsilon` is a random variable with zero mean
 and standard deviation :math:`\sigma_{\varepsilon}` independent of the
 input variables :math:`X_i`. If the random variables
 :math:`X_1,\ldots,X_{n_X}` are independent and with finite variance
-:math:`\Var{X_i} = \sigma_i^2`, the variance of :math:`Y` can be
+:math:`\Var{X_i}`, the variance of :math:`Y` can be
 estimated as follows:
 
 .. math::
@@ -41,7 +41,7 @@ The estimators for the regression coefficients
 :math:`a_0,\ldots,a_{n_X}`, and the standard deviation
 :math:`\sigma` are obtained from a sample of
 :math:`(Y,X_1,\ldots,X_{n_X})`.
-The SRC coefficients are defined as the estimators :math:`\widehat{C}_i`
+The SRC coefficients are defined as the estimators :math:`\widehat{\operatorname{SRC}}_i`
 of the coefficients :math:`SRC_i`:
 
 .. math::
@@ -92,7 +92,7 @@ If the input random variables :math:`(X_i)_{i = 1, ..., n_X}` are dependent,
 then the SRC is not a valid importance measure anymore (see [daveiga2022]_ remark 4
 page 33).
 In this case, the partial correlation coefficient (PCC) has been suggested, but
-this index is more a measure of the linear relationship between the input and the
+this index is rather a measure of the linear relationship between the input and the
 output.
 Other indices such as the Lindeman-Merenda-Gold (LMG) have been suggested in the
 dependent case (see [daveiga2022]_ page 33).


### PR DESCRIPTION
Fixed wrong definition of SRC indices.
Create new squared SRC indices definition (the current text lets this undefined). Made clear that the validation of the linear model is mandatory (not optional, as the current text suggests). Made the link to the `CorrelationAnalysis` class.
Create new bibliographic references (the current text has no one).