### PR TITLE
Improve linear model

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -800,8 +800,13 @@
   <LeastSquaresExpansion-DecompositionMethod       value_str="QR" />
 
   <!-- OT::LinearModelAlgorithm parameters -->
-  <LinearModelAnalysis-Identifiers                 value_int="3"      />
   <LinearModelAlgorithm-DecompositionMethod        value_str="QR"      />
+  
+  <!-- OT::LinearModelAnalysis parameters -->
+  <LinearModelAnalysis-Identifiers            value_int="3"      />
+  <LinearModelAnalysis-PrintEllipsisThreshold value_int="20"     />
+  <LinearModelAnalysis-SmallPValueFormat      value_str="{:.4e}" />
+  <LinearModelAnalysis-LargePValueFormat      value_int="{:.4f}" />
 
   <!-- OT::LinearModelStepwiseAlgorithm parameters -->
   <LinearModelStepwiseAlgorithm-Penalty                  value_float="2.0"      />

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1431,7 +1431,12 @@ void ResourceMap::loadDefaultConfiguration()
 
   // LinearModelAlgorithm parameters //
   addAsString("LinearModelAlgorithm-DecompositionMethod", "QR");
+  
+  // LinearModelAnalysis parameters //
   addAsUnsignedInteger("LinearModelAnalysis-Identifiers", 3);
+  addAsUnsignedInteger("LinearModelAnalysis-PrintEllipsisThreshold", 20);
+  addAsString("LinearModelAnalysis-SmallPValueFormat", "{:.4e}");
+  addAsString("LinearModelAnalysis-LargePValueFormat", "{:.4f}");
 
   // LinearModelStepwiseAlgorithm parameters //
   addAsScalar("LinearModelStepwiseAlgorithm-Penalty", 2.0);

--- a/lib/src/Base/Func/LinearEvaluation.cxx
+++ b/lib/src/Base/Func/LinearEvaluation.cxx
@@ -50,9 +50,15 @@ LinearEvaluation::LinearEvaluation(const Point & center,
   , linear_(linear.transpose())
 {
   /* Check if the dimension of the constant term is compatible with the linear term */
-  if (constant.getDimension() != linear.getNbColumns()) throw InvalidDimensionException(HERE) << "Constant term dimension is incompatible with the linear term";
+  if (constant.getDimension() != linear.getNbColumns())
+    throw InvalidDimensionException(HERE) << "Constant term dimension is incompatible with the linear term. "
+      <<"The constant has dimension: " << constant.getDimension()
+      <<" but the number of columns in the linear matrix is: " << linear.getNbColumns();
   /* Check if the dimension of the center term is compatible with the linear term */
-  if (center.getDimension() != linear.getNbRows()) throw InvalidDimensionException(HERE) << "Center term dimension is incompatible with the linear term";
+  if (center.getDimension() != linear.getNbRows())
+    throw InvalidDimensionException(HERE) << "Center term dimension is incompatible with the linear term. "
+      << "The dimension of the center is: " << center.getDimension()
+      << " but the number of rows of the linear matrix is: " << linear.getNbRows();
   setInputDescription(Description::BuildDefault(getInputDimension(), "x"));
   setOutputDescription(Description::BuildDefault(getOutputDimension(), "y"));
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAlgorithm.cxx
@@ -98,10 +98,10 @@ void LinearModelAlgorithm::run()
   // Do not run again if already computed
   if (hasRun_) return;
 
-  const UnsignedInteger size = inputSample_.getSize();
+  const UnsignedInteger sampleSize = inputSample_.getSize();
   const UnsignedInteger basisSize = basis_.getSize();
-  if (basisSize > size)
-    throw InvalidArgumentException(HERE) << "Number of basis elements is greater than sample size. Data size = " << outputSample_.getSize()
+  if (basisSize > sampleSize)
+    throw InvalidArgumentException(HERE) << "Number of basis elements is greater than sample size. Sample size = " << outputSample_.getSize()
                                          << ", basis size = " << basisSize;
 
   // No particular strategy : using the full basis
@@ -141,12 +141,12 @@ void LinearModelAlgorithm::run()
   const Sample residualSample(outputSample_ - metaModel(inputSample_));
 
   // noise variance
-  const Scalar sigma2 = (basisSize >= size) ? 0.0 : size * residualSample.computeRawMoment(2)[0] / (size - basisSize);
+  const Scalar sigma2 = (basisSize >= sampleSize) ? 0.0 : sampleSize * residualSample.computeRawMoment(2)[0] / (sampleSize - basisSize);
 
-  Sample standardizedResiduals(size, 1);
+  Sample standardizedResiduals(sampleSize, 1);
 
   // Loop over residual sample
-  for(UnsignedInteger i = 0; i < size; ++i)
+  for(UnsignedInteger i = 0; i < sampleSize; ++i)
   {
     const Scalar factorOneMinusLeverageI = sigma2 * (1.0 - leverages[i]);
     if (!(factorOneMinusLeverageI > 0))
@@ -155,8 +155,8 @@ void LinearModelAlgorithm::run()
       standardizedResiduals(i, 0) = residualSample(i, 0) / std::sqrt(factorOneMinusLeverageI);
   }
 
-  Point cookDistances(size);
-  for (UnsignedInteger i = 0; i < size; ++i)
+  Point cookDistances(sampleSize);
+  for (UnsignedInteger i = 0; i < sampleSize; ++i)
   {
     cookDistances[i] = (1.0 / basisSize) * standardizedResiduals(i, 0) * standardizedResiduals(i, 0) * (leverages[i] / (1.0 - leverages[i]));
   }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx
@@ -81,9 +81,7 @@ String LinearModelAnalysis::__str__(const String & offset) const
   const Point tscores(getCoefficientsTScores());
   const Point pValues(getCoefficientsPValues());
   const Description names(linearModelResult_.getCoefficientsNames());
-  const Scalar sigma2 = linearModelResult_.getSampleResiduals().computeRawMoment(2)[0];
   const SignedInteger dof = linearModelResult_.getDegreesOfFreedom();
-  const UnsignedInteger n = linearModelResult_.getSampleResiduals().getSize();
   const String separator(" | ");
   const String separatorEndLine(" |");
   size_t twidth = 0; // column title max width
@@ -134,7 +132,8 @@ String LinearModelAnalysis::__str__(const String & offset) const
     oss << "\n";
   }
   oss << offset << String( awidth, '-' ) << "\n\n";
-  oss << offset << "Residual standard error: " <<  std::sqrt(sigma2 * n / dof)  << " on " << dof << " degrees of freedom\n";
+  const Scalar residualStandardError = getResidualsStandardError();
+  oss << offset << "Residual standard error: " <<  residualStandardError  << " on " << dof << " degrees of freedom\n";
 
   // In case of only intercept in the basis, no more print
   if ((basisSize == 1) && (hasIntercept))
@@ -166,17 +165,17 @@ String LinearModelAnalysis::__str__(const String & offset) const
   // normality tests
   lwidth = 7; // width of "p-value"
   twidth = 20;
-  const Scalar normalitytest1(getNormalityTestResultAndersonDarling().getPValue());
-  const Scalar normalitytest2(getNormalityTestResultChiSquared().getPValue());
-  const Scalar normalitytest3(getNormalityTestResultKolmogorovSmirnov().getPValue());
-  const Scalar normalitytest4(getNormalityTestCramerVonMises().getPValue());
-  st = OSS() << normalitytest1;
+  const Scalar normalityTestAD(getNormalityTestResultAndersonDarling().getPValue());
+  const Scalar normalityTestCS(getNormalityTestResultChiSquared().getPValue());
+  const Scalar normalityTestKS(getNormalityTestResultKolmogorovSmirnov().getPValue());
+  const Scalar normalityTestCVM(getNormalityTestCramerVonMises().getPValue());
+  st = OSS() << normalityTestAD;
   lwidth = std::max( lwidth, st.size() );
-  st = OSS() << normalitytest2;
+  st = OSS() << normalityTestCS;
   lwidth = std::max( lwidth, st.size() );
-  st = OSS() << normalitytest3;
+  st = OSS() << normalityTestKS;
   lwidth = std::max( lwidth, st.size() );
-  st = OSS() << normalitytest4;
+  st = OSS() << normalityTestCVM;
   lwidth = std::max( lwidth, st.size() );
   awidth = twidth + 2 * separator.size() + lwidth - 1;
   oss << "\n" << offset << String( awidth, '-' ) << "\n";
@@ -187,22 +186,22 @@ String LinearModelAnalysis::__str__(const String & offset) const
   oss << "\n" <<  String( awidth, '-' ) << "\n";
   st = "Anderson-Darling";
   oss << offset << st << String( twidth - st.size(), ' ') << separator;
-  st = OSS() << normalitytest1;
+  st = OSS() << normalityTestAD;
   oss << st << String( lwidth - st.size(), ' ') << separatorEndLine;
   oss << "\n";
   st = "Cramer-Von Mises";
   oss << offset << st << String( twidth - st.size(), ' ') << separator;
-  st = OSS() << normalitytest4;
+  st = OSS() << normalityTestCVM;
   oss << st << String( lwidth - st.size(), ' ') << separatorEndLine;
   oss << "\n";
   st = "Chi-Squared";
   oss << offset << st << String( twidth - st.size(), ' ') << separator;
-  st = OSS() << normalitytest2;
+  st = OSS() << normalityTestCS;
   oss << st << String( lwidth - st.size(), ' ') << separatorEndLine;
   oss << "\n";
   st = "Kolmogorov-Smirnov";
   oss << offset << st << String( twidth - st.size(), ' ') << separator;
-  st = OSS() << normalitytest3;
+  st = OSS() << normalityTestKS;
   oss << st << String( lwidth - st.size(), ' ') << separatorEndLine;
   oss << "\n" <<  String( awidth, '-' ) << "\n";
   return oss;
@@ -316,24 +315,32 @@ Scalar LinearModelAnalysis::getFisherPValue() const
   return FisherSnedecor(dofModel, dof).computeComplementaryCDF(FStatistic);
 }
 
-/* Kolmogorov-Smirnov normality test */
+/* Estimator of the standard deviation */
+Scalar LinearModelAnalysis::getResidualsStandardError() const
+{
+  const Scalar sumOfSquaredErrors = linearModelResult_.getSampleResiduals().asPoint().normSquare();
+  const UnsignedInteger dof = linearModelResult_.getDegreesOfFreedom();
+  const Scalar stdError = std::sqrt(sumOfSquaredErrors / dof);
+  return stdError;
+}
+
+/* Kolmogorov-Smirnov normality test of the residuals */
 TestResult LinearModelAnalysis::getNormalityTestResultKolmogorovSmirnov() const
 {
-  // We check that residuals are centered with variance = sigma2
+  // We check that residuals have a Normal distribution
   const Sample residuals(linearModelResult_.getSampleResiduals());
-  // Compute Sigma2
-  const Scalar sigma2(residuals.computeRawMoment(2)[0]);
+  const Scalar sigma2 = residuals.computeRawMoment(2)[0];
   const Normal dist(0.0, std::sqrt(sigma2));
   return FittingTest::Kolmogorov(residuals, dist);
 }
 
-/* Anderson-Darling normality test */
+/* Anderson-Darling normality test of the residuals */
 TestResult LinearModelAnalysis::getNormalityTestResultAndersonDarling() const
 {
   return NormalityTest::AndersonDarlingNormal(linearModelResult_.getSampleResiduals());
 }
 
-/* Chi-Squared normality test */
+/* Chi-Squared normality test of the residuals */
 TestResult LinearModelAnalysis::getNormalityTestResultChiSquared() const
 {
   // Using OT::FittingTest::ChiSquared
@@ -342,7 +349,7 @@ TestResult LinearModelAnalysis::getNormalityTestResultChiSquared() const
   return FittingTest::ChiSquared(residuals, normalDistribution);
 }
 
-/* Cramer Von Mises normality test */
+/* Cramer Von Mises normality test of the residuals */
 TestResult LinearModelAnalysis::getNormalityTestCramerVonMises() const
 {
   return NormalityTest::CramerVonMisesNormal(linearModelResult_.getSampleResiduals());
@@ -365,7 +372,7 @@ Graph LinearModelAnalysis::drawModelVsFitted() const
   // The graph object
   Graph graph("Model vs Fitted", "Model", "Fitted values", true, "topright");
 
-  // Bissectrice graph
+  // Validation graph
   Sample bissectriceCurve(2, 2);
   bissectriceCurve(0, 0) = outputData.getMin()[0];
   bissectriceCurve(0, 1) = outputData.getMin()[0];

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
@@ -44,7 +44,7 @@ LinearModelResult::LinearModelResult(const Sample & inputSample,
                                      const Matrix & design,
                                      const Sample & outputSample,
                                      const Function & metaModel,
-                                     const Point & trendCoefficients,
+                                     const Point & coefficients,
                                      const String & formula,
                                      const Description & coefficientsNames,
                                      const Sample & sampleResiduals,
@@ -52,11 +52,11 @@ LinearModelResult::LinearModelResult(const Sample & inputSample,
                                      const Point & diagonalGramInverse,
                                      const Point & leverages,
                                      const Point & cookDistances,
-                                     const Scalar sigma2)
+                                     const Scalar residualsVariance)
   : MetaModelResult(inputSample, outputSample, metaModel, Point(1, 0.0), Point(1, 0.0))
   , basis_(basis)
   , design_(design)
-  , beta_(trendCoefficients)
+  , coefficients_(coefficients)
   , condensedFormula_(formula)
   , coefficientsNames_(coefficientsNames)
   , sampleResiduals_(sampleResiduals)
@@ -64,7 +64,7 @@ LinearModelResult::LinearModelResult(const Sample & inputSample,
   , diagonalGramInverse_(diagonalGramInverse)
   , leverages_(leverages)
   , cookDistances_(cookDistances)
-  , sigma2_(sigma2)
+  , residualsVariance_(residualsVariance)
   , hasIntercept_(false)
 {
   const UnsignedInteger size = inputSample.getSize();
@@ -74,7 +74,7 @@ LinearModelResult::LinearModelResult(const Sample & inputSample,
   const SignedInteger degreesOfFreedom = getDegreesOfFreedom();
   if (degreesOfFreedom < 0)
     throw InvalidArgumentException(HERE) << "Degrees of freedom is less than 0. Data size = " << outputSample.getSize()
-                                         << ", basis size = " << beta_.getSize()
+                                         << ", basis size = " << coefficients_.getSize()
                                          << ", degrees of freedom = " << degreesOfFreedom;
   checkIntercept();
 }
@@ -118,16 +118,49 @@ Bool LinearModelResult::hasIntercept() const
 }
 
 /* String converter */
+String LinearModelResult::__str__(const String & /*offset*/) const
+{
+  return __repr_markdown__();
+}
+
+String LinearModelResult::__repr_markdown__() const
+{
+  OSS oss(false);
+  const UnsignedInteger inputDimension = basis_[0].getInputDimension();
+  oss << getClassName() << "\n"
+      << "- input dimension=" << inputDimension << "\n"
+      << "- basis size=" << basis_.getSize() << "\n"
+      << "- design matrix=" << design_.getNbRows() << " x " << design_.getNbColumns() << "\n"
+      << "- coefficients=" << coefficients_.getDimension() << "\n"
+      << "- formula=" << condensedFormula_ << "\n"
+      << "- coefficients names=" << coefficientsNames_ << "\n"
+      << "- residuals size=" << sampleResiduals_.getSize() << "\n"
+      << "- standard residuals size=" << standardizedResiduals_.getSize() << "\n"
+      << "- inverse Gram diagonal=" << diagonalGramInverse_ << "\n"
+      << "- leverages size=" << leverages_.getSize() << "\n"
+      << "- Cook's distances size=" << cookDistances_.getSize() << "\n"
+      << "- residuals variance=" << residualsVariance_ << "\n"
+      << "- has intercept=" << hasIntercept_ << "\n";
+  oss << "\n";
+  return oss;
+}
+
+/* String converter */
 String LinearModelResult::__repr__() const
 {
   return OSS(true) << "class=" << getClassName()
-         << " beta=" << beta_
+         << " beta=" << coefficients_
          << " formula=" << condensedFormula_;
 }
 
 Basis LinearModelResult::getBasis() const
 {
   return basis_;
+}
+
+Matrix LinearModelResult::getDesign() const
+{
+  return design_;
 }
 
 /* Fitted sample accessor */
@@ -139,7 +172,7 @@ Sample LinearModelResult::getFittedSample() const
 /* Formula accessor */
 Point LinearModelResult::getCoefficients() const
 {
-  return beta_;
+  return coefficients_;
 }
 
 /* Formula accessor */
@@ -162,7 +195,7 @@ Sample LinearModelResult::getSampleResiduals() const
 SignedInteger LinearModelResult::getDegreesOfFreedom() const
 {
   const UnsignedInteger size = inputSample_.getSize();
-  const UnsignedInteger basisSize = beta_.getSize();
+  const UnsignedInteger basisSize = coefficients_.getSize();
   return size - basisSize;
 }
 
@@ -173,7 +206,7 @@ Normal LinearModelResult::getNoiseDistribution() const
   const SignedInteger dof = getDegreesOfFreedom();
   if (dof <= 0)
     throw NotDefinedException(HERE) << "The noise variance is undefined when DOF is null";
-  return Normal(0, std::sqrt(sigma2_));
+  return Normal(0, std::sqrt(residualsVariance_));
 }
 
 Sample LinearModelResult::getStandardizedResiduals() const
@@ -196,6 +229,11 @@ Point LinearModelResult::getCookDistances() const
   return cookDistances_;
 }
 
+Scalar LinearModelResult::getResidualsVariance() const
+{
+  return residualsVariance_;
+}
+
 /* R-squared test */
 Scalar LinearModelResult::getRSquared() const
 {
@@ -204,7 +242,8 @@ Scalar LinearModelResult::getRSquared() const
   const Scalar RSS = residuals.computeRawMoment(2)[0];
   // get outputSample and SYY
   // See https://stats.stackexchange.com/questions/26176/removal-of-statistically-significant-intercept-term-increases-r2-in-linear-mo
-  // In case there is no intercept convention for R^2 is to have the ration between sum of squared predicted over sum of squared real
+  // In case there is no intercept, the convention for R^2 is to have the ratio 
+  // between sum of squared predicted over sum of squared real
   // values.
   const Sample outputSample(getOutputSample());
   Scalar SYY = 1.0;
@@ -251,7 +290,7 @@ void LinearModelResult::save(Advocate & adv) const
   MetaModelResult::save(adv);
   adv.saveAttribute( "basis_", basis_ );
   adv.saveAttribute( "design_", design_ );
-  adv.saveAttribute( "beta_", beta_ );
+  adv.saveAttribute( "coefficients_", coefficients_ );
   adv.saveAttribute( "condensedFormula_", condensedFormula_ );
   adv.saveAttribute( "coefficientsNames_", coefficientsNames_ );
   adv.saveAttribute( "sampleResiduals_", sampleResiduals_ );
@@ -259,7 +298,7 @@ void LinearModelResult::save(Advocate & adv) const
   adv.saveAttribute( "diagonalGramInverse_", diagonalGramInverse_ );
   adv.saveAttribute( "leverages_", leverages_ );
   adv.saveAttribute( "cookDistances_", cookDistances_ );
-  adv.saveAttribute( "sigma2_", sigma2_ );
+  adv.saveAttribute( "residualsVariance_", residualsVariance_ );
 }
 
 
@@ -269,7 +308,10 @@ void LinearModelResult::load(Advocate & adv)
   MetaModelResult::load(adv);
   adv.loadAttribute( "basis_", basis_ );
   adv.loadAttribute( "design_", design_ );
-  adv.loadAttribute( "beta_", beta_ );
+  if (adv.hasAttribute("coefficients_"))
+    adv.loadAttribute("coefficients_", coefficients_);
+  else
+    adv.loadAttribute("beta_", coefficients_);
   adv.loadAttribute( "condensedFormula_", condensedFormula_ );
   adv.loadAttribute( "coefficientsNames_", coefficientsNames_ );
   adv.loadAttribute( "sampleResiduals_", sampleResiduals_ );
@@ -277,7 +319,10 @@ void LinearModelResult::load(Advocate & adv)
   adv.loadAttribute( "diagonalGramInverse_", diagonalGramInverse_ );
   adv.loadAttribute( "leverages_", leverages_ );
   adv.loadAttribute( "cookDistances_", cookDistances_ );
-  adv.loadAttribute( "sigma2_", sigma2_ );
+  if (adv.hasAttribute("residualsVariance_"))
+    adv.loadAttribute( "residualsVariance_", residualsVariance_ );
+  else
+    adv.loadAttribute( "sigma2_", residualsVariance_ );
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelAnalysis.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelAnalysis.hxx
@@ -71,16 +71,19 @@ public:
   Scalar getFisherScore() const;
   Scalar getFisherPValue() const;
 
-  /** Kolmogorov-Smirnov normality test */
+  /** Estimator of the standard deviation */
+  Scalar getResidualsStandardError() const;
+
+  /** Kolmogorov-Smirnov normality test of the residuals */
   TestResult getNormalityTestResultKolmogorovSmirnov() const;
 
-  /** Anderson-Darling normality test */
+  /** Anderson-Darling normality test of the residuals */
   TestResult getNormalityTestResultAndersonDarling() const;
 
-  /** Chi-Squared normality test */
+  /** Chi-Squared normality test of the residuals */
   TestResult getNormalityTestResultChiSquared() const;
 
-  /** Cramer Von mises normality test */
+  /** Cramer Von mises normality test of the residuals */
   TestResult getNormalityTestCramerVonMises() const;
 
   /* [0] Draw model versus fitted values */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
@@ -52,7 +52,7 @@ public:
                     const Matrix & design,
                     const Sample & outputSample,
                     const Function & metaModel,
-                    const Point & trendCoefficients,
+                    const Point & coefficients,
                     const String & formula,
                     const Description & coefficientsNames,
                     const Sample & sampleResiduals,
@@ -67,10 +67,13 @@ public:
 
   /** String converter */
   String __repr__() const override;
+  String __str__(const String & offset = "") const override;
+  String __repr_markdown__() const override;
 
   /** Sample accessors */
   virtual Basis getBasis() const;
   virtual Sample getFittedSample() const;
+  virtual Matrix getDesign() const;
 
   /** Condensed formula accessor */
   virtual Point getCoefficients() const;
@@ -103,6 +106,9 @@ public:
   /** Cook distance accessor */
   virtual Point getCookDistances() const;
 
+  /** residualsVariance accessor */
+  virtual Scalar getResidualsVariance() const;
+
   Bool hasIntercept() const;
 
   /** R-squared */
@@ -127,8 +133,8 @@ private:
   /** input data */
   Matrix design_;
 
-  /** Intercept and trend coefficients */
-  Point beta_;
+  /** Coefficients */
+  Point coefficients_;
 
   /** The formula description */
   String condensedFormula_;
@@ -151,8 +157,8 @@ private:
   /** Cook's distances */
   Point cookDistances_;
 
-  /** Sigma2 */
-  Scalar sigma2_;
+  /** Residuals variance */
+  Scalar residualsVariance_ = 0.0;
 
   /** hasIntercept */
   Bool hasIntercept_;

--- a/lib/test/t_LinearModelAlgorithm_std.cxx
+++ b/lib/test/t_LinearModelAlgorithm_std.cxx
@@ -45,6 +45,9 @@ int main(int, char *[])
       }
       LinearModelAlgorithm test(oneSample, twoSample);
       LinearModelResult result(test.getResult());
+      fullprint << "result = " << std::endl;
+      fullprint << result << std::endl;
+      fullprint << result.__str__() << std::endl;
       fullprint << "trend coefficients = " << result.getCoefficients() << std::endl;
     }
 
@@ -52,7 +55,7 @@ int main(int, char *[])
       setRandomGenerator();
       fullprint << "Fit y ~ 1 + 0.1 x + 10 x^2 model using 100 points" << std::endl;
       UnsignedInteger size = 100;
-      // Define a linespace from 0 to 10 with size points
+      // Define a linear grid from 0 to 10 with size points
       // We use a Box experiment ==> remove 0 & 1 points
       const Box experiment(Indices(1, size - 2));
       Sample X(experiment.generate());

--- a/lib/test/t_LinearModelAlgorithm_std.expout
+++ b/lib/test/t_LinearModelAlgorithm_std.expout
@@ -1,4 +1,22 @@
 Fit y ~ 3 - 2 x + 0.05 * sin(x) model using 20 points (sin(x) ~ noise)
+result = 
+class=LinearModelResult beta=class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025] formula=Basis( [[v0]->[1],[v0]->[v0]] )
+LinearModelResult
+- input dimension=1
+- basis size=2
+- design matrix=20 x 2
+- coefficients=2
+- formula=Basis( [[v0]->[1],[v0]->[v0]] )
+- coefficients names=[[v0]->[1],[v0]->[v0]]
+- residuals size=20
+- standard residuals size=20
+- inverse Gram diagonal=[0.0600543,0.00219481]
+- leverages size=20
+- Cook's distances size=20
+- residuals variance=0.00141733
+- has intercept=true
+
+
 trend coefficients = class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025]
 Fit y ~ 1 + 0.1 x + 10 x^2 model using 100 points
 trend coefficients = class=Point name=Unnamed dimension=3 values=[0.978992,0.110565,9.99924]

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -37,6 +37,8 @@ Bibliography
     https://www.sciencedirect.com/science/article/abs/pii/S0167947302002839
 .. [bhattacharyya1997] Bhattacharyya G.K., and R.A. Johnson, *Statistical
     Concepts and Methods*, John Wiley and Sons, New York, 1997.
+.. [bjork1996] A. Bjorck (1996),
+    *Numerical methods for least squares problems*, SIAM Press, Philadelphia.
 .. [blatman2009] Blatman, G. *Adaptive sparse polynomial chaos expansions for
     uncertainty propagation and sensitivity analysis.*, PhD thesis.
     Blaise Pascal University-Clermont II, France, 2009.

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -27,6 +27,7 @@ Bibliography
     *OpenTURNS: An Industrial Software for Uncertainty Quantification in Simulation.*
     In: Ghanem R., Higdon D., Owhadi H. (eds) Handbook of Uncertainty Quantification. Springer
     `pdf <https://arxiv.org/pdf/1501.05242>`__
+.. [baron2014] Baron, M. (2019). *Probability and statistics for computer scientists*. CRC press.
 .. [beirlant2004] Beirlant J., Goegebeur Y., Teugels J., Segers J.,
     *Statistics of extremes: theory and applications*, Wiley, 2004
 .. [benton2003] Benton D. and Krishnamoorthy K. (2003). *Computing
@@ -50,6 +51,8 @@ Bibliography
 .. [burnham2002] Burnham, K.P., and Anderson, D.R. *Model Selection and
     Multimodel Inference: A Practical Information Theoretic Approach*, Springer,
     2002.
+.. [bingham2010] Bingham, N. H., & Fry, J. M. (2010).
+    *Regression: Linear models in statistics*. Springer.
 .. [cambou2017] Mathieu Cambou, Marius Hofert, Christiane Lemieux, *Quasi-Random numbers for copula models*, Stat. Comp., 2017, 27(5), 1307-1329.
     `pdf <https://arxiv.org/pdf/1508.03483.pdf>`__
 .. [caniou2012] Caniou, Y. *Global sensitivity analysis for nested and
@@ -105,6 +108,7 @@ Bibliography
     `pdf <https://tel.archives-ouvertes.fr/tel-00697026v2/document>`__
 .. [fang2006] K-T. Fang, R. Li, and A. Sudjianto. *Design and modeling for
     computer experiments.* Chapman & Hall CRC, 2006.
+.. [faraway2014] Faraway, J. J. (2014). *Linear models with R*. Second Edition CRC press.
 .. [freedman1981] David Freedman, Persi Diaconis, *On the histogram as a density
     estimator: L2 theory*, December 1981, Probability Theory and Related Fields.
     57 (4): 453–476.
@@ -361,6 +365,8 @@ Bibliography
 .. [ScottStewart2011] W. F. Scott & B. Stewart.
     *Tables for the Lilliefors and Modified Cramer–von Mises Tests of Normality.*,
     Communications in Statistics - Theory and Methods. Volume 40, 2011 - Issue 4. Pages 726-730.
+.. [sen1990] Sen, A., & Srivastava, M. (1990). *Regression analysis: theory, methods, and applications*.
+    Springer.
 .. [sheather1991] Sheather, S. J. and Jones, M. C. (1991).
     *A reliable data-based bandwidth selection method for kernel density estimation.*
     Journal of the Royal Statistical Society. Series B (Methodological),
@@ -402,6 +408,7 @@ Bibliography
 .. [sudret2008] Sudret, B. (2008). *Global sensitivity analysis using polynomial
     chaos expansions.* Reliability engineering & system safety, *93* (7), 964-979.
 .. [sullivan2015] Sullivan, T. J. (2015). *Introduction to uncertainty quantification*, Vol. 63. Springer.
+.. [vaart2000] Van der Vaart, A. W. (2000). *Asymptotic statistics*. Cambridge university press.
 .. [wand1994] Wand M.P, Jones M.C. *Kernel Smoothing*
     First Edition, Chapman & Hall, 1994.
 .. [wertz1999] Wertz, J. and Larson, W. *Space Mission Analysis and Design.*

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_distribution_linear_regression.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_distribution_linear_regression.py
@@ -1,0 +1,252 @@
+"""
+Distribution of estimators in linear regression
+===============================================
+"""
+
+# %%
+# Introduction
+# ~~~~~~~~~~~~
+#
+# In this example, we are interested in the distribution of the estimator of the variance
+# of the observation error in linear regression.
+# We are also interested in the estimator of the standard deviation of the
+# observation error.
+# We show how to use the :class:`~openturns.PythonRandomVector` class in order to
+# perform a study of the sample distribution of these estimators.
+#
+# In the general linear regression model, the observation error :math:`\epsilon` has the
+# normal distribution :math:`\cN(0, \sigma^2)` where :math:`\sigma > 0`
+# is the standard deviation.
+# We are interested in the estimators of the variance :math:`\sigma^2`
+# and the standard deviation :math:`\sigma`:
+#
+# - the variance of the residuals, :math:`\sigma^2`, is estimated from :meth:`~openturns.LinearModelResult.getResidualsVariance`;
+# - the standard deviation :math:`\sigma` is estimated from :meth:`~openturns.LinearModelAnalysis.getResidualsStandardError`.
+#
+# The asymptotic distribution of these estimators is known (see [vaart2000]_)
+# but we want to perform an empirical study, based on simulation.
+# In order to see the distribution of the estimator, we simulate an observation of the estimator,
+# and repeat that experiment :math:`r \in \Nset` times, where :math:`r`
+# is a large integer.
+# Then we approximate the distribution using :class:`~openturns.KernelSmoothing`.
+
+
+import openturns as ot
+import openturns.viewer as otv
+import pylab as pl
+
+# %%
+# The simulation engine
+# ~~~~~~~~~~~~~~~~~~~~~
+# The simulation is based on the :class:`~openturns.PythonRandomVector` class,
+# which simulates independent observations of a random vector.
+# The `getRealization()` method implements the simulation of the observation
+# of the estimator.
+#
+
+
+class SampleEstimatorLinearRegression(ot.PythonRandomVector):
+    def __init__(
+        self, sample_size, true_standard_deviation, coefficients, estimator="variance"
+    ):
+        """
+        Create a RandomVector for an estimator from a linear regression model.
+
+        Parameters
+        ----------
+        sample_size : int
+            The sample size n.
+        true_standard_deviation : float
+            The standard deviation of the Gaussian observation error.
+        coefficients: sequence of p floats
+            The coefficients of the linear model.
+        estimator: str
+            The estimator.
+            Available estimators are "variance" or "standard-deviation".
+        """
+        super(SampleEstimatorLinearRegression, self).__init__(1)
+        self.sample_size = sample_size
+        self.numberOfParameters = coefficients.getDimension()
+        input_dimension = self.numberOfParameters - 1  # Because of the intercept
+        centerCoefficient = [0.0] * input_dimension
+        constantCoefficient = [coefficients[0]]
+        linearCoefficient = ot.Matrix([coefficients[1:]])
+        self.linearModel = ot.LinearFunction(
+            centerCoefficient, constantCoefficient, linearCoefficient
+        )
+        self.distribution = ot.Normal(input_dimension)
+        self.distribution.setDescription(["x%d" % (i) for i in range(input_dimension)])
+        self.errorDistribution = ot.Normal(0.0, true_standard_deviation)
+        self.estimator = estimator
+        # In classical linear regression, the input is deterministic.
+        # Here, we set it once and for all.
+        self.input_sample = self.distribution.getSample(self.sample_size)
+        self.output_sample = self.linearModel(self.input_sample)
+
+    def getRealization(self):
+        errorSample = self.errorDistribution.getSample(self.sample_size)
+        noisy_output_sample = self.output_sample + errorSample
+        algo = ot.LinearModelAlgorithm(self.input_sample, noisy_output_sample)
+        lmResult = algo.getResult()
+        if self.estimator == "variance":
+            output = lmResult.getResidualsVariance()
+        elif self.estimator == "standard-deviation":
+            lmAnalysis = ot.LinearModelAnalysis(lmResult)
+            output = lmAnalysis.getResidualsStandardError()
+        else:
+            raise ValueError("Unknown estimator %s" % (self.estimator))
+        return [output]
+
+
+def plot_sample_by_kernel_smoothing(
+    sample_size, true_standard_deviation, coefficients, estimator, repetitions_size
+):
+    """
+    Plot the estimated distribution of the biased sample variance from a sample
+
+    The method uses Kernel Smoothing with default kernel.
+
+    Parameters
+    ----------
+    repetitions_size : int
+        The number of repetitions of the experiments.
+        This is the (children) size of the sample of the biased
+        sample variance
+
+    Returns
+    -------
+    graph : ot.Graph
+        The plot of the PDF of the estimated distribution.
+
+    """
+    myRV = ot.RandomVector(
+        SampleEstimatorLinearRegression(
+            sample_size, true_standard_deviation, coefficients, estimator
+        )
+    )
+    sample_estimator = myRV.getSample(repetitions_size)
+    if estimator == "variance":
+        sample_estimator.setDescription([r"$\hat{\sigma}^2$"])
+    elif estimator == "standard-deviation":
+        sample_estimator.setDescription([r"$\hat{\sigma}$"])
+    else:
+        raise ValueError("Unknown estimator %s" % (estimator))
+    mean_sample_estimator = sample_estimator.computeMean()
+
+    graph = ot.KernelSmoothing().build(sample_estimator).drawPDF()
+    graph.setLegends(["Sample"])
+    bb = graph.getBoundingBox()
+    ylb = bb.getLowerBound()[1]
+    yub = bb.getUpperBound()[1]
+    curve = ot.Curve([true_standard_deviation ** 2] * 2, [ylb, yub])
+    curve.setLegend("Exact")
+    curve.setLineWidth(2.0)
+    graph.add(curve)
+    graph.setTitle(
+        "Size = %d, True S.D. = %.4f, Mean = %.4f, Rep. = %d"
+        % (
+            sample_size,
+            true_standard_deviation,
+            mean_sample_estimator[0],
+            repetitions_size,
+        )
+    )
+    return graph
+
+
+# %%
+# Distribution of the variance estimator
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# We first consider the estimation of the variance :math:`\sigma^2`.
+# In the next cell, we consider a sample size equal to :math:`n = 6` with
+# :math:`p = 3` parameters.
+# We use :math:`r = 1000` repetitions.
+
+
+repetitions_size = 1000
+true_standard_deviation = 0.1
+sample_size = 6
+coefficients = ot.Point([3.0, 2.0, -1.0])
+estimator = "variance"
+view = otv.View(
+    plot_sample_by_kernel_smoothing(
+        sample_size, true_standard_deviation, coefficients, estimator, repetitions_size
+    ),
+    figure_kw={"figsize": (6.0, 3.5)},
+)
+pl.subplots_adjust(bottom=0.25)
+
+
+# %%
+# If we use a sample size equal to :math:`n = 6` with
+# :math:`p = 3` parameters, the distribution is not symmetric.
+# The mean of the observations of the sample variances remains close to
+# the true value :math:`0.1^2 = 0.01`.
+
+# %%
+# Then we increase the sample size :math:`n`.
+
+repetitions_size = 1000
+true_standard_deviation = 0.1
+sample_size = 100
+coefficients = ot.Point([3.0, 2.0, -1.0])
+view = otv.View(
+    plot_sample_by_kernel_smoothing(
+        sample_size, true_standard_deviation, coefficients, estimator, repetitions_size
+    ),
+    figure_kw={"figsize": (6.0, 3.5)},
+)
+pl.subplots_adjust(bottom=0.25)
+
+
+# %%
+# If we use a sample size equal to :math:`n = 6` with
+# :math:`p = 3` parameters, the distribution is almost symmetric and
+# almost normal.
+
+# %%
+# Distribution of the standard deviation estimator
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# We now consider the estimation of the standard deviation :math:`\sigma`.
+
+
+repetitions_size = 1000
+true_standard_deviation = 0.1
+sample_size = 6
+coefficients = ot.Point([3.0, 2.0, -1.0])
+estimator = "standard-deviation"
+view = otv.View(
+    plot_sample_by_kernel_smoothing(
+        sample_size, true_standard_deviation, coefficients, estimator, repetitions_size
+    ),
+    figure_kw={"figsize": (6.0, 3.5)},
+)
+pl.subplots_adjust(bottom=0.25)
+
+
+# %%
+# If we use a sample size equal to :math:`n = 6` with
+# :math:`p = 3` parameters, we see that the distribution is almost symmetric.
+# We notice a slight bias, since the mean of the observations of the
+# standard deviation is not as close to the true value 0.1
+# as we could expect.
+
+
+repetitions_size = 1000
+true_standard_deviation = 0.1
+sample_size = 100
+coefficients = ot.Point([3.0, 2.0, -1.0])
+estimator = "standard-deviation"
+view = otv.View(
+    plot_sample_by_kernel_smoothing(
+        sample_size, true_standard_deviation, coefficients, estimator, repetitions_size
+    ),
+    figure_kw={"figsize": (6.0, 3.5)},
+)
+pl.subplots_adjust(bottom=0.25)
+
+
+# %%
+# If we use a sample size equal to :math:`n = 100` with
+# :math:`p = 3` parameters, we see that the distribution is almost normal.
+# We notice that the bias disappeared.

--- a/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_linear_model.py
+++ b/python/doc/examples/meta_modeling/general_purpose_metamodels/plot_linear_model.py
@@ -1,11 +1,43 @@
 """
 Create a linear model
 =====================
-In this example we create a surrogate model using linear model approximation.
+In this example we create a surrogate model using linear model approximation
+using the :class:`~openturns.LinearModelAlgorithm` class.
+We show how the :class:`~openturns.LinearModelAnalysis` class
+can be used to produce the statistical analysis of the least squares
+regression model.
 """
 # %%
-# The following 2-dimensional function is used in this example
-# :math:`h(x,y) = 2x - y + 3 + 0.05 \sin(0.8x)`.
+# Introduction
+# ~~~~~~~~~~~~
+#
+# The following 2-dimensional function is used in this example:
+#
+# .. math::
+#
+#     \model(x,y) = 3 + 2x - y
+#
+# for any :math:`x, y \in \Rset`.
+#
+# Notice that this model is linear:
+#
+# .. math::
+#
+#     \model(x,y) = \beta_1 + \beta_2 x + \beta_3 y
+#
+# where :math:`\beta_1 = 3`, :math:`\beta_2 = 2` and :math:`\beta_3 = -1`.
+#
+# We consider noisy observations of the output:
+#
+# .. math::
+#
+#     Y = \model(x,y) + \epsilon
+#
+# where :math:`\epsilon \sim \cN(0, \sigma^2)` with :math:`\sigma > 0`
+# is the standard deviation.
+# In our example, we use :math:`\sigma = 0.1`.
+#
+# Finally, we use :math:`n = 1000` independent observations of the model.
 #
 
 # %%
@@ -13,8 +45,8 @@ import openturns as ot
 import openturns.viewer as viewer
 
 # %%
-# Generation of the data set
-# --------------------------
+# Simulate the data set
+# ~~~~~~~~~~~~~~~~~~~~~
 #
 # We first generate the data and we add noise to the output observations:
 
@@ -22,16 +54,19 @@ import openturns.viewer as viewer
 ot.RandomGenerator.SetSeed(0)
 distribution = ot.Normal(2)
 distribution.setDescription(["x", "y"])
-func = ot.SymbolicFunction(["x", "y"], ["2 * x - y + 3 + 0.05 * sin(0.8*x)"])
-input_sample = distribution.getSample(30)
-epsilon = ot.Normal(0, 0.1).getSample(30)
+sampleSize = 1000
+func = ot.SymbolicFunction(["x", "y"], ["3 + 2 * x - y"])
+input_sample = distribution.getSample(sampleSize)
+epsilon = ot.Normal(0, 0.1).getSample(sampleSize)
 output_sample = func(input_sample) + epsilon
 
 # %%
 # Linear regression
-# -----------------
+# ~~~~~~~~~~~~~~~~~
 #
-# Let us run the linear model algorithm using the `LinearModelAlgorithm` class and get the associated results :
+# Let us run the linear model algorithm using the
+# :class:`~openturns.LinearModelAlgorithm` class and get the associated
+# results:
 
 # %%
 algo = ot.LinearModelAlgorithm(input_sample, output_sample)
@@ -39,48 +74,68 @@ result = algo.getResult()
 
 # %%
 # Residuals analysis
-# ------------------
+# ~~~~~~~~~~~~~~~~~~
 #
 # We can now analyse the residuals of the regression on the training data.
 # For clarity purposes, only the first 5 residual values are printed.
 
 # %%
 residuals = result.getSampleResiduals()
-print(residuals[:5])
+residuals[:5]
 
 # %%
 # Alternatively, the `standardized` or `studentized` residuals can be used:
 
 # %%
 stdresiduals = result.getStandardizedResiduals()
-print(stdresiduals[:5])
+stdresiduals[:5]
 
 # %%
-# Similarly, we can also obtain the underyling distribution characterizing the residuals:
+# Similarly, we can also obtain the underyling distribution characterizing
+# the residuals:
 
 # %%
-print(result.getNoiseDistribution())
+result.getNoiseDistribution()
 
 
 # %%
-# ANOVA table
-# -----------
+# Analysis of the results
+# ~~~~~~~~~~~~~~~~~~~~~~~
 #
-# In order to post-process the linear regression results, the `LinearModelAnalysis` class can be used:
+# In order to post-process the linear regression results, the
+# :class:`~openturns.LinearModelAnalysis` class can be used:
 
 # %%
 analysis = ot.LinearModelAnalysis(result)
-print(analysis)
+analysis
 
 # %%
-# The results seem to indicate that the linear hypothesis can be accepted. Indeed, the `R-Squared` value is nearly `1`.
-# Furthermore, the adjusted value, which takes into account the data set size and the number of hyperparameters, is similar to `R-Squared`.
+# The results seem to indicate that the linear model is satisfactory.
 #
-# We can also notice that the `Fisher-Snedecor` and `Student` p-values detailed above are lower than 1%. This ensures an acceptable quality of the linear model.
+# - The basis uses the three functions :math:`1` (i.e. the intercept),
+#   :math:`x` and :math:`y`.
+# - Each row of the table of coefficients tests if one single coefficient is zero.
+#   The probability of observing a large value of the T statistics is close to
+#   zero for all coefficients.
+#   Hence, we can reject the hypothesis that any coefficient is zero.
+#   In other words, all the coefficients are significantly nonzero.
+# - The R2 score is close to 1.
+#   Furthermore, the adjusted R2 value, which takes into account the size of
+#   the data set and the number of hyperparameters, is similar to the
+#   unadjusted R2 score.
+#   Most of the variance is explained by the linear model.
+# - The F-test tests if all coefficients are simultaneously zero.
+#   The `Fisher-Snedecor` p-value is lower than 1%.
+#   Hence, there is at least one nonzero coefficient.
+# - The normality test checks that the residuals have a normal distribution.
+#   The normality assumption can be rejected if the p-value is close to zero.
+#   The p-values are larger than 0.05: the normality assumption of the
+#   residuals is not rejected.
+#
 
 # %%
 # Graphical analyses
-# ------------------
+# ~~~~~~~~~~~~~~~~~~
 #
 # Let us compare model and fitted values:
 
@@ -89,7 +144,8 @@ graph = analysis.drawModelVsFitted()
 view = viewer.View(graph)
 
 # %%
-# The previous figure seems to indicate that the linearity hypothesis is accurate.
+# The previous figure seems to indicate that the linearity hypothesis
+# is accurate.
 
 # %%
 # Residuals can be plotted against the fitted values.
@@ -107,9 +163,11 @@ graph = analysis.drawQQplot()
 view = viewer.View(graph)
 
 # %%
-# In this case, the two distributions are very close: there is no obvious outlier.
+# In this case, the two distributions are very close: there is no obvious
+# outlier.
 #
-# Cook's distance measures the impact of every individual data point on the linear regression, and can be plotted as follows:
+# Cook's distance measures the impact of every individual data point on the
+# linear regression, and can be plotted as follows:
 
 # %%
 graph = analysis.drawCookDistance()
@@ -118,27 +176,32 @@ view = viewer.View(graph)
 # %%
 # This graph shows us the index of the points with disproportionate influence.
 #
-# One of the components of the computation of Cook's distance at a given point is that point's *leverage*.
-# High-leverage points are far from their closest neighbors, so the fitted linear regression model must pass close to them.
+# One of the components of the computation of Cook's distance at a given
+# point is that point's *leverage*.
+# High-leverage points are far from their closest neighbors, so the fitted
+# linear regression model must pass close to them.
 
-# %%
+# sphinx_gallery_thumbnail_number = 6
 graph = analysis.drawResidualsVsLeverages()
 view = viewer.View(graph)
 
 # %%
-# In this case, there seem to be no obvious influential outlier characterized by large leverage and residual values, as is also shown in the figure below:
+# In this case, there seem to be no obvious influential outlier characterized
+# by large leverage and residual values.
 #
-# Similarly, we can also plot Cook's distances as a function of the sample leverages:
+# Similarly, we can also plot Cook's distances as a function of the sample
+# leverages:
 
 # %%
 graph = analysis.drawCookVsLeverages()
 view = viewer.View(graph)
 
 # %%
-# Finally, we give the intervals for each estimated coefficient (95% confidence interval):
+# Finally, we give the intervals for each estimated coefficient (95% confidence
+# interval):
 
 # %%
 alpha = 0.95
 interval = analysis.getCoefficientsConfidenceInterval(alpha)
-print("confidence intervals with level=%1.2f : " % (alpha))
+print("confidence intervals with level=%1.2f: " % (alpha))
 print("%s" % (interval))

--- a/python/doc/theory/data_analysis/data_analysis.rst
+++ b/python/doc/theory/data_analysis/data_analysis.rst
@@ -61,8 +61,17 @@ Detection and quantification of dependencies
     spearman_coefficient
     spearman_test
     chi2_independence_test
-    linear_regression
     tail_dependence
+
+Regression
+----------
+
+.. toctree::
+    :maxdepth: 1
+
+
+    linear_regression
+    regression_analysis
 
 Estimating a quantile
 ---------------------

--- a/python/doc/theory/data_analysis/linear_regression.rst
+++ b/python/doc/theory/data_analysis/linear_regression.rst
@@ -222,11 +222,13 @@ be abandoned, or at least used very cautiously.
     graph.setTitle('')
     View(graph)
 
+The analysis of a linear regression model is presented in :ref:`regression_analysis`.
 
 .. topic:: API:
 
     - See :class:`~openturns.LinearModelAlgorithm` to build a linear model
     - See :class:`~openturns.LinearModelResult` for the associated results
+    - See :class:`~openturns.LinearModelAnalysis` for the analysis
     - See :py:func:`~openturns.VisualTest.DrawLinearModel` to draw a linear model
     - See :py:func:`~openturns.VisualTest.DrawLinearModelResidual` to draw the residual
     - See :py:func:`~openturns.LinearModelTest.LinearModelFisher` to assess the nullity of the coefficients

--- a/python/doc/theory/data_analysis/regression_analysis.rst
+++ b/python/doc/theory/data_analysis/regression_analysis.rst
@@ -1,0 +1,242 @@
+.. _regression_analysis:
+
+Regression analysis
+-------------------
+
+In this page, we analyse the result from linear regression.
+These statistics make it possible to analyse a :ref:`Linear regression<linear_regression>`.
+
+The linear model is:
+
+.. math::
+
+    Y = \sum_{k = 1}^{p} a_k \Psi_k(\vect{x}) + \epsilon
+
+where:
+
+- :math:`n_x \in \Nset` is the dimension of the input vector,
+- :math:`\vect{x} \in \Rset^{n_x}` is the input vector,
+- :math:`p \in \Nset` is the number of parameters,
+- :math:`(\Psi_k)_{k = 1, ..., p}` are the
+  basis functions where :math:`\Psi_k: \Rset^{n_x} \rightarrow \Rset` for
+  :math:`k \in \{1, ..., p\}`,
+- :math:`(a_k)_{k = 1, ..., p}` are the coefficients where
+  :math:`a_k \in \Rset` for :math:`k \in \{1, ..., p\}`,
+- :math:`\epsilon \sim \cN(0, \sigma^2)` where
+  :math:`\cN` is a normal distribution and
+  :math:`\sigma > 0` is its standard deviation.
+
+The main goal of considering a normal noise is to be able to make tests of
+significance (see [rawlings2001]_ page 3).
+In particular, this enables to use the F-test and T-test that
+we are going to review later in this document.
+Furthermore, if the errors are normal, then the method of least squares
+and the maximum likelihood method are equivalent (see [bingham2010]_ theorem
+1.8 page 22).
+
+Caution
+~~~~~~~
+
+There is an ambiguity when the number of parameters is unspecified in the
+text, which may explain the differences between the various formulas
+we find in the books.
+In some texts, the intercept has the index 0, which leads to an
+increased number of parameters.
+In the present document, the number of parameters is equal to :math:`p`,
+but not all books use the same convention:
+
+- in [baron2014]_ (eq. 11.11 page 396), in [sen1990]_ (eq. 2.1 page 28)
+  and in [rawlings2001]_ (eq. 3.1 page 75),
+  the number of parameters is equal to :math:`p + 1`,
+- in [bingham2010]_ (page 61) and in [faraway2014]_ (page 15),
+  the number of parameters is equal to :math:`p`.
+
+Experimental design
+~~~~~~~~~~~~~~~~~~~
+
+Let :math:`n \in \Nset` be the sample size.
+A set of observations of the input variables is required:
+
+.. math::
+
+    \cX = \left\{ \vect{x}^{(1)}, \dots, \vect{x}^{(n)} \right\}.
+
+We assume that the random errors :math:`\left\{ \epsilon^{(1)}, \dots, \epsilon^{(n)} \right\}`
+are independent.
+We consider the corresponding model evaluations:
+
+.. math::
+
+    \cY = \left\{ y^{(1)}, \dots, y^{(n)} \right\}
+
+where:
+
+.. math::
+
+    y^{(i)} = \sum_{k = 1}^{p} a_k \Psi_k \left(\vect{x}^{(i)}\right) + \epsilon^{(i)}
+
+
+for :math:`i \in \{1, ..., n\}`.
+Since the errors :math:`(\epsilon^{(i)})_{i = 1, ..., n}` are independent,
+then the output observations :math:`\cY` are independent too.
+Let :math:`\vect{y} = (y^{(1)},\dots,y^{(n)})^T \in \Rset^{n}` be the
+vector of output observations.
+
+Solution of the least squares problem
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *design matrix* :math:`\mat{\Psi} \in \Rset^{n \times p}` is the value
+of the basis functions over the inputs variables in the sample:
+
+.. math::
+
+    \mat{\Psi}_{ij} = \Psi_j \left(\vect{x}^{(i)}\right)
+
+for :math:`i = 1, ..., n` and :math:`j = 1, ..., p`.
+Assume that the design matrix has full rank.
+The solution of the linear least squares problem is:
+
+.. math::
+
+    \widehat{\vect{a}}
+    = \left(\Tr{\mat{\Psi}} \mat{\Psi}\right)^{-1} \Tr{\mat{\Psi}} \vect{y}.
+
+Statistics
+~~~~~~~~~~
+
+Let :math:`\bar{y}` be the sample mean:
+
+.. math::
+
+    \bar{y} = \frac{1}{n} \sum_{j = 1}^n y_j.
+
+The total sum of squares (see [baron2014]_ page 398) is:
+
+.. math::
+
+    SS_{TOT}
+    = \sum_{j = 1}^n \left(y_j - \bar{y}_j\right)^2
+    = \left(\vect{y} - \bar{\vect{y}}\right)^T \left(\vect{y} - \bar{\vect{y}}\right).
+
+where :math:`\bar{\vect{y}} = (\bar{y}, ..., \bar{y})^T \in \Rset^n`.
+The regression sum of squares is:
+
+.. math::
+
+    SS_{REG}
+    = \sum_{j = 1}^n \left(\hat{y}_j - \bar{y}_j\right)^2
+    = \left(\hat{\vect{y}} - \bar{\vect{y}}\right)^T \left(\hat{\vect{y}} - \bar{\vect{y}}\right).
+
+The error sum of squares is:
+
+.. math::
+
+    SS_{ERR}
+    = \sum_{j = 1}^n \left(y_j - \hat{y}_j\right)^2
+    = \left(\vect{y} - \hat{\vect{y}}\right)^T \left(\vect{y} - \hat{\vect{y}}\right).
+
+Coefficient of determination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The coefficient of determination is (see [baron2014]_ page 399):
+
+.. math::
+
+    R^2 = \frac{SS_{REG}}{SS_{TOT}}.
+
+The coefficient of determination measures the part
+of the variance explained by the linear regression model.
+
+Variance
+~~~~~~~~
+
+The unbiased estimator of the variance is (see [baron2014]_ page 400,
+[bingham2010]_ page 67):
+
+.. math::
+
+    \hat{\sigma}^2 = \frac{SS_{ERR}}{n - p}.
+
+ANOVA F-test
+~~~~~~~~~~~~
+
+The F-statistic is based on the hypothesis that all coefficients
+are simultaneously zero (see [baron2014]_ page 400).
+The ANOVA F-test is based on the hypothesis:
+
+.. math::
+
+    H_0 : a_1 = . . . = a_p = 0
+    \qquad \textrm{vs} \qquad
+    H_A : \textrm{at least one } a_k \neq 0.
+
+Let :math:`\vect{y} \in \Rset^n` be the vector of
+observations and :math:`\vect{\hat{y}} \in \Rset^n`
+be the vector of predictions.
+
+The F-statistic is (see [bingham2010]_ Kolodziejcyzk’s theorem 6.5 page 154,
+[baron2014]_ page 400):
+
+.. math::
+
+    f = \frac{SS_{reg} / p}{SS_{ERR} / (n - p)}.
+
+The p-value is computed from the Fisher-Snedecor
+distribution :math:`F_{p, n - p - 1}` (see [baron2014]_ page 400, [faraway2014]_ page 35).
+
+T-test for individual coefficients
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Let :math:`\hat{\sigma}^2` be the estimator of the variance (see [baron2014]_ page 400):
+
+.. math::
+
+    \hat{\sigma}^2 = \frac{SS_{ERR}}{n - p}.
+
+The variance of the estimator of the parameters is:
+
+.. math::
+
+    \Var{\hat{a}_k} = \hat{\sigma}^2 (\Tr{\mat{\Psi}} \mat{\Psi})^{-1}
+
+Let :math:`\operatorname{SD}(\hat{a}_k)` be the standard deviation of the
+estimator of :math:`a_k`:
+
+.. math::
+
+    \operatorname{SD}(\hat{a}_k) = \sqrt{\Var{\hat{a}_k}}
+
+for any :math:`k \in \{1, ..., p\}`.
+For :math:`k = 1, ..., p`, the T-test is (see [baron2014]_ page 401):
+
+.. math::
+
+    H_0 : a_k = 0 \qquad \textrm{vs} \qquad H_A : a_k \neq 0.
+
+The T-statistic is (see [baron2014]_ page 401, [rawlings2001]_ eq. 4.47 page 122):
+
+.. math::
+
+    t = \frac{\hat{a}_k}{\operatorname{SD}(\hat{a}_k)}
+
+for :math:`k = 1, ..., p`.
+The p-value is computed from the Student's T distribution
+with :math:`n - p - 1` degrees of freedom (see [baron2014]_ page 401).
+
+
+.. topic:: API:
+
+    - See :class:`~openturns.LinearModelAnalysis`
+
+.. topic:: Examples:
+
+    - See :doc:`/auto_meta_modeling/general_purpose_metamodels//plot_linear_model`
+
+
+.. topic:: References:
+
+    - [baron2014]_
+    - [faraway2014]_
+    - [rawlings2001]_
+    - [sen1990]_
+    - [bingham2010]_
+

--- a/python/doc/theory/data_analysis/regression_analysis.rst
+++ b/python/doc/theory/data_analysis/regression_analysis.rst
@@ -161,7 +161,7 @@ ANOVA F-test
 
 The F-statistic is based on the hypothesis that all coefficients
 are simultaneously zero (see [baron2014]_ page 400).
-The ANOVA F-test is based on the hypothesis:
+More precisely, the ANOVA F-test is based on the hypothesis:
 
 .. math::
 
@@ -186,7 +186,9 @@ distribution :math:`F_{p, n - p - 1}` (see [baron2014]_ page 400, [faraway2014]_
 T-test for individual coefficients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let :math:`\hat{\sigma}^2` be the estimator of the variance (see [baron2014]_ page 400):
+The T-test is based on the hypothesis that one single coefficient is zero.
+More precisely, let :math:`\hat{\sigma}^2` be the estimator of the variance
+(see [baron2014]_ page 400):
 
 .. math::
 

--- a/python/doc/theory/meta_modeling/meta_modeling.rst
+++ b/python/doc/theory/meta_modeling/meta_modeling.rst
@@ -18,6 +18,7 @@ A special focus will be given to polynomial response surfaces.
     polynomial_sparse_least_squares
     kriging
 
+
 Functional chaos
 ----------------
 

--- a/python/doc/theory/meta_modeling/polynomial_least_squares.rst
+++ b/python/doc/theory/meta_modeling/polynomial_least_squares.rst
@@ -3,95 +3,106 @@
 Least squares polynomial response surface
 -----------------------------------------
 
-| Instead of replacing the model response :math:`h(\underline{x})` for a
-  *local* approximation around a given set :math:`\underline{x}_0` of
-  input parameters, one may seek a *global* approximation of
-  :math:`h(\underline{x})` over its whole domain of definition. A common
-  choice to this end is global polynomial approximation. For the sake of
-  simplicity, a *scalar* model response :math:`y=h(\underline{x})` will
-  be considered from now on. Nonetheless, the following derivations hold
-  for a vector-valued response.
-| In the sequel, one considers global approximations of the model
-  response using:
+Instead of replacing the model response :math:`\model(\vect{x})` with a
+*local* approximation around a given set :math:`\vect{x}_0` of
+input parameters as in :ref:`Taylor expansion <taylor_expansion>`, one may seek a *global* approximation of
+:math:`\model(\vect{x})` over its whole domain of definition. A common
+choice to this end is global polynomial approximation. For the sake of
+simplicity, a *scalar* model response :math:`y=\model(\vect{x})` will
+be considered from now on. Nonetheless, the following derivations hold
+for a vector-valued response.
 
--  a linear function, i.e. a polynomial of degree one;
+In the following, one considers global approximations of the model
+response using:
 
--  a quadratic function, i.e. a polynomial of degree two.
+- a linear function, i.e. a polynomial of degree one;
 
   .. math::
 
-      y \, \, \approx \, \, \widehat{h}(\underline{x}) \, \, = \, \, a_0 \, + \,  \sum_{i=1}^{n_{X}} \; a_{i} \; x_i
+      y  \approx  \widehat{\model}(\vect{x})  =  a_0 \, + \,  \sum_{i=1}^{n_{X}} a_{i} x_i
 
   where :math:`(a_j  \, , \, j=0,\dots,n_X)` is a set of unknown
   coefficients.
 
-  .. math::
-
-     \begin{aligned}
-         \underline{y} \, \, \approx \, \, \widehat{h}(\underline{x}) \, \, = \, \, a_0 \, + \,  \sum_{i=1}^{n_{X}} \; a_{i} \; x_i \, + \,
-         \sum_{i=1}^{n_{X}} \; \sum_{j=1}^{n_{X}} \; a_{i,j} \; x_i \; x_j
-       \end{aligned}
-
-| The two previous equations may be recast using a unique formalism as
-  follows:
+- a quadratic function, i.e. a polynomial of degree two.
 
   .. math::
 
-      \underline{y} \, \, \approx \, \, \widehat{h}(\underline{x}) \, \, = \, \, \sum_{j=0}^{P-1} \; a_j \; \psi_j(\underline{x})
+         y  \approx  \widehat{\model}(\vect{x})  =  a_0 \, + \,  \sum_{i=1}^{n_{X}} a_{i} x_i \, + \,
+         \sum_{i=1}^{n_{X}} \sum_{j=1}^{n_{X}} a_{i,j} x_i x_j
 
-  where :math:`P` denotes the number of terms, which is equal to
-  :math:`(n_X + 1)` (resp. to :math:`(1 + 2n_X + n_X (n_X - 1)/2)`) when
-  using a linear (resp. a quadratic) approximation, and the family
-  :math:`(\psi_j,j=0,\dots,P-1)` gathers the constant monomial
-  :math:`1`, the monomials of degree one :math:`x_i` and possibly the
-  cross-terms :math:`x_i x_j` as well as the monomials of degree two
-  :math:`x_i^2`. Using the vector notation
-  :math:`\underline{a} \, \, = \, \, (a_{0} , \dots , a_{P-1} )^{\textsf{T}}`
-  and
-  :math:`\underline{\psi}(\underline{x}) \, \, = \, \, (\psi_{0}(\underline{x}) , \dots , \psi_{P-1}(\underline{x}) )^{\textsf{T}}`,
-  this rewrites:
+The two previous equations may be recast as:
 
   .. math::
 
-      \underline{y} \, \, \approx \, \, \widehat{h}(\underline{x}) \, \, = \, \, \underline{a}^{\textsf{T}} \; \underline{\psi}(\underline{x})
+      y  \approx  \widehat{\model}(\vect{x})  =  \sum_{j=0}^{P-1} a_j \psi_j(\vect{x})
 
-| A *global* approximation of the model response over its whole
-  definition domain is sought. To this end, the coefficients :math:`a_j`
-  may be computed using a least squares regression approach. In this
-  context, an experimental design
-  :math:`\underline{\cX} =(x^{(1)},\dots,x^{(N)})`, i.e. a set of
-  realizations of input parameters is required, as well as the
-  corresponding model evaluations
-  :math:`\underline{\cY} =(y^{(1)},\dots,y^{(N)})`.
-
-| The following minimization problem has to be solved:
-
-  .. math::
-
-     \mbox{Find} \quad \widehat{\underline{a}} \quad \mbox{that minimizes} \quad \cJ(\underline{a}) \, \, = \, \, \sum_{i=1}^N \; \left( y^{(i)} \; - \; \underline{a}^{\textsf{T}}  \underline{\psi}(\underline{x}^{(i)}) \right)^2
-
-  The solution is given by:
+where :math:`P` denotes the number of terms, which is equal to
+:math:`n_X + 1` (resp. to :math:`1 + 2n_X + n_X (n_X - 1)/2`) when
+using a linear (resp. a quadratic) approximation, and the family
+:math:`(\psi_j,j=0,\dots,P-1)` gathers the constant monomial
+:math:`1`, the monomials of degree one :math:`x_i` and possibly the
+cross-terms :math:`x_i x_j` as well as the monomials of degree two
+:math:`x_i^2`. Using the vector notation
+:math:`\vect{a}  =  (a_{0} , \dots , a_{P-1} )^{\textsf{T}}`
+and
+:math:`\vect{\psi}(\vect{x})  =  (\psi_{0}(\vect{x}) , \dots , \psi_{P-1}(\vect{x}) )^{\textsf{T}}`,
+this can be rewritten:
 
   .. math::
 
-      \widehat{\underline{a}} \, \, = \, \, \left( \underline{\underline{\Psi}}^{\textsf{T}} \underline{\underline{\Psi}}  \right)^{-1} \; \underline{\underline{\Psi}}^{\textsf{T}}  \; \underline{\cY}
+      y  \approx  \widehat{\model}(\vect{x})  =  \Tr{\vect{a}}\vect{\psi}(\vect{x})
 
-  where:
+A *global* approximation of the model response over its whole
+definition domain is sought. To this end, the coefficients :math:`a_j`
+may be computed using a least squares regression approach. In this
+context, an experimental design, that is, a set of observations of
+input parameters, is required:
 
-  .. math::
+.. math::
 
-      \underline{\underline{\Psi}} \, \, = \, \, (\psi_{j}(\underline{x}^{(i)}) \; , \; i=1,\dots,N \; , \; j = 0,\dots,P-1)
+    \cX = \left\{ \vect{x}^{(1)}, \dots, \vect{x}^{(N)} \right\},
 
-  It is clear that the above equation is only valid for a full rank
-  information matrix. A necessary condition is that the size :math:`N`
-  of the experimental design is not less than the number :math:`P` of PC
-  coefficients to estimate. In practice, it is not recommended to
-  directly invert
-  :math:`\underline{\underline{\Psi}}^{\textsf{T}} \underline{\underline{\Psi}}`
-  since the solution may be particularly sensitive to an
-  ill-conditioning of the matrix. The least-square problem is rather
-  solved using more robust numerical methods such as *singular value
-  decomposition* (SVD) or *QR-decomposition*.
+as well as the corresponding model evaluations:
+
+.. math::
+
+    \cY = \left\{ y^{(1)},\dots,y^{(N)} \right\}.
+
+The least squares problem is to solve:
+
+.. math::
+
+    \widehat{\vect{a}} = \argmin_{\vect{a} \in \Rset^P} \cJ(\vect{a})
+
+where :math:`\cJ(\vect{a})` is the cost function, defined as:
+
+.. math::
+    \cJ(\vect{a}) = \sum_{i=1}^N \left( y^{(i)} - \Tr{\vect{a}} \vect{\psi}\left(\vect{x}^{(i)}\right) \right)^2.
+
+Let :math:`\vect{y} = (y^{(1)},\dots,y^{(N)})^T \in \Rset^{N}` be the
+vector of output observations.
+The solution is given by the normal equations:
+
+.. math::
+
+    \widehat{\vect{a}}  =  \left( \mat{\Psi}^{\textsf{T}} \mat{\Psi}  \right)^{-1} \Tr{\mat{\Psi}}  \vect{y}
+
+where:
+
+.. math::
+
+    \mat{\Psi}  =  (\psi_{j}\left(\vect{x}^{(i)}\right) , i=1,\dots,N , j = 0,\dots,P-1)
+
+It is clear that the above equation is only valid for a full rank
+information matrix.
+A necessary condition is that the size :math:`N` of the experimental design
+is not less than the number :math:`P` of coefficients to estimate.
+In practice, directly inverting :math:`\mat{\Psi}^{\textsf{T}} \mat{\Psi}`
+is not necessarily the best method since the solution may be particularly
+sensitive to an ill-conditioned matrix.
+The least-square problem is rather solved using more robust numerical methods
+such as *singular value decomposition* (SVD) or *QR-decomposition*.
 
 
 .. topic:: API:

--- a/python/doc/theory/meta_modeling/polynomial_least_squares.rst
+++ b/python/doc/theory/meta_modeling/polynomial_least_squares.rst
@@ -80,30 +80,32 @@ where :math:`\cJ(\vect{a})` is the cost function, defined as:
 .. math::
     \cJ(\vect{a}) = \sum_{i=1}^N \left( y^{(i)} - \Tr{\vect{a}} \vect{\psi}\left(\vect{x}^{(i)}\right) \right)^2.
 
-Let :math:`\vect{y} = (y^{(1)},\dots,y^{(N)})^T \in \Rset^{N}` be the
+Let :math:`\vect{y} = \Tr{(y^{(1)},\dots,y^{(N)})} \in \Rset^{N}` be the
 vector of output observations.
-The solution is given by the normal equations:
+If the design matrix :math:`\mat{\Psi}` has full rank,
+then the solution is given by the normal equations:
 
 .. math::
+    :label: solutionLLS
 
-    \widehat{\vect{a}}  =  \left( \mat{\Psi}^{\textsf{T}} \mat{\Psi}  \right)^{-1} \Tr{\mat{\Psi}}  \vect{y}
+    \widehat{\vect{a}}  =  \left( \Tr{\mat{\Psi}} \mat{\Psi}  \right)^{-1} \Tr{\mat{\Psi}}  \vect{y}
 
 where:
 
 .. math::
 
-    \mat{\Psi}  =  (\psi_{j}\left(\vect{x}^{(i)}\right) , i=1,\dots,N , j = 0,\dots,P-1)
+    \mat{\Psi}_{ij}  =  \psi_{j}\left(\vect{x}^{(i)}\right)
 
-It is clear that the above equation is only valid for a full rank
-information matrix.
-A necessary condition is that the size :math:`N` of the experimental design
-is not less than the number :math:`P` of coefficients to estimate.
-In practice, directly inverting :math:`\mat{\Psi}^{\textsf{T}} \mat{\Psi}`
-is not necessarily the best method since the solution may be particularly
-sensitive to an ill-conditioned matrix.
-The least-square problem is rather solved using more robust numerical methods
-such as *singular value decomposition* (SVD) or *QR-decomposition*.
-
+for :math:`i = 1, \dots, N` and :math:`j = 0, \dots, P - 1`.
+A necessary condition for having a solution is that the size :math:`N`
+of the experimental design is not less than the number :math:`P` of
+coefficients to estimate.
+The Gram matrix :math:`\Tr{\mat{\Psi}} \mat{\Psi}` can be
+ill-conditionned.
+Hence, the best method is not necessarily to invert the Gram matrix,
+because the solution may be particularly sensitive to rounding errors.
+The least-squares problem is rather solved using more robust numerical methods
+such as the *singular value decomposition* (SVD) or the *QR-decomposition*.
 
 .. topic:: API:
 
@@ -116,5 +118,5 @@ such as *singular value decomposition* (SVD) or *QR-decomposition*.
 
 .. topic:: References:
 
-    - A. Bjorck, 1996, "Numerical methods for least squares problems", SIAM Press, Philadelphia, PA.
+    - [bjork1996]_
 

--- a/python/src/FunctionalChaosAlgorithm_doc.i.in
+++ b/python/src/FunctionalChaosAlgorithm_doc.i.in
@@ -195,6 +195,7 @@ Create the chaos algorithm:
 Get the result:
 
 >>> functionalChaosResult = algo.getResult()
+>>> # print(functionalChaosResult)  # Pretty-print
 >>> metamodel = functionalChaosResult.getMetaModel()
 
 Test it:

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -128,7 +128,7 @@ indices : :class:`~openturns.Indices`
 Returns
 -------
 invTransf : :class:`~openturns.Function`
-     :math:`T^{-1}` such that :math:`T(\vect{X}) = \vect{Z}`."
+     :math:`T^{-1}` such that :math:`T^{-1}(\vect{Z}) = \vect{X}`."
 
 // ---------------------------------------------------------------------
 

--- a/python/src/LinearFunction_doc.i.in
+++ b/python/src/LinearFunction_doc.i.in
@@ -37,10 +37,23 @@ where:
 
 Examples
 --------
+In the next example, we create the linear function :math:`f(x) = 2x + 3` 
+for any :math:`x \in \Rset`.
+
 >>> import openturns as ot
 >>> center = [0.0]
 >>> constant = [3.0]
 >>> linear = ot.Matrix([[2.0]])
 >>> f = ot.LinearFunction(center, constant, linear)
 >>> print(f([1.0]))
-[5]"
+[5]
+
+In the next example, we create the linear function :math:`f(x, y) = 2x - y + 3` 
+for any :math:`x \in \Rset`.
+
+>>> centerCoefficient = [0.0, 0.0]
+>>> constantCoefficient = [3.0]
+>>> linearCoefficient = ot.Matrix([[2.0, -1.0]])
+>>> f = ot.LinearFunction(centerCoefficient, constantCoefficient, linearCoefficient)
+>>> print(f([1.0, 2.0]))
+[3]"

--- a/python/src/LinearModelAnalysis.i
+++ b/python/src/LinearModelAnalysis.i
@@ -9,3 +9,128 @@
 %copyctor OT::LinearModelAnalysis;
 
 %include openturns/LinearModelAnalysis.hxx
+
+
+%pythoncode %{
+import math
+
+def __LinearModelAnalysis_repr_html(self):
+    """Get HTML representation."""
+    def format_pvalue(pValue):
+        fmtLargePValue = openturns.common.ResourceMap.GetAsString("LinearModelAnalysis-LargePValueFormat")
+        fmtSmallPValue = openturns.common.ResourceMap.GetAsString("LinearModelAnalysis-SmallPValueFormat")
+        if pValue == 0.0:
+            pValueStr = "0.0"
+        elif pValue > 1.e-3:
+            pValueStr = fmtLargePValue.format(pValue)
+        else:
+            pValueStr = fmtSmallPValue.format(pValue)
+        return pValueStr
+        
+    html = ""
+    lmResult = self.getLinearModelResult()
+    coefficients = lmResult.getCoefficients()
+    basisSize = coefficients.getSize()
+    hasIntercept = lmResult.hasIntercept()
+    standardErrors = lmResult.getCoefficientsStandardErrors()
+    tscores = self.getCoefficientsTScores()
+    pValues = self.getCoefficientsPValues()
+    names = lmResult.getCoefficientsNames()
+    dof = lmResult.getDegreesOfFreedom()
+    n = lmResult.getSampleResiduals().getSize()
+    maximumNameLength = openturns.common.ResourceMap.GetAsUnsignedInteger("LinearModelAnalysis-PrintEllipsisThreshold")
+
+    # Print the basis
+    html += "<strong>Basis</strong>\n"
+    html += "<br>\n"
+    html += f"{lmResult.getFormula()}"
+    html += "<br>\n"
+
+    # Table of coefficients
+    html += "<strong>Coefficients</strong>\n"
+    html += "<br>\n"
+    # Header
+    html += "<table>\n"
+    html += "  <tr>\n"
+    html += f"    <th>Index</th>\n"
+    html += f"    <th>Function</th>\n"
+    html += f"    <th>Estimate</th>\n"
+    html += f"    <th>Std Error</th>\n"
+    html += f"    <th>t value</th>\n"
+    html += f"    <th>Pr(>|t|)</th>\n"
+    html += "  </tr>\n"
+    # Content
+    for i in range(pValues.getSize()):
+        if len(names[i]) > maximumNameLength:
+            fullName = names[i]
+            printedName = fullName[0:maximumNameLength] + "..."
+        else:
+            printedName = names[i]
+        html += "  <tr>\n"
+        html += f"    <td>{i}</td>\n"
+        html += f"    <td>{printedName}</td>\n"
+        html += f"    <td>{coefficients[i]:.4e}</td>\n"
+        html += f"    <td>{standardErrors[i]:.4e}</td>\n"
+        html += f"    <td>{tscores[i]:.4e}</td>\n"
+        html += f"    <td>{format_pvalue(pValues[i])}</td>\n"
+        html += "  </tr>\n"
+
+    html += "</table>\n"
+    html += "<br>\n"
+
+    # Print statistics
+    html += "<ul>\n"
+    stdError = self.getResidualsStandardError()
+    html += f"  <li>Residual standard error: {stdError:.4e} " \
+            f"on {dof} degrees of freedom </li>\n"
+
+    # In case of only intercept in the basis, no more print
+    if (basisSize == 1 and hasIntercept):
+        html += "</ul>\n"
+        return html
+
+    fisherScore = self.getFisherScore()
+    fisherPValue = self.getFisherPValue()
+    html += f"  <li>F-statistic: {fisherScore:.4e}, "  \
+            f"p-value: {format_pvalue(fisherPValue)}\n";
+
+    #  R-squared & Adjusted R-squared tests
+    test1 = lmResult.getRSquared();
+    html += f"  <li>Multiple R-squared: {test1:.4f}</li>\n"
+    test2 = lmResult.getAdjustedRSquared();
+    html += f"  <li>Adjusted R-squared:  {test2:.4f}</li>\n"
+    html += "</ul>\n"
+
+    # Normality test of the residuals
+    html += "<strong>Normality test of the residuals</strong>\n"
+    html += "<br>\n"
+    normalitytest1 = self.getNormalityTestResultAndersonDarling().getPValue()
+    normalitytest2 = self.getNormalityTestResultChiSquared().getPValue()
+    normalitytest3 = self.getNormalityTestResultKolmogorovSmirnov().getPValue()
+    normalitytest4 = self.getNormalityTestCramerVonMises().getPValue()
+    html += "<table>\n"
+    html += "  <tr>\n"
+    html += f"    <th>Normality test</th>\n"
+    html += f"    <th>p-value</th>\n"
+    html += "  </tr>\n"
+    html += "  <tr>\n"
+    html += f"    <td>Anderson-Darling</td>\n"
+    html += f"    <td>{format_pvalue(normalitytest1)}</td>\n"
+    html += "  </tr>\n"
+    html += "  <tr>\n"
+    html += f"    <td>ChiSquared</td>\n"
+    html += f"    <td>{format_pvalue(normalitytest2)}</td>\n"
+    html += "  </tr>\n"
+    html += "  <tr>\n"
+    html += f"    <td>Kolmogorov-Smirnov</td>\n"
+    html += f"    <td>{format_pvalue(normalitytest3)}</td>\n"
+    html += "  </tr>\n"
+    html += "  <tr>\n"
+    html += f"    <td>Cramer-Von Mises</td>\n"
+    html += f"    <td>{format_pvalue(normalitytest4)}</td>\n"
+    html += "  </tr>\n"
+    html += "</table>\n"
+    return html
+
+LinearModelAnalysis._repr_html_ = __LinearModelAnalysis_repr_html
+%}

--- a/python/src/LinearModelAnalysis_doc.i.in
+++ b/python/src/LinearModelAnalysis_doc.i.in
@@ -12,13 +12,37 @@ LinearModelResult
 
 Notes
 -----
-This class relies on a linear model result structure and performs diagnostic 
-of linearity. This diagnostic mainly relies on graphics and a `summary` like
-function (pretty-print)
+This class relies on a linear model result structure and analyses the results.
 
 By default, on graphs, labels of the 3 most significant points are displayed.
 This number can be changed by modifying the ResourceMap key
 (``LinearModelAnalysis-Identifiers``).
+
+The class has a pretty-print method which is triggered by
+the `print()` function.
+This prints the following results, where we focus on the properties
+of a satisfactory regression model.
+
+- Each row of the table of coefficients tests if one single coefficient is zero.
+  For a single coefficient, if the p-value of the T-test is close to zero,
+  we can reject the hypothesis that this coefficient is zero.
+- The R2 score measures how the predicted output values are close to the
+  observed values.
+  If the R2 is close to 1 (e.g. larger than 0.95), then the predictions are
+  accurate on average.
+  Furthermore, the adjusted R2 value takes into account the data set
+  size and the number of hyperparameters.
+- The F-test tests if all the coefficients are simultaneously zero.
+  If the p-value is close to zero, then we can reject this hypothesis:
+  there is at least one nonzero coefficient.
+- The normality test checks that the residuals have a normal distribution.
+  The normality assumption can be accepted (or, more precisely, cannot be
+  rejected) if the p-value is larger than a threshold (e.g. 0.05).
+
+The essentials of regression theory are presented in :ref:`regression_analysis`.
+The goodness of fit tests for normality are presented in :ref:`graphical_fitting_test`, 
+:ref:`chi2_fitting_test`, :ref:`kolmogorov_smirnov_test`, :ref:`cramer_vonmises_test`  and
+:ref:`anderson_darling_test`.
 
 Examples
 --------
@@ -31,7 +55,7 @@ Examples
 >>> algo = ot.LinearModelAlgorithm(Ysample, Xsample)
 >>> result = algo.getResult()
 >>> analysis = ot.LinearModelAnalysis(result)
-"
+>>> # print(analysis)  # Pretty-print"
 
 // ---------------------------------------------------------------------
 
@@ -76,7 +100,7 @@ confidenceInterval : :class:`~openturns.Interval`
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::LinearModelAnalysis::getFisherScore
-"Accessor to the Fisher test.
+"Accessor to the Fisher statistics.
 
 Returns
 -------
@@ -95,9 +119,38 @@ fisherPValue : float
 
 // ---------------------------------------------------------------------
 
+%feature("docstring") OT::LinearModelAnalysis::getResidualsStandardError
+"Accessor to the standard error of the residuals.
+
+Returns
+-------
+stdError : float
+    This is the unbiased estimator :math:`\hat{\sigma}` of the standard deviation
+    of the Gaussian observation error of the observed output.
+
+Notes
+-----
+The standard error of the residuals is the *root mean squared error* (also
+called *standard error of regression*), estimated as:
+
+.. math::
+    \widehat{\sigma} = \sqrt{\frac{1}{\operatorname{dof}} SSE}
+
+where :math:`\operatorname{dof}` is the number of degrees of freedom
+and :math:`SSE` is the sum of squared errors:
+
+.. math::
+    SSE = \sum_{i = 1}^n (y_i - \widehat{y}_i)^2
+
+where :math:`\{y_i\}_{i = 1, ..., n}` are the observations and
+:math:`\{\widehat{y}_i\}_{i = 1, ..., n}` are the predictions from the linear model.
+"
+
+// ---------------------------------------------------------------------
+
 %feature("docstring") OT::LinearModelAnalysis::getNormalityTestResultChiSquared
 "Performs Chi-Square test.
-The statistical test checks the Gaussian assumption of the model (null hypothesis).
+The statistical test checks the Gaussian assumption of the residuals.
 
 Returns
 -------
@@ -118,7 +171,7 @@ the :meth:`~openturns.FittingTest.ChiSquared` to check the normality.
 %feature("docstring") OT::LinearModelAnalysis::getNormalityTestResultKolmogorovSmirnov
 "Performs Kolmogorov test.
 
-Performs Kolmogorov test to check Gaussian assumption of the model (null hypothesis).
+Performs Kolmogorov test to check Gaussian assumption of the residuals.
 
 Returns
 -------
@@ -134,7 +187,7 @@ We check that the residual is Gaussian thanks to :meth:`~openturns.FittingTest.K
 
 %feature("docstring") OT::LinearModelAnalysis::getNormalityTestResultAndersonDarling
 "Performs Anderson-Darling test.
-The statistical test checks the Gaussian assumption of the model (null hypothesis).
+The statistical test checks the Gaussian assumption of the residuals.
 
 Returns
 -------

--- a/python/src/LinearModelResult_doc.i.in
+++ b/python/src/LinearModelResult_doc.i.in
@@ -13,8 +13,8 @@ outputSample : 2-d sequence of float
    The output sample of a model.
 metaModel : :class:`~openturns.Function`
     The meta model.
-trendCoefficients : sequence of float
-    The trend coeffients associated to the linearmodel. 
+coefficients : sequence of float
+    The trend coefficients associated to the linear model. 
 formula : str
      The formula description. 
 coefficientsNames : sequence of str
@@ -28,9 +28,9 @@ diagonalGramInverse : sequence of float
 leverages : sequence of float
     The leverage score. 
 cookDistances : sequence of float
-    The cook's distances.
+    Cook's distances.
 sigma2 : float
-    The unbiased noise variance.
+    The unbiased variance estimator of the output observation error.
 
 
 See Also
@@ -46,7 +46,15 @@ LinearModelAlgorithm
 Returns
 -------
 basis : :class:`~openturns.Basis`
-    The basis which had been passed to the constructor."
+    The basis."
+
+%feature("docstring") OT::LinearModelResult::getDesign
+"Accessor to the design matrix.
+
+Returns
+-------
+design: :class:`~openturns.Matrix`
+    The design matrix."
 
 // ---------------------------------------------------------------------
 
@@ -65,7 +73,7 @@ outputSample : :class:`~openturns.Sample`
 
 Returns
 -------
-beta : :class:`~openturns.Point`
+coefficients : :class:`~openturns.Point`
 "
 
 // ---------------------------------------------------------------------
@@ -199,4 +207,14 @@ adjustedRSquared : float
 Returns
 -------
 intercept : Bool
+"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LinearModelResult::getResidualsVariance
+"Accessor to the unbiased sample variance of the residuals.
+
+Returns
+-------
+residualsVariance : float
 "

--- a/python/test/t_LinearModelAlgorithm_std.expout
+++ b/python/test/t_LinearModelAlgorithm_std.expout
@@ -1,6 +1,38 @@
 Fit y ~ 3 - 2 x + 0.05 * sin(x) model using 20 points (sin(x) ~ noise)
 trend coefficients =  [3.01168,-2.00025]
 Fit y ~ 1 + 0.1 x + 10 x^2 model using 100 points
+result = 
+LinearModelResult
+- input dimension=2
+- basis size=3
+- design matrix=100 x 3
+- coefficients=3
+- formula=Basis( [[v0,v1]->[1],[v0,v1]->[v0],[v0,v1]->[v1]] )
+- coefficients names=[[v0,v1]->[1],[v0,v1]->[v0],[v0,v1]->[v1]]
+- residuals size=100
+- standard residuals size=100
+- inverse Gram diagonal=[0.0864939,0.0184756,0.000172994]
+- leverages size=100
+- Cook's distances size=100
+- residuals variance=0.00991604
+- has intercept=true
+
+
 trend coefficients =  [0.978992,0.110565,9.99924]
-class=LinearModelResult beta=class=Point name=Unnamed dimension=3 values=[0.978992,0.110565,9.99924] formula=Basis( [[X0,X1]->[1],[X0,X1]->[X0],[X0,X1]->[X1]] )
+LinearModelResult
+- input dimension=2
+- basis size=3
+- design matrix=100 x 3
+- coefficients=3
+- formula=Basis( [[X0,X1]->[1],[X0,X1]->[X0],[X0,X1]->[X1]] )
+- coefficients names=[[X0,X1]->[1],[X0,X1]->[X0],[X0,X1]->[X1]]
+- residuals size=100
+- standard residuals size=100
+- inverse Gram diagonal=[0.0864939,0.0184756,0.000172994]
+- leverages size=100
+- Cook's distances size=100
+- residuals variance=0.00991604
+- has intercept=true
+
+
 [-2,4] 0 [0]

--- a/python/test/t_LinearModelAlgorithm_std.py
+++ b/python/test/t_LinearModelAlgorithm_std.py
@@ -42,6 +42,8 @@ for i in range(size):
     )
 test = ot.LinearModelAlgorithm(X, Y)
 result = test.getResult()
+print("result = ")
+print(result)
 print("trend coefficients = ", result.getCoefficients())
 
 # Test various attributes


### PR DESCRIPTION
The goal of this PR is to improve the features and documentation of the linear model.

PS
The PR contains the sub-part of #2373 which does not have any link to the `FunctionalChaosAlgorithm`.

## Features
- `LinearModelAnalysis`:
  - Creates a new `LinearModelAnalysis::getResidualsStandardError()` method.
  - New HTML Python pretty-print.
- `LinearModelResult`
  - Creates new `LinearModelResult.getDesign()` and `LinearModelResult.getSigma2()` methods. These are attributes of the class which had no corresponding `get` methods.
  - Creates a new `LinearModelResult::__repr_markdown__()` method.

## Doc
- A new example of a `PythonRandomVector` is created: `plot_distribution_linear_regression.py`. It plots the distribution of the estimators of the variance and standard deviation of linear regression. This example uses the `LinearFunction` class.
- A new theory help page of linear regression is created.
- The help page of the `LinearFunction` class is improved.

## Fixed bugs
- In the ASCII-art pretty-print, the standard deviation is estimated using a code which is only available in the pretty-print source code ([see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L137)). This is wrong by design, because it prevents from implementing a unit test. Implement the new `LinearModelAnalysis.getResidualsStandardError()` method instead.
- ~~In the normality test for the residuals, the Kolmogorov-Smirnov uses a biased estimator of the standard deviation ([see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L325)). Uses the new `LinearModelAnalysis.getResidualsStandardError()` method instead.~~ This is wrong: the old code was correct.

## Questions
- [x] The standard deviation estimator looks suspicious to me: [see this code](https://github.com/openturns/openturns/blob/1d861ea09d429a01ae3d946ad99c2baac11b1495/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelAnalysis.cxx#L137). I cannot find a reference for this estimator. I cannot understand why we should not use the square root of the variance. I admit, however, that the distribution of this estimator is correct, as shown in `plot_distribution_linear_regression.py`. Edit (21/03/2024). This is just the root mean squared error, the square root of the estimated variance. 
- [x] Wait for the merge of #2330 for the `isRegression_` attribute of `FunctionalChaosResult`. Then, if regression is false, generate an exception. There is actually no need to way for merging the PR #2330 because the part of the PR that required that merge has been removed.
