### PR TITLE
Fix the "twice-cumulated" counting of evaluationNumber in MultiStart

### DIFF
--- a/lib/src/Base/Optim/MultiStart.cxx
+++ b/lib/src/Base/Optim/MultiStart.cxx
@@ -126,7 +126,7 @@ void MultiStart::run()
                   result.getAbsoluteError(), result.getRelativeError(), result.getResidualError(), result.getConstraintError(),
                   solver.getMaximumConstraintError());
 
-    evaluationNumber += getProblem().getObjective().getEvaluationCallsNumber() - initialEvaluationNumber;
+    evaluationNumber = getProblem().getObjective().getEvaluationCallsNumber() - initialEvaluationNumber;
     LOGDEBUG(OSS() << "Number of evaluations so far=" << evaluationNumber);
     if (evaluationNumber > getMaximumEvaluationNumber())
     {


### PR DESCRIPTION
In `MultiStart.run()`, the counting of `evaluationNumber` is currenlty using the cumulative `+=` operator instead of `+` while the RHS is already the cumulated sum of runs from `getObjective().getEvaluationCallsNumber()`. See [MultiStart.cxx#L129](https://github.com/openturns/openturns/blob/master/lib/src/Base/Optim/MultiStart.cxx#L129). This leads to a kind of "double cumulated counting" of the number of evaluation of the objective function. In the end, the total optimization budget that `MultiStart` is keeping gets empty much too soon.

As a result, `MultiStart.run()` stops much earlier than what is imposed by `setMaximumEvaluationNumber()` (unless the max eval number is very high and then MultiStart stops when the number of starting points is exhausted, of course).

## Reproducible example of the bug symptom

Here is a minimal example which should allow reproducing the bug on master branch for people having access to it.
It was tested with 1.21, sorry. I see that `MultiStart.cxx` was updated since 1.21 by commit https://github.com/openturns/openturns/commit/c683d22d612034a776dcd9934c8d9cab4bd67cef merged in PR #2387, but as far as I can see, this didn't change the evaluationNumber counting.

```python
from openturns.usecases import ackley_function
import openturns as ot

#  Test function to be optimized
am = ackley_function.AckleyModel()
model = am.model # OT's Function object

# Optimization domain:
dim = am.dim
lowerbound = [-4.0] * dim
upperbound = [4.0] * dim

# Optimization problem object:
problem = ot.OptimizationProblem(model)
bounds = ot.Interval(lowerbound, upperbound)
problem.setBounds(bounds)

# Optimization solver(s) definition

# Local solver
localSolver = ot.Cobyla(problem) # no gradient

# Starting points: manually specified by drawing samples from a Uniform distribution
distribList = [
    ot.Uniform(lowerbound[i], upperbound[i]) for i in range(dim)
]
distribution = ot.ComposedDistribution(distribList)

nStart = 10
print(f'MultiStart with {nStart} starting points')

ot.RandomGenerator.SetSeed(0)
startingSample = distribution.getSample(nStart)


# Multi start algo: **with very limited EvaluationNumber budget**
algo = ot.MultiStart(localSolver, startingSample)
algo.setMaximumEvaluationNumber(200)


# Run optimization

# Activate OT logging
ot.Log.Show(ot.Log.ALL)

initialCallsNumber = problem.getObjective().getCallsNumber() # save initial nb of calls
algo.run()

result = algo.getResult()

# → see log output
# → so it's clear that it MultiStart thinks there have been 239 calls, the 4th starting point shouldn't be used

# Effective number of calls to the objective function:
print('n calls to the objective function', problem.getObjective().getCallsNumber() - initialCallsNumber)

# Analysis of the history of local solver runs
nevalTot = 0
MSResults = algo.getResultCollection()
print(f'Number of recorded MS runs: {len(MSResults)}')
for i,res in enumerate(MSResults):
    neval = res.getEvaluationNumber()
    nevalTot += neval
    fopt = res.getOptimalValue()[0]
    print(f'- MS run {i}: found f*={fopt:.2f} in {neval} calls ({nevalTot} cumulated)')
    
print(f'total of neval: {nevalTot}')
```

And the output of that script ( :warning:  run with OT 1.21) is
```
MultiStart with 10 starting points
DBG - Working with starting point[0]=class=Point name=Unnamed dimension=2 values=[1.03901,1.71506], 200 remaining evaluations
INF - Best initial point so far=class=Point name=Unnamed dimension=2 values=[0.982413,1.96462] value=class=Point name=Unnamed dimension=1 values=[5.38186]
DBG - Number of evaluations so far=44
DBG - Working with starting point[1]=class=Point name=Unnamed dimension=2 values=[3.06244,-0.933104], 156 remaining evaluations
DBG - Number of evaluations so far=121
DBG - Working with starting point[2]=class=Point name=Unnamed dimension=2 values=[-2.91779,-1.00986], 79 remaining evaluations
DBG - Number of evaluations so far=239
INF - 3 out of 10 local searches succeeded, 1 improvements
n calls to the objective function 118
Number of recorded MS runs: 3
- MS run 0: found f*=5.38 in 44 calls (44 cumulated)
- MS run 1: found f*=7.18 in 33 calls (77 cumulated)
- MS run 2: found f*=7.18 in 41 calls (118 cumulated)
total of neval: 118
INF - *** Log End ***
```

so it's pretty visible from Logging output that:
- `Number of evaluations so far=...` is way above the truth as soon as for the 2nd starting point
- the corresponding number of `remaining evaluations` is below truth