### PR TITLE
Modification of optimization example to add "setIgnoreFailure".

### DIFF
--- a/python/doc/examples/numerical_methods/optimization/plot_optimization_rosenbrock.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_optimization_rosenbrock.py
@@ -143,7 +143,8 @@ view = viewer.View(graph)
 #
 # In that case, setting a low value of the Maximum Evaluation Number may be not sufficient to satisfy the convergence tolerances, and the optimization algorithm may return an exception.
 #
-# If one wants to still use the results provided by the algorithm in case of a partial convergence, one can use the `setIgnoreFailure` method. This option is also available for :class:`~openturns.TNC` algorithm.
+# If one wants to still use the results provided by the algorithm in case of a partial convergence, one can use the `setIgnoreFailure` method.
+# This option is also available for :class:`~openturns.TNC` algorithm.
 
 # %%
 algo = ot.Cobyla(problem)

--- a/python/doc/examples/numerical_methods/optimization/plot_optimization_rosenbrock.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_optimization_rosenbrock.py
@@ -139,6 +139,25 @@ view = viewer.View(graph)
 # We see that the algorithm made lots of evaluations in the bottom of the valley before getting in the neighbourhood of the minimum.
 
 # %%
+# Sometimes, the simulation budget for the optimization needs to be reduced due to the computational cost.
+#
+# In that case, setting a low value of the Maximum Evaluation Number may be not sufficient to satisfy the convergence tolerances, and the optimization algorithm may return an exception.
+#
+# If one wants to still use the results provided by the algorithm in case of a partial convergence, one can use the `setIgnoreFailure` method. This option is also available for :class:`~openturns.TNC` algorithm.
+
+# %%
+algo = ot.Cobyla(problem)
+algo.setIgnoreFailure(True)
+algo.setMaximumRelativeError(1.0e-1)
+algo.setMaximumEvaluationNumber(1000)
+algo.setStartingPoint(x0)
+algo.run()
+result = algo.getResult()
+
+# %%
+result.getEvaluationNumber()
+
+# %%
 # Solving the problem with NLopt
 # ------------------------------
 #


### PR DESCRIPTION
Hello,

This PR answers the issue #2460. Following the technical committee of 11/20/23, the ["Quick start guide to Optimization"](https://openturns.github.io/openturns/latest/auto_numerical_methods/optimization/plot_optimization_rosenbrock.html#sphx-glr-auto-numerical-methods-optimization-plot-optimization-rosenbrock-py) example has been extended in order to exhibit the method `setIgnoreFailure` for retrieving optimization results in case the convergence is limited by the maximal number of evaluations.