### PR TITLE
CovarianceModel: Add nuggetFactor to optimizable parameters

### DIFF
--- a/lib/src/Base/Stat/CovarianceModel.cxx
+++ b/lib/src/Base/Stat/CovarianceModel.cxx
@@ -300,6 +300,21 @@ Indices CovarianceModel::getActiveParameter() const
   return getImplementation()->getActiveParameter();
 }
 
+/* Easily activate base parameters: scale, nuggetFactor, amplitude */
+void CovarianceModel::activateScale(const Bool isScaleActive)
+{
+  return getImplementation()->activateScale(isScaleActive);
+}
+
+void CovarianceModel::activateNuggetFactor(const Bool isNuggetFactorActive)
+{
+  return getImplementation()->activateNuggetFactor(isNuggetFactorActive);
+}
+
+void CovarianceModel::activateAmplitude(const Bool isAmplitudeActive)
+{
+  return getImplementation()->activateAmplitude(isAmplitudeActive);
+}
 
 /* setter for the full parameter */
 void CovarianceModel::setFullParameter(const Point & parameter)

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -54,9 +54,10 @@ CovarianceModelImplementation::CovarianceModelImplementation(const UnsignedInteg
   , isDiagonal_(true)
   , isStationary_(false)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + outputDimension_)
+  , activeParameter_(0)
 {
-  activeParameter_.fill();
+  for (UnsignedInteger i=0; i < inputDimension_ + 1 + outputDimension_; ++i)
+    if(i != inputDimension_) activeParameter_.add(i);
   updateOutputCovariance();
 }
 
@@ -74,11 +75,12 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , isDiagonal_(true)
   , isStationary_(false)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + outputDimension_)
+  , activeParameter_(0)
 {
   setAmplitude(amplitude);
   setScale(scale);
-  activeParameter_.fill();
+  for (UnsignedInteger i=0; i < inputDimension_ + 1 + outputDimension_; ++i)
+    if(i != inputDimension_) activeParameter_.add(i);
 }
 
 /* Standard constructor with scale, amplitude and spatial correlation parameter parameter */
@@ -96,11 +98,12 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , isDiagonal_(true)
   , isStationary_(false)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + outputDimension_)
+  , activeParameter_(0)
 {
   setAmplitude(amplitude);
   setScale(scale);
-  activeParameter_.fill();
+  for (UnsignedInteger i=0; i < inputDimension_ + 1 + outputDimension_; ++i)
+    if(i != inputDimension_) activeParameter_.add(i);
   setOutputCorrelation(spatialCorrelation);
 }
 
@@ -118,7 +121,7 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
   , isDiagonal_(spatialCovariance.isDiagonal())
   , isStationary_(false)
   , nuggetFactor_(ResourceMap::GetAsScalar("CovarianceModel-DefaultNuggetFactor"))
-  , activeParameter_(inputDimension_ + outputDimension_)
+  , activeParameter_(0)
 {
   setScale(scale);
   for (UnsignedInteger i = 0; i < outputDimension_; ++i)
@@ -136,7 +139,8 @@ CovarianceModelImplementation::CovarianceModelImplementation(const Point & scale
       for (UnsignedInteger i = j + 1; i < outputDimension_; ++i)
         outputCorrelation_(i, j) = spatialCovariance(i, j) / (amplitude_[i] * amplitude_[j]);
   } // !isDiagonal
-  activeParameter_.fill();
+  for (UnsignedInteger i=0; i < inputDimension_ + 1 + outputDimension_; ++i)
+    if(i != inputDimension_) activeParameter_.add(i);
 }
 
 /* Virtual constructor */
@@ -947,7 +951,12 @@ void CovarianceModelImplementation::setFullParameter(const Point & parameter)
     scale_[i] = parameter[index];
     ++ index;
   }
-  // Second the amplitude parameter
+  // Second the nugget factor
+  if (!(parameter[index] >= 0.0))
+      throw InvalidArgumentException(HERE) << "In CovarianceModelImplementation::setFullParameter, the component " << index << " of nuggetFactor is negative";
+  nuggetFactor_ = parameter[index];
+  ++ index;
+  // Third the amplitude parameter
   for (UnsignedInteger i = 0; i < outputDimension_; ++ i)
   {
     if (!(parameter[index] > 0.0))
@@ -956,7 +965,7 @@ void CovarianceModelImplementation::setFullParameter(const Point & parameter)
     ++ index;
   }
   CorrelationMatrix outputCorrelation(outputDimension_);
-  // Third the output correlation parameter, only the lower triangle
+  // Fourth the output correlation parameter, only the lower triangle
   for (UnsignedInteger i = 0; i < outputDimension_; ++ i)
     for (UnsignedInteger j = 0; j < i; ++ j)
     {
@@ -972,9 +981,11 @@ Point CovarianceModelImplementation::getFullParameter() const
   // Here we manage only the generic parameters
   // First the scale parameter
   Point parameter(getScale());
-  // Second the amplitude parameter
+  // Second the nugget factor
+  parameter.add(nuggetFactor_);
+  // Third the amplitude parameter
   parameter.add(getAmplitude());
-  // Third the spatial correation parameter, only the lower triangle
+  // Fourth the spatial correation parameter, only the lower triangle
   if (isDiagonal_)
   {
     if (outputDimension_ > 1)
@@ -995,14 +1006,15 @@ Description CovarianceModelImplementation::getFullParameterDescription() const
   // First the scale parameter
   for (UnsignedInteger j = 0; j < inputDimension_; ++j)
     description.add(OSS() << "scale_" << j);
-  // Second the amplitude parameter
+  // Second the nugget factor
+  description.add(OSS() << "nuggetFactor");
+  // Third the amplitude parameter
   for (UnsignedInteger j = 0; j < outputDimension_; ++j)
     description.add(OSS() << "amplitude_" << j);
-  // Third the spatial correlation parameter, only the lower triangle
+  // Fourth the spatial correlation parameter, only the lower triangle
   for (UnsignedInteger i = 0; i < outputDimension_; ++i)
     for (UnsignedInteger j = 0; j < i; ++j)
       description.add(OSS() << "R_" << i << "_" << j);
-
   return description;
 }
 

--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -1030,6 +1030,56 @@ Indices CovarianceModelImplementation::getActiveParameter() const
   return activeParameter_;
 }
 
+/* Easily activate base parameters: scale, nuggetFactor, amplitude */
+void CovarianceModelImplementation::activateScale(const Bool isScaleActive)
+{
+  const Indices activeParameter(getActiveParameter());
+  const UnsignedInteger scaleSize = getScale().getSize();
+  Indices newActiveParameter(0);
+  if (isScaleActive)
+    for (UnsignedInteger j = 0; j < scaleSize; ++j) newActiveParameter.add(j);
+  for (UnsignedInteger i = 0; i < activeParameter.getSize(); ++i)
+    if (activeParameter[i] >= scaleSize) newActiveParameter.add(activeParameter[i]);
+  setActiveParameter(newActiveParameter);
+}
+
+void CovarianceModelImplementation::activateNuggetFactor(const Bool isNuggetFactorActive)
+{
+  const Indices activeParameter(getActiveParameter());
+  const UnsignedInteger scaleSize = getScale().getSize();
+  Indices newActiveParameter(0);
+  Indices activeAmplitudeAndNext(0);
+  for (UnsignedInteger i = 0; i < activeParameter.getSize(); ++i)
+  {
+    if(activeParameter[i] < scaleSize) newActiveParameter.add(activeParameter[i]);
+    else if (activeParameter[i] > scaleSize) activeAmplitudeAndNext.add(activeParameter[i]);
+  }
+  if (isNuggetFactorActive) newActiveParameter.add(scaleSize);
+  newActiveParameter.add(activeAmplitudeAndNext);
+  setActiveParameter(newActiveParameter);
+}
+
+void CovarianceModelImplementation::activateAmplitude(const Bool isAmplitudeActive)
+{
+  const Indices activeParameter(getActiveParameter());
+  const UnsignedInteger scaleSize = getScale().getSize();
+  const UnsignedInteger amplitudeSize = getAmplitude().getSize();
+  Indices newActiveParameter(0);
+  Indices activeAfterAmplitude(0);
+  for (UnsignedInteger i = 0; i < activeParameter.getSize(); ++i)
+  {
+    if(activeParameter[i] <= scaleSize) newActiveParameter.add(activeParameter[i]);
+    else if (activeParameter[i] > scaleSize + amplitudeSize) activeAfterAmplitude.add(activeParameter[i]);
+  }
+  if (isAmplitudeActive) 
+  {
+    Indices amplitudeIndices(amplitudeSize);
+    amplitudeIndices.fill(scaleSize + 1);
+    newActiveParameter.add(amplitudeIndices);
+  }
+  newActiveParameter.add(activeAfterAmplitude);
+  setActiveParameter(newActiveParameter);
+}
 
 void CovarianceModelImplementation::setParameter(const Point & parameter)
 {

--- a/lib/src/Base/Stat/FractionalBrownianMotionModel.cxx
+++ b/lib/src/Base/Stat/FractionalBrownianMotionModel.cxx
@@ -243,13 +243,13 @@ CorrelationMatrix FractionalBrownianMotionModel::getRho() const
 
 void FractionalBrownianMotionModel::setFullParameter(const Point & parameter)
 {
-  const UnsignedInteger totalSize = inputDimension_ + outputDimension_ * (outputDimension_ + 1);
+  const UnsignedInteger totalSize = inputDimension_ + 1 + outputDimension_ * (outputDimension_ + 1);
   if (!(parameter.getSize() >= totalSize))
     throw InvalidArgumentException(HERE) << "In FractionalBrownianMotionModel::setFullParameter, points have incompatible size. Point size = " << parameter.getSize()
                                          << " whereas expected size = " << totalSize ;
   CovarianceModelImplementation::setFullParameter(parameter);
   // Now the Hurst exponent
-  UnsignedInteger index = inputDimension_ + outputDimension_ * (outputDimension_ + 1) / 2;
+  UnsignedInteger index = inputDimension_ + 1 + outputDimension_ * (outputDimension_ + 1) / 2;
   Point exponent(outputDimension_);
   for (UnsignedInteger i = 0; i < outputDimension_; ++i, ++index)
     exponent[i] = parameter[index];

--- a/lib/src/Base/Stat/IsotropicCovarianceModel.cxx
+++ b/lib/src/Base/Stat/IsotropicCovarianceModel.cxx
@@ -146,9 +146,9 @@ Description IsotropicCovarianceModel::getFullParameterDescription() const
 /** Scale accessor */
 void IsotropicCovarianceModel::setScale(const Point & scale)
 {
-  if (scale.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the scale should have dimension 1, not " << scale.getDimension() << ".";
-  if (!(scale[0] > 0))
-    throw InvalidArgumentException(HERE) << "In IsotropicCovarianceModel::setScale";
+  if (scale.getDimension() != 1) throw InvalidArgumentException(HERE) << "In IsotropicCovarianceModel::setScale: the scale should have dimension 1, not " << scale.getDimension() << ".";
+  if (!(scale[0] > 0.0))
+    throw InvalidArgumentException(HERE) << "In IsotropicCovarianceModel::setScale: the scale is << " << scale[0] << " but should be positive";
   kernel_.setScale(scale);
   scale_ = scale;
 }
@@ -156,6 +156,8 @@ void IsotropicCovarianceModel::setScale(const Point & scale)
 /* Nugget factor accessor */
 void IsotropicCovarianceModel::setNuggetFactor(const Scalar nuggetFactor)
 {
+  if (!(nuggetFactor >= 0.0))
+    throw InvalidArgumentException(HERE) << "In IsotropicCovarianceModel::setNuggetFactor: the nuggetFactor is << " << nuggetFactor << " but should be nonnegative";
   kernel_.setNuggetFactor(nuggetFactor);
   nuggetFactor_ = nuggetFactor;
 }

--- a/lib/src/Base/Stat/ProductCovarianceModel.cxx
+++ b/lib/src/Base/Stat/ProductCovarianceModel.cxx
@@ -21,6 +21,7 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Exception.hxx"
 #include "openturns/AbsoluteExponential.hxx"
+#include "openturns/SpecFunc.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -43,11 +44,33 @@ ProductCovarianceModel::ProductCovarianceModel(const UnsignedInteger inputDimens
     throw InvalidArgumentException(HERE) << "Error: input dimension must be positive, here inputDimension=0";
   // scale parameter
   scale_ = Point(inputDimension, collection_[0].getScale()[0]);
+
+  // nugget factor
+  nuggetFactor_ = collection_[0].getNuggetFactor();
+  for (UnsignedInteger i = 0; i < inputDimension; ++i)
+  {
+    collection_[i].setNuggetFactor(0.0);
+    const Description description(collection_[i].getParameterDescription());
+    const UnsignedInteger nuggetFactorIndex = description.find("nuggetFactor");
+    if (nuggetFactorIndex < description.getSize()) // nuggetFactor is active, make it unactive
+    {
+      const Indices activeParameter(collection_[i].getActiveParameter());
+      Indices newActiveParameter(description.getSize() - 1);
+      for (UnsignedInteger j = 0; j < description.getSize(); ++j)
+      {
+        if (j < nuggetFactorIndex) newActiveParameter[j] = activeParameter[j];
+        else if (j > nuggetFactorIndex) newActiveParameter[j - 1] = activeParameter[j];
+      }
+      collection_[i].setActiveParameter(newActiveParameter);
+    }
+  }
+
   // Update the default values for the amplitude
   setAmplitude(Point(1, collection_[0].getAmplitude()[0]));
   // Active parameters : scale + amplitude
   activeParameter_ = Indices(inputDimension + 1);
   activeParameter_.fill();
+  activeParameter_[inputDimension] = inputDimension + 1;
   isStationary_ = true;
 }
 
@@ -67,6 +90,8 @@ void ProductCovarianceModel::setCollection(const CovarianceModelCollection & col
   const UnsignedInteger size = collection.getSize();
   if (!(size > 0))
     throw InvalidArgumentException(HERE) << "Error: the collection must have a positive size, here size=0";
+  // Nugget factor
+  nuggetFactor_ = collection[0].getNuggetFactor();
   // Scale & amplitude
   Point scale(0);
   Point amplitude(1, 1.0);
@@ -75,8 +100,13 @@ void ProductCovarianceModel::setCollection(const CovarianceModelCollection & col
   outputDimension_ = 1;
 
   // checking if amplitude parameter should be active
-  // Value is True if one of the marginal models activate it
+  // Value is True if one of the marginal models activates it
   Bool isAmplitudeActive = false;
+
+  // checking if nuggetFactor parameter should be active
+  // Value is True if one of the marginal models activates it
+  Bool isNuggetFactorActive = false;
+
   // Handle 'specific' parameters
   extraParameterNumber_ = Indices(collection.getSize());
 
@@ -108,30 +138,37 @@ void ProductCovarianceModel::setCollection(const CovarianceModelCollection & col
     inputDimension_ += localInputDimension;
     scale.add(collection[i].getScale());
 
+    // Should we activate the nuggetFactor parameter?
+    isNuggetFactorActive = isNuggetFactorActive || localActiveParameter.contains(collection[i].getScale().getSize());
+
     // Should we activate the amplitude parameter?
-    isAmplitudeActive = isAmplitudeActive || localActiveParameter.contains(collection[i].getScale().getSize());
+    isAmplitudeActive = isAmplitudeActive || localActiveParameter.contains(collection[i].getScale().getSize() + 1);
 
     // Number of specific parameter
-    extraParameterNumber_[i] = collection[i].getFullParameter().getSize() - (collection[i].getScale().getSize() + 1);
+    extraParameterNumber_[i] = collection[i].getFullParameter().getSize() - (collection[i].getScale().getSize() + 2);
 
     // Check if model is stationary
     if (!collection[i].isStationary())
       isStationary_ = false;
   }
 
-  // Amplitude active
-  if (isAmplitudeActive)
+  // NuggetFactor active
+  if (isNuggetFactorActive)
     activeParameter_.add(scale.getSize());
 
+  // Amplitude active
+  if (isAmplitudeActive)
+    activeParameter_.add(scale.getSize() + 1);
+
   // Handle active extra parameters
-  UnsignedInteger index = scale.getSize() + 1;
+  UnsignedInteger index = scale.getSize() + 2;
   for (UnsignedInteger i = 0; i < size; ++i)
   {
     const Indices localActiveParameter(collection[i].getActiveParameter());
     // if extraParameterNumber_[i] > 0, check if the parameters are active
     for (UnsignedInteger j = 0; j < extraParameterNumber_[i]; ++j)
     {
-      if (localActiveParameter.contains(collection[i].getScale().getSize() + j + 1))
+      if (localActiveParameter.contains(collection[i].getScale().getSize() + j + 2))
         activeParameter_.add(index + j);
     }
     // update index
@@ -139,12 +176,35 @@ void ProductCovarianceModel::setCollection(const CovarianceModelCollection & col
   }
   // Set collection
   collection_ = collection;
-  // Set amplitude & scale
+  // Set amplitude & nuggetFactor & scale
   scale_ = scale;
+  nuggetFactor_ = collection[0].getNuggetFactor();
+
   setAmplitude(amplitude);
   // Fix all submodels as correlation models
   for (UnsignedInteger i = 0; i < size; ++i) collection_[i].setAmplitude(Point(1, 1.0));
 
+  // set all marginal model nugget factors to 0 and deactivate them
+  LOGDEBUG(OSS(false) << "Set marginal nugget factors to 0 and deactivate them ");
+  for (UnsignedInteger i = 0; i < size; ++i)
+  {
+    collection_[i].setNuggetFactor(0.0);
+    const Description description(collection_[i].getParameterDescription());
+    const UnsignedInteger nuggetFactorIndex = description.find("nuggetFactor");
+    if (nuggetFactorIndex < description.getSize()) // nuggetFactor is active, make it unactive
+    {
+      const Indices activeParameter(collection_[i].getActiveParameter());
+      Indices newActiveParameter(description.getSize() - 1);
+      for (UnsignedInteger j = 0; j < description.getSize(); ++j)
+      {
+        if (j < nuggetFactorIndex) newActiveParameter[j] = activeParameter[j];
+        else if (j > nuggetFactorIndex) newActiveParameter[j - 1] = activeParameter[j];
+      }
+      collection_[i].setActiveParameter(newActiveParameter);
+      LOGDEBUG(OSS(false) << "Collection[" << i << "] active parameter = " << collection_[i].getActiveParameter());
+      LOGDEBUG(OSS(false) << "Collection[" << i << "] active parameter description = " << collection_[i].getParameterDescription());
+    }
+  }
 }
 
 ProductCovarianceModel::CovarianceModelCollection ProductCovarianceModel::getCollection() const
@@ -177,6 +237,7 @@ Scalar ProductCovarianceModel::computeAsScalar(const Point & tau) const
     rho *= collection_[i].getImplementation()->computeAsScalar(localTau);
     start += collection_[i].getInputDimension();
   }
+  if (tau.norm() <= SpecFunc::ScalarEpsilon) rho *= (1.0 + getNuggetFactor());
   return rho;
 }
 
@@ -184,13 +245,22 @@ Scalar ProductCovarianceModel::computeAsScalar(const Collection<Scalar>::const_i
     const Collection<Scalar>::const_iterator & t_begin) const
 {
   Scalar rho = amplitude_[0] * amplitude_[0];
+  Scalar squareNorm = 0.0;
   UnsignedInteger start = 0;
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    const Scalar dx = (*s_it - *t_it);
+    squareNorm += dx * dx;
+  }
   for (UnsignedInteger i = 0; i < collection_.getSize(); ++i)
   {
     // Compute as scalar returns the correlation function
     rho *= collection_[i].getImplementation()->computeAsScalar(s_begin + start, t_begin + start);
     start += collection_[i].getInputDimension();
   }
+  if (squareNorm <= SpecFunc::ScalarEpsilon * SpecFunc::ScalarEpsilon) rho *= (1.0 + getNuggetFactor());
   return rho;
 }
 
@@ -200,7 +270,9 @@ Scalar ProductCovarianceModel::computeAsScalar(const Scalar tau) const
     throw NotDefinedException(HERE) << "Error: the covariance model has input dimension=" << inputDimension_ << ", expected input dimension=1.";
   if (outputDimension_ != 1)
     throw NotDefinedException(HERE) << "Error: the covariance model has output dimension=" << outputDimension_ << ", expected dimension=1.";
-  return collection_[0].getImplementation()->computeAsScalar(tau);
+  Scalar rho = collection_[0].getImplementation()->computeAsScalar(tau);
+  if (std::abs(tau) <= SpecFunc::ScalarEpsilon) rho *= (1.0 + getNuggetFactor());
+  return rho;
 }
 
 /* Gradient */
@@ -247,7 +319,10 @@ Matrix ProductCovarianceModel::partialGradient(const Point & s,
 /* Parameters accessor */
 void ProductCovarianceModel::setFullParameter(const Point & parameter)
 {
-  UnsignedInteger parameterDimension = getScale().getSize() + 1;
+  UnsignedInteger scaleSize = getScale().getSize();
+  UnsignedInteger index = scaleSize + 2; // Index for extra parameters
+  // Total parameter dimension
+  UnsignedInteger parameterDimension = index;
   // Increase using the specific parameters
   for (UnsignedInteger i = 0; i < extraParameterNumber_.getSize(); ++i) parameterDimension += extraParameterNumber_[i];
 
@@ -258,9 +333,7 @@ void ProductCovarianceModel::setFullParameter(const Point & parameter)
   // Scale parameters then amplitude parameter and finally other parameters
 
   UnsignedInteger start = 0;
-  // Index for extra parameters
-  UnsignedInteger index = getScale().getSize() + 1;
-  Point scale(getScale().getSize());
+  Point scale(scaleSize);
   for (UnsignedInteger i = 0; i < collection_.getSize(); ++i)
   {
     const UnsignedInteger atomScaleDimension = collection_[i].getScale().getDimension();
@@ -269,6 +342,8 @@ void ProductCovarianceModel::setFullParameter(const Point & parameter)
     std::copy(parameter.begin() + start, parameter.begin() + stop, atomFullParameter.begin());
     // Duplicate scale
     std::copy(parameter.begin() + start, parameter.begin() + stop, scale.begin() + start);
+    // Add 'local' nuggetFactor
+    atomFullParameter.add(0.0);
     // Add 'local' amplitude
     atomFullParameter.add(1.0);
     // Set extra
@@ -283,18 +358,21 @@ void ProductCovarianceModel::setFullParameter(const Point & parameter)
   }
   // Copy scale (for get accessor)
   scale_ = scale;
-  setAmplitude(Point(1, parameter[getScale().getSize()]));
+  setNuggetFactor(parameter[scaleSize]);
+  setAmplitude(Point(1, parameter[scaleSize + 1]));
 }
 
 void ProductCovarianceModel::setActiveParameter(const Indices & active)
 {
   // Propagate information to marginal models
+  // First, check if active contains the nuggetFactor.
+  const Bool isNuggetFactorActive = active.contains(getScale().getSize());
   // First, check if active contains the amplitude.
-  const Bool isAmplitudeActive = active.contains(getScale().getSize());
+  const Bool isAmplitudeActive = active.contains(getScale().getSize() + 1);
   // variables that help to read active parameters
   const UnsignedInteger size = collection_.getSize();
   UnsignedInteger scaleSize = 0;
-  UnsignedInteger index = getScale().getSize() + 1;
+  UnsignedInteger index = getScale().getSize() + 2;
   for (UnsignedInteger i = 0; i < size; ++ i)
   {
     const UnsignedInteger localScaleSize = collection_[i].getScale().getSize();
@@ -306,13 +384,15 @@ void ProductCovarianceModel::setActiveParameter(const Indices & active)
         localActiveParameter.add(j);
     }
     scaleSize += localScaleSize;
-    if (isAmplitudeActive)
+    if (isNuggetFactorActive)
       localActiveParameter.add(localScaleSize);
+    if (isAmplitudeActive)
+      localActiveParameter.add(localScaleSize + 1);
     // Handle extra param
     for (UnsignedInteger j = 0; j < extraParameterNumber_[i]; ++j)
     {
       if (active.contains(index + j))
-        localActiveParameter.add(localScaleSize + j + 1);
+        localActiveParameter.add(localScaleSize + 2 + j);
     }
     // update index
     index += extraParameterNumber_[i];
@@ -327,6 +407,7 @@ Point ProductCovarianceModel::getFullParameter() const
 {
   // Convention scale + amplitude + extras
   Point result(scale_);
+  result.add(nuggetFactor_);
   result.add(amplitude_);
   const UnsignedInteger size = extraParameterNumber_.getSize();
   for (UnsignedInteger i = 0; i < size; ++ i)
@@ -335,7 +416,7 @@ Point ProductCovarianceModel::getFullParameter() const
     {
       const Point localFullParameter(collection_[i].getFullParameter());
       for (UnsignedInteger k = 0; k < extraParameterNumber_[i]; ++ k)
-        result.add(localFullParameter[collection_[i].getScale().getSize() + 1 + k]);
+        result.add(localFullParameter[collection_[i].getScale().getSize() + 2 + k]);
     }
   }
   return result;
@@ -347,6 +428,7 @@ Description ProductCovarianceModel::getFullParameterDescription() const
   Description description(size);
   for (UnsignedInteger i = 0; i < size; ++i)
     description[i] = OSS() << "scale_" << i;
+  description.add("nuggetFactor");
   // Last element is amplitude
   description.add("amplitude_0");
   for (UnsignedInteger i = 0; i < extraParameterNumber_.getSize(); ++ i)
@@ -355,7 +437,7 @@ Description ProductCovarianceModel::getFullParameterDescription() const
     {
       const Description localFullParameterDescription(collection_[i].getFullParameterDescription());
       for (UnsignedInteger k = 0; k < extraParameterNumber_[i]; ++ k)
-        description.add(OSS() << localFullParameterDescription[collection_[i].getScale().getSize() + 1 + k] << "_" << i);
+        description.add(OSS() << localFullParameterDescription[collection_[i].getScale().getSize() + 2 + k] << "_" << i);
     }
   }
 

--- a/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
+++ b/lib/src/Base/Stat/StationaryFunctionalCovarianceModel.cxx
@@ -141,7 +141,7 @@ void StationaryFunctionalCovarianceModel::setFullParameter(const Point & paramet
 {
   CovarianceModelImplementation::setFullParameter(parameter);
   Point functionParameter(rho_.getParameter().getDimension());
-  std::copy(parameter.begin() + getInputDimension() + getOutputDimension(), parameter.end(), functionParameter.begin());
+  std::copy(parameter.begin() + getInputDimension() + 1 + getOutputDimension(), parameter.end(), functionParameter.begin());
   rho_.setParameter(functionParameter);
 }
 

--- a/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
+++ b/lib/src/Base/Stat/TensorizedCovarianceModel.cxx
@@ -39,6 +39,8 @@ TensorizedCovarianceModel::TensorizedCovarianceModel(const UnsignedInteger dimen
 
   activeParameter_ = Indices(getScale().getSize() + getAmplitude().getSize());
   activeParameter_.fill();
+  for (UnsignedInteger i = getScale().getSize(); i < activeParameter_.getSize(); ++i)
+    activeParameter_[i] = i + 1;
   isStationary_ = true;
 }
 
@@ -50,6 +52,8 @@ TensorizedCovarianceModel::TensorizedCovarianceModel(const CovarianceModelCollec
   scale_ = Point(inputDimension_, 1.0);
   activeParameter_ = Indices(getScale().getSize() + getAmplitude().getSize());
   activeParameter_.fill();
+  for (UnsignedInteger i = getScale().getSize(); i < activeParameter_.getSize(); ++i)
+    activeParameter_[i] = i + 1;
 }
 
 /** Parameters constructor */
@@ -62,6 +66,8 @@ TensorizedCovarianceModel::TensorizedCovarianceModel(const CovarianceModelCollec
 
   activeParameter_ = Indices(getScale().getSize() + getAmplitude().getSize());
   activeParameter_.fill();
+  for (UnsignedInteger i = getScale().getSize(); i < activeParameter_.getSize(); ++i)
+    activeParameter_[i] = i + 1;
 }
 
 /* Collection accessor */
@@ -207,9 +213,10 @@ void TensorizedCovarianceModel::setFullParameter(const Point & parameter)
   Point scale(inputDimension_);
   Point amplitude(outputDimension_);
   for (UnsignedInteger i = 0; i < scale_.getDimension(); ++i) scale[i] = parameter[i];
-  for (UnsignedInteger i = 0; i < amplitude_.getDimension(); ++i) amplitude[i] = parameter[i + inputDimension_];
+  for (UnsignedInteger i = 0; i < amplitude_.getDimension(); ++i) amplitude[i] = parameter[i + inputDimension_ + 1];
   // set parameters
   setScale(scale);
+  setNuggetFactor(parameter[inputDimension_]);
   setAmplitude(amplitude);
 }
 
@@ -218,6 +225,7 @@ Point TensorizedCovarianceModel::getFullParameter() const
   // Same convention : scale then amplitude parameters
   Point result(0);
   result.add(scale_);
+  result.add(nuggetFactor_);
   result.add(amplitude_);
   return result;
 }
@@ -226,6 +234,7 @@ Description TensorizedCovarianceModel::getFullParameterDescription() const
 {
   Description description(0);
   for (UnsignedInteger j = 0; j < scale_.getDimension(); ++ j) description.add(OSS() << "scale_" << j);
+  description.add(OSS() << "nuggetFactor");
   for (UnsignedInteger j = 0; j < amplitude_.getDimension(); ++ j) description.add(OSS() << "amplitude_" << j);
   return description;
 }

--- a/lib/src/Base/Stat/openturns/CovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModel.hxx
@@ -148,6 +148,10 @@ public:
   void setActiveParameter(const Indices & active);
   Indices getActiveParameter() const;
 
+  /* Easily activate base parameters: scale, nuggetFactor, amplitude */
+  void activateScale(const Bool isScaleActive);
+  void activateNuggetFactor(const Bool isNuggetFactorActive);
+  void activateAmplitude(const Bool isAmplitudeActive);
 
   /* setter for the full parameter */
   virtual void setFullParameter(const Point & parameter);

--- a/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
+++ b/lib/src/Base/Stat/openturns/CovarianceModelImplementation.hxx
@@ -172,6 +172,11 @@ public:
   virtual void setActiveParameter(const Indices & active);
   virtual Indices getActiveParameter() const;
 
+  /* Easily activate base parameters: scale, nuggetFactor, amplitude */
+  virtual void activateScale(const Bool isScaleActive);
+  virtual void activateNuggetFactor(const Bool isNuggetFactorActive);
+  virtual void activateAmplitude(const Bool isAmplitudeActive);
+
   /* setter for the full parameter */
   virtual void setFullParameter(const Point & parameter);
   virtual Point getFullParameter() const;

--- a/lib/src/Base/Stat/openturns/KroneckerCovarianceModel.hxx
+++ b/lib/src/Base/Stat/openturns/KroneckerCovarianceModel.hxx
@@ -99,6 +99,7 @@ public:
   void setFullParameter(const Point & parameter) override;
   Description getFullParameterDescription() const override;
   void setScale(const Point &scale) override;
+  void setNuggetFactor(const Scalar nuggetFactor) override;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/lib/test/t_CovarianceModel_std.cxx
+++ b/lib/test/t_CovarianceModel_std.cxx
@@ -178,7 +178,6 @@ int main(int, char *[])
 
   try
   {
-
     PlatformInfo::SetNumericalPrecision(3);
     // Default input dimension parameter to evaluate the model
     UnsignedInteger dimension = 2;
@@ -458,24 +457,25 @@ int main(int, char *[])
       test_model(myModel);
       assert_almost_equal(myModel.getInputDimension(), 3, 0, 0, "in kronecker dimension check");
       assert_almost_equal(myModel.getScale(), scale, 0, 0, "in kronecker scale check");
-      // full param size = 5 (scale(1), amplitude(2), spatialCorrelation(1), Matern nu(1))
-      Point fullParameter = {1, 1, 2, 0.8, 1.5};
+      // full param size = 6 (scale(1), nuggetFactor(1), amplitude(2), spatialCorrelation(1), Matern nu(1))
+      Point fullParameter = {1, 1e-12, 1, 2, 0.8, 1.5};
+      assert_almost_equal(myModel.getFullParameter().getSize(), 6, 0, 0, "in kronecker param size check");
       assert_almost_equal(myModel.getFullParameter(), fullParameter, 0, 0, "in kronecker full param check");
-      assert_almost_equal(myModel.getFullParameter().getSize(), 5, 0, 0, "in kronecker param size check");
-      assert_almost_equal(myModel.getFullParameterDescription().getSize(), 5, 0, 0, "in kronecker param description size check");
-      Indices active(3);
-      active.fill();
+      assert_almost_equal(myModel.getFullParameterDescription().getSize(), 6, 0, 0, "in kronecker param description size check");
+      Indices active(1);
+      active.add(2);
+      active.add(3);
       assert_almost_equal(myModel.getActiveParameter(), active, "in kronecker active param check");
-      fullParameter = {2, 1, 2, .5, 2.5};
+      fullParameter = {2, 1e-12, 1, 2, .5, 2.5};
       myModel.setFullParameter(fullParameter);
       assert_almost_equal(myModel.getFullParameter(), fullParameter, 0, 0, "in kronecker param check");
-      active.add(4);
+      active.add(5);
       myModel.setActiveParameter(active);
       assert_almost_equal(myModel.getActiveParameter(), active, "in kronecker active param check");
       // Now we should get all values except correlation
       Point parameter = {2, 1, 2, 2.5};
       assert_almost_equal(myModel.getParameter(), parameter, 0, 0, "in kronecker param check");
-      Description description = {"scale_0", "amplitude_0", "amplitude_1", "R_1_0", "nu"};
+      Description description = {"scale_0", "nuggetFactor", "amplitude_0", "amplitude_1", "R_1_0", "nu"};
       Bool checkDesc = myModel.getFullParameterDescription() == description;
       if (!checkDesc)
         throw TestFailed(OSS() << "descriptions differ");

--- a/lib/test/t_CovarianceModel_std.cxx
+++ b/lib/test/t_CovarianceModel_std.cxx
@@ -475,6 +475,16 @@ int main(int, char *[])
       // Now we should get all values except correlation
       Point parameter = {2, 1, 2, 2.5};
       assert_almost_equal(myModel.getParameter(), parameter, 0, 0, "in kronecker param check");
+      myModel.activateAmplitude(false);
+      assert_almost_equal(myModel.getParameter(), {2, 2.5}, 0, 0, "in kronecker deactivate amplitude check");
+      myModel.activateScale(false);
+      assert_almost_equal(myModel.getParameter(), {2.5}, 0, 0, "in kronecker deactivate scale check");
+      myModel.activateNuggetFactor(true);
+      assert_almost_equal(myModel.getParameter(), {1e-12, 2.5}, 0, 0, "in kronecker activate nuggetFactor check");
+      myModel.activateAmplitude(true);
+      assert_almost_equal(myModel.getParameter(), {1e-12, 1, 2, 2.5}, 0, 0, "in kronecker activate amplitude check");
+      myModel.activateScale(true);
+      assert_almost_equal(myModel.getParameter(), {2, 1e-12, 1, 2, 2.5}, 0, 0, "in kronecker activate scale check");
       Description description = {"scale_0", "nuggetFactor", "amplitude_0", "amplitude_1", "R_1_0", "nu"};
       Bool checkDesc = myModel.getFullParameterDescription() == description;
       if (!checkDesc)

--- a/python/src/CovarianceModelImplementation_doc.i.in
+++ b/python/src/CovarianceModelImplementation_doc.i.in
@@ -550,6 +550,53 @@ OT_CovarianceModel_getActiveParameter_doc
 
 // ---------------------------------------------------------------------
 
+%define OT_CovarianceModel_activateScale_doc
+"Activate/deactivate the scale parameter(s).
+
+In the context of Kriging, defines whether scale parameters should be tuned.
+
+Parameters
+----------
+isScaleActive : bool
+    If True, the scale parameters are all tuned.
+    If False, none of them is tuned."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::activateScale
+OT_CovarianceModel_activateScale_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_activateNuggetFactor_doc
+"Activate/deactivate the nugget factor.
+
+In the context of Kriging, defines whether the nugget factor should be tuned.
+
+Parameters
+----------
+isNuggetFactorActive : bool
+    If True (resp. False), the nugget factor is (resp. is not) tuned."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::activateNuggetFactor
+OT_CovarianceModel_activateNuggetFactor_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_CovarianceModel_activateAmplitude_doc
+"Activate/deactivate the amplitude parameter(s).
+
+In the context of Kriging, defines whether amplitude parameters should be tuned.
+
+Parameters
+----------
+isAmplitudeActive : bool
+    If True, the amplitude parameters are all tuned.
+    If False, none of them is tuned."
+%enddef
+%feature("docstring") OT::CovarianceModelImplementation::activateAmplitude
+OT_CovarianceModel_activateAmplitude_doc
+
+// ---------------------------------------------------------------------
+
 %define OT_CovarianceModel_draw_doc
 "Draw a specific component of the covariance model with input dimension 1.
 

--- a/python/src/CovarianceModel_doc.i.in
+++ b/python/src/CovarianceModel_doc.i.in
@@ -60,6 +60,12 @@ OT_CovarianceModel_operator_doc
 OT_CovarianceModel_setActiveParameter_doc
 %feature("docstring") OT::CovarianceModel::getActiveParameter
 OT_CovarianceModel_getActiveParameter_doc
+%feature("docstring") OT::CovarianceModel::activateScale
+OT_CovarianceModel_activateScale_doc
+%feature("docstring") OT::CovarianceModel::activateNuggetFactor
+OT_CovarianceModel_activateNuggetFactor_doc
+%feature("docstring") OT::CovarianceModel::activateAmplitude
+OT_CovarianceModel_activateAmplitude_doc
 %feature("docstring") OT::CovarianceModel::setFullParameter
 OT_CovarianceModel_setFullParameter_doc
 %feature("docstring") OT::CovarianceModel::getFullParameter

--- a/python/src/StationaryFunctionalCovarianceModel_doc.i.in
+++ b/python/src/StationaryFunctionalCovarianceModel_doc.i.in
@@ -66,7 +66,7 @@ In the example below, we illustrate this by introducing a power parameter :math:
 The full list of parameters for this :class:`~openturns.CovarianceModel` contains the parameter :math:`n`:
 
 >>> covModel.getFullParameterDescription()
-[scale_0,amplitude_0,n]
+[scale_0,nuggetFactor,amplitude_0,n]
 
 However, only the scale and amplitude parameters are active by default:
 
@@ -78,9 +78,10 @@ Active parameters of a :class:`~openturns.CovarianceModel` are those that must b
 Let us make all parameters active, including :math:`n`.
 The :meth:`setActiveParameter` method takes a list of integers as input:
 each integer is understood as the index of a parameter in the list yielded by :meth:`getFullParameterDescription`.
-Here parameter #0 is `scale_0`, parameter #1 is `amplitude_0` and parameter #2 is :math:`n`.
+Here parameter #0 is `scale_0`, parameter #1 is `nuggetFactor`,
+parameter #2 is `amplitude_0` and parameter #3 is :math:`n`.
 
->>> covModel.setActiveParameter([0, 1, 2])
+>>> covModel.setActiveParameter([0, 2, 3])
 
 We can check that all parameters are now active:
 

--- a/python/test/t_CovarianceModel_std.py
+++ b/python/test/t_CovarianceModel_std.py
@@ -424,41 +424,42 @@ ott.assert_almost_equal(
     myModel.getInputDimension(), 3, 0, 0, "in kronecker dimension check"
 )
 ott.assert_almost_equal(myModel.getScale(), [1], 0, 0, "in kronecker scale check")
-# full param size = 5 (scale(1), amplitude(2), spatialCorrelation(1), Matern nu(1))
+# full param size = 6 (scale(1), nuggetFactor(1), amplitude(2), spatialCorrelation(1), Matern nu(1))
 ott.assert_almost_equal(
     myModel.getFullParameter(),
-    [1, 1, 2, 0.8, 1.5],
+    [1, 1e-12, 1, 2, 0.8, 1.5],
     0,
     0,
     "in kronecker full param check",
 )
 ott.assert_almost_equal(
-    myModel.getFullParameter().getSize(), 5, 0, 0, "in kronecker param size check"
+    myModel.getFullParameter().getSize(), 6, 0, 0, "in kronecker param size check"
 )
 ott.assert_almost_equal(
     myModel.getFullParameterDescription().getSize(),
-    5,
+    6,
     0,
     0,
     "in kronecker param description size check",
 )
 ott.assert_almost_equal(
-    myModel.getActiveParameter(), [0, 1, 2], "in kronecker active param check"
+    myModel.getActiveParameter(), [0, 2, 3], "in kronecker active param check"
 )
-myModel.setFullParameter([2, 1, 2, 0.5, 2.5])
+myModel.setFullParameter([2, 0.01, 1, 2, 0.5, 2.5])
 ott.assert_almost_equal(
-    myModel.getFullParameter(), [2, 1, 2, 0.5, 2.5], 0, 0, "in kronecker param check"
+    myModel.getFullParameter(), [2, 0.01, 1, 2, 0.5, 2.5], 0, 0, "in kronecker param check"
 )
-myModel.setActiveParameter([0, 1, 2, 4])
+myModel.setActiveParameter([0, 1, 2, 3, 5])
 ott.assert_almost_equal(
-    myModel.getActiveParameter(), [0, 1, 2, 4], "in kronecker active param check"
+    myModel.getActiveParameter(), [0, 1, 2, 3, 5], "in kronecker active param check"
 )
 # Now we should get all values except correlation
 ott.assert_almost_equal(
-    myModel.getParameter(), [2, 1, 2, 2.5], 0, 0, "in kronecker param check"
+    myModel.getParameter(), [2, 0.01, 1, 2, 2.5], 0, 0, "in kronecker param check"
 )
 assert myModel.getFullParameterDescription() == [
     "scale_0",
+    "nuggetFactor",
     "amplitude_0",
     "amplitude_1",
     "R_1_0",

--- a/python/test/t_CovarianceModel_std.py
+++ b/python/test/t_CovarianceModel_std.py
@@ -447,7 +447,11 @@ ott.assert_almost_equal(
 )
 myModel.setFullParameter([2, 0.01, 1, 2, 0.5, 2.5])
 ott.assert_almost_equal(
-    myModel.getFullParameter(), [2, 0.01, 1, 2, 0.5, 2.5], 0, 0, "in kronecker param check"
+    myModel.getFullParameter(),
+    [2, 0.01, 1, 2, 0.5, 2.5],
+    0,
+    0,
+    "in kronecker param check",
 )
 myModel.setActiveParameter([0, 1, 2, 3, 5])
 ott.assert_almost_equal(
@@ -456,6 +460,42 @@ ott.assert_almost_equal(
 # Now we should get all values except correlation
 ott.assert_almost_equal(
     myModel.getParameter(), [2, 0.01, 1, 2, 2.5], 0, 0, "in kronecker param check"
+)
+myModel.activateAmplitude(False)
+ott.assert_almost_equal(
+    myModel.getParameter(),
+    [2, 0.01, 2.5],
+    0,
+    0,
+    "in kronecker deactivate amplitude check",
+)
+myModel.activateScale(False)
+ott.assert_almost_equal(
+    myModel.getParameter(), [0.01, 2.5], 0, 0, "in kronecker deactivate scale check"
+)
+myModel.activateNuggetFactor(False)
+ott.assert_almost_equal(
+    myModel.getParameter(), [2.5], 0, 0, "in kronecker deactivate nuggetFactor check"
+)
+myModel.activateScale(True)
+ott.assert_almost_equal(
+    myModel.getParameter(), [2, 2.5], 0, 0, "in kronecker activate scale check"
+)
+myModel.activateNuggetFactor(True)
+ott.assert_almost_equal(
+    myModel.getParameter(),
+    [2, 0.01, 2.5],
+    0,
+    0,
+    "in kronecker activate nuggetFactor check",
+)
+myModel.activateAmplitude(True)
+ott.assert_almost_equal(
+    myModel.getParameter(),
+    [2, 0.01, 1, 2, 2.5],
+    0,
+    0,
+    "in kronecker activate amplitude check",
 )
 assert myModel.getFullParameterDescription() == [
     "scale_0",

--- a/python/test/t_ExponentialModel_std.expout
+++ b/python/test/t_ExponentialModel_std.expout
@@ -34,7 +34,7 @@ discretized covariance over the time grid= RegularGrid(start=0, step=0.333333, n
  [ 0.735759 1.47152  0.551819 1.02683  2.05367  0.770126 1.43306  2.86613  1.0748   2        4        1.5      ]
  [ 0        0.551819 3.31091  0        0.770126 4.62075  0        1.0748   6.44878  0        1.5      9        ]]
 parameters= [1,1,2,3] [scale_0,amplitude_0,amplitude_1,amplitude_2]
-marginal= ExponentialModel(scale=[1], amplitude=[1,3], no spatial correlation) marginal.parameter= [1,1,3] [scale_0,amplitude_0,amplitude_1]
-[1,1,1,2,2,0]
-[1,1,1,2,2,0.5]
+marginal= ExponentialModel(scale=[1], amplitude=[1,3], no spatial correlation) marginal.parameter= [1,1e-12,1] [scale_0,nuggetFactor,amplitude_0]
+[1,1,1,1e-12,2,2]
+[1,1,1,1e-12,2,0.5]
 ok

--- a/python/test/t_ProductCovarianceModel_std.expout
+++ b/python/test/t_ProductCovarianceModel_std.expout
@@ -1,22 +1,24 @@
-1D Full parameter :  [0.5,1,2.5]
+1D Full parameter :  [0.5,1e-12,1,2.5]
 1D active cov. param.:  ['scale_0', 'amplitude_0']
 Activate nu parameter
 active cov. param.:  ['scale_0', 'amplitude_0', 'nu']
 Matern d-dimensional covariance as product
-Full parameter :  [0.5,0.5,0.5,1,2.5,2.5,2.5]
+Full parameter :  [0.5,0.5,0.5,1e-12,1,2.5,2.5,2.5]
 active cov. param.:  ['scale_0', 'scale_1', 'scale_2', 'amplitude_0', 'nu_0', 'nu_1', 'nu_2']
-Disable nu for marginals 0 & 1 parameter :  [0.5,0.5,0.5,1,2.5,2.5,2.5]
+Disable nu for marginals 0 & 1 parameter :  [0.5,0.5,0.5,1e-12,1,2.5,2.5,2.5]
 active cov. param.:  ['scale_0', 'scale_1', 'scale_2', 'amplitude_0', 'nu_2']
 Check that active parameter is correctly propagated
 Model  0  : active cov. param.:  ['scale_0', 'amplitude_0']
 Model  1  : active cov. param.:  ['scale_0', 'amplitude_0']
 Model  2  : active cov. param.:  ['scale_0', 'amplitude_0', 'nu']
-Model 1 :  [scale_0,amplitude_0,nu]
+Model 1 :  [scale_0,nuggetFactor,amplitude_0,nu]
 Activate nu parameter and disable sigma2
-model1 active parameter:  ['scale_0', 'nu']
-Model 2 :  [scale_0,amplitude_0,frequency]
+model1 active parameter:  ['scale_0', 'nuggetFactor', 'nu']
+Model 2 :  [scale_0,nuggetFactor,amplitude_0,frequency]
 Activate freq parameter
 model2 active parameter:  ['scale_0', 'amplitude_0', 'frequency']
+Activate nuggetFactor parameter
+model2 active parameter:  ['scale_0', 'nuggetFactor', 'amplitude_0', 'frequency']
 Product covariance model
-Full parameter :  [1,1,1,2.5,1]
-active cov. param.:  ['scale_0', 'scale_1', 'amplitude_0', 'nu_0', 'frequency_1']
+Full parameter :  [1,1,1e-12,1,2.5,1]
+active cov. param.:  ['scale_0', 'scale_1', 'nuggetFactor', 'amplitude_0', 'nu_0', 'frequency_1']

--- a/python/test/t_ProductCovarianceModel_std.py
+++ b/python/test/t_ProductCovarianceModel_std.py
@@ -18,7 +18,7 @@ def test_active_parameter():
         ],
     )
     print("Activate nu parameter")
-    cov_model_1d.setActiveParameter([0, 1, 2])
+    cov_model_1d.setActiveParameter([0, 2, 3])
     print(
         "active cov. param.: ",
         [
@@ -42,7 +42,7 @@ def test_active_parameter():
         ],
     )
     print("Disable nu for marginals 0 & 1 parameter : ", cov_model.getFullParameter())
-    cov_model.setActiveParameter([0, 1, 2, 3, 6])
+    cov_model.setActiveParameter([0, 1, 2, 4, 7])
     print(
         "active cov. param.: ",
         [
@@ -69,7 +69,7 @@ def test_active_amplitude_parameter():
     model1 = ot.MaternModel([1.0], 2.5)
     print("Model 1 : ", model1.getFullParameterDescription())
     print("Activate nu parameter and disable sigma2")
-    model1.setActiveParameter([0, 2])
+    model1.setActiveParameter([0, 1, 3])
     print(
         "model1 active parameter: ",
         [model1.getFullParameterDescription()[i] for i in model1.getActiveParameter()],
@@ -78,7 +78,13 @@ def test_active_amplitude_parameter():
     model2 = ot.ExponentiallyDampedCosineModel()
     print("Model 2 : ", model2.getFullParameterDescription())
     print("Activate freq parameter")
-    model2.setActiveParameter([0, 1, 2])
+    model2.setActiveParameter([0, 2, 3])
+    print(
+        "model2 active parameter: ",
+        [model2.getFullParameterDescription()[i] for i in model2.getActiveParameter()],
+    )
+    print("Activate nuggetFactor parameter")
+    model2.setActiveParameter([0, 1, 2, 3])
     print(
         "model2 active parameter: ",
         [model2.getFullParameterDescription()[i] for i in model2.getActiveParameter()],
@@ -98,6 +104,7 @@ def test_active_amplitude_parameter():
 
 def test_parameters_iso():
     scale = []
+    nuggetFactor = 1e-12
     amplitude = 1.0
     extraParameter = []
 
@@ -130,19 +137,23 @@ def test_parameters_iso():
     ott.assert_almost_equal(model.getScale(), scale, 1e-16, 1e-16)
     ott.assert_almost_equal(model.getAmplitude(), [amplitude], 1e-16, 1e-16)
     ott.assert_almost_equal(
-        model.getFullParameter(), scale + [amplitude] + extraParameter, 1e-16, 1e-16
+        model.getFullParameter(),
+        scale + [nuggetFactor, amplitude] + extraParameter,
+        1e-16,
+        1e-16,
     )
 
     # active parameter should be scale + amplitude
-    ott.assert_almost_equal(model.getActiveParameter(), [0, 1, 2, 3], 1e-16, 1e-16)
+    ott.assert_almost_equal(model.getActiveParameter(), [0, 1, 2, 4], 1e-16, 1e-16)
 
     # setting new parameters
     extraParameter = [2.5, 0.5]
-    model.setFullParameter([6, 7, 8, 2] + extraParameter)
+    model.setFullParameter([6, 7, 8, 0.01, 2] + extraParameter)
 
     ott.assert_almost_equal(model.getCollection()[0].getScale()[0], 6, 1e-16, 1e-16)
     ott.assert_almost_equal(model.getCollection()[1].getScale()[0], 7, 1e-16, 1e-16)
     ott.assert_almost_equal(model.getCollection()[2].getScale()[0], 8, 1e-16, 1e-16)
+    ott.assert_almost_equal(model.getNuggetFactor(), 0.01, 0.0, 0.0)
     ott.assert_almost_equal(model.getAmplitude()[0], 2, 1e-16, 1e-16)
     ott.assert_almost_equal(
         model.getCollection()[0].getFullParameter()[-1], extraParameter[0], 1e-16, 1e-16
@@ -152,7 +163,7 @@ def test_parameters_iso():
     )
 
     # checking active par setting
-    model.setActiveParameter([0, 1, 2, 3, 5])
+    model.setActiveParameter([0, 1, 2, 4, 6])
     ott.assert_almost_equal(
         model.getParameter(), [6, 7, 8, 2, extraParameter[-1]], 1e-16, 1e-16
     )

--- a/python/test/t_StationaryFunctionalCovarianceModel_std.py
+++ b/python/test/t_StationaryFunctionalCovarianceModel_std.py
@@ -21,16 +21,16 @@ print("c=", c)
 c_ref = m.cos(4 * tau) * m.cosh((tau - m.pi) / alpha) / m.cosh(m.pi / alpha)
 ott.assert_almost_equal(c, c_ref)
 
-assert len(cov.getFullParameter()) == 3, "wrong full parameter"
-assert len(cov.getFullParameterDescription()) == 3, "wrong full parameter description"
+assert len(cov.getFullParameter()) == 4, "wrong full parameter"
+assert len(cov.getFullParameterDescription()) == 4, "wrong full parameter description"
 
 print(cov.getFullParameter())
 print(cov.getFullParameterDescription())
 
 assert len(cov.getActiveParameter()) == 2, "wrong active parameter"
-cov.setActiveParameter(range(3))
-cov.setParameter([1.0, 1.0, 0.5])
-assert len(cov.getParameter()) == 3, "wrong parameter"
+cov.setActiveParameter(range(4))
+cov.setParameter([1.0, 0.01, 1.0, 0.5])
+assert len(cov.getParameter()) == 4, "wrong parameter"
 c = cov([tau])[0, 0]
 print("c=", c)
 assert c != c_ref, "inactive parameter"


### PR DESCRIPTION
# Description

This PR adds the `nuggetFactor` to the list of parameters of a `CovarianceModel` so it can be optimized by `GeneralLinearModelAlgorithm`.

It changes the parameter order (size in parentheses) from:

1. scale (inputDimension usually)
2. amplitude (outputDimension)
3. output correlation (outputDimension * (outputDimension-1) / 2)
4. extra parameters (?)

to:
1. scale (inputDimension usually)
2. **nuggetFactor** (1)
3. amplitude (outputDimension)
4. output correlation (outputDimension * (outputDimension-1) / 2)
5. extra parameters (?)

Furthermore, in `GeneralLinearModelAlgorithm`, the default optimization lower bound for the `nuggetFactor` is set to `0.0`. It has the same upper bound as the other parameters (`1e2`).

EDIT: in addition, this PR implements new methods to make activation and deactivation of standard parameters easier: `activateScale`, `activateNuggetFactor` and `activateAmplitude`. Tests and an example are provided.

# Motivation

Although the creation of an algebra of covariance models is planned, which would be a smarter way to handle the nuggetFactor (which could be viewed as the addition of a `DiracCovarianceModel`), @vchabri has an EDF usecase which requires OpenTURNS to estimate nugget factors.

Closes #1330