### PR TITLE
Various improvements

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -412,6 +412,7 @@
   <BoundingVolumeHierarchy-BinNumber value_int="50" />
 
   <!-- OT::EnclosingSimplexAlgorithm parameters -->
+  <EnclosingSimplexAlgorithm-BarycentricCoordinatesEpsilon value_float="1.0e-12" />
   <EnclosingSimplexAlgorithm-LargeDimension value_int="5" />
 
   <!-- OT::Matrix parameters -->

--- a/lib/src/Base/Algo/EnclosingSimplexAlgorithm.cxx
+++ b/lib/src/Base/Algo/EnclosingSimplexAlgorithm.cxx
@@ -135,6 +135,18 @@ Indices EnclosingSimplexAlgorithm::query(const Sample & sample) const
   return getImplementation()->query(sample);
 }
 
+/* Accessor to the barycentric coordinates tolerance */
+void EnclosingSimplexAlgorithm::setBarycentricCoordinatesEpsilon(const Scalar epsilon)
+{
+  copyOnWrite();
+  getImplementation()->setBarycentricCoordinatesEpsilon(epsilon);
+}
+
+Scalar EnclosingSimplexAlgorithm::getBarycentricCoordinatesEpsilon() const
+{
+  return getImplementation()->getBarycentricCoordinatesEpsilon();
+}
+
 /* String converter */
 String EnclosingSimplexAlgorithm::__repr__() const
 {

--- a/lib/src/Base/Algo/openturns/EnclosingSimplexAlgorithm.hxx
+++ b/lib/src/Base/Algo/openturns/EnclosingSimplexAlgorithm.hxx
@@ -74,6 +74,10 @@ public:
   /** Get the indices of the enclosing simplex of the given points */
   virtual Indices query(const Sample & sample) const;
 
+  /** Accessor to the barycentric coordinates tolerance */
+  void setBarycentricCoordinatesEpsilon(const Scalar epsilon);
+  Scalar getBarycentricCoordinatesEpsilon() const;
+
   /** String converter */
   String __repr__() const override;
 

--- a/lib/src/Base/Algo/openturns/EnclosingSimplexAlgorithmImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/EnclosingSimplexAlgorithmImplementation.hxx
@@ -46,7 +46,8 @@ public:
   EnclosingSimplexAlgorithmImplementation();
 
   /** Parameter constructor */
-  EnclosingSimplexAlgorithmImplementation(const Sample & vertices, const IndicesCollection & simplices);
+  EnclosingSimplexAlgorithmImplementation(const Sample & vertices,
+                                          const IndicesCollection & simplices);
 
   /** Virtual copy constructor */
   EnclosingSimplexAlgorithmImplementation * clone() const override;
@@ -69,6 +70,10 @@ public:
 
   /** Get the indices of the enclosing simplex of the given points */
   virtual Indices query(const Sample & sample) const;
+
+  /** Accessor to the barycentric coordinates tolerance */
+  void setBarycentricCoordinatesEpsilon(const Scalar epsilon);
+  Scalar getBarycentricCoordinatesEpsilon() const;
 
   /** String converter */
   String __repr__() const override;
@@ -100,6 +105,9 @@ protected:
   // The bounding boxes of simplices
   Sample lowerBoundingBoxSimplices_;
   Sample upperBoundingBoxSimplices_;
+
+  // The tolerance for the membreship test
+  Scalar barycentricCoordinatesEpsilon_;
 
 } ; /* class EnclosingSimplexAlgorithmImplementation */
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -1037,6 +1037,7 @@ void ResourceMap::loadDefaultConfiguration()
   addAsUnsignedInteger("BoundingVolumeHierarchy-BinNumber", 50);
 
   // EnclosingSimplexAlgorithm parameters
+  addAsScalar("EnclosingSimplexAlgorithm-BarycentricCoordinatesEpsilon", 1.0e-12);
   addAsUnsignedInteger("EnclosingSimplexAlgorithm-LargeDimension", 5);
 
   // Matrix parameters

--- a/lib/src/Base/Geom/LevelSetMesher.cxx
+++ b/lib/src/Base/Geom/LevelSetMesher.cxx
@@ -242,47 +242,30 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
                 OptimizationAlgorithm solver(solver_);
                 solver.setStartingPoint(delta);
                 solver.setProblem(problem);
-                OptimizationResult result;
-                // Here we have to catch exceptions raised by the gradient
+                // Here we have to catch exceptions raised by the algorithm (may be due to e.g the gradient)
                 try
                 {
                   solver.run();
-                  result = solver.getResult();
+                  movedVertices.add(currentVertex + solver.getResult().getOptimalPoint());
                 }
                 catch(...)
                 {
-                  LOGDEBUG(OSS() << "Problem to project point=" << currentVertex << " with solver=" << solver_ << ", using finite differences for gradient");
-                  // Here we may have to fix the gradient eg in the case of analytical functions, when Ev3 does not handle the expression.
-                  const Scalar epsilon = ResourceMap::GetAsScalar("CenteredFiniteDifferenceGradient-DefaultEpsilon");
-                  levelFunction.setGradient(CenteredFiniteDifferenceGradient((localVertices.getMin() - localVertices.getMax()) * epsilon + Point(dimension, epsilon), levelFunction.getEvaluation()).clone());
-                  problem.setLevelFunction(levelFunction);
-                  solver.setProblem(problem);
-                  // Try with the new gradients
+                  // There is a problem with this vertex. Try a gradient-free solver
+                  Cobyla cobyla(solver.getProblem());
+                  cobyla.setStartingPoint(delta);
+                  LOGDEBUG(OSS() << "Problem to project point=" << currentVertex << " with solver=" << solver << " and finite differences for gradient, switching to solver=" << cobyla);
                   try
-                  {
-                    solver.run();
-                    result = solver.getResult();
-                    movedVertices.add(currentVertex + result.getOptimalPoint());
-                  }
-                  catch(...)
-                  {
-                    // There is definitely a problem with this vertex. Try a gradient-free solver
-                    Cobyla cobyla(solver.getProblem());
-                    cobyla.setStartingPoint(solver.getStartingPoint());
-                    LOGDEBUG(OSS() << "Problem to project point=" << currentVertex << " with solver=" << solver << " and finite differences for gradient, switching to solver=" << cobyla);
-                    try
                     {
                       cobyla.run();
-                      result = cobyla.getResult();
-                      movedVertices.add(currentVertex + result.getOptimalPoint());
+                      movedVertices.add(currentVertex + cobyla.getResult().getOptimalPoint());
                     }
-                    catch(...)
+                  catch(...)
                     {
                       LOGDEBUG(OSS() << "Problem to project point=" << currentVertex << " with solver=" << cobyla << ", use basic linear interpolation");
                       movedVertices.add(currentVertex + delta);
                     }
-                  } // Even finite differences gradient failed?
-                } // Gradient failed ?
+                } // User-defined solver failed ?
+                // Restore the use of solve-the-equation if we used minimization due to a difficult vertex
                 minimizeDistance = !solveEquation;
               } // minimizeDistance
             } // project

--- a/lib/src/Uncertainty/Distribution/UniformOverMesh.cxx
+++ b/lib/src/Uncertainty/Distribution/UniformOverMesh.cxx
@@ -178,6 +178,7 @@ Sample UniformOverMesh::getSample(const UnsignedInteger size) const
     } // i
     DistFunc::rUniformSimplex(&vertices(0, 0), dimension, dimension + 1, &result(n, 0));
   } // n
+  result.setDescription(getDescription());
   return result;
 }
 

--- a/lib/src/Uncertainty/Process/openturns/SpectralGaussianProcess.hxx
+++ b/lib/src/Uncertainty/Process/openturns/SpectralGaussianProcess.hxx
@@ -70,7 +70,9 @@ public:
 
   /** Realization accessor */
   Field getRealization() const override;
-
+ private:
+  Field getRealization1D() const;
+ public:
   /** Frequency grid accessor, covering both the negative and the positive axes */
   RegularGrid getFrequencyGrid() const;
 
@@ -141,7 +143,8 @@ private:
 
   /** Cholesky factor  */
   mutable TriangularComplexMatrixPersistentCollection choleskyFactorsCache_;
-
+  Point choleskyFactorsCache1D_;
+  
   /** Cache size */
   mutable UnsignedInteger cacheSize_;
 

--- a/python/src/EnclosingSimplexAlgorithmImplementation_doc.i.in
+++ b/python/src/EnclosingSimplexAlgorithmImplementation_doc.i.in
@@ -142,3 +142,32 @@ simplices : :class:`~openturns.IndicesCollection`
 %feature("docstring") OT::EnclosingSimplexAlgorithmImplementation::getSimplices
 OT_EnclosingSimplexAlgorithm_getSimplices_doc
 
+// ---------------------------------------------------------------------
+
+%define OT_EnclosingSimplexAlgorithm_setBarycentricCoordinatesEpsilon_doc
+"Accessor to the tolerance for membership test.
+
+Parameters
+----------
+epsilon : float
+    Tolerance for the membership. A point is in a simplex if its barycentric coordinates :math:`\xi_i` are
+    all in :math:`[-\varepsilon,1+\varepsilon]` and :math:`\sum_{i=1}^d\xi_i\in[-\varepsilon,1+\varepsilon]`."
+%enddef
+
+%feature("docstring") OT::EnclosingSimplexAlgorithmImplementation::setBarycentricCoordinatesEpsilon
+OT_EnclosingSimplexAlgorithm_setBarycentricCoordinatesEpsilon_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_EnclosingSimplexAlgorithm_getBarycentricCoordinatesEpsilon_doc
+"Accessor to the tolerance for membership test.
+
+Returns
+-------
+epsilon : float
+    Tolerance for the membership. A point is in a simplex if its barycentric coordinates :math:`\xi_i` are
+    all in :math:`[-\varepsilon,1+\varepsilon]` and :math:`\sum_{i=1}^d\xi_i\in[-\varepsilon,1+\varepsilon]`."
+%enddef
+
+%feature("docstring") OT::EnclosingSimplexAlgorithmImplementation::getBarycentricCoordinatesEpsilon
+OT_EnclosingSimplexAlgorithm_getBarycentricCoordinatesEpsilon_doc

--- a/python/src/EnclosingSimplexAlgorithm_doc.i.in
+++ b/python/src/EnclosingSimplexAlgorithm_doc.i.in
@@ -4,5 +4,13 @@
 OT_EnclosingSimplexAlgorithm_doc
 %feature("docstring") OT::EnclosingSimplexAlgorithm::setVerticesAndSimplices
 OT_EnclosingSimplexAlgorithm_setVerticesAndSimplices_doc
+%feature("docstring") OT::EnclosingSimplexAlgorithm::getVertices
+OT_EnclosingSimplexAlgorithm_getVertices_doc
+%feature("docstring") OT::EnclosingSimplexAlgorithm::getSimplices
+OT_EnclosingSimplexAlgorithm_getSimplices_doc
 %feature("docstring") OT::EnclosingSimplexAlgorithm::query
 OT_EnclosingSimplexAlgorithm_query_doc
+%feature("docstring") OT::EnclosingSimplexAlgorithm::setBarycentricCoordinatesEpsilon
+OT_EnclosingSimplexAlgorithm_setBarycentricCoordinatesEpsilon_doc
+%feature("docstring") OT::EnclosingSimplexAlgorithm::getBarycentricCoordinatesEpsilon
+OT_EnclosingSimplexAlgorithm_getBarycentricCoordinatesEpsilon_doc


### PR DESCRIPTION
This PR proposes the following fixes/improvements:
  * SpectralNormalProcess sampling is now almost twice faster
  * ~~XMLH5StorageManager can now deal with very large datasets~~
  * MeshDomain and EnclosingSimplexAlgorithm now have a user-tunable tolerance for the inclusion test.
  * UniformOverMesh was generating samples without description, fixed now.
  * ~~VisualTest::DrawParallelCoordinates was using ranks instead of the actual values to select highlighted paths, leading to spurious selection due to roundoff~~

The third point is of uttermost importance, as the sampling of the boundary of a given mesh produces points which are mostly rejected when tested against the interior of the mesh.