### PR TITLE
Distribution: computeProbability shortcut

### DIFF
--- a/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/BayesDistribution.cxx
@@ -429,6 +429,11 @@ void BayesDistribution::computeCovariance() const
   isAlreadyComputedCovariance_ = true;
 }
 
+Bool BayesDistribution::isAnalyticalCDF() const
+{
+  return false;
+}
+
 /* Method save() stores the object through the StorageManager */
 void BayesDistribution::save(Advocate & adv) const
 {

--- a/lib/src/Uncertainty/Distribution/InverseWishart.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseWishart.cxx
@@ -209,11 +209,9 @@ Scalar InverseWishart::computeLogPDF(const CovarianceMatrix & m) const
   }
 }
 
-/* Get the CDF of the distribution */
-Scalar InverseWishart::computeCDF(const Point & point) const
+Bool InverseWishart::isAnalyticalCDF() const
 {
-  if (point.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=" << getDimension() << ", here dimension=" << point.getDimension();
-  return ContinuousDistribution::computeCDF(point);
+  return false;
 }
 
 /* Compute the mean of the distribution */

--- a/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MarginalDistribution.cxx
@@ -198,6 +198,11 @@ Scalar MarginalDistribution::computeCDF(const Point & point) const
   return distribution_.computeCDF(expandPoint(point));
 }
 
+Bool MarginalDistribution::isAnalyticalCDF() const
+{
+  return distribution_.getImplementation()->isAnalyticalCDF();
+}
+
 Scalar MarginalDistribution::computeSurvivalFunction(const Point & point) const
 {
   return distribution_.computeSurvivalFunction(expandPoint(point, false));

--- a/lib/src/Uncertainty/Distribution/RandomMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/RandomMixture.cxx
@@ -2220,6 +2220,12 @@ void RandomMixture::addPDFOn3DGrid(const Indices & pointNumber, const Point & h,
   }
 }
 
+Bool RandomMixture::isAnalyticalCDF() const
+{
+  // implemented by integration of the PDF through computeProbability
+  return false;
+}
+
 /* Get the CDF of the RandomMixture */
 Scalar RandomMixture::computeCDF(const Point & point) const
 {

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -206,6 +206,11 @@ Sample Student::getSample(const UnsignedInteger size) const
   return result;
 }
 
+// depends on the dimension
+Bool Student::isAnalyticalCDF() const
+{
+  return false;
+}
 
 /* Get the CDF of the distribution */
 Scalar Student::computeCDF(const Point & point) const

--- a/lib/src/Uncertainty/Distribution/VonMises.cxx
+++ b/lib/src/Uncertainty/Distribution/VonMises.cxx
@@ -262,6 +262,11 @@ Bool VonMises::isElliptical() const
   return mu_ == 0.0;
 }
 
+Bool VonMises::isAnalyticalCDF() const
+{
+  return false;
+}
+
 /* Method load() reloads the object from the StorageManager */
 void VonMises::load(Advocate & adv)
 {

--- a/lib/src/Uncertainty/Distribution/Wishart.cxx
+++ b/lib/src/Uncertainty/Distribution/Wishart.cxx
@@ -206,11 +206,9 @@ Scalar Wishart::computeLogPDF(const CovarianceMatrix & m) const
   }
 }
 
-/* Get the CDF of the distribution */
-Scalar Wishart::computeCDF(const Point & point) const
+Bool Wishart::isAnalyticalCDF() const
 {
-  if (point.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=" << getDimension() << ", here dimension=" << point.getDimension();
-  return ContinuousDistribution::computeCDF(point);
+  return false;
 }
 
 /* Compute the mean of the distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/BayesDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/BayesDistribution.hxx
@@ -76,6 +76,9 @@ public:
   using ContinuousDistribution::computePDF;
   Scalar computePDF(const Point & point) const override;
 
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
+
   /* Interface specific to BayesDistribution */
 
   /** Conditioned distribution accessor */

--- a/lib/src/Uncertainty/Distribution/openturns/InverseWishart.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/InverseWishart.hxx
@@ -76,9 +76,8 @@ public:
   Scalar computeLogPDF(const Point & point) const override;
   Scalar computeLogPDF(const CovarianceMatrix & m) const;
 
-  /** Get the CDF of the distribution */
-  using ContinuousDistribution::computeCDF;
-  Scalar computeCDF(const Point & point) const override;
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
 
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;

--- a/lib/src/Uncertainty/Distribution/openturns/MarginalDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MarginalDistribution.hxx
@@ -82,6 +82,9 @@ public:
   Point getRealization() const override;
   Sample getSample(const UnsignedInteger size) const override;
 
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
+
   /** Get the CDF of the MarginalDistribution */
   using DistributionImplementation::computeCDF;
   Scalar computeCDF(const Point & point) const override;
@@ -150,6 +153,7 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+protected:
 
 private:
   /** Compute the mean of the distribution */

--- a/lib/src/Uncertainty/Distribution/openturns/RandomMixture.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/RandomMixture.hxx
@@ -130,6 +130,9 @@ public:
   using DistributionImplementation::computePDF;
   Scalar computePDF(const Point & point) const override;
 
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
+
 #ifndef SWIG
   /** Compute the PDF over a regular grid */
   Sample computePDF(const Scalar xMin,

--- a/lib/src/Uncertainty/Distribution/openturns/Student.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Student.hxx
@@ -80,6 +80,9 @@ public:
   Point getRealization() const override;
   Sample getSample(const UnsignedInteger size) const override;
 
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
+
   /** Get the CDF of the distribution */
   using EllipticalDistribution::computeCDF;
   Scalar computeCDF(const Point & point) const override;

--- a/lib/src/Uncertainty/Distribution/openturns/VonMises.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/VonMises.hxx
@@ -74,6 +74,9 @@ public:
   using ContinuousDistribution::computeLogPDF;
   Scalar computeLogPDF(const Point & point) const override;
 
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Wishart.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Wishart.hxx
@@ -76,9 +76,8 @@ public:
   Scalar computeLogPDF(const Point & point) const override;
   Scalar computeLogPDF(const CovarianceMatrix & m) const;
 
-  /** Get the CDF of the distribution */
-  using ContinuousDistribution::computeCDF;
-  Scalar computeCDF(const Point & point) const override;
+  /** Flag to tell if the distribution implements the CDF analytically */
+  Bool isAnalyticalCDF() const override;
 
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
@@ -99,7 +98,6 @@ public:
   Description getParameterDescription() const override;
 
   /* Interface specific to Wishart */
-
 
   /** V accessor */
   void setV(const CovarianceMatrix & v);

--- a/lib/src/Uncertainty/Model/ContinuousDistribution.cxx
+++ b/lib/src/Uncertainty/Model/ContinuousDistribution.cxx
@@ -68,6 +68,8 @@ Scalar ContinuousDistribution::computePDF(const Point & ) const
 /* Get the CDF of the distribution */
 Scalar ContinuousDistribution::computeCDF(const Point & point) const
 {
+  if (point.getDimension() != getDimension())
+    throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=" << getDimension() << ", here dimension=" << point.getDimension();
   const Interval interval(getRange().getLowerBound(), point);
   LOGINFO(OSS() << "In ContinuousDistribution::computeCDF, using computeProbabilityContinuous(), interval=" << interval.__str__());
   return computeProbabilityContinuous(interval);

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -1136,6 +1136,9 @@ Scalar DistributionImplementation::computeProbabilityContinuous1D(const Scalar a
 /* Generic implementation for discrete distributions */
 Scalar DistributionImplementation::computeProbabilityDiscrete(const Interval & interval) const
 {
+  if (isAnalyticalCDF() && (getDimension() == 1))
+    return computeCDF(interval.getUpperBound()) - computeCDF(interval.getLowerBound()) + computePDF(interval.getLowerBound());
+
   const Sample support(getSupport(interval));
   Scalar value = 0.0;
   for (UnsignedInteger i = 0; i < support.getSize(); ++i) value += computePDF(support[i]);

--- a/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
+++ b/lib/src/Uncertainty/Model/openturns/DistributionImplementation.hxx
@@ -209,6 +209,10 @@ public:
                                const Indices & pointNumber,
                                Sample & gridOut) const;
 
+  /** Flag to tell if the distribution implements the CDF analytically (true in most cases)
+   * or if it is be computed by numerical integration in some generic implementation */
+  virtual Bool isAnalyticalCDF() const;
+
   /** Get the CDF of the distribution */
   virtual Scalar computeCDF(const Scalar scalar) const;
   virtual Scalar computeComplementaryCDF(const Scalar scalar) const;

--- a/python/src/DistributionImplementation.i
+++ b/python/src/DistributionImplementation.i
@@ -35,6 +35,7 @@
 %ignore OT::DistributionImplementation::computeProbabilityContinuous;
 %ignore OT::DistributionImplementation::computeProbabilityContinuous1D;
 %ignore OT::DistributionImplementation::computeProbabilityDiscrete;
+%ignore OT::DistributionImplementation::isAnalyticalCDF;
 
 
 %include openturns/DistributionImplementation.hxx

--- a/python/src/PythonDistribution.cxx
+++ b/python/src/PythonDistribution.cxx
@@ -760,6 +760,25 @@ Bool PythonDistribution::hasIndependentCopula() const
 }
 
 
+Bool PythonDistribution::isAnalyticalCDF() const
+{
+  if (PyObject_HasAttrString(pyObj_, const_cast<char *>("isAnalyticalCDF") ) )
+  {
+    ScopedPyObjectPointer callResult(PyObject_CallMethod ( pyObj_,
+                                     const_cast<char *>( "isAnalyticalCDF" ),
+                                     const_cast<char *>( "()" ) ));
+    if (callResult.isNull())
+    {
+      handleException();
+    }
+    Bool result = convert< _PyBool_, Bool >(callResult.get());
+    return result;
+  }
+  else
+    return false;
+}
+
+
 /* Get the distribution of the marginal distribution corresponding to indices dimensions */
 Distribution PythonDistribution::getMarginal(const Indices & indices) const
 {

--- a/python/src/openturns/PythonDistribution.hxx
+++ b/python/src/openturns/PythonDistribution.hxx
@@ -80,6 +80,9 @@ public:
   Scalar computePDF(const Point & point) const override;
   Scalar computeLogPDF(const Point & point) const override;
 
+  /** Flag to tell if the distribution implements the CDF */
+  Bool isAnalyticalCDF() const override;
+
   /** Get the CDF of the distribution */
   Scalar computeCDF(const Point & point) const override;
 
@@ -168,7 +171,6 @@ public:
   Sample getSupport(const Interval & interval) const override;
 
 protected:
-
 
 private:
 

--- a/python/test/t_Burr_std.py
+++ b/python/test/t_Burr_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -151,3 +152,9 @@ print("covariance=", repr(covariance))
 parameters = distribution.getParametersCollection()
 print("parameters=", repr(parameters))
 print("Standard representative=", distribution.getStandardRepresentative())
+
+# computeProba test with bound far away
+dist1 = ot.Burr(4.14855, 0.0661853)
+ub = dist1.getRange().getUpperBound()[0]
+probability = dist1.computeProbability(ot.Interval(0.0, ub))
+ott.assert_almost_equal(probability, 1.0)


### PR DESCRIPTION
Another idea to enhance 1-d computeProbability on large range (#2492) with heavy tail as its difficult to split the interval for piecewise GaussKronrod integration 
We add a flag to Distribution that states if the CDF is analytical, then computeProbability can use CDF(b)-CDF(a)
instead of GK (we suppose that there are no singularites either)
By default it returns true because most distributions CDF are analytical.
Note that some distributions still implement computeCDF, but end up calling generic integration services anyway so it must be overloaded to return false there too, and also for composite distributions.

Also this should improve speed and may help for #1242: default computeRange could throw when the CDF is implemented by integration

Closes #2492

/cc @regislebrun