### PR TITLE
Distribution: Efficient computeProbability

### DIFF
--- a/lib/src/Uncertainty/Distribution/Arcsine.cxx
+++ b/lib/src/Uncertainty/Distribution/Arcsine.cxx
@@ -217,6 +217,13 @@ Scalar Arcsine::computeScalarQuantile(const Scalar prob,
   return quantile;
 }
 
+Scalar Arcsine::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the roughness, i.e. the L2-norm of the PDF */
 Scalar Arcsine::getRoughness() const
 {

--- a/lib/src/Uncertainty/Distribution/Beta.cxx
+++ b/lib/src/Uncertainty/Distribution/Beta.cxx
@@ -240,6 +240,13 @@ Scalar Beta::computeScalarQuantile(const Scalar prob,
   return a_ + (b_ - a_) * DistFunc::qBeta(alpha_, beta_, prob, tail);
 }
 
+Scalar Beta::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
 Complex Beta::computeCharacteristicFunction(const Scalar x) const
 {

--- a/lib/src/Uncertainty/Distribution/Burr.cxx
+++ b/lib/src/Uncertainty/Distribution/Burr.cxx
@@ -191,6 +191,13 @@ Scalar Burr::computeScalarQuantile(const Scalar prob,
   return std::exp(std::log(expm1(-log1p(-prob) / k_)) / c_);
 }
 
+Scalar Burr::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Burr::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Chi.cxx
+++ b/lib/src/Uncertainty/Distribution/Chi.cxx
@@ -236,6 +236,12 @@ Scalar Chi::computeScalarQuantile(const Scalar prob,
   return M_SQRT2 * std::sqrt(DistFunc::qGamma(0.5 * nu_, prob, tail));
 }
 
+Scalar Chi::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
 
 /* Compute the entropy of the distribution */
 Scalar Chi::computeEntropy() const

--- a/lib/src/Uncertainty/Distribution/ChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/ChiSquare.cxx
@@ -235,6 +235,13 @@ Scalar ChiSquare::computeScalarQuantile(const Scalar prob,
   return 2.0 * DistFunc::qGamma(0.5 * nu_, prob, tail);
 }
 
+Scalar ChiSquare::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void ChiSquare::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Epanechnikov.cxx
+++ b/lib/src/Uncertainty/Distribution/Epanechnikov.cxx
@@ -154,6 +154,13 @@ Scalar Epanechnikov::computeScalarQuantile(const Scalar prob,
   return 2.0 * std::cos(0.3333333333333333333333333 * std::acos(1.0 - 2.0 * prob) - 2.094395102393195492308429);
 }
 
+Scalar Epanechnikov::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar Epanechnikov::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/Exponential.cxx
+++ b/lib/src/Uncertainty/Distribution/Exponential.cxx
@@ -225,6 +225,13 @@ Scalar Exponential::computeScalarQuantile(const Scalar prob,
   return gamma_ - log1p(-prob) / lambda_;
 }
 
+Scalar Exponential::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Exponential::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
+++ b/lib/src/Uncertainty/Distribution/FisherSnedecor.cxx
@@ -187,6 +187,13 @@ Scalar FisherSnedecor::computeScalarQuantile(const Scalar prob,
   return d2_ * q / (d1_ * (1.0 - q));
 }
 
+Scalar FisherSnedecor::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void FisherSnedecor::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Frechet.cxx
+++ b/lib/src/Uncertainty/Distribution/Frechet.cxx
@@ -105,6 +105,13 @@ Scalar Frechet::computeScalarQuantile(const Scalar prob,
   return gamma_ + beta_ * std::pow(-std::log(tail ? 1.0 - prob : prob), -1.0 / alpha_);
 }
 
+Scalar Frechet::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get one realization of the distribution */
 Point Frechet::getRealization() const
 {

--- a/lib/src/Uncertainty/Distribution/Gamma.cxx
+++ b/lib/src/Uncertainty/Distribution/Gamma.cxx
@@ -335,6 +335,13 @@ Scalar Gamma::computeScalarQuantile(const Scalar prob,
   return gamma_ + DistFunc::qGamma(k_, prob, tail) / lambda_;
 }
 
+Scalar Gamma::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Gamma::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
+++ b/lib/src/Uncertainty/Distribution/GeneralizedPareto.cxx
@@ -298,6 +298,13 @@ Scalar GeneralizedPareto::computeScalarQuantile(const Scalar prob,
   else return u_ + sigma_ * expm1(-xi_ * logProb) / xi_;
 }
 
+Scalar GeneralizedPareto::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void GeneralizedPareto::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Geometric.cxx
+++ b/lib/src/Uncertainty/Distribution/Geometric.cxx
@@ -190,7 +190,7 @@ Sample Geometric::getSupport(const Interval & interval) const
 {
   if (interval.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given interval has a dimension that does not match the distribution dimension.";
   const UnsignedInteger kMin = static_cast< UnsignedInteger > (std::max(ceil(interval.getLowerBound()[0]), 0.0));
-  const UnsignedInteger kMax = static_cast< UnsignedInteger > (floor(interval.getUpperBound()[0]));
+  const UnsignedInteger kMax = static_cast< UnsignedInteger > (std::min(getRange().getUpperBound()[0], floor(interval.getUpperBound()[0])));
   Sample result(0, 1);
   for (UnsignedInteger k = kMin; k <= kMax; ++k)
     result.add(Point(1, k));

--- a/lib/src/Uncertainty/Distribution/Gumbel.cxx
+++ b/lib/src/Uncertainty/Distribution/Gumbel.cxx
@@ -232,6 +232,13 @@ Scalar Gumbel::computeScalarQuantile(const Scalar prob,
   return gamma_ - std::log(-std::log(prob)) / (1.0 / beta_);
 }
 
+Scalar Gumbel::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Gumbel::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Histogram.cxx
+++ b/lib/src/Uncertainty/Distribution/Histogram.cxx
@@ -44,7 +44,7 @@ Histogram::Histogram()
   setName( "Histogram" );
   // This call set also the range.
   setData(Point(1, 1.0), Point(1, 1.0));
-  setDimension( 1 );
+  setDimension(1);
 }
 
 /* Parameters constructor */
@@ -269,6 +269,13 @@ Scalar Histogram::computeScalarQuantile(const Scalar prob,
   if (p < currentProba) return first_ + width_[0] * p / currentProba;
   // ... or p >= cumulatedSurface_[currentIndex], which means that p is associated with the bin number currentIndex + 1. Do a linear interpolation.
   return first_ + cumulatedWidth_[currentIndex] + (p - currentProba) / height_[currentIndex + 1];
+}
+
+Scalar Histogram::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
 }
 
 /* Compute the mean of the distribution */

--- a/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseChiSquare.cxx
@@ -204,6 +204,13 @@ Scalar InverseChiSquare::computeComplementaryCDF(const Point & point) const
   return DistFunc::pGamma(0.5 * nu_, 0.5 / x);
 }
 
+Scalar InverseChiSquare::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar InverseChiSquare::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/InverseGamma.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseGamma.cxx
@@ -301,6 +301,13 @@ void InverseGamma::computeMean() const
   isAlreadyComputedMean_ = true;
 }
 
+Scalar InverseGamma::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the standard deviation of the distribution */
 Point InverseGamma::getStandardDeviation() const
 {

--- a/lib/src/Uncertainty/Distribution/InverseNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseNormal.cxx
@@ -143,6 +143,13 @@ Scalar InverseNormal::computeCDF(const Point & point) const
   return DistFunc::pNormal(phiArg1) + std::exp(2.0 * lambda_ / mu_ + std::log(DistFunc::pNormal(phiArg2)));
 }
 
+Scalar InverseNormal::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /** Get the minimum volume level set containing a given probability of the distribution */
 LevelSet InverseNormal::computeMinimumVolumeLevelSetWithThreshold(const Scalar prob, Scalar & threshold) const
 {

--- a/lib/src/Uncertainty/Distribution/InverseWishart.cxx
+++ b/lib/src/Uncertainty/Distribution/InverseWishart.cxx
@@ -213,6 +213,10 @@ Scalar InverseWishart::computeLogPDF(const CovarianceMatrix & m) const
 Scalar InverseWishart::computeCDF(const Point & point) const
 {
   if (point.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=" << getDimension() << ", here dimension=" << point.getDimension();
+  if (point[0] < getRange().getLowerBound()[0])
+    return 0.0;
+  if (point[0] > getRange().getUpperBound()[0])
+    return 1.0;
   return ContinuousDistribution::computeCDF(point);
 }
 

--- a/lib/src/Uncertainty/Distribution/Laplace.cxx
+++ b/lib/src/Uncertainty/Distribution/Laplace.cxx
@@ -150,6 +150,13 @@ Scalar Laplace::computeComplementaryCDF(const Point & point) const
   return 0.5 * std::exp(-u);
 }
 
+Scalar Laplace::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar Laplace::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/LogNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/LogNormal.cxx
@@ -304,6 +304,13 @@ Scalar LogNormal::computeScalarQuantile(const Scalar prob,
   return gamma_ + std::exp(muLog_ + sigmaLog_ * DistFunc::qNormal(prob, tail));
 }
 
+Scalar LogNormal::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void LogNormal::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Logistic.cxx
+++ b/lib/src/Uncertainty/Distribution/Logistic.cxx
@@ -229,6 +229,13 @@ Scalar Logistic::computeScalarQuantile(const Scalar prob,
   return mu_ + beta_ * std::log(prob / (1.0 - prob));
 }
 
+Scalar Logistic::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the roughness, i.e. the L2-norm of the PDF */
 Scalar Logistic::getRoughness() const
 {

--- a/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
+++ b/lib/src/Uncertainty/Distribution/NonCentralStudent.cxx
@@ -136,6 +136,13 @@ Point NonCentralStudent::computeCDFGradient(const Point & point) const
   return cdfGradient;
 }
 
+Scalar NonCentralStudent::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void NonCentralStudent::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -439,8 +439,12 @@ Scalar Normal::computeProbability(const Interval & interval) const
 {
   if (interval.isEmpty()) return 0.0;
   const UnsignedInteger dimension = getDimension();
-  // The generic implementation provided by the DistributionImplementation upper class is more accurate than the generic implementation provided by the ContinuousDistribution upper class for dimension = 1
-  if (dimension == 1) return DistributionImplementation::computeProbability(interval);
+  if (interval.getDimension() != dimension)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+
+  if (dimension == 1)
+    return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+
   // Decompose and normalize the interval
   Point lower(normalize(interval.getLowerBound()));
   Point upper(normalize(interval.getUpperBound()));

--- a/lib/src/Uncertainty/Distribution/Pareto.cxx
+++ b/lib/src/Uncertainty/Distribution/Pareto.cxx
@@ -160,7 +160,7 @@ Scalar Pareto::computeComplementaryCDF(const Point & point) const
 {
   if (point.getDimension() != 1) throw InvalidArgumentException(HERE) << "Error: the given point must have dimension=1, here dimension=" << point.getDimension();
   const Scalar x = point[0] - gamma_;
-  if (x < beta_) return 0.0;
+  if (x < beta_) return 1.0;
   return std::pow(beta_ / x, alpha_);
 }
 
@@ -220,6 +220,13 @@ Scalar Pareto::computeScalarQuantile(const Scalar prob,
 {
   const Scalar q = tail ? 1.0 - prob : prob;
   return gamma_ + beta_ / std::pow(1.0 - q, 1.0 / alpha_);
+}
+
+Scalar Pareto::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
 }
 
 /* Compute the mean of the distribution */

--- a/lib/src/Uncertainty/Distribution/Poisson.cxx
+++ b/lib/src/Uncertainty/Distribution/Poisson.cxx
@@ -227,7 +227,7 @@ Sample Poisson::getSupport(const Interval & interval) const
 {
   if (interval.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given interval has a dimension that does not match the distribution dimension.";
   const UnsignedInteger kMin = static_cast< UnsignedInteger > (std::max(ceil(interval.getLowerBound()[0]), 0.0));
-  const UnsignedInteger kMax = static_cast< UnsignedInteger > (floor(interval.getUpperBound()[0]));
+  const UnsignedInteger kMax = static_cast< UnsignedInteger > (std::min(getRange().getUpperBound()[0], floor(interval.getUpperBound()[0])));
   Sample result(0, 1);
   for (UnsignedInteger k = kMin; k <= kMax; ++k)
     result.add(Point(1, k));

--- a/lib/src/Uncertainty/Distribution/Rayleigh.cxx
+++ b/lib/src/Uncertainty/Distribution/Rayleigh.cxx
@@ -216,6 +216,13 @@ Scalar Rayleigh::computeScalarQuantile(const Scalar prob,
   return gamma_ + beta_ * std::sqrt(-2.0 * log1p(-prob));
 }
 
+Scalar Rayleigh::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Rayleigh::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Rice.cxx
+++ b/lib/src/Uncertainty/Distribution/Rice.cxx
@@ -167,6 +167,13 @@ Scalar Rice::computeComplementaryCDF(const Point & point) const
   return DistFunc::pNonCentralChiSquare(2, lambda, y, true, pdfEpsilon_, maximumIteration_);
 }
 
+Scalar Rice::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void Rice::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Skellam.cxx
+++ b/lib/src/Uncertainty/Distribution/Skellam.cxx
@@ -208,8 +208,8 @@ void Skellam::computeCovariance() const
 Sample Skellam::getSupport(const Interval & interval) const
 {
   if (interval.getDimension() != getDimension()) throw InvalidArgumentException(HERE) << "Error: the given interval has a dimension that does not match the distribution dimension.";
-  const SignedInteger kMin = static_cast< SignedInteger > (ceil(interval.getLowerBound()[0]));
-  const SignedInteger kMax = static_cast< SignedInteger > (floor(interval.getUpperBound()[0]));
+  const SignedInteger kMin = static_cast< SignedInteger > (std::max(getRange().getLowerBound()[0], ceil(interval.getLowerBound()[0])));
+  const SignedInteger kMax = static_cast< SignedInteger > (std::min(getRange().getUpperBound()[0], floor(interval.getUpperBound()[0])));
   Sample result(0, 1);
   for (SignedInteger k = kMin; k <= kMax; ++k)
     result.add(Point(1, k));

--- a/lib/src/Uncertainty/Distribution/SquaredNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/SquaredNormal.cxx
@@ -119,6 +119,13 @@ Scalar SquaredNormal::computePDF(const Point & point) const
   return (std::exp(-0.5 * std::pow((sqrtX + mu_), 2.0) / std::pow(sigma_, 2.0)) + std::exp(-0.5 * std::pow((sqrtX - mu_), 2.0) / std::pow(sigma_, 2.0))) / (2.0 * M_SQRT2 * sigma_ * std::sqrt(x * M_PI));
 } // computePDF
 
+Scalar SquaredNormal::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the characteristic function of the distribution */
 Complex SquaredNormal::computeCharacteristicFunction(const Scalar x) const
 {

--- a/lib/src/Uncertainty/Distribution/StudentFunctions.cxx
+++ b/lib/src/Uncertainty/Distribution/StudentFunctions.cxx
@@ -51,12 +51,35 @@ Scalar StudentCDF(const Scalar nu,
   if (x == 0.0) return 0.5;
   if (nu == 1.0) return (tail ? 0.5 - (std::atan(x) * M_1_PI) : 0.5 + (std::atan(x) * M_1_PI));
   const Scalar x2 = x * x;
-  if (nu == 2.0) return (tail ? 0.5 - 0.5 * (x / std::sqrt(2.0 + x2)) : 0.5 + 0.5 * (x / std::sqrt(2.0 + x2)));
+  if (nu == 2.0)
+  {
+    if (std::abs(x) < 1.0) return (tail ? 0.5 - 0.5 * (x / std::sqrt(2.0 + x2)) : 0.5 + 0.5 * (x / std::sqrt(2.0 + x2)));
+    // tail xor (x < 0.0)
+    return (tail != (x < 0.0) ? 0.5 - 0.5 / std::sqrt(2.0 / x2 + 1.0) : 0.5 + 0.5 / std::sqrt(2.0 / x2 + 1.0));
+  }
   if (nu == 3.0) return (tail ? 0.5 - (std::atan(x / std::sqrt(3.0)) * M_1_PI + x * std::sqrt(3.0) / (M_PI * (3.0 + x2))) : 0.5 + (std::atan(x / std::sqrt(3.0)) * M_1_PI + x * std::sqrt(3.0) / (M_PI * (3.0 + x2))));
-  if (nu == 4.0) return (tail ? 0.5 - (0.5 * x * (x2 + 6.0) * std::pow(4.0 + x2, -1.5)) : 0.5 + (0.5 * x * (x2 + 6.0) * std::pow(4.0 + x2, -1.5)));
-  if (nu == 5.0) return (tail ? 0.5 - (std::atan(x / std::sqrt(5.0)) * M_1_PI + x * std::sqrt(5.0) * (3.0 * x2 + 25.0) / (3.0 * M_PI * std::pow(5.0 + x2, 2))) : 0.5 + (std::atan(x / std::sqrt(5.0)) * M_1_PI + x * std::sqrt(5.0) * (3.0 * x2 + 25.0) / (3.0 * M_PI * std::pow(5.0 + x2, 2))));
-  if (nu == 6.0) return (tail ? 0.5 - (0.25 * x * (135.0 + x2 * (30.0 + 2.0 * x2)) * std::pow(6.0 + x2, -2.5)) : 0.5 + (0.25 * x * (135.0 + x2 * (30.0 + 2.0 * x2)) * std::pow(6.0 + x2, -2.5)));
-  if (nu == 7.0) return (tail ? 0.5 - (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 + x2 * (280.0 + 15.0 * x2)) / (15.0 * M_PI * std::pow(7.0 + x2, 3))) : 0.5 + (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 + x2 * (280.0 + 15.0 * x2)) / (15.0 * M_PI * std::pow(7.0 + x2, 3))));
+  if (nu == 4.0)
+  {
+    if (std::abs(x) < 1.0) return (tail ? 0.5 - (0.5 * x * (x2 + 6.0) * std::pow(4.0 + x2, -1.5)) : 0.5 + (0.5 * x * (x2 + 6.0) * std::pow(4.0 + x2, -1.5)));
+    // tail xor (x < 0.0)
+    return (tail != (x < 0.0) ? 0.5 - 0.5 * (1.0 + 6.0 / x2) / (1.0 + 4.0 / x2) / std::sqrt(1.0 + 4.0 / x2) : 0.5 + 0.5 * (1.0 + 6.0 / x2) / (1.0 + 4.0 / x2) / std::sqrt(1.0 + 4.0 / x2));
+  }
+  if (nu == 5.0)
+  {
+    if (std::abs(x) < 1.0) return (tail ? 0.5 - (std::atan(x / std::sqrt(5.0)) * M_1_PI + x * std::sqrt(5.0) * (3.0 * x2 + 25.0) / (3.0 * M_PI * std::pow(5.0 + x2, 2.0))) : 0.5 + (std::atan(x / std::sqrt(5.0)) * M_1_PI + x * std::sqrt(5.0) * (3.0 * x2 + 25.0) / (3.0 * M_PI * std::pow(5.0 + x2, 2.0))));
+    return (tail ? 0.5 - (std::atan(x / std::sqrt(5.0)) * M_1_PI + std::sqrt(5.0) * (3.0 + 25.0 / x2) / (3.0 * M_PI * (5.0 / x2 + 1.0) * (5.0 / x + x))) : 0.5 + (std::atan(x / std::sqrt(5.0)) * M_1_PI + std::sqrt(5.0) * (3.0 + 25.0 / x2) / (3.0 * M_PI * (5.0 / x2 + 1.0) * (5.0 / x + x))));
+  }
+  if (nu == 6.0)
+  {
+    if (std::abs(x) < 1.0) return (tail ? 0.5 - (0.25 * x * (135.0 + x2 * (30.0 + 2.0 * x2)) * std::pow(6.0 + x2, -2.5)) : 0.5 + (0.25 * x * (135.0 + x2 * (30.0 + 2.0 * x2)) * std::pow(6.0 + x2, -2.5)));
+    // tail xor (x < 0.0)
+    return (tail != (x < 0.0) ? 0.5 - (0.25 * (135.0 / x2 / x2 + (30.0 / x2 + 2.0)) / (1.0 + 6.0 / x2) / (1.0 + 6.0 / x2) / std::sqrt(1.0 + 6.0 / x2)) : 0.5 + (0.25 * (135.0 / x2 / x2 + (30.0 / x2 + 2.0)) / (1.0 + 6.0 / x2) / (1.0 + 6.0 / x2) / std::sqrt(1.0 + 6.0 / x2)));
+  }
+  if (nu == 7.0)
+  {
+    if (std::abs(x) < 1.0) return (tail ? 0.5 - (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 + x2 * (280.0 + 15.0 * x2)) / (15.0 * M_PI * std::pow(7.0 + x2, 3))) : 0.5 + (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 + x2 * (280.0 + 15.0 * x2)) / (15.0 * M_PI * std::pow(7.0 + x2, 3))));
+    return (tail ? 0.5 - (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 / x2 / x2 + 280.0 / x2 + 15) / (15.0 * M_PI * (7.0 + x2) * (1.0 + 7.0 / x2) * (1.0 + 7.0 / x2))) : 0.5 + (std::atan(x / std::sqrt(7.0)) * M_1_PI + x * std::sqrt(7.0) * (1617.0 / x2 / x2 + 280.0 / x2 + 15) / (15.0 * M_PI * (7.0 + x2) * (1.0 + 7.0 / x2) * (1.0 + 7.0 / x2))));
+  }
 #ifdef OPENTURNS_HAVE_BOOST
   return (tail ? boost::math::cdf(boost::math::complement(boost::math::students_t(nu), x)) : boost::math::cdf(boost::math::students_t(nu), x)) ;
 #else

--- a/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
+++ b/lib/src/Uncertainty/Distribution/Trapezoidal.cxx
@@ -311,6 +311,13 @@ Scalar Trapezoidal::computeScalarQuantile(const Scalar prob,
   return d_ - std::sqrt(2.0 * (d_ - c_) * (1.0 - q) / h_);
 }
 
+Scalar Trapezoidal::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar Trapezoidal::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/Triangular.cxx
+++ b/lib/src/Uncertainty/Distribution/Triangular.cxx
@@ -273,6 +273,13 @@ Scalar Triangular::computeScalarQuantile(const Scalar prob,
   return b_ - std::sqrt((1.0 - prob) * ba * bm);
 }
 
+Scalar Triangular::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar Triangular::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedNormal.cxx
@@ -444,6 +444,13 @@ Scalar TruncatedNormal::computeScalarQuantile(const Scalar prob,
   return mu_ + sigma_ * DistFunc::qNormal(PhiANorm_ + prob / normalizationFactor_);
 }
 
+Scalar TruncatedNormal::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the mean of the distribution */
 void TruncatedNormal::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/Uniform.cxx
+++ b/lib/src/Uncertainty/Distribution/Uniform.cxx
@@ -246,6 +246,13 @@ Scalar Uniform::computeScalarQuantile(const Scalar prob,
   return a_ + prob * (b_ - a_);
 }
 
+Scalar Uniform::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Compute the entropy of the distribution */
 Scalar Uniform::computeEntropy() const
 {

--- a/lib/src/Uncertainty/Distribution/WeibullMax.cxx
+++ b/lib/src/Uncertainty/Distribution/WeibullMax.cxx
@@ -167,6 +167,13 @@ Scalar WeibullMax::computeComplementaryCDF(const Point & point) const
   return -expm1(-std::pow(-x / beta_, alpha_));
 }
 
+Scalar WeibullMax::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
 Complex WeibullMax::computeCharacteristicFunction(const Scalar x) const
 {

--- a/lib/src/Uncertainty/Distribution/WeibullMin.cxx
+++ b/lib/src/Uncertainty/Distribution/WeibullMin.cxx
@@ -265,6 +265,13 @@ Scalar WeibullMin::computeScalarQuantile(const Scalar prob,
   return gamma_ + beta_ * std::pow(-std::log(1.0 - prob), 1.0 / alpha_);
 }
 
+Scalar WeibullMin::computeProbability(const Interval & interval) const
+{
+  if (interval.getDimension() != 1)
+    throw InvalidArgumentException(HERE) << "computeProbability expected an interval of dimension=" << dimension_ << ", got dimension=" << interval.getDimension();
+  return computeProbabilityGeneral1D(interval.getLowerBound()[0], interval.getUpperBound()[0]);
+}
+
 /* compute the mean of the distribution */
 void WeibullMin::computeMean() const
 {

--- a/lib/src/Uncertainty/Distribution/openturns/Arcsine.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Arcsine.hxx
@@ -78,7 +78,7 @@ public:
   Scalar computeCDF(const Point & point) const override;
   using ContinuousDistribution::computeComplementaryCDF;
   Scalar computeComplementaryCDF(const Point & point) const override;
-
+  
   /** Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
   Complex computeCharacteristicFunction(const Scalar x) const override;
 
@@ -92,6 +92,9 @@ public:
 
   /** Get the quantile of the distribution */
   Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
 
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;

--- a/lib/src/Uncertainty/Distribution/openturns/Beta.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Beta.hxx
@@ -90,6 +90,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -157,9 +163,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Burr.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Burr.hxx
@@ -86,6 +86,9 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Chi.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Chi.hxx
@@ -97,6 +97,9 @@ public:
   /** Get the quantile of the distribution */
   Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/ChiSquare.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/ChiSquare.hxx
@@ -98,6 +98,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+    /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -140,9 +146,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Epanechnikov.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Epanechnikov.hxx
@@ -82,6 +82,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -124,9 +130,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
 }; /* class Epanechnikov */
 

--- a/lib/src/Uncertainty/Distribution/openturns/Exponential.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Exponential.hxx
@@ -100,6 +100,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -148,10 +154,7 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
-
+  
   /** The lamdbda of the Exponential distribution */
   Scalar lambda_;
 

--- a/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/FisherSnedecor.hxx
@@ -82,6 +82,12 @@ public:
   using ContinuousDistribution::computeCDF;
   Scalar computeCDF(const Point & point) const override;
 
+  /** Get the quantile of the Triangular distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -130,9 +136,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the Triangular distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Update the derivative attributes */
   void update();

--- a/lib/src/Uncertainty/Distribution/openturns/Frechet.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Frechet.hxx
@@ -93,6 +93,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -141,9 +147,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Gamma.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Gamma.hxx
@@ -101,6 +101,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -153,9 +159,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/GeneralizedPareto.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/GeneralizedPareto.hxx
@@ -105,6 +105,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -157,9 +163,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Gumbel.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Gumbel.hxx
@@ -100,6 +100,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -146,9 +152,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** The main parameter set of the distribution */
   Scalar beta_;

--- a/lib/src/Uncertainty/Distribution/openturns/Histogram.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Histogram.hxx
@@ -97,6 +97,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the Histogram distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard representative in the parametric family, associated with the standard moments */
   Distribution getStandardRepresentative() const override;
 
@@ -148,9 +154,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the Histogram distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/InverseChiSquare.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/InverseChiSquare.hxx
@@ -96,6 +96,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -138,9 +144,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/InverseGamma.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/InverseGamma.hxx
@@ -82,6 +82,12 @@ public:
   using ContinuousDistribution::computeComplementaryCDF;
   Scalar computeComplementaryCDF(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -145,9 +151,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/InverseNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/InverseNormal.hxx
@@ -75,6 +75,9 @@ public:
   using ContinuousDistribution::computeCDF;
   Scalar computeCDF(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the minimum volume level set containing a given probability of the distribution */
   LevelSet computeMinimumVolumeLevelSetWithThreshold(const Scalar prob, Scalar & thresholdOut) const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Laplace.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Laplace.hxx
@@ -96,6 +96,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -147,9 +153,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** The mu of the Laplace distribution */
   Scalar mu_;

--- a/lib/src/Uncertainty/Distribution/openturns/LogNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/LogNormal.hxx
@@ -98,6 +98,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the LogNormal distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -151,9 +157,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the LogNormal distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the integrand that is involved in the computation of the characteristic function */
   Complex characteristicIntegrand(const Scalar eta,

--- a/lib/src/Uncertainty/Distribution/openturns/Logistic.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Logistic.hxx
@@ -97,6 +97,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the Logistic distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the roughness, i.e. the L2-norm of the PDF */
   Scalar getRoughness() const override;
 
@@ -150,9 +156,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the Logistic distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** The main parameter set of the distribution */
   Scalar mu_;

--- a/lib/src/Uncertainty/Distribution/openturns/MeixnerDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/MeixnerDistribution.hxx
@@ -88,6 +88,9 @@ public:
   using ContinuousDistribution::computePDFGradient;
   Point computePDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
   /** Get the gradient of the CDF w.r.t the parameters of the distribution */
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
@@ -150,9 +153,6 @@ protected:
 private:
   /** Initialize optimization solver parameter using the ResourceMap */
   void initializeOptimizationAlgorithmParameter();
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/NonCentralStudent.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/NonCentralStudent.hxx
@@ -78,6 +78,9 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Pareto.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Pareto.hxx
@@ -80,6 +80,12 @@ public:
   using ContinuousDistribution::computeComplementaryCDF;
   Scalar computeComplementaryCDF(const Point & point) const override;
 
+  /** Get the quantile of the distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the product minimum volume interval containing a given probability of the distribution */
   Interval computeMinimumVolumeIntervalWithMarginalProbability(const Scalar prob, Scalar & marginalProbOut) const override;
 
@@ -146,9 +152,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Rayleigh.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Rayleigh.hxx
@@ -93,6 +93,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -137,9 +143,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Rice.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Rice.hxx
@@ -79,6 +79,9 @@ public:
   using ContinuousDistribution::computeComplementaryCDF;
   Scalar computeComplementaryCDF(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/SquaredNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/SquaredNormal.hxx
@@ -74,6 +74,9 @@ public:
   using ContinuousDistribution::computePDF;
   Scalar computePDF(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the characteristic function of the distribution */
   Complex computeCharacteristicFunction(const Scalar x) const override;
 

--- a/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Trapezoidal.hxx
@@ -92,6 +92,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -152,9 +158,6 @@ protected:
 
 
 private:
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the mean of the distribution */
   void computeMean() const override;

--- a/lib/src/Uncertainty/Distribution/openturns/Triangular.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Triangular.hxx
@@ -81,6 +81,12 @@ public:
   Scalar computeCDF(const Scalar scalar) const override;
   Scalar computeCDF(const Point & point) const override;
 
+  /** Get the quantile of the Triangular distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
   Complex computeCharacteristicFunction(const Scalar x) const override;
 
@@ -153,9 +159,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the Triangular distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/TruncatedNormal.hxx
@@ -112,6 +112,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the TruncatedNormal distribution */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the standard deviation of the distribution */
   Point getStandardDeviation() const override;
 
@@ -168,9 +174,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the TruncatedNormal distribution */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/Uniform.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/Uniform.hxx
@@ -103,6 +103,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
   /** Compute the entropy of the distribution */
   Scalar computeEntropy() const override;
 
@@ -160,9 +166,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/WeibullMax.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/WeibullMax.hxx
@@ -81,6 +81,12 @@ public:
   using ContinuousDistribution::computeComplementaryCDF;
   Scalar computeComplementaryCDF(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
   /** Get the characteristic function of the distribution, i.e. phi(u) = E(exp(I*u*X)) */
   Complex computeCharacteristicFunction(const Scalar x) const override;
 
@@ -150,9 +156,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Distribution/openturns/WeibullMin.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/WeibullMin.hxx
@@ -99,6 +99,12 @@ public:
   using ContinuousDistribution::computeCDFGradient;
   Point computeCDFGradient(const Point & point) const override;
 
+  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
+  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
+
+  /** Get the probability content of an interval */
+  Scalar computeProbability(const Interval & interval) const override;
+
 protected:
   /** Set simultaneously alpha and beta to factorize the call to computeRange() */
   void setAlphaBeta(const Scalar alpha,
@@ -154,9 +160,6 @@ private:
 
   /** Compute the covariance of the distribution */
   void computeCovariance() const override;
-
-  /** Get the quantile of the distribution, i.e the value Xp such that P(X <= Xp) = prob */
-  Scalar computeScalarQuantile(const Scalar prob, const Bool tail = false) const override;
 
   /** Compute the numerical range of the distribution given the parameters values */
   void computeRange() override;

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -1044,11 +1044,7 @@ Scalar DistributionImplementation::computeProbabilityGeneral(const Interval & in
     probability = SpecFunc::AccurateSum(probabilities);
   } // not independent
 
-  // clip to [0, 1]
-  probability = std::max(probability, 0.0);
-  probability = std::min(probability, 1.0);
-
-  return probability;
+  return SpecFunc::Clip01(probability);
 }
 
 /* Generic implementation for 1D continuous distributions */
@@ -1089,7 +1085,7 @@ Scalar DistributionImplementation::computeProbabilityContinuous(const Interval &
 }
 
 /* Generic implementation for 1D continuous distribution by integration of the PDF */
-Scalar DistributionImplementation::computeProbabilityContinuous1D(const Scalar a, const Scalar b) const
+Scalar DistributionImplementation::computeProbabilityContinuous1D(const Scalar aa, const Scalar bb) const
 {
   // Use adaptive multidimensional integration of the PDF on the reduced interval
   const PDFWrapper pdfWrapper(this);
@@ -1100,6 +1096,9 @@ Scalar DistributionImplementation::computeProbabilityContinuous1D(const Scalar a
   Sample fi;
   Point ei;
   const Point singularities(getSingularities());
+  // Consider only the intersection with the range
+  const Scalar a = std::max(aa, range_.getLowerBound()[0]);
+  const Scalar b = std::min(bb, range_.getUpperBound()[0]);
   // If no singularity inside of the given reduced interval
   const UnsignedInteger singularitiesNumber = singularities.getSize();
   if (singularitiesNumber == 0 || singularities[0] >= b || singularities[singularitiesNumber - 1] <= a) probability = GaussKronrod().integrate(pdfWrapper, a, b, error, ai, bi, fi, ei)[0];

--- a/python/test/t_Burr_std.py
+++ b/python/test/t_Burr_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -151,3 +152,7 @@ print("covariance=", repr(covariance))
 parameters = distribution.getParametersCollection()
 print("parameters=", repr(parameters))
 print("Standard representative=", distribution.getStandardRepresentative())
+
+# computeProba test with bound far away
+p = distribution.computeProbability(ot.Interval(-ot.MaxScalar, ot.MaxScalar))
+ott.assert_almost_equal(p, 1.0)

--- a/python/test/t_DistFunc_student.py
+++ b/python/test/t_DistFunc_student.py
@@ -25,6 +25,14 @@ for i1 in range(n1):
             ", complementary=%.6g" % ot.DistFunc.pStudent(nu, x, True),
         )
     print("pStudent(", grid, ")=", ot.DistFunc.pStudent(nu, grid))
+
+# check for nans
+for x in [-1e300, -1e200, -1e100, 1e10, -10.0, -0.1, 0.0, 0.1, 10.0, 1e10, 1e100, 1e200, 1e300]:
+    for nu in [2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5]:
+        for tail in [False, True]:
+            p = ot.DistFunc.pStudent(nu, x, tail)
+            assert ot.SpecFunc.IsNormal(p), "pStudent returns nan"
+
 # qStudent
 nuMin = 0.2
 nuMax = 5.0

--- a/python/test/t_Distribution_std.py
+++ b/python/test/t_Distribution_std.py
@@ -129,6 +129,7 @@ for factory in factories:
                 str(distribution),
             )
 
+            # check computeProbability on full float range
             interval = ot.Interval(-ot.SpecFunc.MaxScalar, ot.SpecFunc.MaxScalar)
             # FIXME: StudentCDF returns nan with MaxScalar
             if distribution.getName() == "Student":
@@ -194,6 +195,11 @@ for factory in factories:
             ott.assert_almost_equal(ccdf, 0.0)
             surv = distribution.computeSurvivalFunction(ub)
             ott.assert_almost_equal(surv, 0.0)
+
+            # check computeProbability on full float range
+            interval = ot.Interval(-ot.SpecFunc.MaxScalar, ot.SpecFunc.MaxScalar)
+            p = distribution.computeProbability(interval)
+            ott.assert_almost_equal(p, 1.0)
 
     # parameters
     p = distribution.getParameter()

--- a/python/test/t_Distribution_std.py
+++ b/python/test/t_Distribution_std.py
@@ -131,9 +131,6 @@ for factory in factories:
 
             # check computeProbability on full float range
             interval = ot.Interval(-ot.SpecFunc.MaxScalar, ot.SpecFunc.MaxScalar)
-            # FIXME: StudentCDF returns nan with MaxScalar
-            if distribution.getName() == "Student":
-                interval = ot.Interval(-1e300, 1e300)
             p = distribution.computeProbability(interval)
             ott.assert_almost_equal(p, 1.0)
 

--- a/python/test/t_Distribution_std.py
+++ b/python/test/t_Distribution_std.py
@@ -129,6 +129,13 @@ for factory in factories:
                 str(distribution),
             )
 
+            interval = ot.Interval(-ot.SpecFunc.MaxScalar, ot.SpecFunc.MaxScalar)
+            # FIXME: StudentCDF returns nan with MaxScalar
+            if distribution.getName() == "Student":
+                interval = ot.Interval(-1e300, 1e300)
+            p = distribution.computeProbability(interval)
+            ott.assert_almost_equal(p, 1.0)
+
             # MinimumVolumeInterval
             probability = 0.9
             interval = distribution.computeMinimumVolumeIntervalWithMarginalProbability(

--- a/python/test/t_Hypergeometric_std.py
+++ b/python/test/t_Hypergeometric_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -88,3 +89,7 @@ print("Standard representative=", distribution.getStandardRepresentative())
 
 # should not hang when the range is [0] (dirac)
 ot.Hypergeometric(25, 0, 0).computeScalarQuantile(0.6)
+
+# computeProba test with bound far away
+p = distribution.computeProbability(ot.Interval(-ot.MaxScalar, ot.MaxScalar))
+ott.assert_almost_equal(p, 1.0)

--- a/python/test/t_InverseChiSquare_std.py
+++ b/python/test/t_InverseChiSquare_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -159,3 +160,7 @@ for n in range(len(allDistributions)):
     print("skewness=", skewness)
     kurtosis = distribution.getKurtosis()
     print("kurtosis=", kurtosis)
+
+    # computeProba test with bound far away
+    p = distribution.computeProbability(ot.Interval(-ot.MaxScalar, ot.MaxScalar))
+    ott.assert_almost_equal(p, 1.0)

--- a/python/test/t_InverseGamma_std.py
+++ b/python/test/t_InverseGamma_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -186,3 +187,7 @@ for n in range(len(allDistributions)):
     print("skewness=", skewness)
     kurtosis = distribution.getKurtosis()
     print("kurtosis=", kurtosis)
+
+    # computeProba test with bound far away
+    p = distribution.computeProbability(ot.Interval(-ot.MaxScalar, ot.MaxScalar))
+    ott.assert_almost_equal(p, 1.0)

--- a/python/test/t_InverseWishart_std.py
+++ b/python/test/t_InverseWishart_std.py
@@ -4,9 +4,7 @@ import unittest as ut
 from math import log, pi
 
 import openturns as ot
-
-# (value, reference, rtol, atol)
-from openturns.testing import assert_almost_equal
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 ot.TBB.Disable()
@@ -95,9 +93,9 @@ class TestInverseWishartMethods(ut.TestCase):
             logPDFx = logPDF(x)
             logPDFx_IW = self.one_dimensional_inverse_wishart.computeLogPDF(x)
             logPDFx_IG = self.inverse_gamma.computeLogPDF(x)
-            assert_almost_equal(logPDFx_IW, logPDFx)
-            assert_almost_equal(logPDFx_IG, logPDFx)
-            assert_almost_equal(logPDFx_IW, logPDFx_IG)
+            ott.assert_almost_equal(logPDFx_IW, logPDFx)
+            ott.assert_almost_equal(logPDFx_IG, logPDFx)
+            ott.assert_almost_equal(logPDFx_IW, logPDFx_IG)
 
     # Not a test
     # The log multi-gamma function appears in the log PDF
@@ -130,7 +128,7 @@ class TestInverseWishartMethods(ut.TestCase):
             inverse_gamma = ot.InverseGamma(2.0 / Scale[d, d], k)
             logdensity = logdensity - inverse_gamma.computeLogPDF(diagX[d, 0])
             logratio = logratio + 0.5 * (1 - dimension) * log(0.5 * Scale[d, d])
-        assert_almost_equal(logdensity, logratio)
+        ott.assert_almost_equal(logdensity, logratio)
 
     # Test InverseWishart.computeLogPDF by evaluating the log PDF
     # at the scale covariance matrix
@@ -142,7 +140,7 @@ class TestInverseWishartMethods(ut.TestCase):
         logPDFatX = -self.logmultigamma(dimension, 0.5 * DoF) - 0.5 * (
             DoF * dimension * log(2.0) + dimension + (dimension + 1) * log(determinant)
         )
-        assert_almost_equal(inverse_wishart.computeLogPDF(Scale), logPDFatX)
+        ott.assert_almost_equal(inverse_wishart.computeLogPDF(Scale), logPDFatX)
 
     # Compare the empirical expectations of a large matrix sample
     # and of the corresponding inverse matrix sample
@@ -171,14 +169,14 @@ class TestInverseWishartMethods(ut.TestCase):
         indice, coefficient = 0, 1.0 / (DoF - d - 1)
         for j in range(d):
             for k in range(j + 1):
-                assert_almost_equal(
+                ott.assert_almost_equal(
                     theoretical_mean_inverse[indice], coefficient * Scale[k, j]
                 )
-                assert_almost_equal(theoretical_mean[indice], DoF * Scale_wishart[k, j])
-                assert_almost_equal(
+                ott.assert_almost_equal(theoretical_mean[indice], DoF * Scale_wishart[k, j])
+                ott.assert_almost_equal(
                     mean_inverse[indice], coefficient * Scale[k, j], 0.15, 1.0e-3
                 )
-                assert_almost_equal(
+                ott.assert_almost_equal(
                     mean[indice], DoF * Scale_wishart[k, j], 0.15, 1.0e-3
                 )
                 indice += 1

--- a/python/test/t_SquaredNormal_std.py
+++ b/python/test/t_SquaredNormal_std.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import openturns as ot
+import openturns.testing as ott
 
 ot.TESTPREAMBLE()
 
@@ -184,3 +185,7 @@ print("covariance=", repr(covariance))
 parameters = distribution.getParametersCollection()
 print("parameters=", repr(parameters))
 print("Standard representative=", distribution.getStandardRepresentative())
+
+# computeProba test with bound far away
+p = distribution.computeProbability(ot.Interval(-ot.MaxScalar, ot.MaxScalar))
+ott.assert_almost_equal(p, 1.0)


### PR DESCRIPTION
- for 1d-continuous distributions with analytical CDF override computeProbability to call computeProbabilityGeneral1D
benchmark: with Burr 1e5 computeProbability calls in 0.5s instead of 7s before
- for 1d-continuous distributions where GaussKronrod is used (eg Meixner), make sure we dont integrate outside the range
- for discrete distributions, make sure getSupport(interval) does not return points outside range, else computeProbability can be very slow and inexact (was done for most but not all)
- student.computeCDF returns nan with big values (#2506)

/cc @regislebrun 