### PR TITLE
DistributionImplementation::computeQuantile fix

### DIFF
--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2434,13 +2434,12 @@ Point DistributionImplementation::computeQuantile(const Scalar prob,
     const Bool tail,
     Scalar & marginalProb) const
 {
-  const Scalar q = tail ? 1.0 - prob : prob;
-  marginalProb = q;
-  // Special case for bording values
-  if (prob < quantileEpsilon_) return (tail ? range_.getUpperBound() : range_.getLowerBound());
-  if (prob >= 1.0 - quantileEpsilon_) return (tail ? range_.getLowerBound() : range_.getUpperBound());
   // Special case for dimension 1
   if (dimension_ == 1) return Point(1, computeScalarQuantile(prob, tail));
+  // Special case for border values
+  if (prob < cdfEpsilon_) return (tail ? range_.getUpperBound() : range_.getLowerBound());
+  if (prob >= 1.0 - cdfEpsilon_) return (tail ? range_.getLowerBound() : range_.getUpperBound());
+  const Scalar q = tail ? 1.0 - prob : prob;
   // Special case for independent copula
   if (hasIndependentCopula())
   {

--- a/lib/test/t_DistFunc_binomial.cxx
+++ b/lib/test/t_DistFunc_binomial.cxx
@@ -84,11 +84,7 @@ int main(int, char *[])
         assert_almost_equal(binomial.computeCDF(x), cdf, precision, 0.0);
         assert_almost_equal(binomial.computeSurvivalFunction(x), surv, precision, 0.0);
         if (i > 0)  // FIXME: test fails for i = 0 (x=0, N=10, P=0)
-        {
-          #if 0 // FIXME: tests fail for i = 7 (x=400, N=1030, P=0.5)
-            assert_almost_equal(binomial.computeQuantile(cdf), Point({x}), 0.0, 1.0); // Can be off by 1 unit
-          #endif
-        }
+          assert_almost_equal(binomial.computeQuantile(cdf), Point({x}), 0.0, 1.0); // Can be off by 1 unit
     }
 
     // 2147483647 is the maximum integer.


### PR DESCRIPTION
- Checks for dimension 1 first.
- Extremities of the range are used only for prob (resp. 1 - prob) < cdfEpsilon_ rather than quantileEpsilon_ 
- Fixes #2513