### PR TITLE
Update DistributionImplementation_doc.i.in

### DIFF
--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -1745,7 +1745,7 @@ k : int
 Returns
 -------
 m : :class:`~openturns.Point`
-    Componentwise central moment of order :math:`k`.
+    Componentwise central moment of order *k*.
 
 Notes
 -----
@@ -1778,7 +1778,7 @@ shift : sequence of float
 Returns
 -------
 m : :class:`~openturns.Point`
-    Componentwise central moment of order *k*`.
+    Componentwise central moment of order *k*.
 
 Notes
 -----
@@ -2149,7 +2149,7 @@ k : int
 Returns
 -------
 m : :class:`~openturns.Point`
-    Componentwise moment of order *k*`.
+    Componentwise moment of order *k*.
 
 Notes
 -----

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -139,13 +139,12 @@ p : float, sequence of float
 Notes
 -----
 The conditional cumulative distribution function of the component :math:`X_j`
-given that the components of indices :math:`k \leq j-1` are fixed. It is defined as follows:
+given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})` is defined by:
 
 .. math::
 
-    p = F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}},
-        \quad x_j \in \Rset
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
 For :math:`j=1` it
 reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
@@ -174,17 +173,21 @@ ddf : float,
 
 Notes
 -----
-The conditional derivative density function is defined as follows:
+The conditional derivative density function of the component :math:`X_j`
+given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
+is defined by:
 
 .. math::
 
-    \dfrac{d^2}{d\,x_j^2}\Prob{X_j \leq x_j \mid X_1=x_1, \ldots,
-    X_{j-1}=x_{j-1}}
+     \dfrac{d^2}{d\,x_j^2}F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1})
 
-ie the :math:`j`-th component is the conditional DDF of :math:`X_j` at :math:`x_j` given that :math:`X_1=x_1,
-\ldots,X_{j-1}=x_{j-1}`. For :math:`j=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}\Prob{X_1 \leq x_1}`, ie the DDF of
+where for :math:`2 \leq j \leq d`:
+
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+For :math:`j=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}F_{X_1}(x_1)`, ie the DDF of
 the first component at :math:`x_1`.
-    
 
 See Also
 --------
@@ -211,6 +214,24 @@ Returns
 -------
 cpdf : float, sequence of float
     Conditional PDF at *xd*, given *xcond*.
+
+Notes
+-----
+The conditional probability density function of the component :math:`X_j`
+given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
+is defined by:
+
+.. math::
+
+     \dfrac{d}{d\,x_j}F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1})
+
+where for :math:`2 \leq j \leq d`:
+
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+For :math:`j=1` it
+reduces to :math:`\dfrac{d}{d\,x_1}F_{X_1}(x_1)`.
 
 See Also
 --------
@@ -239,7 +260,20 @@ xj : float
     Conditional quantile of order *p* of the component :math:`X_j`
     given that the components of indices :math:`k \leq j-1` are fixed and
     equal to *xcond*.
-    
+
+Notes
+-----
+The conditional quantile of order :math:`p` of the component :math:`X_j`
+given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
+is defined by:
+
+.. math::
+
+     F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p; x_1, \dots, x_{j-1})
+
+where the generalized inverse is defined in :eq:`quantileDef`.
+For :math:`j=1` it
+reduces to :math:`F^{-1}_{X_1}(p)`.
 
 See Also
 --------
@@ -269,11 +303,14 @@ The sequential conditional cumulative distribution function is defined as follow
 
 .. math::
 
-    \left(\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
+    \left(F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1})\right)_{j=1,\ldots,d}
 
-ie the :math:`i`-th component is the conditional CDF of :math:`X_i` at :math:`x_i` given
-that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it
-reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
+where for :math:`2 \leq j \leq d`:
+
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+The first term, for :math:`j=1`, is :math:`F_{X_1}(x_1}`."
 
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalCDF
@@ -296,17 +333,19 @@ ddf : sequence of float
 
 Notes
 -----
-The sequential conditional derivative density function is defined as follows:
+The sequential conditional derivative density function is defined by:
 
 .. math::
 
-    \left(\dfrac{d^2}{d\,x_i^2}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots,
-    X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
+    \left(\dfrac{d^2}{d\,x_j^2}F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1})
+    \right)_{j=1,\ldots,d}
 
-ie the :math:`i`-th component is the conditional DDF of :math:`X_i` at :math:`x_i` given that :math:`X_1=x_1,
-\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}\Prob{X_1 \leq x_1}`, ie the DDF of
-the first component at :math:`x_1`."
+where for :math:`2 \leq j \leq d`:
 
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+The first term, for :math:`j=1`, is :math:`\dfrac{d^2}{d\,x_1^2}F_{X_1}(x_1)`."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalDDF
 OT_Distribution_computeSequentialConditionalDDF_doc
@@ -332,11 +371,14 @@ The sequential conditional density function is defined as follows:
 
 .. math::
 
-    \left(\dfrac{d}{d\,x_i}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
+    \left(\dfrac{d}{d\,x_j}F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1})\right)_{j=1,\ldots,d}
 
-ie the :math:`i`-th component is the conditional PDF of :math:`X_i` at :math:`x_i` given
-that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it reduces to
-:math:`\dfrac{d}{d\,x_1}\Prob{X_1 \leq x_1}`, ie the PDF of the first component at :math:`x_1`."
+where for :math:`2 \leq j \leq d`:
+
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+The first term, for :math:`j=1`, is :math:`\dfrac{d}{d\,x_1}F_{X_1}(x_1)`."
 
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalPDF
@@ -349,26 +391,26 @@ OT_Distribution_computeSequentialConditionalPDF_doc
 
 Parameters
 ----------
-q : sequence of float in :math:`[0,1]`, with size :math:`d`
+p : sequence of float in :math:`[0,1]`, with size :math:`d`
     Values to be taken sequentially as the argument of the conditional quantile.
 
 Returns
 -------
 Q : sequence of float
-    Sequance of conditional quantiles values at *q*
+    Sequence of conditional quantiles values at *p*
 
 Notes
 -----
-The sequential conditional quantile function is defined as follows:
+The sequential conditional quantile function is defined by:
 
 .. math::
 
-    \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i-1}\right)_{i=1,\ldots,d}
+    \left(F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p_j; x_1, \dots, x_{j-1})\right)_{i=1,\ldots,d}
 
-where :math:`x_1,\ldots,x_{i-1}` are defined recursively as :math:`x_1=F_1^{-1}(q_1)` and for :math:`2\leq i \leq d`,
-:math:`x_i=F_i^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i-1})`: the conditioning part is the set of already
+where the generalized inverse is defined in :eq:`quantileDef` and
+where :math:`x_1,\ldots,x_{j-1}` are defined recursively as :math:`x_1=F_1^{-1}(p_1)` and for :math:`2\leq j \leq d`,
+:math:`x_j=F_{X_j}^{-1}(p_j|X_1=x_1,\ldots,X_{j-1}=x_{j-1})`: the conditioning part is the set of already
 computed conditional quantiles."
-
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalQuantile
 OT_Distribution_computeSequentialConditionalQuantile_doc
@@ -578,8 +620,8 @@ The probability density function is defined as follows:
 
 .. math::
 
-    f_{\vect{X}}(\vect{x}) = \frac{\partial^n F_{\vect{X}}(\vect{x})}
-                                  {\prod_{i=1}^n \partial x_i},
+    f_{\vect{X}}(\vect{x}) = \frac{\partial^d F_{\vect{X}}(\vect{x})}
+                                  {\prod_{i=1}^d \partial x_i},
                              \quad \vect{x} \in \Rset^d"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computePDF
@@ -599,7 +641,16 @@ Returns
 -------
 dfdtheta : :class:`~openturns.Point`
     Partial derivatives of the PDF with respect to the distribution
-    parameters at input *x*."
+    parameters at input *x*.
+
+Notes
+-----
+Let :math:`\vect{\theta}` be the vector of parameters of the distribution. Then
+the gradient of the probability density function :math:`f_{\vect{X})` is defined by:
+
+.. math::
+
+    (\frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_1}, \dots, \frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_d})"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computePDFGradient
 OT_Distribution_computePDFGradient_doc
@@ -663,6 +714,7 @@ If the underlying variable :math:`X` is scalar, then the quantile of order :math
 is defined as the generalized inverse of its cumulative distribution function:
 
 .. math::
+      :label: quantileDef
 
       x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset\, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -126,26 +126,26 @@ OT_Distribution_computeComplementaryCDF_doc
 
 Parameters
 ----------
-xd : float, sequence of float
-    Conditional CDF input (last component).
-xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
-    Conditioning values for the other components.
+xj : float, sequence of float,
+    Conditional CDF input.
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
 
 Returns
 -------
-F : float, sequence of float
-    Conditional CDF value at  *xd* given *xcond*.
+p : float, sequence of float
+    Conditional CDF value at  *xj* given *xcond*.
 
 Notes
 -----
-The conditional cumulative distribution function of the last component with
-respect to the other fixed components is defined as follows:
+The conditional cumulative distribution function of the component :math:`X_j`
+given that the components of indices :math:`k \leq j-1` are fixed. It is defined as follows:
 
 .. math::
 
-    F_{X_d \mid X_1, \ldots, X_{d - 1}}(x_d) =
-        \Prob{X_d \leq x_d \mid X_1=x_1, \ldots, X_{d-1}=x_{d-1}},
-        \quad x_d \in \Rset"
+    p = F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; (x_1, \dots, x_{j-1}) =
+        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}},
+        \quad x_j \in \Rset"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeConditionalCDF
 OT_Distribution_computeConditionalCDF_doc
@@ -159,16 +159,15 @@ With respect to the other fixed components.
 
 Parameters
 ----------
-xd : float
-    Real number.
-xcond : sequence of float with dimension :math:`d-1`
-    Conditioning values.
+xj : float, sequence of float,
+    Conditional CDF input.
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
 
 Returns
 -------
-d : float
-    Conditional DDF value at *xd*, given *xcond*
-    where *xd* is the last component of the multivariate distribution.
+ddf : float,
+    Conditional DDF value at  *xj* given *xcond*.
     
 
 See Also
@@ -187,16 +186,15 @@ Conditional PDF of the last component with respect to the other fixed components
 
 Parameters
 ----------
-xd : float, sequence of float
-    The input value where the conditional CDF must be evaluated.
-xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
-    Conditioning values.
+xj : float, sequence of float,
+    Conditional CDF input.
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
 
 Returns
 -------
-F : float, sequence of float
-    Conditional PDF at *xd*, given *xcond*
-    where *xd* is the last component of the multivariate distribution.
+cpdf : float, sequence of float
+    Conditional PDF at *xd*, given *xcond*.
 
 See Also
 --------
@@ -216,14 +214,16 @@ Parameters
 ----------
 p : float, sequence of float, :math:`p \in [0, 1]`
     Conditional quantile.
-xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
-    Conditioning values.
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
 
 Returns
 -------
-x1 : float
-    Conditional quantile at input :math:`p` given *xcond*
-    where *x1* is the first component of the multivariate distribution.
+xj : float
+    Conditional quantile of order *p* of the component :math:`X_j`
+    given that the components of indices :math:`k \leq j-1` are fixed and
+    equal to *xcond*.
+    
 
 See Also
 --------

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -650,7 +650,7 @@ dfdtheta : :class:`~openturns.Point`
 Notes
 -----
 Let :math:`\vect{\theta}` be the vector of parameters of the distribution. Then
-the gradient of the probability density function :math:`f_{\vect{X})` is defined by:
+the gradient of the probability density function :math:`f_{\vect{X}}` is defined by:
 
 .. math::
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -365,7 +365,7 @@ OT_Distribution_computeSequentialConditionalQuantile_doc
 Parameters
 ----------
 x : sequence of float, 2-d sequence of float
-    Point in :math:`\Rset^d`.
+    The input value where the conditional derivative density function must be evaluated.
 
 Returns
 -------

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -15,13 +15,13 @@ OT_Distribution_doc
 
 Parameters
 ----------
-X : sequence of float, 2-d sequence of float
-    CDF input(s).
+x : sequence of float, 2-d sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 F : float, :class:`~openturns.Point`
-    CDF value(s) at input(s) :math:`X`.
+    CDF value at *x*.
 
 Notes
 -----
@@ -30,7 +30,7 @@ The cumulative distribution function is defined as:
 .. math::
 
     F_{\vect{X}}(\vect{x}) = \Prob{\bigcap_{i=1}^n X_i \leq x_i},
-                             \quad \vect{x} \in \supp{\vect{X}}"
+                             \quad \vect{x} \in \Rset^d"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeCDF
 OT_Distribution_computeCDF_doc
@@ -42,14 +42,14 @@ OT_Distribution_computeCDF_doc
 
 Parameters
 ----------
-X : sequence of float
-    CDF input.
+x : sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 dFdtheta : :class:`~openturns.Point`
     Partial derivatives of the CDF with respect to the distribution
-    parameters at input :math:`X`."
+    parameters at *x*."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeCDFGradient
 OT_Distribution_computeCDFGradient_doc
@@ -67,7 +67,7 @@ t : float
 Returns
 -------
 phi : complex
-    Characteristic function value at input :math:`t`.
+    Characteristic function value at input *t*.
 
 Notes
 -----
@@ -93,13 +93,13 @@ OT_Distribution_computeCharacteristicFunction_doc
 
 Parameters
 ----------
-X : sequence of float, 2-d sequence of float
-    Complementary CDF input(s).
+x : sequence of float, 2-d sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 C : float, :class:`~openturns.Point`
-    Complementary CDF value(s) at input(s) :math:`X`.
+    Complementary CDF value at *x*.
 
 Notes
 -----
@@ -107,11 +107,10 @@ The complementary cumulative distribution function.
 
 .. math::
 
-    1 - F_{\vect{X}}(\vect{x}) = 1 - \Prob{\bigcap_{i=1}^n X_i \leq x_i}, \quad \vect{x} \in \supp{\vect{X}}
+    1 - F_{\vect{X}}(\vect{x}) = 1 - \Prob{\bigcap_{i = 1}^d \left\{X_i \leq x_i \right\}}, \qquad \vect{x} \in \Rset^d
 
 .. warning::
-    This is not the survival function (except for 1-dimensional
-    distributions).
+    The complementary CDF is different from the survival function (except for scalar distributions).
 
 See Also
 --------
@@ -127,15 +126,15 @@ OT_Distribution_computeComplementaryCDF_doc
 
 Parameters
 ----------
-Xn : float, sequence of float
+xd : float, sequence of float
     Conditional CDF input (last component).
-Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
     Conditioning values for the other components.
 
 Returns
 -------
 F : float, sequence of float
-    Conditional CDF value(s) at input :math:`X_n`, :math:`X_{cond}`.
+    Conditional CDF value at  *xd* given *xcond*.
 
 Notes
 -----
@@ -144,9 +143,9 @@ respect to the other fixed components is defined as follows:
 
 .. math::
 
-    F_{X_n \mid X_1, \ldots, X_{n - 1}}(x_n) =
-        \Prob{X_n \leq x_n \mid X_1=x_1, \ldots, X_{n-1}=x_{n-1}},
-        \quad x_n \in \supp{X_n}"
+    F_{X_d \mid X_1, \ldots, X_{d - 1}}(x_d) =
+        \Prob{X_d \leq x_d \mid X_1=x_1, \ldots, X_{d-1}=x_{d-1}},
+        \quad x_d \in \Rset"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeConditionalCDF
 OT_Distribution_computeConditionalCDF_doc
@@ -160,15 +159,17 @@ With respect to the other fixed components.
 
 Parameters
 ----------
-Xn : float
-    Conditional DDF input (last component).
-Xcond : sequence of float with dimension :math:`n-1`
-    Conditioning values for the other components.
+Xd : float
+    Real in :math:`\Rset`.
+xcond : sequence of float with dimension :math:`d-1`
+    Conditioning values.
 
 Returns
 -------
 d : float
-    Conditional DDF value at input :math:`X_n`, :math:`X_{cond}`.
+    Conditional DDF value at *xd*, given Xcond
+    where *xd* is the last component of the multivariate distribution.
+    
 
 See Also
 --------
@@ -186,15 +187,16 @@ Conditional PDF of the last component with respect to the other fixed components
 
 Parameters
 ----------
-Xn : float, sequence of float
-    Conditional PDF input (last component).
-Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
-    Conditioning values for the other components.
+xd : float, sequence of float
+    Point in :math:`\Rset`.
+xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
+    Conditioning values.
 
 Returns
 -------
 F : float, sequence of float
-    Conditional PDF value(s) at input :math:`X_n`, :math:`X_{cond}`.
+    Conditional PDF at *xd*, given *xcond*
+    where *xd* is the last component of the multivariate distribution.
 
 See Also
 --------
@@ -212,15 +214,16 @@ Conditional quantile with respect to the other fixed components.
 
 Parameters
 ----------
-p : float, sequence of float, :math:`0 < p < 1`
-    Conditional quantile function input.
-Xcond : sequence of float, 2-d sequence of float with size :math:`n-1`
-    Conditioning values for the other components.
+p : float, sequence of float, :math:`p \in [0, 1]`
+    Conditional quantile.
+Xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
+    Conditioning values.
 
 Returns
 -------
-X1 : float
-    Conditional quantile at input :math:`p`, :math:`X_{cond}`.
+x1 : float
+    Conditional quantile at input :math:`p` given *xcond*
+    where *x1* is the first component of the multivariate distribution.
 
 See Also
 --------
@@ -236,13 +239,13 @@ OT_Distribution_computeConditionalQuantile_doc
 
 Parameters
 ----------
-X : sequence of float, with size :math:`d`
+x : sequence of float, with size :math:`d`
     Values to be taken sequentially as argument and conditioning part of the CDF.
 
 Returns
 -------
 F : sequence of float
-    Conditional CDF values at input.
+    Conditional CDF values at *x*.
 
 Notes
 -----
@@ -250,9 +253,11 @@ The sequential conditional cumulative distribution function is defined as follow
 
 .. math::
 
-    F^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\Prob{X_n \leq x_n \mid X_1=x_1, \ldots, X_{n-1}=x_{n-1}}\right)_{i=1,\ldots,d}
+    F^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
-ie its :math:`n`-th component is the conditional CDF of :math:`X_n` at :math:`x_n` given that :math:`X_1=x_1,\ldots,X_{n-1}=x_{n-1}`. For :math:`n=1` it reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
+ie the :math:`i`-th component is the conditional CDF of :math:`X_i` at :math:`x_i` given
+that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it
+reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
 
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalCDF
@@ -265,13 +270,13 @@ OT_Distribution_computeSequentialConditionalCDF_doc
 
 Parameters
 ----------
-X : sequence of float, with size :math:`d`
+x : sequence of float, with size :math:`d`
     Values to be taken sequentially as argument and conditioning part of the DDF.
 
 Returns
 -------
 ddf : sequence of float
-    Conditional DDF values at input.
+    Conditional DDF values at *x*.
 
 Notes
 -----
@@ -279,11 +284,11 @@ The sequential conditional derivative density function is defined as follows:
 
 .. math::
 
-    ddf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d^2}{d\,x_n^2}\Prob{X_n \leq x_n \mid X_1=x_1, \ldots, 
-    X_{n-1}=x_{n-1}}\right)_{i=1,\ldots,d}
+    ddf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d^2}{d\,x_i^2}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots,
+    X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
-ie its :math:`n`-th component is the conditional DDF of :math:`X_n` at :math:`x_n` given that :math:`X_1=x_1,
-\ldots,X_{n-1}=x_{n-1}`. For :math:`n=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}\Prob{X_1 \leq x_1}`, ie the DDF of 
+ie the :math:`i`-th component is the conditional DDF of :math:`X_i` at :math:`x_i` given that :math:`X_1=x_1,
+\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}\Prob{X_1 \leq x_1}`, ie the DDF of
 the first component at :math:`x_1`."
 
 %enddef
@@ -297,13 +302,13 @@ OT_Distribution_computeSequentialConditionalDDF_doc
 
 Parameters
 ----------
-X : sequence of float, with size :math:`d`
+x : sequence of float, with size :math:`d`
     Values to be taken sequentially as argument and conditioning part of the PDF.
 
 Returns
 -------
 pdf : sequence of float
-    Conditional PDF values at input.
+    Conditional PDF values at *x*.
 
 Notes
 -----
@@ -311,9 +316,11 @@ The sequential conditional density function is defined as follows:
 
 .. math::
 
-    pdf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d}{d\,x_n}\Prob{X_n \leq x_n \mid X_1=x_1, \ldots, X_{n-1}=x_{n-1}}\right)_{i=1,\ldots,d}
+    pdf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d}{d\,x_i}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
-ie its :math:`n`-th component is the conditional PDF of :math:`X_n` at :math:`x_n` given that :math:`X_1=x_1,\ldots,X_{n-1}=x_{n-1}`. For :math:`n=1` it reduces to :math:`\dfrac{d}{d\,x_1}\Prob{X_1 \leq x_1}`, ie the PDF of the first component at :math:`x_1`."
+ie the :math:`i`-th component is the conditional PDF of :math:`X_i` at :math:`x_i` given
+that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it reduces to
+:math:`\dfrac{d}{d\,x_1}\Prob{X_1 \leq x_1}`, ie the PDF of the first component at :math:`x_1`."
 
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalPDF
@@ -340,10 +347,10 @@ The sequential conditional quantile function is defined as follows:
 
 .. math::
 
-    Q^{seq}_{X_1,\ldots,X_d}(q_1,\ldots,q_d) = \left(F^{-1}(q_n|X_1=x_1,\ldots,X_{n-1}=x_{n_1}\right)_{i=1,\ldots,d}
+    Q^{seq}_{X_1,\ldots,X_d}(q_1,\ldots,q_d) = \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1}\right)_{i=1,\ldots,d}
 
-where :math:`x_1,\ldots,x_{n-1}` are defined recursively as :math:`x_1=F_1^{-1}(q_1)` and given :math:`(x_i)_{i=1,
-\ldots,n-1}`, :math:`x_n=F^{-1}(q_n|X_1=x_1,\ldots,X_{n-1}=x_{n_1})`: the conditioning part is the set of already 
+where :math:`x_1,\ldots,x_{i-1}` are defined recursively as :math:`x_1=F_1^{-1}(q_1)` and for :math:`2\leq i \leq d`,
+:math:`x_i=F_i^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1})`: the conditioning part is the set of already
 computed conditional quantiles."
 
 %enddef
@@ -357,13 +364,13 @@ OT_Distribution_computeSequentialConditionalQuantile_doc
 
 Parameters
 ----------
-X : sequence of float, 2-d sequence of float
-    PDF input(s).
+x : sequence of float, 2-d sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 d : :class:`~openturns.Point`, :class:`~openturns.Sample`
-    DDF value(s) at input(s) :math:`X`.
+    DDF value at *x*.
 
 Notes
 -----
@@ -375,7 +382,7 @@ function with respect to :math:`\vect{x}`:
     \vect{\nabla}_{\vect{x}} f_{\vect{X}}(\vect{x}) =
         \Tr{\left(\frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_i},
                   \quad i = 1, \ldots, n\right)},
-        \quad \vect{x} \in \supp{\vect{X}}"
+        \quad \vect{x} \in \Rset^d"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeDDF
 OT_Distribution_computeDDF_doc
@@ -420,7 +427,7 @@ z : float or complex
 Returns
 -------
 g : float
-    Probability-generating function value at input :math:`X`.
+    Probability-generating function value at input *z*.
 
 Notes
 -----
@@ -453,7 +460,7 @@ t : float
 Returns
 -------
 phi : complex
-    Logarithm of the characteristic function value at input :math:`t`.
+    Logarithm of the characteristic function value at input *t*.
 
 Notes
 -----
@@ -483,7 +490,7 @@ z : float or complex
 Returns
 -------
 lg : float
-    Logarithm of the probability-generating function value at input :math:`X`.
+    Logarithm of the probability-generating function value at input *z*.
 
 Notes
 -----
@@ -504,13 +511,13 @@ OT_Distribution_computeLogGeneratingFunction_doc
 
 Parameters
 ----------
-X : sequence of float, 2-d sequence of float
-    PDF input(s).
+x : sequence of float, 2-d sequence of float
+    Point in :math:`\Rset^d` such that the PDF at this point is non equal to 0.
 
 Returns
 -------
 f : float, :class:`~openturns.Point`
-    Logarithm of the PDF value(s) at input(s) :math:`X`."
+    Logarithm of the PDF at *x*."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeLogPDF
 OT_Distribution_computeLogPDF_doc
@@ -522,14 +529,14 @@ OT_Distribution_computeLogPDF_doc
 
 Parameters
 ----------
-X : sequence of float
-    PDF input.
+x : sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 dfdtheta : :class:`~openturns.Point`
     Partial derivatives of the logPDF with respect to the distribution
-    parameters at input :math:`X`."
+    parameters at input *x*."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeLogPDFGradient
 OT_Distribution_computeLogPDFGradient_doc
@@ -541,13 +548,13 @@ OT_Distribution_computeLogPDFGradient_doc
 
 Parameters
 ----------
-X : sequence of float, 2-d sequence of float
-    PDF input(s).
+x : sequence of float, 2-d sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 f : float, :class:`~openturns.Point`
-    PDF value(s) at input(s) :math:`X`.
+    PDF value at *x*.
 
 Notes
 -----
@@ -557,7 +564,7 @@ The probability density function is defined as follows:
 
     f_{\vect{X}}(\vect{x}) = \frac{\partial^n F_{\vect{X}}(\vect{x})}
                                   {\prod_{i=1}^n \partial x_i},
-                             \quad \vect{x} \in \supp{\vect{X}}"
+                             \quad \vect{x} \in \Rset^d"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computePDF
 OT_Distribution_computePDF_doc
@@ -569,14 +576,14 @@ OT_Distribution_computePDF_doc
 
 Parameters
 ----------
-X : sequence of float
-    PDF input.
+x : sequence of float
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
 dfdtheta : :class:`~openturns.Point`
     Partial derivatives of the PDF with respect to the distribution
-    parameters at input :math:`X`."
+    parameters at input *x*."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computePDFGradient
 OT_Distribution_computePDFGradient_doc
@@ -589,27 +596,26 @@ OT_Distribution_computePDFGradient_doc
 Parameters
 ----------
 interval : :class:`~openturns.Interval`
-    An interval, possibly multivariate.
+    An interval in :math:`\Rset^d`.
 
 Returns
 -------
-P : float
-    Interval probability.
+p : float
+    The probability of *interval*.
 
 Notes
 -----
-This computes the probability that the random vector :math:`\vect{X}` lies in
-the hyper-rectangular region formed by the vectors :math:`\vect{a}` and
-:math:`\vect{b}`:
+This computes the probability that the random vector :math:`\vect{X}` lies in :math:`interval`.
+
+If the interval is rectangular, i.e. if :math:`I = \bigcap\limits_{i=1}^d [a_i, b_i]`, then we have:
 
 .. math::
 
-    \Prob{\bigcap\limits_{i=1}^n a_i < X_i \leq b_i} =
-        \sum\limits_{\vect{c}} (-1)^{n(\vect{c})}
+    \Prob{\vect{X} \in I} = \sum\limits_{\vect{c}} (-1)^{n(\vect{c})}
             F_{\vect{X}}\left(\vect{c}\right)
 
-where the sum runs over the :math:`2^n` vectors such that
-:math:`\vect{c} = \Tr{(c_i, i = 1, \ldots, n)}` with :math:`c_i \in [a_i, b_i]`,
+where the sum runs over the :math:`2^d` vectors such that
+:math:`\vect{c} = \Tr{(c_i, i = 1, \ldots, d)}` with :math:`c_i \in \{a_i, b_i\}`,
 and :math:`n(\vect{c})` is the number of components in
 :math:`\vect{c}` such that :math:`c_i = a_i`."
 %enddef
@@ -623,25 +629,46 @@ OT_Distribution_computeProbability_doc
 
 Parameters
 ----------
-p : float (or sequence of float), :math:`0 < p < 1`
-    Quantile function input (a probability).
-tail : bool, optional (default=False)
-    Whether p should be interpreted as the complementary probability.
+p : float (or sequence of float), :math:`p \in [0, 1]`
+    A probability.
+tail : bool, optional
+    `True` indicates that the order considered is :math:`1-p`.
+    Default value is `False`.
 
 Returns
 -------
-X : :class:`~openturns.Point` (or :class:`~openturns.Sample`)
-    Quantile at probability level :math:`p`.
+xp : :class:`~openturns.Point` (or :class:`~openturns.Sample`)
+    If `tail=False`, the quantile of order :math:`p`.
+    If `tail=True`, the quantile of order  :math:`1-p`.
 
 Notes
 -----
-The quantile function is also known as the inverse cumulative distribution
-function:
+If the underlying variable :math:`X` is scalar, then the quantile of order :math:`p`, denoted by :math:`x_p`,
+is defined as the generalized inverse of its cumulative distribution function:
 
 .. math::
 
-    Q_{\vect{X}}(p) = F_{\vect{X}}^{-1}(p),
-                      \quad p \in [0; 1]"
+      x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset\, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
+
+If the distribution is scalar and discrete, then the quantile of order :math:`p=0` is defined by:
+
+.. math::
+
+    x_0 = \sup \{ x \in \Rset \, |\, F(x) = 0 \}.
+
+If the underlying variable :math:`\vect{X} = (X_1, \dots, X_d)` is of dimension :math:`d>1`, then
+the quantile of order :math:`p`, denoted by :math:`\vect{x}_p \in \Rset^d`, is such that:
+
+.. math::
+
+    \begin{aligned}
+        F_{\vect{X}}(\vect{x}_p) & =  p \\    
+        F_{X_i}(\vect{x}_{p,i}) & =  F_{X_j}(\vect{x}_{p,j}) \quad \forall (i,j)
+    \end{aligned}
+
+where :math:`F_{X_i}` is the :math:`i`-th marginal cdf. The last condition means that the quantile of order :math:`p`
+is such that all the components are associated to the same order of quantile of their margin.
+"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeQuantile
 OT_Distribution_computeQuantile_doc
@@ -656,13 +683,13 @@ distributions only).
 
 Parameters
 ----------
-r2 : float, :math:`0 \leq r^2`
+r2 : float, :math:`0 \leq R^2`
     Squared radius.
 
 Returns
 -------
 F : float
-    CDF value at input :math:`r^2`.
+    CDF value at input *r2*.
 
 Notes
 -----
@@ -683,22 +710,28 @@ OT_Distribution_computeRadialDistributionCDF_doc
 
 Parameters
 ----------
-p : float, :math:`0 < p < 1`
-    Quantile function input (a probability).
+p : float, :math:`p \in [0; 1]`
+    A probability.
 
 Returns
 -------
-X : float
-    Quantile at probability level :math:`p`.
+xp : float
+    Quantile of order *p*.
 
 Notes
 -----
-The quantile function is also known as the inverse cumulative distribution
-function:
+The quantile of order :math:`p`, denoted by :math:`x_p`,
+is defined as the generalized inverse of its cumulative distribution function:
 
 .. math::
 
-    Q_X(p) = F_X^{-1}(p), \quad p \in [0; 1]
+      x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset \, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
+
+If the distribution is discrete, then the quantile of order :math:`p=0` is defined by:
+
+.. math::
+
+    x_0 = \sup \{ x \in \Rset \, |\, F(x)= 0 \}.
 
 See Also
 --------
@@ -715,27 +748,25 @@ OT_Distribution_computeScalarQuantile_doc
 Parameters
 ----------
 x : sequence of float, 2-d sequence of float
-    Survival function input(s).
+    Point in :math:`\Rset^d`.
 
 Returns
 -------
-S : float, :class:`~openturns.Point`
-    Survival function value(s) at input(s) `x`.
+s : float, :class:`~openturns.Point`
+    Survival function at *x*.
 
 Notes
 -----
-The survival function of the random vector :math:`\vect{X}` is defined as follows:
+The survival function of the random vector :math:`\vect{X}` of dimension :math:`d` is defined as follows:
 
 .. math::
 
- 
-    S_{\vect{X}}(\vect{x}) = \Prob{\bigcap_{i=1}^d X_i > x_i}
-             \quad \forall \vect{x} \in \Rset^d
+    S_{\vect{X}}(\vect{x}) = \Prob{\bigcap_{i = 1}^d \left\{X_i > x_i \right\}}, \qquad \vect{x} \in \Rset^d
 
 .. warning::
 
-    This is not the complementary cumulative distribution function (except for
-    1-dimensional distributions).
+    This is not the complementary cumulative distribution function except for
+    scalar distributions.
 
 See Also
 --------
@@ -752,7 +783,7 @@ OT_Distribution_computeSurvivalFunction_doc
 Parameters
 ----------
 p : float, :math:`p \in [0; 1]`
-    Level of the survival function.
+    Value of the survival function.
 
 Returns
 -------
@@ -761,8 +792,9 @@ x : :class:`~openturns.Point`
 
 Notes
 -----
-The inverse survival function writes: :math:`S^{-1}(p)  =  \vect{x}^p` where :math:`S( \vect{x}^p) = \Prob{\bigcap_{i=1}^d X_i > x_i^p}`. OpenTURNS returns the point :math:`\vect{x}^p` such that 
-:math:`\Prob{ X_1 > x_1^p}   =  \dots = \Prob{ X_d > x_d^p}`.
+Among the points :math:`\vect{x}` that satisfy :math:`S_{\vect{X}}(\vect{x}) = p`,
+the method returns the one which also satisfies
+:math:`\Prob{X_1 > x_1}   =  \dots = \Prob{X_d > x_d}`.
 
 See Also
 --------
@@ -785,11 +817,11 @@ Available constructors:
 
 Parameters
 ----------
-x_min : float, optional
+xMin : float, optional
     The min-value of the mesh of the x-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMin` from the :class:`~openturns.ResourceMap`.
-x_max : float, optional, :math:`x_{\max} > x_{\min}`
+xMax : float, optional, *xMax > xMin*
     The max-value of the mesh of the y-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMax` from the :class:`~openturns.ResourceMap`.
@@ -851,13 +883,13 @@ OT_Distribution_drawCDF_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the margin of interest.
-x_min : float
+xMin : float
     The starting value that is used for meshing the x-axis.
-x_max : float, :math:`x_{\max} > x_{\min}`
+xMax : float, *xMax > xMin*
     The ending value that is used for meshing the x-axis.
-n_points : int
+nPoints : int
     The number of points that is used for meshing the x-axis.
 logScale : bool
     Flag to tell if the plot is done on a logarithmic scale. Default is *False*.
@@ -897,7 +929,7 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 levelSet : :class:`~openturns.LevelSet`
-    The minimum volume domain of measure :math:`\alpha`.
+    The minimum volume domain of measure *alpha*.
 
 Notes
 -----
@@ -964,7 +996,7 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 levelSet : :class:`~openturns.LevelSet`
-    The minimum volume domain of measure :math:`\alpha`.
+    The minimum volume domain of measure *alpha*.
 level : float
     The value :math:`p_{\alpha}` of the density function defining the frontier of the domain.
 
@@ -1002,13 +1034,16 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 confInterval : :class:`~openturns.Interval`
-    The confidence interval of level :math:`\alpha`.
+    The confidence interval of level *alpha*.
 
 Notes
 -----
 We consider an absolutely continuous measure :math:`\mu` with density function :math:`p`. 
 
-The minimum volume confidence interval :math:`I^*_{\alpha}` is the cartesian product :math:`I^*_{\alpha} = [a_1, b_1] \times \dots \times [a_d, b_d]` where :math:`[a_i, b_i]   = \argmin_{I \in \Rset \, | \, \mu_i(I) = \beta} \lambda_i(I)` and :math:`\mu(I^*_{\alpha})  =  \alpha` with :math:`\lambda` is the Lebesgue measure on :math:`\Rset^d`. 
+The minimum volume confidence interval :math:`I^*_{\alpha}` is the Cartesian product
+:math:`I^*_{\alpha} = [a_1, b_1] \times \dots \times [a_d, b_d]` where
+:math:`[a_i, b_i]   = \argmin_{I \in \Rset \, | \, \mu_i(I) = \beta} \lambda_i(I)`
+and :math:`\mu(I^*_{\alpha})  =  \alpha` with :math:`\lambda` is the Lebesgue measure on :math:`\Rset^d`.
 
 This problem resorts to solving :math:`d` univariate non linear equations: for a fixed value :math:`\beta`, we find each intervals :math:`[a_i, b_i]` such that:
 
@@ -1066,7 +1101,7 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 confInterval : :class:`~openturns.Interval`
-    The confidence interval of level :math:`\alpha`.
+    The confidence interval of level *alpha*.
 marginalProb : float
     The value :math:`\beta` which is the common marginal probability of each marginal interval.
 
@@ -1107,30 +1142,30 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 confInterval : :class:`~openturns.Interval`
-    The confidence interval of level :math:`\alpha`.
+    The confidence interval of level *alpha*.
 
 Notes
 -----
 We consider an absolutely continuous measure :math:`\mu` with density function :math:`p`. 
 
-The bilateral confidence interval :math:`I^*_{\alpha}` is the cartesian product :math:`I^*_{\alpha} = [a_1, b_1] \times \dots \times [a_d, b_d]` where :math:`a_i = F_i^{-1}((1-\beta)/2)` and :math:`b_i = F_i^{-1}((1+\beta)/2)` for all :math:`i` and which verifies :math:`\mu(I^*_{\alpha}) = \alpha`. 
+The bilateral confidence interval :math:`I^*_{\alpha}` is the Cartesian product
+:math:`I^*_{\alpha} = [a_1, b_1] \times \dots \times [a_d, b_d]`
+such that there exists :math:`\beta \in [0,1]` which satisfies the equations :math:`a_i = F_i^{-1}((1 - \beta) / 2)` and :math:`b_i = F_i^{-1}((1 + \beta) / 2)`
+for all :math:`i` and :math:`\mu(I^*_{\alpha}) = \alpha`.
 
 Examples
 --------
-Create a sample from a Normal distribution:
+We consider a Normal(2) distribution with zero mean, unit standard deviation and independent components.
+We note :math:`\Phi_2` its cdf. Due to
+symetries of the distribution, the bilateral confidence interval is :math:`I^*_{\alpha} = [-a, a] \times \times [-a, a]`
+where :math:`a = \Phi^{-1}((1+\beta)/2)` where :math:`\Phi` is the marginal cdf of each component. Then :math:`\beta` is such that
+:math:`\Phi_2(I^*_{\alpha}) = \alpha`. As :math:`\Phi_2(I^*_{\alpha}) = (2\Phi(a) - 1)^2 = _beta^2`,
+then, :math:`\beta` is equal to :math:`\beta = \sqrt{\alpha} \simeq 0.9486`
+and :math:`a \simeq -1.9488`.
 
 >>> import openturns as ot
->>> sample = ot.Normal().getSample(10)
->>> ot.ResourceMap.SetAsUnsignedInteger('DistributionFactory-DefaultBootstrapSize', 100)
-
-Fit a Normal distribution and extract the asymptotic parameters distribution:
-
->>> fittedRes = ot.NormalFactory().buildEstimator(sample)
->>> paramDist = fittedRes.getParameterDistribution()
-
-Determine the bilateral confidence interval at level 0.9:
-
->>> confInt = paramDist.computeBilateralConfidenceInterval(0.9)"
+>>> dist = ot.Normal(2)
+>>> confInt = dist.computeBilateralConfidenceInterval(0.9)"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeBilateralConfidenceInterval
 OT_Distribution_computeBilateralConfidenceInterval_doc
@@ -1150,26 +1185,23 @@ alpha : float, :math:`\alpha \in [0,1]`
 Returns
 -------
 confInterval : :class:`~openturns.Interval`
-    The confidence interval of level :math:`\alpha`.
-marginalProb : float
-    The value :math:`\beta` which is the common marginal probability of each marginal interval.
+    The confidence interval of level *\alpha*.
+beta : float
+    The probability :math:`\beta`.
 
 Examples
 --------
-Create a sample from a Normal distribution:
+We consider a Normal(2) distribution with zero mean, unit standard deviation and independent components.
+We note :math:`\Phi_2` its cdf. Due to
+symetries of the distribution, the bilateral confidence interval is :math:`I^*_{\alpha} = [-a, a] \times [-a, a]`
+where :math:`a = \Phi^{-1}((1 + \beta) / 2)` where :math:`\Phi` is the marginal cdf of each 1D marginal standard Gaussian component. Then :math:`\beta` is such that
+:math:`\Phi_2(I^*_{\alpha}) = \alpha`. As :math:`\Phi_2(I^*_{\alpha}) = (2\Phi(a) - 1)^2 = \beta^2`,
+then, :math:`\beta` is equal to :math:`\beta = \sqrt{\alpha} = 0.9486`
+and :math:`a = -1.9488` with 4 significant digits.
 
 >>> import openturns as ot
->>> sample = ot.Normal().getSample(10)
->>> ot.ResourceMap.SetAsUnsignedInteger('DistributionFactory-DefaultBootstrapSize', 100)
-
-Fit a Normal distribution and extract the asymptotic parameters distribution:
-
->>> fittedRes = ot.NormalFactory().buildEstimator(sample)
->>> paramDist = fittedRes.getParameterDistribution()
-
-Determine the bilateral confidence interval at level 0.9 with marginal probability:
-
->>> confInt, marginalProb = paramDist.computeBilateralConfidenceIntervalWithMarginalProbability(0.9)"
+>>> dist = ot.Normal(2)
+>>> confInt, beta = dist.computeBilateralConfidenceIntervalWithMarginalProbability(0.9)"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeBilateralConfidenceIntervalWithMarginalProbability
 OT_Distribution_computeBilateralConfidenceIntervalWithMarginalProbability_doc
@@ -1247,7 +1279,7 @@ tail : boolean
 Returns
 -------
 confInterval : :class:`~openturns.Interval`
-    The unilateral confidence interval of level :math:`\alpha`.
+    The unilateral confidence interval of level *alpha*.
 marginalProb : float
     The value :math:`\beta` which is the common marginal probability of each marginal interval.
 
@@ -1284,16 +1316,17 @@ OT_Distribution_computeUnilateralConfidenceIntervalWithMarginalProbability_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the margin of interest.
-x_min : float
+xMin : float
     The starting value that is used for meshing the x-axis.
-x_max : float, :math:`x_{\max} > x_{\min}`
+xMax : float, *xMax > xMin*
     The ending value that is used for meshing the x-axis.
-n_points : int
+nPoints : int
     The number of points that is used for meshing the x-axis.
 logScale : bool
-    Flag to tell if the plot is done on a logarithmic scale. Default is *False*.
+    Flag to tell if the plot is done on a logarithmic scale.
+    Default is *False*.
 
 Returns
 -------
@@ -1323,13 +1356,13 @@ OT_Distribution_drawMarginal1DPDF_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the margin of interest.
-x_min : float
+xMin : float
     The starting value that is used for meshing the x-axis.
-x_max : float, :math:`x_{\max} > x_{\min}`
+xMax : float, *xMax > xMin*
     The ending value that is used for meshing the x-axis.
-n_points : int
+nPoints : int
     The number of points that is used for meshing the x-axis.
 logScale : bool
     Flag to tell if the plot is done on a logarithmic scale. Default is *False*.
@@ -1362,15 +1395,15 @@ OT_Distribution_drawMarginal1DLogPDF_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the first margin of interest.
-j : int, :math:`1 \leq i \neq j \leq n`
+j : int, :math:`1 \leq i \neq j \leq d`
     The index of the second margin of interest.
-x_min : list of 2 floats
+xMin : list of 2 floats
     The starting values that are used for meshing the x- and y- axes.
-x_max : list of 2 floats, :math:`x_{\max} > x_{\min}`
+xMax : list of 2 floats, *xMax > xMin*
     The ending values that are used for meshing the x- and y- axes.
-n_points : list of 2 ints
+nPoints : list of 2 ints
     The number of points that are used for meshing the x- and y- axes.
 logScaleX : bool
     Flag to tell if the plot is done on a logarithmic scale for X. Default is *False*.
@@ -1406,15 +1439,15 @@ OT_Distribution_drawMarginal2DCDF_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the first margin of interest.
-j : int, :math:`1 \leq i \neq j \leq n`
+j : int, :math:`1 \leq i \neq j \leq d`
     The index of the second margin of interest.
-x_min : list of 2 floats
+xMin : list of 2 floats
     The starting values that are used for meshing the x- and y- axes.
-x_max : list of 2 floats, :math:`x_{\max} > x_{\min}`
+xMax : list of 2 floats, *xMax > xMin*
     The ending values that are used for meshing the x- and y- axes.
-n_points : list of 2 ints
+nPoints : list of 2 ints
     The number of points that are used for meshing the x- and y- axes.
 logScaleX : bool
     Flag to tell if the plot is done on a logarithmic scale for X. Default is *False*.
@@ -1450,15 +1483,15 @@ OT_Distribution_drawMarginal2DPDF_doc
 
 Parameters
 ----------
-i : int, :math:`1 \leq i \leq n`
+i : int, :math:`1 \leq i \leq d`
     The index of the first margin of interest.
-j : int, :math:`1 \leq i \neq j \leq n`
+j : int, :math:`1 \leq i \neq j \leq d`
     The index of the second margin of interest.
-x_min : list of 2 floats
+xMin : list of 2 floats
     The starting values that are used for meshing the x- and y- axes.
-x_max : list of 2 floats, :math:`x_{\max} > x_{\min}`
+xMax : list of 2 floats, *xMax > xMin*
     The ending values that are used for meshing the x- and y- axes.
-n_points : list of 2 ints
+nPoints : list of 2 ints
     The number of points that are used for meshing the x- and y- axes.
 logScaleX : bool
     Flag to tell if the plot is done on a logarithmic scale for X. Default is *False*.
@@ -1501,11 +1534,11 @@ Available constructors:
 
 Parameters
 ----------
-x_min : float, optional
+xMin : float, optional
     The min-value of the mesh of the x-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMin` from the :class:`~openturns.ResourceMap`.
-x_max : float, optional, :math:`x_{\max} > x_{\min}`
+xMax : float, optional, *xMax > xMin*
     The max-value of the mesh of the y-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMax` from the :class:`~openturns.ResourceMap`.
@@ -1574,11 +1607,11 @@ Available constructors:
 
 Parameters
 ----------
-x_min : float, optional
+xMin : float, optional
     The min-value of the mesh of the x-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMin` from the :class:`~openturns.ResourceMap`.
-x_max : float, optional, :math:`x_{\max} > x_{\min}`
+xMax : float, optional, *xMax > xMin*
     The max-value of the mesh of the y-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMax` from the :class:`~openturns.ResourceMap`.
@@ -1640,11 +1673,11 @@ OT_Distribution_drawLogPDF_doc
 
 Parameters
 ----------
-q_min : float, in :math:`[0,1]`
+qmin : float, in :math:`[0,1]`
     The min value of the mesh of the x-axis.
-q_max : float, in :math:`[0,1]`
+qmax : float, in :math:`[0,1]`
     The max value of the mesh of the x-axis.
-n_points : int, optional
+nPoints : int, optional
     The number of points that is used for meshing the quantile curve.
     Defaults uses `DistributionImplementation-DefaultPointNumber` from the
     :class:`~openturns.ResourceMap`.
@@ -1745,7 +1778,7 @@ shift : sequence of float
 Returns
 -------
 m : :class:`~openturns.Point`
-    Componentwise central moment of order :math:`k`.
+    Componentwise central moment of order *k*`.
 
 Notes
 -----
@@ -2071,7 +2104,7 @@ OT_Distribution_getKurtosis_doc
 
 Parameters
 ----------
-i : int or list of ints, :math:`0 \leq i < n`
+i : int or list of ints, :math:`0 \leq i < d`
     Component(s) indice(s).
 
 Returns
@@ -2116,7 +2149,7 @@ k : int
 Returns
 -------
 m : :class:`~openturns.Point`
-    Componentwise moment of order :math:`k`.
+    Componentwise moment of order *k*`.
 
 Notes
 -----
@@ -2124,7 +2157,7 @@ The componentwise moment of order :math:`k` is defined as:
 
 .. math::
 
-    \vect{m}^{(k)} = \Tr{\left(\Expect{X_i^k}, \quad i = 1, \ldots, n\right)}"
+    \vect{m}^{(k)} = \Tr{\left(\Expect{X_i^k}, \quad i = 1, \ldots, d\right)}"
 %enddef
 %feature("docstring") OT::DistributionImplementation::getMoment
 OT_Distribution_getMoment_doc
@@ -2232,9 +2265,9 @@ Pearson's correlation is defined as the normalized covariance matrix:
 .. math::
 
     \mat{\rho} & = \left[\frac{\Cov{X_i, X_j}}{\sqrt{\Var{X_i}\Var{X_j}}},
-                         \quad i,j = 1, \ldots, n\right] \\
+                         \quad i,j = 1, \ldots, d\right] \\
                & = \left[\frac{\Sigma_{i,j}}{\sqrt{\Sigma_{i,i}\Sigma_{j,j}}},
-                         \quad i,j = 1, \ldots, n\right]"
+                         \quad i,j = 1, \ldots, d\right]"
 %enddef
 %feature("docstring") OT::DistributionImplementation::getPearsonCorrelation
 OT_Distribution_getPearsonCorrelation_doc
@@ -2430,7 +2463,7 @@ The skewness is the third-order central moment standardized by the standard devi
 
     \vect{\delta} = \Tr{\left(\Expect{\left(\frac{X_i - \mu_i}
                                                  {\sigma_i}\right)^3},
-                              \quad i = 1, \ldots, n\right)}"
+                              \quad i = 1, \ldots, d\right)}"
 %enddef
 %feature("docstring") OT::DistributionImplementation::getSkewness
 OT_Distribution_getSkewness_doc
@@ -2454,7 +2487,7 @@ of the copula (ie that of the uniform margins):
 
     \mat{\rho_S} = \left[\frac{\Cov{F_{X_i}(X_i), F_{X_j}(X_j)}}
                               {\sqrt{\Var{F_{X_i}(X_i)} \Var{F_{X_j}(X_j)}}},
-                         \quad i,j = 1, \ldots, n\right]
+                         \quad i,j = 1, \ldots, d\right]
 
 See Also
 --------
@@ -2517,7 +2550,10 @@ std_repr_dist : :class:`~openturns.Distribution`
 
 Notes
 -----
-The standard representative distribution is defined on a distribution by distribution basis, most of the time by scaling the distribution with bounded support to :math:`[0,1]` or by standardizing (ie zero mean, unit variance) the distributions with unbounded support. It is the member of the family for which orthonormal polynomials will be built using generic algorithms of orthonormalization."
+The standard representative distribution is defined on a distribution-by-distribution basis, most of the time by
+scaling the distribution with bounded support to :math:`[0,1]` or by standardizing (ie zero mean, unit variance) the
+distributions with unbounded support. It is the member of the family for which orthonormal polynomials will be built using
+generic algorithms of orthonormalization (see :class:`~openturns.StandardDistributionPolynomialFactory`)."
 %enddef
 %feature("docstring") OT::DistributionImplementation::getStandardRepresentative
 OT_Distribution_getStandardRepresentative_doc
@@ -2535,11 +2571,12 @@ interval : :class:`~openturns.Interval`
 Returns
 -------
 support : :class:`~openturns.Interval`
-    The intersection of the support of the discrete part of the distribution with the given `interval`.
+    The intersection of the support of the discrete part of the distribution with the given *interval*.
 
 Notes
 -----
-The mathematical support :math:`\supp{\vect{X}}` of the discrete part of a distribution is the collection of points with nonzero probability.
+The mathematical support :math:`\supp{\vect{X}}` of the discrete part of a distribution is the
+collection of points with nonzero probability.
 
 This is yet implemented for discrete distributions only.
 
@@ -2568,7 +2605,8 @@ OT_Distribution_getProbabilities_doc
 %define OT_Distribution_getSingularities_doc
 "Accessor to the singularities of the PDF function.
 
-It is defined for univariate distributions only, and gives all the singularities (ie discontinuities of any order) strictly inside of the range of the distribution.
+It is defined for univariate distributions only, and gives all the singularities
+(i.e. discontinuities of any order) strictly inside of the range of the distribution.
 
 Returns
 -------
@@ -2670,7 +2708,7 @@ function is of the form:
 
     \phi(\vect{t}) = \exp\left(i \Tr{\vect{t}} \vect{\mu}\right)
                      \Psi\left(\Tr{\vect{t}} \mat{\Sigma} \vect{t}\right),
-                     \quad \vect{t} \in \Rset^n
+                     \quad \vect{t} \in \Rset^d
 
 for specified vector :math:`\vect{\mu}` and positive-definite matrix
 :math:`\mat{\Sigma}`. The function :math:`\Psi` is known as the
@@ -3018,11 +3056,11 @@ Available constructors:
 
 Parameters
 ----------
-x_min : float, optional
+xMin : float, optional
     The min-value of the mesh of the x-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMin` from the :class:`~openturns.ResourceMap`.
-x_max : float, optional, :math:`x_{\max} > x_{\min}`
+xMax : float, optional, *xMax > xMin*
     The max-value of the mesh of the y-axis.
     Defaults uses the quantile associated to the probability level
     `Distribution-QMax` from the :class:`~openturns.ResourceMap`.
@@ -3084,13 +3122,13 @@ OT_Distribution_drawSurvivalFunction_doc
 
 Parameters
 ----------
-i : int, :math:`0 \leq i < n`
+i : int, :math:`0 \leq i < d`
     The index of the margin of interest.
-x_min : float
+xMin : float
     The starting value that is used for meshing the x-axis.
-x_max : float, :math:`x_{\max} > x_{\min}`
+xMax : float, *xMax > xMin*
     The ending value that is used for meshing the x-axis.
-n_points : int
+nPoints : int
     The number of points that is used for meshing the x-axis.
 logScale : bool
     Flag to tell if the plot is done on a logarithmic scale. Default is *False*.
@@ -3124,15 +3162,15 @@ OT_Distribution_drawMarginal1DSurvivalFunction_doc
 
 Parameters
 ----------
-i : int, :math:`0 \leq i < n`
+i : int, :math:`0 \leq i < d`
     The index of the first margin of interest.
-j : int, :math:`0 \leq i \neq j < n`
+j : int, :math:`0 \leq i \neq j < d`
     The index of the second margin of interest.
-x_min : list of 2 floats
+xMin : list of 2 floats
     The starting values that are used for meshing the x- and y- axes.
-x_max : list of 2 floats, :math:`x_{\max} > x_{\min}`
+xMax : list of 2 floats,
     The ending values that are used for meshing the x- and y- axes.
-n_points : list of 2 ints
+nPoints : list of 2 ints
     The number of points that are used for meshing the x- and y- axes.
 logScaleX : bool
     Flag to tell if the plot is done on a logarithmic scale for X. Default is *False*.

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -314,7 +314,7 @@ where for :math:`2 \leq j \leq d`:
     F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
         \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
-The first term, for :math:`j=1`, is :math:`F_{X_1}(x_1}`."
+The first term, for :math:`j=1`, is :math:`F_{X_1}(x_1)`."
 
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeSequentialConditionalCDF

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -275,7 +275,7 @@ is defined by:
 
      F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p; x_1, \dots, x_{j-1})
 
-where the generalized inverse is defined in :eq:`quantileDefinition`.
+where :math:`F^{-1}` is the quantile function.
 For :math:`j=1` it
 reduces to :math:`F^{-1}_{X_1}(p)`.
 
@@ -411,7 +411,7 @@ The sequential conditional quantile function is defined by:
 
     \left(F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p_j; x_1, \dots, x_{j-1})\right)_{i=1,\ldots,d}
 
-where the generalized inverse is defined in :eq:`quantileDefinition` and
+where :math:`F^{-1}` is the quantile function and
 where :math:`x_1,\ldots,x_{j-1}` are defined recursively as :math:`x_1=F_1^{-1}(p_1)` and for :math:`2\leq j \leq d`,
 :math:`x_j=F_{X_j}^{-1}(p_j|X_1=x_1,\ldots,X_{j-1}=x_{j-1})`: the conditioning part is the set of already
 computed conditional quantiles."
@@ -718,9 +718,8 @@ If the underlying variable :math:`X` is scalar, then the quantile of order :math
 is defined as the generalized inverse of its cumulative distribution function:
 
 .. math::
-      :label: quantileDefinition
 
-      x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset\, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
+     x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset\, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
 
 If the distribution is scalar and discrete, then the quantile of order :math:`p=0` is defined by:
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -147,8 +147,8 @@ given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1
     F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
         \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
-For :math:`j=1` it
-reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
+For :math:`j=1`, it
+reduces to :math:`F_{X_1}(x_1)`."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeConditionalCDF
 OT_Distribution_computeConditionalCDF_doc
@@ -185,10 +185,12 @@ is defined by:
 
 where for :math:`2 \leq j \leq d`:
 
-    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+.. math::
 
-For :math:`j=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}F_{X_1}(x_1)`, ie the DDF of
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+    \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+For :math:`j=1`, it reduces to :math:`\dfrac{d^2}{d\,x_1^2}F_{X_1}(x_1)`, ie the DDF of
 the first component at :math:`x_1`.
 
 See Also
@@ -230,10 +232,12 @@ is defined by:
 
 where for :math:`2 \leq j \leq d`:
 
-    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+.. math::
 
-For :math:`j=1` it
+    F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
+    \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+
+For :math:`j=1`, it
 reduces to :math:`\dfrac{d}{d\,x_1}F_{X_1}(x_1)`.
 
 See Also
@@ -276,7 +280,7 @@ is defined by:
      F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p; x_1, \dots, x_{j-1})
 
 where :math:`F^{-1}` is the quantile function.
-For :math:`j=1` it
+For :math:`j=1`, it
 reduces to :math:`F^{-1}_{X_1}(p)`.
 
 See Also
@@ -311,8 +315,10 @@ The sequential conditional cumulative distribution function is defined as follow
 
 where for :math:`2 \leq j \leq d`:
 
+.. math::
+
     F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+    \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
 The first term, for :math:`j=1`, is :math:`F_{X_1}(x_1)`."
 
@@ -346,8 +352,10 @@ The sequential conditional derivative density function is defined by:
 
 where for :math:`2 \leq j \leq d`:
 
+.. math::
+
     F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+    \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
 The first term, for :math:`j=1`, is :math:`\dfrac{d^2}{d\,x_1^2}F_{X_1}(x_1)`."
 %enddef
@@ -379,8 +387,10 @@ The sequential conditional density function is defined as follows:
 
 where for :math:`2 \leq j \leq d`:
 
+.. math::
+
     F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
-        \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
+    \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}}.
 
 The first term, for :math:`j=1`, is :math:`\dfrac{d}{d\,x_1}F_{X_1}(x_1)`."
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -159,7 +159,7 @@ With respect to the other fixed components.
 
 Parameters
 ----------
-Xd : float
+xd : float
     Real in :math:`\Rset`.
 xcond : sequence of float with dimension :math:`d-1`
     Conditioning values.

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -167,7 +167,7 @@ xcond : sequence of float with dimension :math:`d-1`
 Returns
 -------
 d : float
-    Conditional DDF value at *xd*, given Xcond
+    Conditional DDF value at *xd*, given *xcond*
     where *xd* is the last component of the multivariate distribution.
     
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -160,7 +160,7 @@ With respect to the other fixed components.
 Parameters
 ----------
 xd : float
-    Real in :math:`\Rset`.
+    Real number.
 xcond : sequence of float with dimension :math:`d-1`
     Conditioning values.
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -126,9 +126,9 @@ OT_Distribution_computeComplementaryCDF_doc
 
 Parameters
 ----------
-xj : float, sequence of float,
+xj : float, sequence of float
     Conditional CDF input.
-xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`, :math:`j \leq d`
     Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
@@ -138,6 +138,7 @@ p : float, sequence of float
 
 Notes
 -----
+Let :math:`\vect{X}` be a random vector of dimension :math:`d`.
 The conditional cumulative distribution function of the component :math:`X_j`
 given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})` is defined by:
 
@@ -161,9 +162,9 @@ With respect to the other fixed components.
 
 Parameters
 ----------
-xj : float, sequence of float,
+xj : float, sequence of float
     Conditional CDF input.
-xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`, :math:`j \leq d`
     Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
@@ -173,6 +174,7 @@ ddf : float,
 
 Notes
 -----
+Let :math:`\vect{X}` be a random vector of dimension :math:`d`.
 The conditional derivative density function of the component :math:`X_j`
 given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
 is defined by:
@@ -205,9 +207,9 @@ Conditional PDF of the last component with respect to the other fixed components
 
 Parameters
 ----------
-xj : float, sequence of float,
+xj : float, sequence of float, 
     Conditional CDF input.
-xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`, :math:`j \leq d`
     Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
@@ -217,6 +219,7 @@ cpdf : float, sequence of float
 
 Notes
 -----
+Let :math:`\vect{X}` be a random vector of dimension :math:`d`.
 The conditional probability density function of the component :math:`X_j`
 given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
 is defined by:
@@ -251,7 +254,7 @@ Parameters
 ----------
 p : float, sequence of float, :math:`p \in [0, 1]`
     Conditional quantile.
-xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`j-1`, :math:`j \leq d`
     Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
@@ -263,6 +266,7 @@ xj : float
 
 Notes
 -----
+Let :math:`\vect{X}` be a random vector of dimension :math:`d`.
 The conditional quantile of order :math:`p` of the component :math:`X_j`
 given that the components of indices :math:`k \leq j-1` are fixed to :math:`(x_1, \dots, x_{j-1})`
 is defined by:
@@ -271,7 +275,7 @@ is defined by:
 
      F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p; x_1, \dots, x_{j-1})
 
-where the generalized inverse is defined in :eq:`quantileDef`.
+where the generalized inverse is defined in :eq:`quantileDefinition`.
 For :math:`j=1` it
 reduces to :math:`F^{-1}_{X_1}(p)`.
 
@@ -407,7 +411,7 @@ The sequential conditional quantile function is defined by:
 
     \left(F^{-1}_{X_j \mid X_1, \ldots, X_{j - 1}}(p_j; x_1, \dots, x_{j-1})\right)_{i=1,\ldots,d}
 
-where the generalized inverse is defined in :eq:`quantileDef` and
+where the generalized inverse is defined in :eq:`quantileDefinition` and
 where :math:`x_1,\ldots,x_{j-1}` are defined recursively as :math:`x_1=F_1^{-1}(p_1)` and for :math:`2\leq j \leq d`,
 :math:`x_j=F_{X_j}^{-1}(p_j|X_1=x_1,\ldots,X_{j-1}=x_{j-1})`: the conditioning part is the set of already
 computed conditional quantiles."
@@ -714,7 +718,7 @@ If the underlying variable :math:`X` is scalar, then the quantile of order :math
 is defined as the generalized inverse of its cumulative distribution function:
 
 .. math::
-      :label: quantileDef
+      :label: quantileDefinition
 
       x_p  = F_X^{-1}(p) = \inf \{ x \in \Rset\, |\, F(x) \geq p \}, \quad 0 \leq p \leq 1.
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -3168,7 +3168,7 @@ j : int, :math:`0 \leq i \neq j < d`
     The index of the second margin of interest.
 xMin : list of 2 floats
     The starting values that are used for meshing the x- and y- axes.
-xMax : list of 2 floats,
+xMax : list of 2 floats, *xMax > xMin*
     The ending values that are used for meshing the x- and y- axes.
 nPoints : list of 2 ints
     The number of points that are used for meshing the x- and y- axes.

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -753,7 +753,7 @@ x : sequence of float, 2-d sequence of float
 Returns
 -------
 s : float, :class:`~openturns.Point`
-    Survival function at *x*.
+    Value of the survival function at point *x*.
 
 Notes
 -----

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -188,7 +188,7 @@ Conditional PDF of the last component with respect to the other fixed components
 Parameters
 ----------
 xd : float, sequence of float
-    Point in :math:`\Rset`.
+    The input value where the conditional CDF must be evaluated.
 xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
     Conditioning values.
 

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -143,7 +143,7 @@ given that the components of indices :math:`k \leq j-1` are fixed. It is defined
 
 .. math::
 
-    p = F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; (x_1, \dots, x_{j-1}) =
+    p = F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; x_1, \dots, x_{j-1}) =
         \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}},
         \quad x_j \in \Rset
 
@@ -300,7 +300,7 @@ The sequential conditional derivative density function is defined as follows:
 
 .. math::
 
-    ddf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d^2}{d\,x_i^2}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots,
+    \left(\dfrac{d^2}{d\,x_i^2}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots,
     X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
 ie the :math:`i`-th component is the conditional DDF of :math:`X_i` at :math:`x_i` given that :math:`X_1=x_1,
@@ -363,10 +363,10 @@ The sequential conditional quantile function is defined as follows:
 
 .. math::
 
-    \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1}\right)_{i=1,\ldots,d}
+    \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i-1}\right)_{i=1,\ldots,d}
 
 where :math:`x_1,\ldots,x_{i-1}` are defined recursively as :math:`x_1=F_1^{-1}(q_1)` and for :math:`2\leq i \leq d`,
-:math:`x_i=F_i^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1})`: the conditioning part is the set of already
+:math:`x_i=F_i^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i-1})`: the conditioning part is the set of already
 computed conditional quantiles."
 
 %enddef
@@ -385,7 +385,7 @@ x : sequence of float, 2-d sequence of float
 
 Returns
 -------
-d : :class:`~openturns.Point`, :class:`~openturns.Sample`
+ddf : :class:`~openturns.Point`, :class:`~openturns.Sample`
     DDF value at *x*.
 
 Notes
@@ -396,8 +396,8 @@ function with respect to :math:`\vect{x}`:
 .. math::
 
     \vect{\nabla}_{\vect{x}} f_{\vect{X}}(\vect{x}) =
-        \Tr{\left(\frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_i},
-                  \quad i = 1, \ldots, n\right)},
+        \Tr{\left(\frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_1},
+                 \dots, \frac{\partial f_{\vect{X}}(\vect{x})}{\partial x_d}\right)},
         \quad \vect{x} \in \Rset^d"
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeDDF

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -216,7 +216,7 @@ Parameters
 ----------
 p : float, sequence of float, :math:`p \in [0, 1]`
     Conditional quantile.
-Xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
+xcond : sequence of float, 2-d sequence of float with size :math:`d-1`
     Conditioning values.
 
 Returns

--- a/python/src/DistributionImplementation_doc.i.in
+++ b/python/src/DistributionImplementation_doc.i.in
@@ -129,7 +129,7 @@ Parameters
 xj : float, sequence of float,
     Conditional CDF input.
 xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
-    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
 -------
@@ -145,7 +145,10 @@ given that the components of indices :math:`k \leq j-1` are fixed. It is defined
 
     p = F_{X_j \mid X_1, \ldots, X_{j - 1}}(x_j; (x_1, \dots, x_{j-1}) =
         \Prob{X_j \leq x_j \mid X_1=x_1, \ldots, X_{j-1}=x_{j-1}},
-        \quad x_j \in \Rset"
+        \quad x_j \in \Rset
+
+For :math:`j=1` it
+reduces to :math:`\Prob{X_1 \leq x_1}`, ie the CDF of the first component at :math:`x_1`."
 %enddef
 %feature("docstring") OT::DistributionImplementation::computeConditionalCDF
 OT_Distribution_computeConditionalCDF_doc
@@ -162,12 +165,25 @@ Parameters
 xj : float, sequence of float,
     Conditional CDF input.
 xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
-    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
 -------
 ddf : float,
     Conditional DDF value at  *xj* given *xcond*.
+
+Notes
+-----
+The conditional derivative density function is defined as follows:
+
+.. math::
+
+    \dfrac{d^2}{d\,x_j^2}\Prob{X_j \leq x_j \mid X_1=x_1, \ldots,
+    X_{j-1}=x_{j-1}}
+
+ie the :math:`j`-th component is the conditional DDF of :math:`X_j` at :math:`x_j` given that :math:`X_1=x_1,
+\ldots,X_{j-1}=x_{j-1}`. For :math:`j=1` it reduces to :math:`\dfrac{d^2}{d\,x_1^2}\Prob{X_1 \leq x_1}`, ie the DDF of
+the first component at :math:`x_1`.
     
 
 See Also
@@ -189,7 +205,7 @@ Parameters
 xj : float, sequence of float,
     Conditional CDF input.
 xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
-    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
 -------
@@ -215,7 +231,7 @@ Parameters
 p : float, sequence of float, :math:`p \in [0, 1]`
     Conditional quantile.
 xcond : sequence of float, 2-d sequence of float with size :math:`j-1`
-    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1}`.
+    Conditioning values for the components :math:`(X_{1}, \dots, X_{j-1})`.
 
 Returns
 -------
@@ -253,7 +269,7 @@ The sequential conditional cumulative distribution function is defined as follow
 
 .. math::
 
-    F^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
+    \left(\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
 ie the :math:`i`-th component is the conditional CDF of :math:`X_i` at :math:`x_i` given
 that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it
@@ -308,7 +324,7 @@ x : sequence of float, with size :math:`d`
 Returns
 -------
 pdf : sequence of float
-    Conditional PDF values at *x*.
+    Sequence of conditional PDF values at *x*.
 
 Notes
 -----
@@ -316,7 +332,7 @@ The sequential conditional density function is defined as follows:
 
 .. math::
 
-    pdf^{seq}_{X_1,\ldots,X_d}(x_1,\ldots,x_d) = \left(\dfrac{d}{d\,x_i}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
+    \left(\dfrac{d}{d\,x_i}\Prob{X_i \leq x_i \mid X_1=x_1, \ldots, X_{i-1}=x_{i-1}}\right)_{i=1,\ldots,d}
 
 ie the :math:`i`-th component is the conditional PDF of :math:`X_i` at :math:`x_i` given
 that :math:`X_1=x_1,\ldots,X_{i-1}=x_{i-1}`. For :math:`i=1` it reduces to
@@ -339,7 +355,7 @@ q : sequence of float in :math:`[0,1]`, with size :math:`d`
 Returns
 -------
 Q : sequence of float
-    Conditional quantiles values at input.
+    Sequance of conditional quantiles values at *q*
 
 Notes
 -----
@@ -347,7 +363,7 @@ The sequential conditional quantile function is defined as follows:
 
 .. math::
 
-    Q^{seq}_{X_1,\ldots,X_d}(q_1,\ldots,q_d) = \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1}\right)_{i=1,\ldots,d}
+    \left(F^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1}\right)_{i=1,\ldots,d}
 
 where :math:`x_1,\ldots,x_{i-1}` are defined recursively as :math:`x_1=F_1^{-1}(q_1)` and for :math:`2\leq i \leq d`,
 :math:`x_i=F_i^{-1}(q_i|X_1=x_1,\ldots,X_{i-1}=x_{i_1})`: the conditioning part is the set of already


### PR DESCRIPTION
Improved the documentation of:

- computeQuantile and computeScalarQuantile.
- computeComplementaryCDF and computeSurvivalFunction: Closes #2507 
- the inputs of the cdf, pdf and other related functions are in $\mathbb{R}^d$ and not only in the support of the random vector,
- dimension of the random vector is denoted by d and not n
- Closes #2593
