### PR TITLE
Improve doc of polynomial chaos expansion

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -148,6 +148,8 @@ Bibliography
 .. [halko2011] Nathan Halko, Per-Gunnar Martisson, Yoel Shkolnisky and Mark Tygert,
     *An algorithm for the principal component analysis of large data sets*,
     `pdf <https://arxiv.org/pdf/1007.5510.pdf>`__
+.. [hammersley1961] Hammersley, J. M., & Handscomb, D. C. (1961).
+    *Monte Carlo Methods.* Chapman and Hall. Monographs on Statistics and Applied Probability.
 .. [helton2003] Helton, J.C., and Davis, F. J.,
     *Latin Hypercube sampling and the propagation of uncertainty analyses of complex systems*,
     Reliability Engineering and System Safety 81, 23-69.
@@ -233,6 +235,8 @@ Bibliography
 .. [lemaire2009] Lemaire M., *Structural reliability*, John Wiley & Sons, 2009.
 .. [lemaitre2010] Le Maître, O., & Knio, O. M. (2010).
     *Spectral methods for uncertainty quantification: with applications to computational fluid dynamics*. Springer Science & Business Media.
+.. [lemieux2009] Lemieux, C. (2009). *Monte Carlo and Quasi-Monte Carlo Sampling*.
+    Springer. Springer Series in Statistics.
 .. [liu2006] Liu, R., & Owen, A. B. (2006). *Estimating mean dimensionality of
     analysis of variance decompositions.* Journal of the American Statistical
     Association, 101 (474), 712-721.
@@ -279,6 +283,8 @@ Bibliography
     methods for selecting values of input variables in the analysis of output
     from a computer code.* Technometrics 21(2): 239-245.
     `pdf <https://www.asc.ohio-state.edu/statistics/comp_exp/jour.club/McKayConoverBeckman.pdf>`__
+.. [melchers1990] Melchers, R. E. (1990).
+    *Radial importance sampling for structural reliability.* Journal of engineering mechanics, 116(1), 189-203.
 .. [minka2012] Thomas P. Minka,
     *Estimating a Dirichlet distribution*, Microsoft Research report, 2000 (revised 2003, 2009, 2012).
     `pdf <http://research.microsoft.com/en-us/um/people/minka/papers/dirichlet/minka-dirichlet.pdf>`__
@@ -369,6 +375,8 @@ Bibliography
     `pdf <http://www.andreasaltelli.eu/file/repository/Making_best_use.pdf>`__
 .. [sankararaman2012] Sankararaman, S. and Mahadevan, S. *Likelihood-based approach to multidisciplinary analysis under uncertainty.*
     Journal of Mechanical Design, 134(3):031008, 2012.
+.. [santner2003] Santner, T. J., Williams, B. J., Notz, W. I., & Williams, B. J. (2003).
+    *The design and analysis of computer experiments*. New York: Springer.
 .. [saporta1990] Saporta, G. (1990). *Probabilités, Analyse de données et
     Statistique*, Technip
 .. [scott1992] Scott, D. W. (1992). *Multivariate density estimation*,
@@ -413,6 +421,8 @@ Bibliography
     discrete random variates*. Journal of Computational and Applied Mathematics,
     vol. 31, no. 1, pp. 181-189, 1990.
     `pdf <https://openturns.github.io/openturns/papers/stadlober1990.pdf>`__
+.. [stein1987] Stein, M. (1987). *Large sample properties of simulations using Latin hypercube sampling.*
+    Technometrics, 29(2), 143-151.
 .. [stoer1993] Stoer, J., Bulirsch, R. *Introduction to Numerical
     Analysis*, Second Edition, Springer-Verlag, 1993.
     `pdf <https://zhilin.math.ncsu.edu/TEACHING/MA580/Stoer_Bulirsch.pdf>`__

--- a/python/doc/examples/numerical_methods/general_methods/plot_pce_design.py
+++ b/python/doc/examples/numerical_methods/general_methods/plot_pce_design.py
@@ -235,6 +235,36 @@ def ComputeSparseLeastSquaresFunctionalChaos(
     distribution,
     sparse=True,
 ):
+    """
+    Create a sparse polynomial chaos based on least squares.
+
+    * Uses the enumerate rule in multivariateBasis.
+    * Uses the LeastSquaresStrategy to compute the coefficients based on
+      least squares.
+    * Uses LeastSquaresMetaModelSelectionFactory to use the LARS selection method.
+    * Uses FixedStrategy in order to keep all the coefficients that the
+      LARS method selected.
+
+    Parameters
+    ----------
+    inputTrain : ot.Sample
+        The input design of experiments.
+    outputTrain : ot.Sample
+        The output design of experiments.
+    multivariateBasis : ot.Basis
+        The multivariate chaos basis.
+    basisSize : int
+        The size of the function basis.
+    distribution : ot.Distribution.
+        The distribution of the input variable.
+    sparse: bool
+        If True, create a sparse PCE.
+
+    Returns
+    -------
+    result : ot.PolynomialChaosResult
+        The estimated polynomial chaos.
+    """
     if sparse:
         selectionAlgorithm = ot.LeastSquaresMetaModelSelectionFactory()
     else:

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_sobol.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_sobol.py
@@ -4,38 +4,50 @@ Estimate Sobol' indices for the Ishigami function by a sampling method: a quick 
 """
 # %%
 #
-# In this example, we estimate the Sobol' indices for the :ref:`Ishigami function <use-case-ishigami>` by sampling methods.
+# In this example, we estimate the Sobol' indices for the
+# :ref:`Ishigami function <use-case-ishigami>` by sampling methods.
 #
 
 # %%
 # Introduction
 # ------------
 #
-# In this example we are going to quantify the correlation between the input variables and the output variable of a model thanks to Sobol indices.
+# In this example we are going to quantify the correlation between the input
+# variables and the output variable of a model thanks to Sobol indices.
 #
-# Sobol indices are designed to evaluate the importance of a single variable or a specific set of variables.
-# Here the Sobol indices are estimated by sampling from the distributions of the input variables and propagating uncertainty through a function.
+# Sobol indices are designed to evaluate the importance of a single variable
+# or a specific set of variables.
+# Here the Sobol indices are estimated by sampling from the distributions of
+# the input variables and propagating uncertainty through a function.
 #
-# In theory, Sobol indices range from 0 to 1; the closer an index value is to 1, the better the associated input variable explains the function output.
+# In theory, Sobol indices range from 0 to 1; the closer an index value is
+# to 1, the better the associated input variable explains the function output.
 #
 # Let us denote by :math:`d` the input dimension of the model.
 #
 # Sobol' indices can be computed at different orders.
 #
-# * First order indices evaluate the importance of one input variable at a time.
+# * First order indices evaluate the importance of one input variable
+#   at a time.
 #
-# * Total indices give the relative importance of one input variable and all its interactions with other variables.
-#   Alternatively, they can be viewed as measuring how much wriggle room remains to the output when all but one input variables are fixed.
+# * Total indices give the relative importance of one input variable
+#   and all its interactions with other variables.
+#   Alternatively, they can be viewed as measuring how much wriggle room
+#   remains to the output when all but one input variables are fixed.
 #
 # * In general, we are only interested in first order and total Sobol' indices.
 #   There are situations, however, where we want to estimate interactions.
-#   Second order indices evaluate the importance of every pair of input variables. The number of second order indices is:
+#   Second order indices evaluate the importance of every pair of input variables.
+#   The number of second order indices is:
 #
 # .. math::
 #    \binom{d}{2} = \frac{d \times \left( d-1\right)}{2}.
 #
-# In practice, when the number of input variables is not small (say, when :math:`d>5`), then the number of second order indices is too large to be easily analyzed.
-# In these situations, we limit the analysis to the first order and total Sobol' indices.
+# In practice, when the number of input variables is not small (say,
+# when :math:`d>5`), then the number of second order indices is too large
+# to be easily analyzed.
+# In these situations, we limit the analysis to the first order and total
+# Sobol' indices.
 
 # %%
 # Define the model
@@ -44,7 +56,6 @@ Estimate Sobol' indices for the Ishigami function by a sampling method: a quick 
 # %%
 from openturns.usecases import ishigami_function
 import openturns as ot
-import pylab as pl
 import openturns.viewer
 import openturns.viewer as viewer
 from matplotlib import pylab as plt
@@ -56,8 +67,10 @@ ot.Log.Show(ot.Log.NONE)
 im = ishigami_function.IshigamiModel()
 
 # %%
-# The `IshigamiModel` data class contains the input distribution :math:`X=(X_1, X_2, X_3)` in `im.distributionX` and the Ishigami function in `im.model`.
-# We also have access to the input variable names with
+# The :class:`~openturns.usecases.ishigami_function.IshigamiModel` data class contains the input distribution
+# :math:`\vect{X}=(X_1, X_2, X_3)` in `im.distributionX` and the Ishigami
+# function in `im.model`.
+# We also have access to the input variable names with:
 input_names = im.distributionX.getDescription()
 
 # %%
@@ -71,20 +84,46 @@ sampleY = im.model(sampleX)
 
 
 # %%
-def plotXvsY(sampleX, sampleY, figsize=(15, 3)):
+def plotXvsY(sampleX, sampleY):
+    """
+    Plot a Y sample against a X sample on a grid.
+
+    Parameters
+    ----------
+    sampleX : ot.Sample(sampleSize, inputDimension)
+        The input sample.
+    sampleY : ot.Sample(sampleSize, outputDimension)
+        The output sample.
+
+    Returns
+    -------
+    grid: ot.GridLayout(outputDimension, inputDimension)
+        The grid of plots of all projections of Y vs X.
+    """
     dimX = sampleX.getDimension()
-    inputdescr = sampleX.getDescription()
-    fig = pl.figure(figsize=figsize)
-    for i in range(dimX):
-        ax = fig.add_subplot(1, dimX, i + 1)
-        graph = ot.Graph("", inputdescr[i], "Y", True, "")
-        cloud = ot.Cloud(sampleX[:, i], sampleY)
-        graph.add(cloud)
-        _ = ot.viewer.View(graph, figure=fig, axes=[ax])
-    return fig
+    dimY = sampleY.getDimension()
+    descriptionX = sampleX.getDescription()
+    descriptionY = sampleY.getDescription()
+    grid = ot.GridLayout(dimY, dimX)
+    for i in range(dimY):
+        for j in range(dimX):
+            graph = ot.Graph("", descriptionX[j], descriptionY[i], True, "")
+            cloud = ot.Cloud(sampleX[:, j], sampleY[:, i])
+            graph.add(cloud)
+            if j == 0:
+                graph.setYTitle(descriptionY[i])
+            else:
+                graph.setYTitle("")
+            if i == dimY - 1:
+                graph.setXTitle(descriptionX[j])
+            else:
+                graph.setXTitle("")
+            grid.setGraph(i, j, graph)
+    return grid
 
 
-plotXvsY(sampleX, sampleY, figsize=(10, 4))
+grid = plotXvsY(sampleX, sampleY)
+_ = ot.viewer.View(grid, figure_kw={"figsize": (10.0, 4.0)})
 
 # %%
 graph = ot.HistogramFactory().build(sampleY).drawPDF()
@@ -99,7 +138,9 @@ view = viewer.View(graph)
 
 # %%
 # We first create a design of experiments with the `SobolIndicesExperiment`.
-# Since we are not interested in second order indices for the moment, we use the default value of the third argument (we will come back to this topic later).
+# Since we are not interested in second order indices for the moment,
+# we use the default value of the third argument (we will come back to this
+# topic later).
 
 # %%
 size = 1000
@@ -110,7 +151,8 @@ inputDesign.setDescription(input_names)
 inputDesign.getSize()
 
 # %%
-# We see that 5000 function evaluations are required to estimate the first order and total Sobol' indices.
+# We see that 5000 function evaluations are required to estimate the first
+# order and total Sobol' indices.
 
 # %%
 # Then we evaluate the outputs corresponding to this design of experiments.
@@ -125,7 +167,7 @@ outputDesign = im.model(inputDesign)
 sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
 
 # %%
-# The `getFirstOrderIndices` and `getTotalOrderIndices` method respectively return estimates of all first order and total Sobol' indices.
+# Let us estimate first order and total Sobol' indices.
 
 # %%
 sensitivityAnalysis.getFirstOrderIndices()
@@ -134,7 +176,8 @@ sensitivityAnalysis.getFirstOrderIndices()
 sensitivityAnalysis.getTotalOrderIndices()
 
 # %%
-# The `draw` method produces the following graph. The vertical bars represent the 95% confidence intervals of the estimates.
+# In the following graph, the vertical bars represent
+# the 95% confidence intervals of the estimates.
 
 # %%
 graph = sensitivityAnalysis.draw()
@@ -147,11 +190,15 @@ view = viewer.View(graph)
 #   Its first order index is close to 0.3, which implies that its interactions
 #   alone produce almost 30% (0.6 - 0.3) of the total variance.
 # - The variable :math:`X_2` has the highest first order index: approximately 0.4.
-#   However, it has little interaction with other variables since its total order indice is close to its first order index.
+#   However, it has little interaction with other variables since its total
+#   order index is close to its first order index.
 # - The variable :math:`X_3` has a first order index close to zero.
-#   However, it has an impact to the total variance thanks to its interactions with :math:`X_1`.
-# - We see that the variability of the estimates is quite high even with a relatively large sample size.
-#   Moreover, since the exact first order Sobol' index for :math:`X_3` is zero, its estimate has a 50% chance of being nonpositive.
+#   However, it has an impact on the total variance thanks to its interactions
+#   with :math:`X_1`.
+# - We see that the variability of the estimates is quite high even with a
+#   relatively large sample size.
+#   Moreover, since the exact first order Sobol' index for :math:`X_3` is zero,
+#   its estimate has a 50% chance of being nonpositive.
 
 # %%
 # Estimate the second order indices
@@ -167,7 +214,8 @@ inputDesign.setDescription(input_names)
 outputDesign = im.model(inputDesign)
 
 # %%
-# We see that 8000 function evaluations are now required; that is 3000 more evaluations than in the previous situation.
+# We see that 8000 function evaluations are now required; that is 3000 more
+# evaluations than in the previous situation.
 
 # %%
 sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign, size)
@@ -176,16 +224,18 @@ sensitivityAnalysis = ot.SaltelliSensitivityAlgorithm(inputDesign, outputDesign,
 second_order = sensitivityAnalysis.getSecondOrderIndices()
 for i in range(im.dim):
     for j in range(i):
-        print("2nd order indice (%d,%d)=%g" % (i, j, second_order[i, j]))
+        print("2nd order index (%d,%d)=%g" % (i, j, second_order[i, j]))
 
 # %%
-# This shows that the only significant interaction is the one between :math:`X_1` and :math:`X_3` (beware of Python's index shift: 0 denotes the first input variable).
+# This shows that the only significant interaction is the one between :math:`X_1`
+# and :math:`X_3` (beware of Python's index shift: 0 denotes the first input variable).
 
 # %%
 # Using a different estimator
 # ---------------------------
 #
-# We have used the `SaltelliSensitivityAlgorithm` class to estimate the indices. Others are available in the library:
+# We have used the `SaltelliSensitivityAlgorithm` class to estimate the indices.
+# Others are available in the library:
 #
 # * `SaltelliSensitivityAlgorithm`
 # * `MartinezSensitivityAlgorithm`
@@ -194,7 +244,8 @@ for i in range(im.dim):
 #
 
 # %%
-# In order to compare the results with another method, we use the `MartinezSensitivityAlgorithm` class.
+# In order to compare the results with another method, we use the
+# `MartinezSensitivityAlgorithm` class.
 
 # %%
 sensitivityAnalysis = ot.MartinezSensitivityAlgorithm(inputDesign, outputDesign, size)

--- a/python/doc/math_notations.sty
+++ b/python/doc/math_notations.sty
@@ -10,6 +10,12 @@
 \DeclareSIUnit{\rpm}{rpm}
 \DeclareSIUnit{\year}{y}
 
+% A random variable is upcase.
+% An observation of a random variable (or a real number) is downcase.
+% A random vector is in latin, upcase, letter.
+% A vector is in latin, downcase, letter.
+% A set is in latin, caligraphic, upcase, letter.
+
 % The physical model
 \newcommand{\model}{g}
 \newcommand{\inputDim}{d}  % The input dimension of the model
@@ -25,17 +31,28 @@
 % Realization of the random vetor
 \newcommand{\inputReal}{\vect{x}}  % An observation of the input random vector of the model
 \newcommand{\outputReal}{\vect{y}}  % An observation of the output random vector of the model
-\newcommand{\standardRV}{\vect{Z}}
+\newcommand{\standardRV}{\vect{Z}}  % The standard random vector (e.g. for polynomial chaos expansion)
 \newcommand{\RVU}{\vect{U}}
-\newcommand{\standardDim}{d_Z}
+\newcommand{\standardDim}{d_Z}  % The dimension of the standard random vector
 \newcommand{\dimU}{d_U}
-\newcommand{\standardReal}{\vect{z}}
+\newcommand{\standardReal}{\vect{z}}  % An observation of the standard random vector
 \newcommand{\realU}{\vect{u}}
 \newcommand{\supp}[1] {\operatorname{supp}\left(#1\right)}  % The support of a distribution
-\newcommand{\sampleSize}{n}
-
+\newcommand{\sampleSize}{n}  % The sample size
 
 \newcommand{\scalarproduct}[2]{\left\langle #1, #2 \right\rangle}
+
+% The probability density function of the input random vector
+\newcommand{\inputProbabilityDensityFunction}{f}
+
+% A set
+\newcommand{\set}[1]{\mathcal{#1}}
+% The set of standard input random observations
+\newcommand{\standardInputSpace}{\set{Z}}
+% The set of physical input random observations
+\newcommand{\physicalInputSpace}{\set{X}}
+% The set of physical output random observations
+\newcommand{\physicalOutputSpace}{\set{Y}}
 
 % For matrixes and vectors
 \newcommand{\vect}[1]{{\mathbf{\boldsymbol{{#1}}}}}

--- a/python/src/FunctionImplementation_doc.i.in
+++ b/python/src/FunctionImplementation_doc.i.in
@@ -151,6 +151,17 @@ where :math:`\forall 1 \leq i \leq N, \,   \vect{c}_i \in \Rset^p`
 >>> print(myFunction2([1, 2, 3]))
 [25,35]
 
+If the input and output dimensions of two functions are equal
+then we can perform arithmetic operations on these functions
+using the `+`, `-` and `*` operators.
+
+>>> g1 = ot.SymbolicFunction(['x1', 'x2', 'x3'],
+...                          ['x1 + 2 * x2 + x3'])
+>>> g2 = ot.SymbolicFunction(['x1', 'x2', 'x3'],
+...                          ['x1^2 + x2'])
+>>> g_sum = g1 + g2
+>>> g_difference = g1 - g2
+>>> g_product = g1 * g2
 
 Create a *Function* from values of the inputs and the outputs:
 

--- a/python/src/FunctionalChaosRandomVector_doc.i.in
+++ b/python/src/FunctionalChaosRandomVector_doc.i.in
@@ -24,7 +24,7 @@ The functional chaos decomposition of *h* is:
 
 .. math::
 
-    h = g\circ T^{-1} = \sum_{k=0}^{\infty} \vect{a}_k \Psi_k 
+    h = \model \circ T^{-1} = \sum_{k=0}^{\infty} \vect{a}_k \Psi_k 
 
 
 which can be truncated to the finite set :math:`\cK \subset \Nset`:
@@ -34,17 +34,17 @@ which can be truncated to the finite set :math:`\cK \subset \Nset`:
     \widetilde{h} =  \sum_{k \in \cK} \vect{a}_k \Psi_k.
 
 The approximation :math:`\widetilde{h}` can be used to build an efficient random 
-generator of :math:`Y` based on the random vector :math:`\vect{Z}`,
+generator of :math:`Y` based on the random vector :math:`\standardRV`,
 using the equation:
 
 .. math::
 
-    \widetilde{Y} = \widetilde{h}(\vect{Z}).
+    \widetilde{Y} = \widetilde{h}(\standardRV).
 
 This equation can be used to simulate independent random observations
 from the PCE.
 This can be done by simulating independent observations from
-the distribution of the standardized random vector :math:`\vect{Z}`,
+the distribution of the standardized random vector :math:`\standardRV`,
 which are then pushed forward through the expansion.
 
 See also
@@ -121,47 +121,45 @@ functionalChaosResult : :class:`~openturns.FunctionalChaosResult`
 %feature("docstring") OT::FunctionalChaosRandomVector::getMean
 "Accessor to the mean of the functional chaos expansion.
 
-Let :math:`n_X \in \Nset` be the dimension of the input random vector, 
-let :math:`n_Y \in \Nset` be the dimension of the output random vector.
-and let :math:`P \in \Nset` be the number of coefficients in the basis.
+Let :math:`\inputDim \in \Nset` be the dimension of the input random vector, 
+let :math:`\outputDim \in \Nset` be the dimension of the output random vector,
+and let :math:`P + 1 \in \Nset` be the size of the basis.
 We consider the following functional chaos expansion:
 
 .. math::
 
-      \widetilde{\vect{Y}} = \sum_{k = 0}^P \vect{a}_k \psi_k(\vect{Z})
+      \widetilde{\outputRV} = \sum_{k = 0}^P \vect{a}_k \psi_k(\standardRV)
 
-where :math:`\widetilde{\vect{Y}} \in \Rset^{n_Y}` is the approximation of the output 
-random variable :math:`\vect{Y}` by the expansion, 
-:math:`\left\{\vect{a}_k \in \Rset^{n_Y}\right\}_{k = 0, ..., P}` are the coefficients, 
-:math:`\left\{\psi_k: \Rset^{n_X} \rightarrow \Rset\right\}_{k = 0, ..., P}` are the 
+where :math:`\widetilde{\outputRV} \in \Rset^{\outputDim}` is the approximation of the output 
+random variable :math:`\outputRV` by the expansion, 
+:math:`\left\{\vect{a}_k \in \Rset^{\outputDim}\right\}_{k = 0, ..., P}` are the coefficients, 
+:math:`\left\{\psi_k: \Rset^{\inputDim} \rightarrow \Rset\right\}_{k = 0, ..., P}` are the 
 orthonormal functions in the basis, 
-and :math:`\vect{Z} \in \Rset^{n_X}` is the standardized random input vector.
+and :math:`\standardRV \in \Rset^{\inputDim}` is the standardized random input vector.
 The previous equation can be equivalently written as follows:
 
 .. math::
 
-      \widetilde{Y}_i = \sum_{k = 0}^P a_{ki} \psi_k(\vect{Z})
+      \widetilde{Y}_i = \sum_{k = 0}^P a_{ki} \psi_k(\standardRV)
 
-for :math:`i = 1, ..., n_Y`
+for :math:`i = 1, ..., \outputDim`
 where :math:`a_{ki} \in \Rset` is the :math:`i`-th component of the
 :math:`k`-th coefficient in the expansion:
 
 .. math::
 
-      \vect{a}_k = \begin{pmatrix}a_{k, 1} \\ \vdots\\ a_{k, n_Y} \end{pmatrix}.
+      \vect{a}_k = \begin{pmatrix}a_{k, 1} \\ \vdots\\ a_{k, \outputDim} \end{pmatrix}.
 
 The mean of the functional chaos expansion is the first coefficient
 in the expansion:
 
 .. math::
 
-      \Expect{\widetilde{Y}_i} = a_{0,i}
-
-for :math:`i = 1, ..., n_Y`.
+      \Expect{\widetilde{\outputRV}} = \vect{a}_0.
 
 Returns
 -------
-mean : :class:`~openturns.Point`, dimension :math:`n_Y`
+mean : :class:`~openturns.Point`, dimension :math:`\outputDim`
     The mean of the functional chaos expansion.
 
 Examples
@@ -195,65 +193,65 @@ mean= 3.50..."
 %feature("docstring") OT::FunctionalChaosRandomVector::getCovariance
 "Accessor to the covariance of the functional chaos expansion.
 
-Let :math:`n_X \in \Nset` be the dimension of the input random vector, 
-let :math:`n_Y \in \Nset` be the dimension of the output random vector.
-and let :math:`P \in \Nset` be the number of coefficients in the basis.
+Let :math:`\inputDim \in \Nset` be the dimension of the input random vector, 
+let :math:`\outputDim \in \Nset` be the dimension of the output random vector.
+and let :math:`P + 1 \in \Nset` be the size of the basis.
 We consider the following functional chaos expansion:
 
 .. math::
 
-      \widetilde{\vect{Y}} = \sum_{k = 0}^P \vect{a}_k \psi_k(\vect{Z})
+      \widetilde{\outputRV} = \sum_{k = 0}^P \vect{a}_k \psi_k(\standardRV)
 
 where
-:math:`\widetilde{\vect{Y}} \in \Rset^{n_Y}` is the approximation of the output 
-random variable :math:`\vect{Y}` by the expansion, 
-:math:`\left\{\vect{a}_k \in \Rset^{n_Y}\right\}_{k = 0, ..., P}` are the coefficients, 
-:math:`\left\{\psi_k: \Rset^{n_X} \rightarrow \Rset\right\}_{k = 0, ..., P}` are the 
+:math:`\widetilde{\outputRV} \in \Rset^{\outputDim}` is the approximation of the output 
+random variable :math:`\outputRV` by the expansion, 
+:math:`\left\{\vect{a}_k \in \Rset^{\outputDim}\right\}_{k = 0, ..., P}` are the coefficients, 
+:math:`\left\{\psi_k: \Rset^{\inputDim} \rightarrow \Rset\right\}_{k = 0, ..., P}` are the 
 orthonormal functions in the basis, 
-and :math:`\vect{Z} \in \Rset^{n_X}` is the standardized random input vector.
+and :math:`\standardRV \in \Rset^{\inputDim}` is the standardized random input vector.
 The previous equation can be equivalently written as follows:
 
 .. math::
 
-      \widetilde{Y}_i = \sum_{k = 0}^P a_{ki} \psi_k(\vect{Z})
+      \widetilde{Y}_i = \sum_{k = 0}^P a_{k, i} \psi_k(\standardRV)
 
-for :math:`i = 1, ..., n_Y`
+for :math:`i = 1, ..., \outputDim`
 where :math:`a_{ki} \in \Rset` is the :math:`i`-th component of the
 :math:`k`-th coefficient in the expansion:
 
 .. math::
 
-      \vect{a}_k = \begin{pmatrix}a_{k, 1} \\ \vdots\\ a_{k, n_Y} \end{pmatrix}.
+      \vect{a}_k = \begin{pmatrix}a_{k, 1} \\ \vdots\\ a_{k, \outputDim} \end{pmatrix}.
 
 The covariance matrix of the functional chaos expansion is
-the matrix :math:`\matcov \in \Rset^{n_Y \times n_Y}`, where each
+the matrix :math:`\matcov \in \Rset^{\outputDim \times \outputDim}`, where each
 component is:
 
 .. math::
 
-      c_{ij} = \Cov{\widetilde{Y}_i, \tilde{Y}_j}
+      c_{ij} = \Cov{\widetilde{Y}_i, \widetilde{Y}_j}
 
-for :math:`i,j = 1, ..., n_Y`.
+for :math:`i,j = 1, ..., \outputDim`.
 The covariance can be computed using the coefficients of the 
 expansion:
 
 .. math::
 
-      \Cov{\widetilde{Y}_i, \tilde{Y}_j} = \sum_{k = 1}^P a_{ki} a_{jk}
+      \Cov{\widetilde{Y}_i, \widetilde{Y}_j} = \sum_{k = 1}^P a_{k, i} a_{k, j}
 
-for :math:`i,j = 1, ..., n_Y`.
+for :math:`i,j = 1, ..., \outputDim`.
 This covariance involves all the coefficients, except the first one.
 The diagonal of the covariance matrix is the marginal variance:
 
 .. math::
 
-      \Var{\widetilde{Y}_i} = \sum_{k = 1}^P a_{ki}^2
+      \Var{\widetilde{Y}_i} = \sum_{k = 1}^P a_{k, i}^2
 
-for :math:`i,j = 1, ..., n_Y`.
+for :math:`i = 1, ..., \outputDim`.
 
 Returns
 -------
-covariance : :class:`~openturns.CovarianceMatrix`, dimension :math:`n_Y \times n_Y`
+covariance : :class:`~openturns.CovarianceMatrix`, dimension :math:`\outputDim \times \outputDim`
     The covariance of the functional chaos expansion.
 
 Examples

--- a/python/src/ImportanceSamplingExperiment_doc.i.in
+++ b/python/src/ImportanceSamplingExperiment_doc.i.in
@@ -21,11 +21,29 @@ importanceDistribution : :class:`~openturns.Distribution`
 
 Notes
 -----
-ImportanceSamplingExperiment is a random weighted design of experiments to get a sample 
-:math:`(X_i)_{1 \leq i \leq size}`
-independently according to the distribution :math:`\mu`. 
+ImportanceSamplingExperiment is a random weighted design of experiments.
+We can use it to generate a sample :math:`(\inputReal_i)_{1 \leq i \leq \sampleSize}`
+based on independent observations from the distribution :math:`\inputMeasure`
+(see [hammersley1961]_ page 57, [lemieux2009]_ page 11). 
+Importance sampling is a variance reduction method i.e. it aims at 
+reducing the variance of the estimator of the weighted integral.
 The sample is generated from the importance distribution :math:`p` and each realization is weighted by   
-:math:`\frac{\mu(X_i)}{p(X_i)}`
+:math:`w_i = \frac{\inputProbabilityDensityFunction(\inputReal_i)}{p(\inputReal_i)}` where
+:math:`\inputProbabilityDensityFunction` is the probability density function of the 
+input random vector.
+
+There is no general method in the library to provide the importance distribution, 
+which must be specified by the user.
+In the specific case of rare event estimation, [morio2015]_ page 53 provides 
+different methods to compute the instrumental distribution, 
+including simple changes of measure and exponential twisting.
+The :class:`~openturns.PostAnalyticalImportanceSampling` class combines the :class:`~openturns.FORM` class
+and importance sampling to estimate a probability.
+
+The `ImportanceSamplingExperiment` class is nonadaptive, i.e. the parameters of the instrumental distribution are 
+set once for all.
+See :class:`~openturns.NAIS` for an adaptive importance sampling algorithm 
+and :class:`~openturns.experimental.CrossEntropyImportanceSampling` for another algorithm.
 
 See also
 --------

--- a/python/src/LHSExperiment_doc.i.in
+++ b/python/src/LHSExperiment_doc.i.in
@@ -25,16 +25,17 @@ randomShift : bool
 
 Notes
 -----
-LHSExperiment is a random weighted design of experiments.
-The method generates a sample of points :math:`\Xi_i` according to the
-distribution :math:`\mu` with the LHS technique: some cells are determined,
+LHSExperiment is a random weighted design of experiments ([stein1987]_, [santner2003]_ page 127).
+The method generates a sample of points :math:`\inputReal_i` according to the
+distribution :math:`\inputMeasure` with the Latin Hypercube Sample (LHS) technique: some cells are determined,
 with the same probabilistic content according to the distribution, each line
 and each column contains exactly one cell, then points are selected among these
 selected cells. The weights associated to the points are all equal to
-:math:`1/\mathrm{card}\,I`. When recalled, the :meth:`generate` method generates a new
+:math:`\frac{1}{\sampleSize}` where :math:`\sampleSize` is the sample size.
+When recalled, the :meth:`generate` method generates a new
 sample: the point selection within the cells changes but not the cells
-selection. To change the cell selection, it is necessary to create a new LHS
-Experiment.
+selection. To change the cell selection, it is necessary to create a new 
+`LHSExperiment`.
 
 .. warning::
 

--- a/python/src/MonteCarloExperiment_doc.i.in
+++ b/python/src/MonteCarloExperiment_doc.i.in
@@ -16,11 +16,12 @@ size : positive int
 
 Notes
 -----
-MonteCarloExperiment is a random weighted design of experiments.
-The :meth:`generate` method generates points :math:`(\Xi_i)_{i \in I}`
-independently from the distribution :math:`\mu`. The weights associated to the
-points are all equal to :math:`1/\mathrm{card}\,I`. When the :meth:`generate` method is
-recalled, the generated sample changes.
+MonteCarloExperiment is a random weighted design of experiments ([hammersley1961]_ page 51, [lemieux2009]_ page 3).
+The :meth:`generate` method computes the nodes :math:`(\inputReal_i)_{i = 1, ..., \sampleSize}`
+by generating independent observations from the distribution :math:`\mu`. The weights associated to the
+points are all equal to :math:`w_i = \frac{1}{\sampleSize}` where :math:`\sampleSize` is the sample size. 
+When the :meth:`generate` method is
+called a second time, the generated sample changes.
 
 See also
 --------

--- a/python/src/PostAnalyticalImportanceSampling_doc.i.in
+++ b/python/src/PostAnalyticalImportanceSampling_doc.i.in
@@ -4,6 +4,9 @@
 Simulation method where the original distribution is replaced by the
 distribution in the standard space centered around the provided design point.
 
+This method, based on importance sampling, uses a normal instrumental 
+distribution in the standard space (see [lemaire2009]_ page 255, [melchers1990]_).
+
 Parameters
 ----------
 analyticalResult : :class:`~openturns.AnalyticalResult`
@@ -13,7 +16,7 @@ analyticalResult : :class:`~openturns.AnalyticalResult`
 
 See also
 --------
-PostAnalyticalControlledImportanceSampling
+PostAnalyticalControlledImportanceSampling, NAIS, experimental.CrossEntropyImportanceSampling
 
 Examples
 --------

--- a/python/src/WeightedExperimentImplementation_doc.i.in
+++ b/python/src/WeightedExperimentImplementation_doc.i.in
@@ -9,47 +9,70 @@ Parameters
 distribution : :class:`~openturns.Distribution`
     Distribution :math:`\mu` used to generate the set of input data.
 size : positive int
-    Number :math:`cardI` of points that will be generated in the experiment.
+    Number :math:`\sampleSize` of points that will be generated in the experiment.
 
 Notes
 -----
-WeightedExperiment is used to generate the points :math:`\Xi_i` so that the
-mean :math:`E_{\mu}` is approximated as follows:
+This class is used to generate nodes and their associated weights
+to approximate the weighted integral of a physical model with respect
+to a distribution (see [sullivan2015]_ chapter 9 page 165).
+
+Let :math:`\model : \physicalInputSpace \rightarrow \physicalOutputSpace` 
+be a function where :math:`\physicalInputSpace \subseteq \Rset^{\inputDim}` 
+is the input space and :math:`\physicalOutputSpace \subseteq \Rset^{\outputDim}`
+is the output space.
+Let :math:`\inputRV` be a random vector with dimension :math:`\outputDim`. 
+We are interested in the expected value of the physical model:
 
 .. math::
 
-    \Expect{ f(\vect{Z})}_{\mu} \simeq \sum_{i \in I} \omega_i f(\Xi_i)
+    \Expect{ \model(\inputRV)}
+    = \int_{\physicalInputSpace} \model(\inputReal) 
+    d\inputMeasure(\inputReal)
 
-where :math:`\mu` is a distribution, :math:`f` is a function :math:`L_1(\mu)`
-and :math:`\omega_i` are the weights associated with the points. By default,
-all the weights are equal to :math:`1/cardI`.
+where :math:`\inputMeasure` is the distribution of the input random vector.
+If the input has a probability density function, then:
 
-A WeightedExperiment object can be created only through its derived classes
-which are distributed in three groups:
+.. math::
 
-1. The first category is made up of the random patterns, where the set of input
+    \Expect{ \model(\inputRV)}
+    = \int_{\physicalInputSpace} \model(\inputReal) 
+    \inputProbabilityDensityFunction(\inputReal) d\inputReal
+
+where :math:`\inputProbabilityDensityFunction` is the probability density 
+function of the input random vector.
+
+The class computes the weights :math:`\{w_i \in \Rset\}_{i = 1, ..., \sampleSize}`
+and the nodes :math:`\{\inputReal_i \in \Rset^{\inputDim}\}_{i = 1, ..., \sampleSize}`
+such that 
+
+.. math::
+
+    \Expect{ \model(\inputRV)}
+    \approx \sum_{i = 1}^\sampleSize w_i \model\left(\inputReal_i\right)
+
+By default, all the weights are equal to :math:`w_i = \frac{1}{\sampleSize}`.
+Some quadrature rules e.g. the tensorised Gauss product rule guarantee 
+that all nodes are non negative, but not all rules have that 
+property.
+
+A `WeightedExperiment` object can be created only through its derived classes
+which are in three groups:
+
+1. The random patterns, where the set of input
    data is generated from the joint distribution of the input random vector,
-   according to these sampling techniques:
+   e.g. 
+   :class:`Monte Carlo <openturns.MonteCarloExperiment>`.
+   In this case, the value returned by :meth:`~openturns.WeightedExperiment.isRandom()` is `True`.
 
-   - :class:`Monte Carlo <openturns.MonteCarloExperiment>`
+2. The :class:`low discrepancy sequences
+   <openturns.LowDiscrepancySequence>` e.g. 
+   :class:`~openturns.SobolSequence`.
+   In this case, the value returned by :meth:`~openturns.WeightedExperiment.isRandom()` is `False`.
 
-   - :class:`LHS <openturns.LHSExperiment>`
-
-   - :class:`Bootstrap <openturns.BootstrapExperiment>`
-
-   - :class:`Importance Sampling <openturns.ImportanceSamplingExperiment>`
-
-2. The second category contains the :class:`low discrepancy sequences
-   <openturns.LowDiscrepancySequence>`. OpenTURNS proposes the Faure, Halton,
-   Haselgrove, Reverse Halton and Sobol sequences.
-
-3. The third category consists of deterministic patterns:
-
-   - :class:`Gauss product <openturns.GaussProductExperiment>`
-
-   - :class:`~openturns.FixedExperiment`
-
-   - :class:`~openturns.LowDiscrepancyExperiment`"
+3. The deterministic patterns or *quadrature rules* e.g.
+   :class:`Gauss product <openturns.GaussProductExperiment>`.
+   In this case, the value returned by :meth:`~openturns.WeightedExperiment.isRandom()` is `False`."
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation
 OT_WeightedExperiment_doc
@@ -62,9 +85,9 @@ OT_WeightedExperiment_doc
 Returns
 -------
 sample : :class:`~openturns.Sample`
-    Points :math:`(\Xi_i)_{i \in I}` which constitute the design of experiments
-    with :math:`card I = size`. The sampling method is defined by the nature of
-    the weighted experiment.
+    Points :math:`(\inputReal_i)_{i = 1, ..., \sampleSize}` 
+    of the design of experiments. 
+    The sampling method is defined by the type of the weighted experiment.
 
 Examples
 --------
@@ -91,11 +114,11 @@ OT_WeightedExperiment_generate_doc
 Returns
 -------
 sample : :class:`~openturns.Sample`
-    The points which constitute the design of experiments. The sampling method
+    The points of the design of experiments. The sampling method
     is defined by the nature of the experiment.
-weights : :class:`~openturns.Point` of size :math:`cardI`
-    Weights :math:`(\omega_i)_{i \in I}` associated with the points. By default,
-    all the weights are equal to :math:`1/cardI`.
+weights : :class:`~openturns.Point` of size :math:`\sampleSize`
+    Weights :math:`(w_i)_{i = 1, ..., \sampleSize}` associated with the points. By default,
+    all the weights are equal to :math:`\frac{1}{\sampleSize}`.
 
 Examples
 --------
@@ -124,7 +147,7 @@ OT_WeightedExperiment_generateWithWeights_doc
 Returns
 -------
 distribution : :class:`~openturns.Distribution`
-    Distribution used to generate the set of input data."
+    Distribution of the input random vector."
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation::getDistribution
 OT_WeightedExperiment_getDistribution_doc
@@ -137,7 +160,7 @@ OT_WeightedExperiment_getDistribution_doc
 Parameters
 ----------
 distribution : :class:`~openturns.Distribution`
-    Distribution used to generate the set of input data."
+    Distribution of the input random vector."
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation::setDistribution
 OT_WeightedExperiment_setDistribution_doc
@@ -150,7 +173,7 @@ OT_WeightedExperiment_setDistribution_doc
 Returns
 -------
 size : positive int
-    Number :math:`cardI` of points constituting the design of experiments."
+    Number :math:`\sampleSize` of points constituting the design of experiments."
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation::getSize
 OT_WeightedExperiment_getSize_doc
@@ -163,7 +186,7 @@ OT_WeightedExperiment_getSize_doc
 Parameters
 ----------
 size : positive int
-    Number :math:`cardI` of points constituting the design of experiments."
+    Number :math:`\sampleSize` of points constituting the design of experiments."
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation::setSize
 OT_WeightedExperiment_setSize_doc
@@ -194,3 +217,4 @@ isRandom : bool
 %enddef
 %feature("docstring") OT::WeightedExperimentImplementation::isRandom
 OT_WeightedExperiment_isRandom_doc
+


### PR DESCRIPTION
This PR improves some help pages.

I introduced a set of macro in `math_notations.sty` to solve #2366. The goal is to consistently use them across the help pages. This is because I notice that the `FunctionalChaosResult` and `FunctionalChaosAlgorithm` help pages do not use the same notations consistently. Indeed, we should use consistent notations not only within a single page, but also across pages on the same topic. Moreover, because some help pages are inherited from mother classes, several help pages must be updated accordingly. For example, `FunctionalChaosResult` inherits from `MetaModelResult`. Hence, both pages must be updated accordingly. Otherwise, the sample size, for example, is denoted $n$ in some pages, but $N$ in the inherited page. The only way to consistently use the same notation is to introduce a macro and use it everywhere it is needed.

This is the doc part of the PR #2372 which is unrelated to other developments.
