### PR TITLE
Create new leastSquares and modelSelection attributes for linear models

### DIFF
--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
@@ -142,19 +142,16 @@ String ApproximationAlgorithmImplementation::__repr__() const
          << " psi=" << psi_;
 }
 
-
 String ApproximationAlgorithmImplementation::__str__(const String & ) const
 {
   return __repr__();
 }
-
 
 void ApproximationAlgorithmImplementation::setCoefficients(const Point & coefficients)
 {
   coefficients_ = coefficients;
   isAlreadyComputedCoefficients_ = true;
 }
-
 
 Point ApproximationAlgorithmImplementation::getCoefficients()
 {
@@ -183,6 +180,11 @@ Scalar ApproximationAlgorithmImplementation::getRelativeError()
 {
   if (! isAlreadyComputedCoefficients_) run();
   return relativeError_;
+}
+
+Bool ApproximationAlgorithmImplementation::isModelSelection() const
+{
+  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementation::isModelSelection()";
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementation.cxx
@@ -182,9 +182,9 @@ Scalar ApproximationAlgorithmImplementation::getRelativeError()
   return relativeError_;
 }
 
-Bool ApproximationAlgorithmImplementation::isModelSelection() const
+Bool ApproximationAlgorithmImplementation::involvesModelSelection() const
 {
-  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementation::isModelSelection()";
+  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementation::involvesModelSelection()";
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementationFactory.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementationFactory.cxx
@@ -45,7 +45,6 @@ ApproximationAlgorithmImplementationFactory * ApproximationAlgorithmImplementati
   return new ApproximationAlgorithmImplementationFactory( *this );
 }
 
-
 ApproximationAlgorithmImplementation * ApproximationAlgorithmImplementationFactory::build(const Sample & x,
     const Sample & y,
     const FunctionCollection & psi,
@@ -82,5 +81,10 @@ void ApproximationAlgorithmImplementationFactory::load(Advocate & adv)
   PersistentObject::load(adv);
 }
 
+/* isModelSelection accessor */
+Bool ApproximationAlgorithmImplementationFactory::isModelSelection() const
+{
+  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementationFactory::isModelSelection()";
+}
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/ApproximationAlgorithmImplementationFactory.cxx
+++ b/lib/src/Base/Algo/ApproximationAlgorithmImplementationFactory.cxx
@@ -81,10 +81,10 @@ void ApproximationAlgorithmImplementationFactory::load(Advocate & adv)
   PersistentObject::load(adv);
 }
 
-/* isModelSelection accessor */
-Bool ApproximationAlgorithmImplementationFactory::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool ApproximationAlgorithmImplementationFactory::involvesModelSelection() const
 {
-  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementationFactory::isModelSelection()";
+  throw NotYetImplementedException(HERE) << "In ApproximationAlgorithmImplementationFactory::involvesModelSelection()";
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
@@ -50,7 +50,7 @@ LeastSquaresMetaModelSelection::LeastSquaresMetaModelSelection(const Sample & x,
     const Indices & indices,
     const BasisSequenceFactory & basisSequenceFactory,
     const FittingAlgorithm & fittingAlgorithm)
-  : ApproximationAlgorithmImplementation( x, y, psi, indices )
+  : ApproximationAlgorithmImplementation(x, y, psi, indices)
   , basisSequenceFactory_(basisSequenceFactory)
   , fittingAlgorithm_(fittingAlgorithm)
 
@@ -66,13 +66,12 @@ LeastSquaresMetaModelSelection::LeastSquaresMetaModelSelection(const Sample & x,
     const Indices & indices,
     const BasisSequenceFactory & basisSequenceFactory,
     const FittingAlgorithm & fittingAlgorithm)
-  : ApproximationAlgorithmImplementation( x, y, weight, psi, indices )
+  : ApproximationAlgorithmImplementation(x, y, weight, psi, indices)
   , basisSequenceFactory_(basisSequenceFactory)
   , fittingAlgorithm_(fittingAlgorithm)
 {
   // Nothing to do
 }
-
 
 /* Virtual constructor */
 LeastSquaresMetaModelSelection * LeastSquaresMetaModelSelection::clone() const
@@ -101,7 +100,6 @@ FittingAlgorithm LeastSquaresMetaModelSelection::getFittingAlgorithm() const
 {
   return fittingAlgorithm_;
 }
-
 
 /* String converter */
 String LeastSquaresMetaModelSelection::__repr__() const
@@ -194,7 +192,6 @@ void LeastSquaresMetaModelSelection::run(const DesignProxy & proxy)
   LOGINFO(OSS() << "optimalRelativeError=" << optimalRelativeError);
 }
 
-
 /* Method save() stores the object through the StorageManager */
 void LeastSquaresMetaModelSelection::save(Advocate & adv) const
 {
@@ -202,7 +199,6 @@ void LeastSquaresMetaModelSelection::save(Advocate & adv) const
   adv.saveAttribute( "basisSequenceFactory_", basisSequenceFactory_ );
   adv.saveAttribute( "fittingAlgorithm_", fittingAlgorithm_ );
 }
-
 
 /* Method load() reloads the object from the StorageManager */
 void LeastSquaresMetaModelSelection::load(Advocate & adv)
@@ -220,6 +216,11 @@ Collection<Indices> LeastSquaresMetaModelSelection::getSelectionHistory(Collecti
 Point LeastSquaresMetaModelSelection::getErrorHistory() const
 {
   return errorHistory_;
+}
+
+Bool LeastSquaresMetaModelSelection::isModelSelection() const
+{
+  return true;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelection.cxx
@@ -218,7 +218,7 @@ Point LeastSquaresMetaModelSelection::getErrorHistory() const
   return errorHistory_;
 }
 
-Bool LeastSquaresMetaModelSelection::isModelSelection() const
+Bool LeastSquaresMetaModelSelection::involvesModelSelection() const
 {
   return true;
 }

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
@@ -27,9 +27,6 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-
-
-
 CLASSNAMEINIT(LeastSquaresMetaModelSelectionFactory)
 
 static const Factory<LeastSquaresMetaModelSelectionFactory> Factory_LeastSquaresMetaModelSelectionFactory;
@@ -44,14 +41,12 @@ LeastSquaresMetaModelSelectionFactory::LeastSquaresMetaModelSelectionFactory(con
   // Nothing to do
 }
 
-
 /* Virtual constructor */
 LeastSquaresMetaModelSelectionFactory * LeastSquaresMetaModelSelectionFactory::clone() const
 
 {
   return new LeastSquaresMetaModelSelectionFactory(*this);
 }
-
 
 /* Accessors */
 BasisSequenceFactory LeastSquaresMetaModelSelectionFactory::getBasisSequenceFactory() const
@@ -63,7 +58,6 @@ FittingAlgorithm LeastSquaresMetaModelSelectionFactory::getFittingAlgorithm() co
 {
   return fittingAlgorithm_;
 }
-
 
 /* String converter */
 String LeastSquaresMetaModelSelectionFactory::__repr__() const
@@ -79,6 +73,12 @@ LeastSquaresMetaModelSelection * LeastSquaresMetaModelSelectionFactory::build(co
     const Indices & indices) const
 {
   return new LeastSquaresMetaModelSelection( x, y, weight, psi, indices, basisSequenceFactory_, fittingAlgorithm_ );
+}
+
+/* isModelSelection accessor */
+Bool LeastSquaresMetaModelSelectionFactory::isModelSelection() const
+{
+  return true;
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
+++ b/lib/src/Base/Algo/LeastSquaresMetaModelSelectionFactory.cxx
@@ -75,8 +75,8 @@ LeastSquaresMetaModelSelection * LeastSquaresMetaModelSelectionFactory::build(co
   return new LeastSquaresMetaModelSelection( x, y, weight, psi, indices, basisSequenceFactory_, fittingAlgorithm_ );
 }
 
-/* isModelSelection accessor */
-Bool LeastSquaresMetaModelSelectionFactory::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool LeastSquaresMetaModelSelectionFactory::involvesModelSelection() const
 {
   return true;
 }

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -48,7 +48,7 @@ PenalizedLeastSquaresAlgorithm::PenalizedLeastSquaresAlgorithm(const Sample & x,
     const Indices & indices,
     const Scalar penalizationFactor,
     const Bool useNormal)
-  : ApproximationAlgorithmImplementation( x, y, psi, indices )
+  : ApproximationAlgorithmImplementation(x, y, psi, indices)
   , penalizationFactor_(penalizationFactor)
   , penalizationMatrix_(0)
   , useNormal_(useNormal)
@@ -70,7 +70,7 @@ PenalizedLeastSquaresAlgorithm::PenalizedLeastSquaresAlgorithm(const Sample & x,
     const Indices & indices,
     const Scalar penalizationFactor,
     const Bool useNormal)
-  : ApproximationAlgorithmImplementation( x, y, weight, psi, indices )
+  : ApproximationAlgorithmImplementation(x, y, weight, psi, indices)
   , penalizationFactor_(penalizationFactor)
   , penalizationMatrix_(0)
   , useNormal_(useNormal)
@@ -92,7 +92,7 @@ PenalizedLeastSquaresAlgorithm::PenalizedLeastSquaresAlgorithm(const Sample & x,
     const Scalar penalizationFactor,
     const CovarianceMatrix & penalizationMatrix,
     const Bool useNormal)
-  : ApproximationAlgorithmImplementation( x, y, weight, psi, indices )
+  : ApproximationAlgorithmImplementation(x, y, weight, psi, indices)
   , penalizationFactor_(penalizationFactor)
   , penalizationMatrix_(penalizationMatrix)
   , useNormal_(useNormal)
@@ -290,6 +290,11 @@ Collection<Indices> PenalizedLeastSquaresAlgorithm::getSelectionHistory(Collecti
 Point PenalizedLeastSquaresAlgorithm::getErrorHistory() const
 {
   return Point();  
+}
+
+Bool PenalizedLeastSquaresAlgorithm::isModelSelection() const
+{
+  return false;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithm.cxx
@@ -292,7 +292,7 @@ Point PenalizedLeastSquaresAlgorithm::getErrorHistory() const
   return Point();  
 }
 
-Bool PenalizedLeastSquaresAlgorithm::isModelSelection() const
+Bool PenalizedLeastSquaresAlgorithm::involvesModelSelection() const
 {
   return false;
 }

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
@@ -61,6 +61,12 @@ PenalizedLeastSquaresAlgorithm * PenalizedLeastSquaresAlgorithmFactory::build(co
   return new PenalizedLeastSquaresAlgorithm(x, y, weight, psi, indices, 0.0, useNormal_);
 }
 
+/* isModelSelection accessor */
+Bool PenalizedLeastSquaresAlgorithmFactory::isModelSelection() const
+{
+  return false;
+}
+
 /* Method save() stores the object through the StorageManager */
 void PenalizedLeastSquaresAlgorithmFactory::save(Advocate & adv) const
 {

--- a/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
+++ b/lib/src/Base/Algo/PenalizedLeastSquaresAlgorithmFactory.cxx
@@ -61,8 +61,8 @@ PenalizedLeastSquaresAlgorithm * PenalizedLeastSquaresAlgorithmFactory::build(co
   return new PenalizedLeastSquaresAlgorithm(x, y, weight, psi, indices, 0.0, useNormal_);
 }
 
-/* isModelSelection accessor */
-Bool PenalizedLeastSquaresAlgorithmFactory::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool PenalizedLeastSquaresAlgorithmFactory::involvesModelSelection() const
 {
   return false;
 }

--- a/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
@@ -104,6 +104,9 @@ public:
   virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
   virtual Point getErrorHistory() const;
 
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
 protected:
 
   void setCoefficients(const Point & coefficients);
@@ -135,10 +138,10 @@ protected:
 
 private:
   /** Residual */
-  Scalar residual_ = 0.0;
+  Scalar residual_ = -1.0;
 
   /** Relative error */
-  Scalar relativeError_ = 0.0;
+  Scalar relativeError_ = -1.0;
 
 }; /* class ApproximationAlgorithmImplementation */
 

--- a/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
+++ b/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementation.hxx
@@ -104,8 +104,8 @@ public:
   virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
   virtual Point getErrorHistory() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
 protected:
 

--- a/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementationFactory.hxx
+++ b/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementationFactory.hxx
@@ -71,8 +71,8 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
 }; /* class ApproximationAlgorithmImplementationFactory */
 

--- a/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementationFactory.hxx
+++ b/lib/src/Base/Algo/openturns/ApproximationAlgorithmImplementationFactory.hxx
@@ -71,6 +71,9 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
 }; /* class ApproximationAlgorithmImplementationFactory */
 
 

--- a/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
@@ -88,8 +88,8 @@ public:
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
   Point getErrorHistory() const override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
 protected:
 

--- a/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelection.hxx
@@ -88,6 +88,9 @@ public:
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
   Point getErrorHistory() const override;
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
 protected:
 
   /** Algorithm that builds the BasisSequence */

--- a/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelectionFactory.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelectionFactory.hxx
@@ -70,8 +70,8 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
 private:
   /** The algorithm that generates a family of basis */

--- a/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelectionFactory.hxx
+++ b/lib/src/Base/Algo/openturns/LeastSquaresMetaModelSelectionFactory.hxx
@@ -70,6 +70,9 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
 private:
   /** The algorithm that generates a family of basis */
   BasisSequenceFactory basisSequenceFactory_;

--- a/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
+++ b/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
@@ -93,8 +93,8 @@ public:
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
   Point getErrorHistory() const override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
 protected:
 

--- a/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
+++ b/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithm.hxx
@@ -93,6 +93,9 @@ public:
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
   Point getErrorHistory() const override;
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
 protected:
 
 private:

--- a/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithmFactory.hxx
+++ b/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithmFactory.hxx
@@ -57,6 +57,9 @@ public:
   /** String converter */
   String __repr__() const override;
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithmFactory.hxx
+++ b/lib/src/Base/Algo/openturns/PenalizedLeastSquaresAlgorithmFactory.hxx
@@ -57,8 +57,8 @@ public:
   /** String converter */
   String __repr__() const override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
@@ -111,10 +111,10 @@ AdaptiveStrategyImplementation::FunctionCollection AdaptiveStrategyImplementatio
   return Psi_k_p_;
 }
 
-/* isModelSelection accessor */
-Bool AdaptiveStrategyImplementation::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool AdaptiveStrategyImplementation::involvesModelSelection() const
 {
-  throw NotYetImplementedException(HERE) << "in AdaptiveStrategyImplementation::isModelSelection";
+  throw NotYetImplementedException(HERE) << "in AdaptiveStrategyImplementation::involvesModelSelection";
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/AdaptiveStrategyImplementation.cxx
@@ -61,13 +61,11 @@ AdaptiveStrategyImplementation::AdaptiveStrategyImplementation(const OrthogonalB
   // Nothing to do
 }
 
-
 /* Virtual constructor */
 AdaptiveStrategyImplementation * AdaptiveStrategyImplementation::clone() const
 {
   return new AdaptiveStrategyImplementation(*this);
 }
-
 
 /* String converter */
 String AdaptiveStrategyImplementation::__repr__() const
@@ -76,13 +74,11 @@ String AdaptiveStrategyImplementation::__repr__() const
          << " maximumDimension=" << maximumDimension_;
 }
 
-
 /* Basis accessor */
 OrthogonalBasis AdaptiveStrategyImplementation::getBasis() const
 {
   return basis_;
 }
-
 
 /* Maximum dimension accessor */
 void AdaptiveStrategyImplementation::setMaximumDimension(const UnsignedInteger maximumDimension)
@@ -94,7 +90,6 @@ UnsignedInteger AdaptiveStrategyImplementation::getMaximumDimension() const
 {
   return maximumDimension_;
 }
-
 
 /* Compute initial basis for the approximation */
 void AdaptiveStrategyImplementation::computeInitialBasis()
@@ -116,6 +111,12 @@ AdaptiveStrategyImplementation::FunctionCollection AdaptiveStrategyImplementatio
   return Psi_k_p_;
 }
 
+/* isModelSelection accessor */
+Bool AdaptiveStrategyImplementation::isModelSelection() const
+{
+  throw NotYetImplementedException(HERE) << "in AdaptiveStrategyImplementation::isModelSelection";
+}
+
 /* Method save() stores the object through the StorageManager */
 void AdaptiveStrategyImplementation::save(Advocate & adv) const
 {
@@ -123,14 +124,11 @@ void AdaptiveStrategyImplementation::save(Advocate & adv) const
   adv.saveAttribute( "basis_", basis_ );
 }
 
-
 /* Method load() reloads the object from the StorageManager */
 void AdaptiveStrategyImplementation::load(Advocate & adv)
 {
   PersistentObject::load(adv);
   adv.loadAttribute( "basis_", basis_ );
 }
-
-
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
@@ -30,14 +30,11 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-
-
 CLASSNAMEINIT(CleaningStrategy)
 
 typedef Collection<Scalar> ScalarCollection;
 
 static const Factory<CleaningStrategy> Factory_CleaningStrategy;
-
 
 /* Default constructor */
 CleaningStrategy::CleaningStrategy()
@@ -57,7 +54,6 @@ CleaningStrategy::CleaningStrategy(const OrthogonalBasis & basis,
   // Nothing to do
 }
 
-
 /* Constructor from an orthogonal basis */
 CleaningStrategy::CleaningStrategy(const OrthogonalBasis & basis,
                                    const UnsignedInteger maximumDimension,
@@ -69,7 +65,6 @@ CleaningStrategy::CleaningStrategy(const OrthogonalBasis & basis,
 {
   // Nothing to do
 }
-
 
 /* Compute initial basis for the approximation */
 void CleaningStrategy::computeInitialBasis()
@@ -217,13 +212,11 @@ void CleaningStrategy::updateBasis(const Point & alpha_k,
   LOGDEBUG(OSS() << "  I_p         =" << I_p_);
 }
 
-
 /* Virtual constructor */
 CleaningStrategy * CleaningStrategy::clone() const
 {
   return new CleaningStrategy(*this);
 }
-
 
 /* String converter */
 String CleaningStrategy::__repr__() const
@@ -233,7 +226,6 @@ String CleaningStrategy::__repr__() const
          << " significance factor=" << significanceFactor_
          << " derived from " << AdaptiveStrategyImplementation::__repr__();
 }
-
 
 /* Current vector index accessor */
 UnsignedInteger CleaningStrategy::getCurrentVectorIndex() const
@@ -263,19 +255,22 @@ void CleaningStrategy::setSignificanceFactor(const Scalar significanceFactor)
   significanceFactor_ = significanceFactor;
 }
 
+/* isModelSelection accessor */
+Bool CleaningStrategy::isModelSelection() const
+{
+  return true;
+}
+
 /* Method save() stores the object through the StorageManager */
 void CleaningStrategy::save(Advocate & adv) const
 {
   AdaptiveStrategyImplementation::save(adv);
 }
 
-
 /* Method load() reloads the object from the StorageManager */
 void CleaningStrategy::load(Advocate & adv)
 {
   AdaptiveStrategyImplementation::load(adv);
 }
-
-
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/CleaningStrategy.cxx
@@ -255,8 +255,8 @@ void CleaningStrategy::setSignificanceFactor(const Scalar significanceFactor)
   significanceFactor_ = significanceFactor;
 }
 
-/* isModelSelection accessor */
-Bool CleaningStrategy::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool CleaningStrategy::involvesModelSelection() const
 {
   return true;
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
@@ -89,8 +89,8 @@ String FixedStrategy::__repr__() const
          << " derived from " << AdaptiveStrategyImplementation::__repr__();
 }
 
-/* isModelSelection accessor */
-Bool FixedStrategy::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool FixedStrategy::involvesModelSelection() const
 {
   return false;
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FixedStrategy.cxx
@@ -24,8 +24,6 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-
-
 CLASSNAMEINIT(FixedStrategy)
 
 static const Factory<FixedStrategy> Factory_FixedStrategy;
@@ -37,7 +35,6 @@ FixedStrategy::FixedStrategy()
   // Nothing to do
 }
 
-
 /* Constructor from an orthogonal basis */
 FixedStrategy::FixedStrategy(const OrthogonalBasis & basis,
                              const UnsignedInteger maximumDimension)
@@ -45,7 +42,6 @@ FixedStrategy::FixedStrategy(const OrthogonalBasis & basis,
 {
   // Nothing to do
 }
-
 
 /* Compute initial basis for the approximation */
 void FixedStrategy::computeInitialBasis()
@@ -71,7 +67,7 @@ void FixedStrategy::computeInitialBasis()
 /* Update the basis for the next iteration of approximation */
 void FixedStrategy::updateBasis(const Point &,
                                 const Scalar,
-                                const Scalar )
+                                const Scalar)
 {
   // No change to the basis in the fixed strategy
   addedPsi_k_ranks_ = Indices(0);
@@ -80,13 +76,11 @@ void FixedStrategy::updateBasis(const Point &,
   conservedPsi_k_ranks_.fill();
 }
 
-
 /* Virtual constructor */
 FixedStrategy * FixedStrategy::clone() const
 {
   return new FixedStrategy(*this);
 }
-
 
 /* String converter */
 String FixedStrategy::__repr__() const
@@ -95,6 +89,11 @@ String FixedStrategy::__repr__() const
          << " derived from " << AdaptiveStrategyImplementation::__repr__();
 }
 
+/* isModelSelection accessor */
+Bool FixedStrategy::isModelSelection() const
+{
+  return false;
+}
 
 /* Method save() stores the object through the StorageManager */
 void FixedStrategy::save(Advocate & adv) const
@@ -102,13 +101,10 @@ void FixedStrategy::save(Advocate & adv) const
   AdaptiveStrategyImplementation::save(adv);
 }
 
-
 /* Method load() reloads the object from the StorageManager */
 void FixedStrategy::load(Advocate & adv)
 {
   AdaptiveStrategyImplementation::load(adv);
 }
-
-
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -342,8 +342,8 @@ void FunctionalChaosAlgorithm::run()
                                   inverseTransformation_, basis, I_k, alpha_k, Psi_k,
                                   residuals, relativeErrors);
   result_.setIsLeastSquares(projectionStrategy_.isLeastSquares());
-  result_.setIsModelSelection(adaptiveStrategy_.getImplementation()->isModelSelection() || 
-    projectionStrategy_.getImplementation()->isModelSelection());
+  result_.setInvolvesModelSelection(adaptiveStrategy_.getImplementation()->involvesModelSelection() || 
+    projectionStrategy_.getImplementation()->involvesModelSelection());
 
   // set selection history
   Collection<Point> coefficientsHistory;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosAlgorithm.cxx
@@ -338,7 +338,12 @@ void FunctionalChaosAlgorithm::run()
     Psi_k.add(basis.build(i));
   }
   // Build the result
-  result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis, I_k, alpha_k, Psi_k, residuals, relativeErrors);
+  result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_,
+                                  inverseTransformation_, basis, I_k, alpha_k, Psi_k,
+                                  residuals, relativeErrors);
+  result_.setIsLeastSquares(projectionStrategy_.isLeastSquares());
+  result_.setIsModelSelection(adaptiveStrategy_.getImplementation()->isModelSelection() || 
+    projectionStrategy_.getImplementation()->isModelSelection());
 
   // set selection history
   Collection<Point> coefficientsHistory;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
@@ -103,7 +103,9 @@ String FunctionalChaosResult::__repr__() const
          << " residuals=" << residuals_
          << " relativeErrors=" << relativeErrors_
          << " composedMetaModel=" << composedMetaModel_
-         << " metaModel=" << metaModel_;
+         << " metaModel=" << metaModel_
+         << " isLeastSquares=" << isLeastSquares_
+         << " isModelSelection=" << isModelSelection_;
 }
 
 String FunctionalChaosResult::__str__(const String & /*offset*/) const
@@ -127,10 +129,12 @@ String FunctionalChaosResult::__repr_markdown__() const
       << "- orthogonal basis dimension=" << orthogonalBasis_.getMeasure().getDimension() << "\n"
       << "- indices size=" << indicesSize << "\n"
       << "- relative errors=" << relativeErrors_ << "\n"
-      << "- residuals=" << residuals_ << "\n";
+      << "- residuals=" << residuals_ << "\n"
+      << "- is least squares=" << isLeastSquares_ << "\n"
+      << "- is model selection=" << isModelSelection_ << "\n";
   oss << "\n";
 
-  const Scalar ell_threshold = ResourceMap::GetAsUnsignedInteger("FunctionalChaosResult-PrintEllipsisThreshold");
+  const UnsignedInteger ell_threshold = ResourceMap::GetAsUnsignedInteger("FunctionalChaosResult-PrintEllipsisThreshold");
   const UnsignedInteger ell_size = ResourceMap::GetAsUnsignedInteger("FunctionalChaosResult-PrintEllipsisSize");
   const UnsignedInteger columnWidth = ResourceMap::GetAsUnsignedInteger("FunctionalChaosResult-PrintColumnWidth");
   const UnsignedInteger ellipsis = (indicesSize * outputDimension > ell_threshold);
@@ -181,10 +185,8 @@ String FunctionalChaosResult::__repr_markdown__() const
       if (i == ell_size)
       {
         oss << "| ...   |";
-        const String blankColumn(String(columnWidth, ' ') + "|");
-        oss << OSS::RepeatString(1 + ell_size, blankColumn)
-            << OSS::PadString(" ... ", columnWidth) << "|"
-            << OSS::RepeatString(ell_size, blankColumn) << "\n";
+        const String ellipsisColumn(OSS::PadString(" ... ", columnWidth) + "|");
+        oss << OSS::RepeatString(1 + outputDimension, ellipsisColumn) << "\n";
         continue;
       }
       else if (i > ell_size && i < indicesSize - ell_size) continue;
@@ -273,6 +275,38 @@ Function FunctionalChaosResult::getComposedMetaModel() const
   return composedMetaModel_;
 }
 
+/* Residuals accessor */
+Sample FunctionalChaosResult::getSampleResiduals() const
+{
+  const Sample predictionsSample(metaModel_(inputSample_));
+  const Sample residualsSample(outputSample_ - predictionsSample);
+  return residualsSample;
+}
+
+/* isLeastSquares accessor */
+Bool FunctionalChaosResult::isLeastSquares() const
+{
+  return isLeastSquares_;
+}
+
+/* isModelSelection accessor */
+Bool FunctionalChaosResult::isModelSelection() const
+{
+  return isModelSelection_;
+}
+
+/* isLeastSquares accessor */
+void FunctionalChaosResult::setIsLeastSquares(const Bool isLeastSquares)
+{
+  isLeastSquares_ = isLeastSquares;
+}
+
+/* isModelSelection accessor */
+void FunctionalChaosResult::setIsModelSelection(const Bool isModelSelection)
+{
+  isModelSelection_ = isModelSelection;
+}
+
 /* Method save() stores the object through the StorageManager */
 void FunctionalChaosResult::save(Advocate & adv) const
 {
@@ -288,6 +322,8 @@ void FunctionalChaosResult::save(Advocate & adv) const
   adv.saveAttribute( "indicesHistory_", indicesHistory_ );
   adv.saveAttribute( "coefficientsHistory_", coefficientsHistory_ );
   adv.saveAttribute( "errorHistory_", errorHistory_ );
+  adv.saveAttribute( "isLeastSquares_", isLeastSquares_ );
+  adv.saveAttribute( "isModelSelection_", isModelSelection_ );
 }
 
 
@@ -308,6 +344,11 @@ void FunctionalChaosResult::load(Advocate & adv)
     adv.loadAttribute( "indicesHistory_", indicesHistory_ );
     adv.loadAttribute( "coefficientsHistory_", coefficientsHistory_ );
     adv.loadAttribute( "errorHistory_", errorHistory_ );
+  }
+  if (adv.hasAttribute("isLeastSquares_"))
+  {
+    adv.loadAttribute( "isLeastSquares_", isLeastSquares_ );
+    adv.loadAttribute( "isModelSelection_", isModelSelection_ );
   }
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/FunctionalChaosResult.cxx
@@ -105,7 +105,7 @@ String FunctionalChaosResult::__repr__() const
          << " composedMetaModel=" << composedMetaModel_
          << " metaModel=" << metaModel_
          << " isLeastSquares=" << isLeastSquares_
-         << " isModelSelection=" << isModelSelection_;
+         << " involvesModelSelection=" << involvesModelSelection_;
 }
 
 String FunctionalChaosResult::__str__(const String & /*offset*/) const
@@ -131,7 +131,7 @@ String FunctionalChaosResult::__repr_markdown__() const
       << "- relative errors=" << relativeErrors_ << "\n"
       << "- residuals=" << residuals_ << "\n"
       << "- is least squares=" << isLeastSquares_ << "\n"
-      << "- is model selection=" << isModelSelection_ << "\n";
+      << "- is model selection=" << involvesModelSelection_ << "\n";
   oss << "\n";
 
   const UnsignedInteger ell_threshold = ResourceMap::GetAsUnsignedInteger("FunctionalChaosResult-PrintEllipsisThreshold");
@@ -289,10 +289,10 @@ Bool FunctionalChaosResult::isLeastSquares() const
   return isLeastSquares_;
 }
 
-/* isModelSelection accessor */
-Bool FunctionalChaosResult::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool FunctionalChaosResult::involvesModelSelection() const
 {
-  return isModelSelection_;
+  return involvesModelSelection_;
 }
 
 /* isLeastSquares accessor */
@@ -301,10 +301,10 @@ void FunctionalChaosResult::setIsLeastSquares(const Bool isLeastSquares)
   isLeastSquares_ = isLeastSquares;
 }
 
-/* isModelSelection accessor */
-void FunctionalChaosResult::setIsModelSelection(const Bool isModelSelection)
+/* involvesModelSelection accessor */
+void FunctionalChaosResult::setInvolvesModelSelection(const Bool involvesModelSelection)
 {
-  isModelSelection_ = isModelSelection;
+  involvesModelSelection_ = involvesModelSelection;
 }
 
 /* Method save() stores the object through the StorageManager */
@@ -323,7 +323,7 @@ void FunctionalChaosResult::save(Advocate & adv) const
   adv.saveAttribute( "coefficientsHistory_", coefficientsHistory_ );
   adv.saveAttribute( "errorHistory_", errorHistory_ );
   adv.saveAttribute( "isLeastSquares_", isLeastSquares_ );
-  adv.saveAttribute( "isModelSelection_", isModelSelection_ );
+  adv.saveAttribute( "involvesModelSelection_", involvesModelSelection_ );
 }
 
 
@@ -348,7 +348,7 @@ void FunctionalChaosResult::load(Advocate & adv)
   if (adv.hasAttribute("isLeastSquares_"))
   {
     adv.loadAttribute( "isLeastSquares_", isLeastSquares_ );
-    adv.loadAttribute( "isModelSelection_", isModelSelection_ );
+    adv.loadAttribute( "involvesModelSelection_", involvesModelSelection_ );
   }
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
@@ -176,6 +176,8 @@ void IntegrationExpansion::run()
   }
   // Build the result
   result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis_, activeFunctions_, coefficients, designProxy_.getBasis(activeFunctions_), residuals, relativeErrors);
+  result_.setIsLeastSquares(false);
+  result_.setIsModelSelection(false);
 }
 
 /* Method to get/set the active functions */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
@@ -177,7 +177,7 @@ void IntegrationExpansion::run()
   // Build the result
   result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis_, activeFunctions_, coefficients, designProxy_.getBasis(activeFunctions_), residuals, relativeErrors);
   result_.setIsLeastSquares(false);
-  result_.setIsModelSelection(false);
+  result_.setInvolvesModelSelection(false);
 }
 
 /* Method to get/set the active functions */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
@@ -188,7 +188,6 @@ void IntegrationStrategy::computeCoefficients(const Function & function,
   relativeError_p_ = 0.0;
 }
 
-
 /* Method save() stores the object through the StorageManager */
 void IntegrationStrategy::save(Advocate & adv) const
 {
@@ -212,6 +211,18 @@ Collection<Indices> IntegrationStrategy::getSelectionHistory(Collection<Point> &
 Point IntegrationStrategy::getErrorHistory() const
 {
   return Point();
+}
+
+/* isLeastSquares accessor */
+Bool IntegrationStrategy::isLeastSquares() const
+{
+  return false;
+}
+
+/* isModelSelection accessor */
+Bool IntegrationStrategy::isModelSelection() const
+{
+  return false;
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationStrategy.cxx
@@ -219,8 +219,8 @@ Bool IntegrationStrategy::isLeastSquares() const
   return false;
 }
 
-/* isModelSelection accessor */
-Bool IntegrationStrategy::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool IntegrationStrategy::involvesModelSelection() const
 {
   return false;
 }

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
@@ -164,6 +164,8 @@ void LeastSquaresExpansion::run()
   }
   // Build the result
   result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis_, activeFunctions_, coefficients, designProxy_.getBasis(activeFunctions_), residuals, relativeErrors);
+  result_.setIsLeastSquares(true);
+  result_.setIsModelSelection(false);
 }
 
 /* Method to get/set the active functions */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
@@ -165,7 +165,7 @@ void LeastSquaresExpansion::run()
   // Build the result
   result_ = FunctionalChaosResult(inputSample_, outputSample_, distribution_, transformation_, inverseTransformation_, basis_, activeFunctions_, coefficients, designProxy_.getBasis(activeFunctions_), residuals, relativeErrors);
   result_.setIsLeastSquares(true);
-  result_.setIsModelSelection(false);
+  result_.setInvolvesModelSelection(false);
 }
 
 /* Method to get/set the active functions */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
@@ -177,4 +177,16 @@ Point LeastSquaresStrategy::getErrorHistory() const
   return errorHistory_;
 }
 
+/* isLeastSquares accessor */
+Bool LeastSquaresStrategy::isLeastSquares() const
+{
+  return true;
+}
+
+/* isModelSelection accessor */
+Bool LeastSquaresStrategy::isModelSelection() const
+{
+  return p_approximationAlgorithmImplementationFactory_.getImplementation()->isModelSelection();
+}
+
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresStrategy.cxx
@@ -183,10 +183,10 @@ Bool LeastSquaresStrategy::isLeastSquares() const
   return true;
 }
 
-/* isModelSelection accessor */
-Bool LeastSquaresStrategy::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool LeastSquaresStrategy::involvesModelSelection() const
 {
-  return p_approximationAlgorithmImplementationFactory_.getImplementation()->isModelSelection();
+  return p_approximationAlgorithmImplementationFactory_.getImplementation()->involvesModelSelection();
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
@@ -142,10 +142,10 @@ Bool ProjectionStrategy::isLeastSquares() const
   return getImplementation()->isLeastSquares();
 }
 
-/* isModelSelection accessor */
-Bool ProjectionStrategy::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool ProjectionStrategy::involvesModelSelection() const
 {
-  return getImplementation()->isModelSelection();
+  return getImplementation()->involvesModelSelection();
 }
 
 /* Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategy.cxx
@@ -136,6 +136,18 @@ DesignProxy ProjectionStrategy::getDesignProxy() const
   return getImplementation()->getDesignProxy();
 }
 
+/* isLeastSquares accessor */
+Bool ProjectionStrategy::isLeastSquares() const
+{
+  return getImplementation()->isLeastSquares();
+}
+
+/* isModelSelection accessor */
+Bool ProjectionStrategy::isModelSelection() const
+{
+  return getImplementation()->isModelSelection();
+}
+
 /* Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
 void ProjectionStrategy::computeCoefficients(const Function & function,
     const FunctionCollection & basis,
@@ -160,6 +172,7 @@ String ProjectionStrategy::__str__(const String & offset) const
 {
   return OSS() << getImplementation()->__str__(offset);
 }
+
 /* String converter */
 String ProjectionStrategy::_repr_html_() const
 {

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -317,10 +317,10 @@ Bool ProjectionStrategyImplementation::isLeastSquares() const
   throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::isLeastSquares()";
 }
 
-/* isModelSelection accessor */
-Bool ProjectionStrategyImplementation::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool ProjectionStrategyImplementation::involvesModelSelection() const
 {
-  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::isModelSelection()";
+  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::involvesModelSelection()";
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/ProjectionStrategyImplementation.cxx
@@ -265,7 +265,7 @@ Scalar ProjectionStrategyImplementation::getRelativeError() const
   return relativeError_p_;
 }
 
-/* Relative error accessor */
+/* Coefficients accessor */
 Point ProjectionStrategyImplementation::getCoefficients() const
 {
   return alpha_k_p_;
@@ -289,13 +289,11 @@ void ProjectionStrategyImplementation::computeCoefficients(const Function &,
   throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::computeCoefficients(const Function & function, const FunctionCollection & basis, const Indices & indices, const Indices & addedRanks, const Indices & conservedRanks, const Indices & removedRanks, const UnsignedInteger marginalIndex)";
 }
 
-
 /* Method save() stores the object through the StorageManager */
 void ProjectionStrategyImplementation::save(Advocate & adv) const
 {
   PersistentObject::save(adv);
 }
-
 
 /* Method load() reloads the object from the StorageManager */
 void ProjectionStrategyImplementation::load(Advocate & adv)
@@ -311,6 +309,18 @@ Collection<Indices> ProjectionStrategyImplementation::getSelectionHistory(Collec
 Point ProjectionStrategyImplementation::getErrorHistory() const
 {
   throw NotYetImplementedException(HERE) << "in ProjectionStrategyImplementation::getErrorHistory";
+}
+
+/* isLeastSquares accessor */
+Bool ProjectionStrategyImplementation::isLeastSquares() const
+{
+  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::isLeastSquares()";
+}
+
+/* isModelSelection accessor */
+Bool ProjectionStrategyImplementation::isModelSelection() const
+{
+  throw NotYetImplementedException(HERE) << "In ProjectionStrategyImplementation::isModelSelection()";
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/AdaptiveStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/AdaptiveStrategyImplementation.hxx
@@ -86,6 +86,9 @@ public:
   /** Psi accessor */
   FunctionCollection getPsi() const;
 
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 
@@ -117,8 +120,6 @@ protected:
 
   /** The full basis */
   FunctionCollection Psi_;
-private:
-
 } ; /* class AdaptiveStrategyImplementation */
 
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/AdaptiveStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/AdaptiveStrategyImplementation.hxx
@@ -86,8 +86,8 @@ public:
   /** Psi accessor */
   FunctionCollection getPsi() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/CleaningStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/CleaningStrategy.hxx
@@ -77,6 +77,9 @@ public:
   Scalar getSignificanceFactor() const;
   void setSignificanceFactor(const Scalar significanceFactor);
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/CleaningStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/CleaningStrategy.hxx
@@ -77,8 +77,8 @@ public:
   Scalar getSignificanceFactor() const;
   void setSignificanceFactor(const Scalar significanceFactor);
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FixedStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FixedStrategy.hxx
@@ -57,8 +57,8 @@ public:
                    const Scalar residual,
                    const Scalar relativeError) override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
   /** String converter */
   String __repr__() const override;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FixedStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FixedStrategy.hxx
@@ -57,6 +57,9 @@ public:
                    const Scalar residual,
                    const Scalar relativeError) override;
 
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
   /** String converter */
   String __repr__() const override;
 
@@ -65,7 +68,6 @@ public:
 
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
-
 
 private:
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
@@ -106,14 +106,14 @@ public:
   /** isLeastSquares_ accessor */
   virtual Bool isLeastSquares() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
   /** isLeastSquares_ accessor */
   virtual void setIsLeastSquares(const Bool isLeastSquares);
 
-  /** isModelSelection accessor */
-  virtual void setIsModelSelection(const Bool isModelSelection);
+  /** involvesModelSelection accessor */
+  virtual void setInvolvesModelSelection(const Bool involvesModelSelection);
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -170,7 +170,7 @@ private:
   Bool isLeastSquares_ = true;
 
   /** Is model selection? */
-  Bool isModelSelection_ = false;
+  Bool involvesModelSelection_ = false;
 
 } ; /* class FunctionalChaosResult */
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/FunctionalChaosResult.hxx
@@ -65,7 +65,8 @@ public:
                         const Sample & alpha_k,
                         const FunctionCollection & Psi_k,
                         const Point & residuals,
-                        const Point & relativeErrors);
+                        const Point & relativeErrors
+                       );
 
   /** Virtual constructor */
   FunctionalChaosResult * clone() const override;
@@ -98,6 +99,21 @@ public:
 
   /** Composed meta model accessor */
   virtual Function getComposedMetaModel() const;
+
+  /** Residuals accessor */
+  virtual Sample getSampleResiduals() const;
+
+  /** isLeastSquares_ accessor */
+  virtual Bool isLeastSquares() const;
+
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
+  /** isLeastSquares_ accessor */
+  virtual void setIsLeastSquares(const Bool isLeastSquares);
+
+  /** isModelSelection accessor */
+  virtual void setIsModelSelection(const Bool isModelSelection);
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -149,6 +165,12 @@ private:
 
   /** Error history */
   Point errorHistory_;
+
+  /** Is regression? */
+  Bool isLeastSquares_ = true;
+
+  /** Is model selection? */
+  Bool isModelSelection_ = false;
 
 } ; /* class FunctionalChaosResult */
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
@@ -77,8 +77,15 @@ public:
 
   /** Selection/error history accessor */
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
+
   Point getErrorHistory() const override;
 
+  /** isLeastSquares accessor */
+  Bool isLeastSquares() const override;
+  
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+  
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
   void computeCoefficients(const Function & function,

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/IntegrationStrategy.hxx
@@ -83,8 +83,8 @@ public:
   /** isLeastSquares accessor */
   Bool isLeastSquares() const override;
   
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
   
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
@@ -89,8 +89,8 @@ public:
   /** isLeastSquares accessor */
   Bool isLeastSquares() const override;
 
-  /** isModelSelection accessor */
-  Bool isModelSelection() const override;
+  /** involvesModelSelection accessor */
+  Bool involvesModelSelection() const override;
 
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/LeastSquaresStrategy.hxx
@@ -86,6 +86,12 @@ public:
   Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const override;
   Point getErrorHistory() const override;
 
+  /** isLeastSquares accessor */
+  Bool isLeastSquares() const override;
+
+  /** isModelSelection accessor */
+  Bool isModelSelection() const override;
+
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
   void computeCoefficients(const Function & function,

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
@@ -87,6 +87,12 @@ public:
   /** Design proxy accessor */
   virtual DesignProxy getDesignProxy() const;
 
+  /** isLeastSquares accessor */
+  virtual Bool isLeastSquares() const;
+
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
   /** String converter */
   String __repr__() const override;
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategy.hxx
@@ -90,8 +90,8 @@ public:
   /** isLeastSquares accessor */
   virtual Bool isLeastSquares() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
   /** String converter */
   String __repr__() const override;

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
@@ -34,8 +34,6 @@
 
 BEGIN_NAMESPACE_OPENTURNS
 
-
-
 /**
  * @class ProjectionStrategyImplementation
  *
@@ -104,7 +102,7 @@ public:
   /** Relative error accessor */
   virtual Scalar getRelativeError() const;
 
-  /** Relative error accessor */
+  /** Coefficients accessor */
   virtual Point getCoefficients() const;
 
   /** Experiment accessors */
@@ -122,6 +120,12 @@ public:
 
   virtual Collection<Indices> getSelectionHistory(Collection<Point> & coefficientsHistory) const;
   virtual Point getErrorHistory() const;
+
+  /** isLeastSquares accessor */
+  virtual Bool isLeastSquares() const;
+
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
 
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */
@@ -142,7 +146,7 @@ protected:
   /** Relative error */
   Scalar relativeError_p_;
 
-  /** The measureing function for projection */
+  /** The measure function for projection */
   Distribution measure_;
 
   // An  experiment that will be used to discretize the L2 integral

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/openturns/ProjectionStrategyImplementation.hxx
@@ -124,8 +124,8 @@ public:
   /** isLeastSquares accessor */
   virtual Bool isLeastSquares() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
 protected:
   /** Compute the components alpha_k_p_ by projecting the model on the partial L2 basis */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx
@@ -142,7 +142,7 @@ String LinearModelResult::__repr_markdown__() const
       << "- Cook's distances size=" << cookDistances_.getSize() << "\n"
       << "- residuals variance=" << residualsVariance_ << "\n"
       << "- has intercept=" << hasIntercept_ << "\n"
-      << "- is model selection=" << isModelSelection_ << "\n";
+      << "- is model selection=" << involvesModelSelection_ << "\n";
   oss << "\n";
   return oss;
 }
@@ -164,7 +164,7 @@ String LinearModelResult::__repr__() const
          << " cookDistances dimension=" << cookDistances_.getDimension()
          << " residuals variance= " << residualsVariance_
          << " hasIntercept=" << hasIntercept_
-         << " isModelSelection=" << isModelSelection_;
+         << " involvesModelSelection=" << involvesModelSelection_;
 }
 
 Basis LinearModelResult::getBasis() const
@@ -311,16 +311,16 @@ LeastSquaresMethod LinearModelResult::buildMethod() const
   return leastSquaresMethod;
 }
 
-/* isModelSelection accessor */
-Bool LinearModelResult::isModelSelection() const
+/* involvesModelSelection accessor */
+Bool LinearModelResult::involvesModelSelection() const
 {
-  return isModelSelection_;
+  return involvesModelSelection_;
 }
 
-/* isModelSelection accessor */
-void LinearModelResult::setIsModelSelection(const Bool isModelSelection)
+/* involvesModelSelection accessor */
+void LinearModelResult::setInvolvesModelSelection(const Bool involvesModelSelection)
 {
-  isModelSelection_ = isModelSelection;
+  involvesModelSelection_ = involvesModelSelection;
 }
 
 /* Method save() stores the object through the StorageManager */
@@ -338,7 +338,7 @@ void LinearModelResult::save(Advocate & adv) const
   adv.saveAttribute( "leverages_", leverages_ );
   adv.saveAttribute( "cookDistances_", cookDistances_ );
   adv.saveAttribute( "residualsVariance_", residualsVariance_ );
-  adv.saveAttribute( "isModelSelection_", isModelSelection_ );
+  adv.saveAttribute( "involvesModelSelection_", involvesModelSelection_ );
 }
 
 
@@ -363,8 +363,8 @@ void LinearModelResult::load(Advocate & adv)
     adv.loadAttribute( "residualsVariance_", residualsVariance_ );
   else
     adv.loadAttribute( "sigma2_", residualsVariance_ );
-  if (adv.hasAttribute("isModelSelection_"))
-    adv.loadAttribute("isModelSelection_", isModelSelection_);
+  if (adv.hasAttribute("involvesModelSelection_"))
+    adv.loadAttribute("involvesModelSelection_", involvesModelSelection_);
 }
 
 END_NAMESPACE_OPENTURNS

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
@@ -573,7 +573,7 @@ void LinearModelStepwiseAlgorithm::run()
   result_ = LinearModelResult(inputSample_, Basis(currentFunctions), currentX_, outputSample_, metaModel,
                               regression, currentFunctions.__str__(), coefficientsNames, residualSample, standardizedResiduals,
                               diagonalGramInverse, leverages, cookDistances, sigma2[0]);
-  result_.setIsModelSelection(true);
+  result_.setInvolvesModelSelection(true);
   hasRun_ = true;
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelStepwiseAlgorithm.cxx
@@ -573,6 +573,7 @@ void LinearModelStepwiseAlgorithm::run()
   result_ = LinearModelResult(inputSample_, Basis(currentFunctions), currentX_, outputSample_, metaModel,
                               regression, currentFunctions.__str__(), coefficientsNames, residualSample, standardizedResiduals,
                               diagonalGramInverse, leverages, cookDistances, sigma2[0]);
+  result_.setIsModelSelection(true);
   hasRun_ = true;
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
@@ -121,11 +121,11 @@ public:
   /** Least squares method accessor */
   virtual LeastSquaresMethod buildMethod() const;
 
-  /** isModelSelection accessor */
-  virtual Bool isModelSelection() const;
+  /** involvesModelSelection accessor */
+  virtual Bool involvesModelSelection() const;
 
-  /** isModelSelection accessor */
-  virtual void setIsModelSelection(const Bool isModelSelection);
+  /** involvesModelSelection accessor */
+  virtual void setInvolvesModelSelection(const Bool involvesModelSelection);
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -173,8 +173,8 @@ private:
   /** hasIntercept */
   Bool hasIntercept_;
 
-  /** isModelSelection */
-  Bool isModelSelection_ = false;
+  /** involvesModelSelection */
+  Bool involvesModelSelection_ = false;
   
 }; /* class LinearModelResult */
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/openturns/LinearModelResult.hxx
@@ -27,6 +27,7 @@
 #include "openturns/Matrix.hxx"
 #include "openturns/Function.hxx"
 #include "openturns/Normal.hxx"
+#include "openturns/LeastSquaresMethod.hxx"
 
 
 BEGIN_NAMESPACE_OPENTURNS
@@ -60,7 +61,7 @@ public:
                     const Point & diagonalGramInverse,
                     const Point & leverages,
                     const Point & cookDistances,
-                    const Scalar sigma2);
+                    const Scalar residualsVariance);
 
   /** Virtual constructor */
   LinearModelResult * clone() const override;
@@ -116,6 +117,15 @@ public:
 
   /** Adjusted R-squared */
   Scalar getAdjustedRSquared() const;
+  
+  /** Least squares method accessor */
+  virtual LeastSquaresMethod buildMethod() const;
+
+  /** isModelSelection accessor */
+  virtual Bool isModelSelection() const;
+
+  /** isModelSelection accessor */
+  virtual void setIsModelSelection(const Bool isModelSelection);
 
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
@@ -163,6 +173,9 @@ private:
   /** hasIntercept */
   Bool hasIntercept_;
 
+  /** isModelSelection */
+  Bool isModelSelection_ = false;
+  
 }; /* class LinearModelResult */
 
 END_NAMESPACE_OPENTURNS

--- a/lib/test/t_FunctionalChaos_ishigami.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami.cxx
@@ -140,6 +140,12 @@ int main(int, char *[])
           fullprint << "residuals=" << std::fixed << std::setprecision(5) << residuals << std::endl;
           Point relativeErrors(result.getRelativeErrors());
           fullprint << "relative errors=" << std::fixed << std::setprecision(5) << relativeErrors << std::endl;
+          Bool isLeastSquaresPCE = result.isLeastSquares();
+          Bool isLeastSquaresProjection = projectionStrategy.isLeastSquares();
+          assert_equal(isLeastSquaresProjection, isLeastSquaresPCE);
+          Bool isModelSelectionPCE = result.isModelSelection();
+          Bool isModelSelection = projectionStrategy.isModelSelection() || adaptiveStrategy.getImplementation()->isModelSelection();
+          assert_equal(isModelSelection, isModelSelectionPCE);
 
           // Post-process the results
           FunctionalChaosRandomVector vector(result);

--- a/lib/test/t_FunctionalChaos_ishigami.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami.cxx
@@ -143,9 +143,9 @@ int main(int, char *[])
           Bool isLeastSquaresPCE = result.isLeastSquares();
           Bool isLeastSquaresProjection = projectionStrategy.isLeastSquares();
           assert_equal(isLeastSquaresProjection, isLeastSquaresPCE);
-          Bool isModelSelectionPCE = result.isModelSelection();
-          Bool isModelSelection = projectionStrategy.isModelSelection() || adaptiveStrategy.getImplementation()->isModelSelection();
-          assert_equal(isModelSelection, isModelSelectionPCE);
+          Bool involvesModelSelectionPCE = result.involvesModelSelection();
+          Bool involvesModelSelection = projectionStrategy.involvesModelSelection() || adaptiveStrategy.getImplementation()->involvesModelSelection();
+          assert_equal(involvesModelSelection, involvesModelSelectionPCE);
 
           // Post-process the results
           FunctionalChaosRandomVector vector(result);

--- a/lib/test/t_FunctionalChaos_ishigami.expout
+++ b/lib/test/t_FunctionalChaos_ishigami.expout
@@ -19,6 +19,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0178023]
 - residuals=[0.0313673]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -54,6 +56,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0178023]
 - residuals=[0.0313673]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -146,6 +150,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0196503]
 - residuals=[0.032434]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -181,6 +187,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0196503]
 - residuals=[0.032434]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -274,6 +282,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0154051]
 - residuals=[0.0290505]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -309,6 +319,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0.0154051]
 - residuals=[0.0290505]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -402,6 +414,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.134395]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -437,6 +451,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.134395]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -549,6 +565,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.15998]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -584,6 +602,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.15998]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -697,6 +717,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.0782409]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -732,6 +754,8 @@ FunctionalChaosResult
 - indices size=21
 - relative errors=[0]
 - residuals=[0.0782409]
+- is least squares=false
+- is model selection=true
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -837,6 +861,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0105163]
 - residuals=[0.0241084]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -935,6 +961,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0105163]
 - residuals=[0.0241084]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1098,6 +1126,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0115022]
 - residuals=[0.0248146]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1196,6 +1226,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0115022]
 - residuals=[0.0248146]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1359,6 +1391,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0111528]
 - residuals=[0.024718]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1457,6 +1491,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.0111528]
 - residuals=[0.024718]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1614,6 +1650,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.199582]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1712,6 +1750,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.199582]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -1922,6 +1962,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.205762]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -2020,6 +2062,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.205762]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -2229,6 +2273,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.0865757]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|
@@ -2327,6 +2373,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0]
 - residuals=[0.0865757]
+- is least squares=false
+- is model selection=false
 
 | Index | Multi-index   | Coefficient   |
 |-------|---------------|---------------|

--- a/lib/test/t_FunctionalChaos_nd.expout
+++ b/lib/test/t_FunctionalChaos_nd.expout
@@ -8,6 +8,8 @@ FunctionalChaosResult
 - indices size=36
 - relative errors=[0.0107646,0.0196501]
 - residuals=[0.00527094,0.0324338]
+- is least squares=true
+- is model selection=true
 
 | Index | Multi-index   | Coeff. #0     | Coeff. #1     |
 |-------|---------------|---------------|---------------|
@@ -97,6 +99,8 @@ FunctionalChaosResult
 - indices size=84
 - relative errors=[0.00708265,0.0115021]
 - residuals=[0.0042755,0.0248145]
+- is least squares=true
+- is model selection=false
 
 | Index | Multi-index   | Coeff. #0     | Coeff. #1     |
 |-------|---------------|---------------|---------------|

--- a/lib/test/t_LinearModelAlgorithm_std.cxx
+++ b/lib/test/t_LinearModelAlgorithm_std.cxx
@@ -90,6 +90,20 @@ int main(int, char *[])
       for (UnsignedInteger i = 0; i < leverageFirstElements.getSize(); ++i)
         leverageFirstElements[i] = leverages[i];
       assert_almost_equal(leverageFirstElements, leverages_reference, 1e-6, 0.0);
+
+      LeastSquaresMethod lsMethod(result.buildMethod());
+      SymmetricMatrix projectionMatrix(lsMethod.getH());
+      assert_equal(projectionMatrix.getNbRows(), size);
+      assert_equal(projectionMatrix.getNbColumns(), size);
+      Point predictionsReference(result.getFittedSample().asPoint());
+      Point predictionsFromProjection(projectionMatrix * Y.asPoint());
+      assert_almost_equal(predictionsFromProjection, predictionsReference);
+
+      Sample residuals(result.getSampleResiduals());
+      assert_equal(residuals.getSize(), size);
+      assert_equal(residuals.getDimension(), (UnsignedInteger) 1);
+      Point residualsReference(Y.asPoint() - predictionsReference);
+      assert_almost_equal(residuals.asPoint(), residualsReference);
     }
   }
   catch (TestFailed &ex)

--- a/lib/test/t_LinearModelAlgorithm_std.expout
+++ b/lib/test/t_LinearModelAlgorithm_std.expout
@@ -1,6 +1,6 @@
 Fit y ~ 3 - 2 x + 0.05 * sin(x) model using 20 points (sin(x) ~ noise)
 result = 
-class=LinearModelResult beta=class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025] formula=Basis( [[v0]->[1],[v0]->[v0]] )
+class=LinearModelResult coefficients_=class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025] formula=Basis( [[v0]->[1],[v0]->[v0]] ) basis size=2 design dimension=20 x 2 coefficients dimension=2 coefficientsNames=[[v0]->[1],[v0]->[v0]] sampleResiduals dimension=20 x 1 standardizedResiduals dimension=20 x 1 diagonalGramInverse dimension=2 leverages dimension=20 cookDistances dimension=20 residuals variance= 0.00141733 hasIntercept=true isModelSelection=false
 LinearModelResult
 - input dimension=1
 - basis size=2
@@ -15,6 +15,7 @@ LinearModelResult
 - Cook's distances size=20
 - residuals variance=0.00141733
 - has intercept=true
+- is model selection=false
 
 
 trend coefficients = class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025]

--- a/lib/test/t_LinearModelAlgorithm_std.expout
+++ b/lib/test/t_LinearModelAlgorithm_std.expout
@@ -1,6 +1,6 @@
 Fit y ~ 3 - 2 x + 0.05 * sin(x) model using 20 points (sin(x) ~ noise)
 result = 
-class=LinearModelResult coefficients_=class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025] formula=Basis( [[v0]->[1],[v0]->[v0]] ) basis size=2 design dimension=20 x 2 coefficients dimension=2 coefficientsNames=[[v0]->[1],[v0]->[v0]] sampleResiduals dimension=20 x 1 standardizedResiduals dimension=20 x 1 diagonalGramInverse dimension=2 leverages dimension=20 cookDistances dimension=20 residuals variance= 0.00141733 hasIntercept=true isModelSelection=false
+class=LinearModelResult coefficients_=class=Point name=Unnamed dimension=2 values=[3.01168,-2.00025] formula=Basis( [[v0]->[1],[v0]->[v0]] ) basis size=2 design dimension=20 x 2 coefficients dimension=2 coefficientsNames=[[v0]->[1],[v0]->[v0]] sampleResiduals dimension=20 x 1 standardizedResiduals dimension=20 x 1 diagonalGramInverse dimension=2 leverages dimension=20 cookDistances dimension=20 residuals variance= 0.00141733 hasIntercept=true involvesModelSelection=false
 LinearModelResult
 - input dimension=1
 - basis size=2

--- a/python/doc/math_notations.sty
+++ b/python/doc/math_notations.sty
@@ -40,6 +40,8 @@
 \newcommand{\supp}[1] {\operatorname{supp}\left(#1\right)}  % The support of a distribution
 \newcommand{\sampleSize}{n}  % The sample size
 
+\newcommand{\metamodel}{{\widehat{\model}}}
+
 \newcommand{\scalarproduct}[2]{\left\langle #1, #2 \right\rangle}
 
 % A set

--- a/python/src/AdaptiveStrategyImplementation_doc.i.in
+++ b/python/src/AdaptiveStrategyImplementation_doc.i.in
@@ -138,7 +138,7 @@ OT_AdaptiveStrategy_updateBasis_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_AdaptiveStrategy_isModelSelection_doc
+%define OT_AdaptiveStrategy_involvesModelSelection_doc
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -147,9 +147,9 @@ Model selection can lead to a sparse functional chaos expansion.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 
 %enddef
-%feature("docstring") OT::AdaptiveStrategyImplementation::isModelSelection
-OT_AdaptiveStrategy_isModelSelection_doc
+%feature("docstring") OT::AdaptiveStrategyImplementation::involvesModelSelection
+OT_AdaptiveStrategy_involvesModelSelection_doc

--- a/python/src/AdaptiveStrategyImplementation_doc.i.in
+++ b/python/src/AdaptiveStrategyImplementation_doc.i.in
@@ -1,11 +1,6 @@
 %define OT_AdaptiveStrategy_doc
 "Base class for the construction of the truncated multivariate orthogonal basis.
 
-Available constructors:
-    AdaptiveStrategy(*orthogonalBasis, dimension*)
-
-    AdaptiveStrategy(*adaptiveStrategyImplementation*)
-
 Parameters
 ----------
 orthogonalBasis : :class:`~openturns.OrthogonalBasis`
@@ -13,9 +8,6 @@ orthogonalBasis : :class:`~openturns.OrthogonalBasis`
 dimension : positive int
     Number of terms of the basis. This first usage has the same implementation
     as the second with a :class:`~openturns.FixedStrategy`. 
-adaptiveStrategyImplementation : AdaptiveStrategyImplementation
-    Adaptive strategy implementation which is a :class:`~openturns.FixedStrategy` 
-    or a :class:`~openturns.CleaningStrategy`.
 
 See also
 --------
@@ -84,12 +76,16 @@ OT_AdaptiveStrategy_getMaximumDimension_doc
 // ---------------------------------------------------------------------
 
 %define OT_AdaptiveStrategy_getPsi_doc
-"Accessor to the orthogonal polynomials of the basis.
+"Accessor to the selected orthogonal polynomials in the basis.
+
+The value returned by this method depends on the specific
+choice of adaptive strategy and the previous calls to the
+:meth:`updateBasis` method.
 
 Returns
 -------
 polynomials : list of polynomials
-    Sequence of :math:`P` analytical polynomials.
+    Sequence of :math:`P` polynomials.
 
 Notes
 -----
@@ -127,10 +123,33 @@ OT_AdaptiveStrategy_setMaximumDimension_doc
 %define OT_AdaptiveStrategy_updateBasis_doc
 "Update the basis for the next iteration of approximation.
 
-Notes
------
-No changes are made to the basis in the fixed strategy."
+Parameters
+----------
+alpha_k: sequence of floats
+    The coefficients of the expansion at this step.
+residual: float
+    The current value of the residual.
+relativeError: float
+    The relative error."
 
 %enddef
 %feature("docstring") OT::AdaptiveStrategyImplementation::updateBasis
 OT_AdaptiveStrategy_updateBasis_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_AdaptiveStrategy_isModelSelection_doc
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection can lead to a sparse functional chaos expansion.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+
+%enddef
+%feature("docstring") OT::AdaptiveStrategyImplementation::isModelSelection
+OT_AdaptiveStrategy_isModelSelection_doc

--- a/python/src/ApproximationAlgorithmImplementationFactory_doc.i.in
+++ b/python/src/ApproximationAlgorithmImplementationFactory_doc.i.in
@@ -26,7 +26,7 @@ PenalizedLeastSquaresAlgorithmFactory, LeastSquaresMetaModelSelectionFactory"
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::ApproximationAlgorithmImplementationFactory::isModelSelection
+%feature("docstring") OT::ApproximationAlgorithmImplementationFactory::involvesModelSelection
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -35,7 +35,7 @@ Model selection leads to a sparse functional chaos expansion.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 
 // ---------------------------------------------------------------------

--- a/python/src/ApproximationAlgorithmImplementationFactory_doc.i.in
+++ b/python/src/ApproximationAlgorithmImplementationFactory_doc.i.in
@@ -1,4 +1,4 @@
-%feature("docstring") OT::ApproximationAlgorithmImplementation
+%feature("docstring") OT::ApproximationAlgorithmImplementationFactory
 "Approximation algorithm implementation factory.
 
 Available constructor:
@@ -15,11 +15,60 @@ Notes
 -----
 It represents a generic class (virtual) for different factories like
 :class:`~openturns.PenalizedLeastSquaresAlgorithmFactory` or
-    :class:`~openturns.LeastSquaresMetaModelSelectionFactory`
+:class:`~openturns.LeastSquaresMetaModelSelectionFactory`
 
-This class is not usable because it has sense only within the
+This class is not usable because it operates only within the class
 :class:`~openturns.FunctionalChaosAlgorithm`.
 
 See also
 --------
 PenalizedLeastSquaresAlgorithmFactory, LeastSquaresMetaModelSelectionFactory"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::ApproximationAlgorithmImplementationFactory::isModelSelection
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection leads to a sparse functional chaos expansion.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::ApproximationAlgorithmImplementationFactory::build
+"Build the approximation.
+
+Parameters
+----------
+x : 2-d sequence of float
+    The input random observations :math:`\left\{\vect{X}^{(1)}, ..., \vect{X}^{(n)}\right\}` 
+    where :math:`\vect{X}=(X_1, \dots, X_{n_X})^T` is the input of the physical
+    model, :math:`n_X` is the input dimension and :math:`n` is the sample size.
+y : 2-d sequence of float
+    The output random observations :math:`\left\{\vect{Y}^{(1)}, ..., \vect{Y}^{(n)}\right\}` 
+    where :math:`\vect{Y}=(Y_1, \dots, Y_{n_Y})^T` is the output of the physical
+    model, :math:`n_Y` is the output dimension and :math:`n` is the sample size.
+weight : sequence of float
+    Weights associated to the input sample points
+    such that the corresponding weighted experiment is a good approximation of
+    :math:`\mu`, where :math:`\mu` is the distribution of the standard
+    random vector :math:`\vect{Z}` associated with the physical input random
+    vector :math:`\vect{X}`. If unspecified, all weights are equal to
+    :math:`\frac{1}{n}`, where :math:`n` is the size of the
+    sample.
+psi : sequence of :class:`~openturns.Function`
+    The functional basis.
+indices : sequence of int
+    Indices in the basis.
+
+Returns
+-------
+algorithm: :class:`~openturns.ApproximationAlgorithm`
+    The estimation algorithm."
+
+// ---------------------------------------------------------------------

--- a/python/src/ApproximationAlgorithmImplementation_doc.i.in
+++ b/python/src/ApproximationAlgorithmImplementation_doc.i.in
@@ -115,7 +115,7 @@ OT_ApproximationAlgorithm_run_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_ApproximationAlgorithm_isModelSelection_doc
+%define OT_ApproximationAlgorithm_involvesModelSelection_doc
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -124,9 +124,9 @@ Model selection can lead to a sparse functional chaos expansion.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 %enddef
-%feature("docstring") OT::ApproximationAlgorithmImplementation::isModelSelection
-OT_ApproximationAlgorithm_isModelSelection_doc
+%feature("docstring") OT::ApproximationAlgorithmImplementation::involvesModelSelection
+OT_ApproximationAlgorithm_involvesModelSelection_doc
 

--- a/python/src/ApproximationAlgorithmImplementation_doc.i.in
+++ b/python/src/ApproximationAlgorithmImplementation_doc.i.in
@@ -8,7 +8,7 @@ LeastSquaresStrategy
 
 Notes
 -----
-This class is not usable because it has sense only within the
+This class is not usable because it operates only within the
 :class:`~openturns.FunctionalChaosAlgorithm`."
 %enddef
 %feature("docstring") OT::ApproximationAlgorithmImplementation
@@ -112,3 +112,21 @@ OT_ApproximationAlgorithm_getY_doc
 %enddef
 %feature("docstring") OT::ApproximationAlgorithmImplementation::run
 OT_ApproximationAlgorithm_run_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_ApproximationAlgorithm_isModelSelection_doc
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection can lead to a sparse functional chaos expansion.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+%enddef
+%feature("docstring") OT::ApproximationAlgorithmImplementation::isModelSelection
+OT_ApproximationAlgorithm_isModelSelection_doc
+

--- a/python/src/BasisSequenceFactoryImplementation_doc.i.in
+++ b/python/src/BasisSequenceFactoryImplementation_doc.i.in
@@ -15,7 +15,7 @@ LARS
 Notes
 -----
 BasisSequenceFactory is the interface of the BasisSequenceFactoryImplementation.
-This class is not usable because it has sense only within the
+This class is not usable because it operates only within the
 :class:`~openturns.FunctionalChaosAlgorithm`."
 %enddef
 %feature("docstring") OT::BasisSequenceFactoryImplementation

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -256,7 +256,7 @@ isLeastSquares : bool
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::FunctionalChaosResult::isModelSelection
+%feature("docstring") OT::FunctionalChaosResult::involvesModelSelection
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -265,7 +265,7 @@ Model selection can lead to a sparse functional chaos expansion.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 
 // ---------------------------------------------------------------------
@@ -289,7 +289,7 @@ Model selection can lead to a sparse functional chaos expansion.
 
 Parameters
 ----------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 
 // ---------------------------------------------------------------------

--- a/python/src/FunctionalChaosResult_doc.i.in
+++ b/python/src/FunctionalChaosResult_doc.i.in
@@ -245,3 +245,60 @@ Parameters
 ----------
 errorHistory : sequence of float
     The error history"
+
+%feature("docstring") OT::FunctionalChaosResult::isLeastSquares
+"Get the least squares flag.
+
+Returns
+-------
+isLeastSquares : bool
+    True if the coefficients were estimated from least squares."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::isModelSelection
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection can lead to a sparse functional chaos expansion.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::setIsLeastSquares
+"Set the least squares flag.
+
+Parameters
+----------
+isLeastSquares : bool
+    True if the coefficients were estimated from least squares."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::setIsModelSelection
+"Set the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection can lead to a sparse functional chaos expansion.
+
+Parameters
+----------
+isModelSelection: bool
+    True if the method involves a model selection method."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::FunctionalChaosResult::getSampleResiduals
+"Get residuals sample.
+
+Returns
+-------
+residualsSample : :class:`~openturns.Sample`
+    The sample of residuals :math:`r_{ji} = y_{ji} - \metamodel_i(\vect{x^{(j)}})`
+    for :math:`i = 1, ..., n_Y` and :math:`j = 1, ..., n`."

--- a/python/src/LeastSquaresStrategy_doc.i.in
+++ b/python/src/LeastSquaresStrategy_doc.i.in
@@ -28,14 +28,19 @@ measure : :class:`~openturns.Distribution`
     Distribution :math:`\mu` with respect to which the basis is orthonormal.
     By default, the limit measure defined within the class
     :class:`~openturns.WeightedExperiment` is used.
-inputSample, outputSample : 2-d sequence of float
-    The input random variables :math:`\vect{X}=(X_1, \dots, X_{n_X})^T`
-    and the output samples :math:`\vect{Y}` that describe the model.
+inputSample : 2-d sequence of float
+    The input random observations :math:`\left\{\vect{X}^{(1)}, ..., \vect{X}^{(n)}\right\}` 
+    where :math:`\vect{X}=(X_1, \dots, X_{n_X})^T` is the input of the physical
+    model, :math:`n_X` is the input dimension and :math:`n` is the sample size.
+outputSample : 2-d sequence of float
+    The output random observations :math:`\left\{\vect{Y}^{(1)}, ..., \vect{Y}^{(n)}\right\}` 
+    where :math:`\vect{Y}=(Y_1, \dots, Y_{n_Y})^T` is the output of the physical
+    model, :math:`n_Y` is the output dimension and :math:`n` is the sample size.
 weights : sequence of float
     Numerical point that are the weights associated to the input sample points
     such that the corresponding weighted experiment is a good approximation of
     :math:`\mu`. If not precised, all weights are equals to 
-    :math:`\omega_i = \frac{1}{size}`, where :math:`size` is the size of the
+    :math:`\omega_i = \frac{1}{n}`, where :math:`n` is the size of the
     sample.
 
 See also

--- a/python/src/LinearModelAlgorithm_doc.i.in
+++ b/python/src/LinearModelAlgorithm_doc.i.in
@@ -98,7 +98,15 @@ Examples
 >>> outputSample = func(inputSample)
 >>> algo = ot.LinearModelAlgorithm(inputSample, outputSample)
 >>> algo.run()
->>> result = algo.getResult()"
+>>> result = algo.getResult()
+>>> design = result.getDesign()
+>>> gram = design.computeGram()
+>>> leverages = result.getLeverages()
+
+In order to access the projection matrix, we build the least squares method.
+
+>>> lsMethod = result.buildMethod()
+>>> projectionMatrix = lsMethod.getH()"
 
 // ---------------------------------------------------------------------
 

--- a/python/src/LinearModelResult_doc.i.in
+++ b/python/src/LinearModelResult_doc.i.in
@@ -232,7 +232,7 @@ leastSquaresMethod: :class:`~openturns.LeastSquaresMethod`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::LinearModelResult::isModelSelection
+%feature("docstring") OT::LinearModelResult::involvesModelSelection
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -241,7 +241,7 @@ Model selection can lead to a sparse model.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 
 // ---------------------------------------------------------------------
@@ -255,5 +255,5 @@ Model selection can lead to a sparse model.
 
 Parameters
 ----------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."

--- a/python/src/LinearModelResult_doc.i.in
+++ b/python/src/LinearModelResult_doc.i.in
@@ -29,9 +29,8 @@ leverages : sequence of float
     The leverage score. 
 cookDistances : sequence of float
     Cook's distances.
-sigma2 : float
+residualsVariance : float
     The unbiased variance estimator of the output observation error.
-
 
 See Also
 --------
@@ -47,6 +46,8 @@ Returns
 -------
 basis : :class:`~openturns.Basis`
     The basis."
+
+// ---------------------------------------------------------------------
 
 %feature("docstring") OT::LinearModelResult::getDesign
 "Accessor to the design matrix.
@@ -218,3 +219,41 @@ Returns
 -------
 residualsVariance : float
 "
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LinearModelResult::buildMethod
+"Accessor to the least squares method.
+
+Returns
+-------
+leastSquaresMethod: :class:`~openturns.LeastSquaresMethod`
+    The least squares method."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LinearModelResult::isModelSelection
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+to best predict the output.
+Model selection can lead to a sparse model.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::LinearModelResult::setIsModelSelection
+"Set the model selection flag.
+
+A model selection method can be used to select the coefficients
+to best predict the output.
+Model selection can lead to a sparse model.
+
+Parameters
+----------
+isModelSelection: bool
+    True if the method involves a model selection method."

--- a/python/src/ProjectionStrategyImplementation_doc.i.in
+++ b/python/src/ProjectionStrategyImplementation_doc.i.in
@@ -279,7 +279,7 @@ OT_ProjectionStrategy_isLeastSquares_doc
 
 // ---------------------------------------------------------------------
 
-%define OT_ProjectionStrategy_isModelSelection_doc
+%define OT_ProjectionStrategy_involvesModelSelection_doc
 "Get the model selection flag.
 
 A model selection method can be used to select the coefficients
@@ -288,8 +288,8 @@ Model selection can lead to a sparse functional chaos expansion.
 
 Returns
 -------
-isModelSelection: bool
+involvesModelSelection: bool
     True if the method involves a model selection method."
 %enddef
-%feature("docstring") OT::ProjectionStrategyImplementation::isModelSelection
-OT_ProjectionStrategy_isModelSelection_doc
+%feature("docstring") OT::ProjectionStrategyImplementation::involvesModelSelection
+OT_ProjectionStrategy_involvesModelSelection_doc

--- a/python/src/ProjectionStrategyImplementation_doc.i.in
+++ b/python/src/ProjectionStrategyImplementation_doc.i.in
@@ -262,3 +262,34 @@ designProxy : :class:`~openturns.DesignProxy`
 %enddef
 %feature("docstring") OT::ProjectionStrategyImplementation::getDesignProxy
 OT_ProjectionStrategy_getDesignProxy_doc
+
+%define OT_ProjectionStrategy_isLeastSquares_doc
+"Get the least squares flag.
+
+There are two methods to compute the coefficients: integration
+or least squares.
+
+Returns
+-------
+isLeastSquares: bool
+    True if the coefficients are estimated from least squares."
+%enddef
+%feature("docstring") OT::ProjectionStrategyImplementation::isLeastSquares
+OT_ProjectionStrategy_isLeastSquares_doc
+
+// ---------------------------------------------------------------------
+
+%define OT_ProjectionStrategy_isModelSelection_doc
+"Get the model selection flag.
+
+A model selection method can be used to select the coefficients
+of the decomposition which enable to best predict the output.
+Model selection can lead to a sparse functional chaos expansion.
+
+Returns
+-------
+isModelSelection: bool
+    True if the method involves a model selection method."
+%enddef
+%feature("docstring") OT::ProjectionStrategyImplementation::isModelSelection
+OT_ProjectionStrategy_isModelSelection_doc

--- a/python/src/ProjectionStrategy_doc.i.in
+++ b/python/src/ProjectionStrategy_doc.i.in
@@ -32,5 +32,5 @@ OT_ProjectionStrategy_setMeasure_doc
 OT_ProjectionStrategy_getDesignProxy_doc
 %feature("docstring") OT::ProjectionStrategy::isLeastSquares
 OT_ProjectionStrategy_isLeastSquares_doc
-%feature("docstring") OT::ProjectionStrategy::isModelSelection
-OT_ProjectionStrategy_isModelSelection_doc
+%feature("docstring") OT::ProjectionStrategy::involvesModelSelection
+OT_ProjectionStrategy_involvesModelSelection_doc

--- a/python/src/ProjectionStrategy_doc.i.in
+++ b/python/src/ProjectionStrategy_doc.i.in
@@ -30,3 +30,7 @@ OT_ProjectionStrategy_setExperiment_doc
 OT_ProjectionStrategy_setMeasure_doc
 %feature("docstring") OT::ProjectionStrategy::getDesignProxy
 OT_ProjectionStrategy_getDesignProxy_doc
+%feature("docstring") OT::ProjectionStrategy::isLeastSquares
+OT_ProjectionStrategy_isLeastSquares_doc
+%feature("docstring") OT::ProjectionStrategy::isModelSelection
+OT_ProjectionStrategy_isModelSelection_doc

--- a/python/test/t_FunctionalChaos_gsobol_sparse.py
+++ b/python/test/t_FunctionalChaos_gsobol_sparse.py
@@ -84,3 +84,9 @@ for fittingAlgorithmIndex in range(len(listFittingAlgorithm)):
     print("coeffs = ", result.getCoefficients())
     print("residuals = ", result.getResiduals())
     print("relative errors = ", result.getRelativeErrors())
+
+    isLeastSquaresPCE = result.isLeastSquares()
+    assert isLeastSquaresPCE
+    isModelSelectionPCE = result.isModelSelection()
+    isModelSelection = adaptiveStrategy.isModelSelection() or projectionStrategy.isModelSelection()
+    assert isModelSelection == isModelSelectionPCE

--- a/python/test/t_FunctionalChaos_gsobol_sparse.py
+++ b/python/test/t_FunctionalChaos_gsobol_sparse.py
@@ -87,6 +87,6 @@ for fittingAlgorithmIndex in range(len(listFittingAlgorithm)):
 
     isLeastSquaresPCE = result.isLeastSquares()
     assert isLeastSquaresPCE
-    isModelSelectionPCE = result.isModelSelection()
-    isModelSelection = adaptiveStrategy.isModelSelection() or projectionStrategy.isModelSelection()
-    assert isModelSelection == isModelSelectionPCE
+    involvesModelSelectionPCE = result.involvesModelSelection()
+    involvesModelSelection = adaptiveStrategy.involvesModelSelection() or projectionStrategy.involvesModelSelection()
+    assert involvesModelSelection == involvesModelSelectionPCE

--- a/python/test/t_FunctionalChaos_ishigami.py
+++ b/python/test/t_FunctionalChaos_ishigami.py
@@ -98,6 +98,11 @@ for adaptiveStrategyIndex in range(len(listAdaptiveStrategy)):
         print("residuals=", residuals)
         relativeErrors = result.getRelativeErrors()
         print("relativeErrors=", relativeErrors)
+        isLeastSquaresPCE = result.isLeastSquares()
+        assert isLeastSquaresPCE
+        isModelSelectionPCE = result.isModelSelection()
+        isModelSelection = adaptiveStrategy.isModelSelection()
+        assert isModelSelection == isModelSelectionPCE
 
         # Post-process the results
         vector = ot.FunctionalChaosRandomVector(result)

--- a/python/test/t_FunctionalChaos_ishigami.py
+++ b/python/test/t_FunctionalChaos_ishigami.py
@@ -100,9 +100,9 @@ for adaptiveStrategyIndex in range(len(listAdaptiveStrategy)):
         print("relativeErrors=", relativeErrors)
         isLeastSquaresPCE = result.isLeastSquares()
         assert isLeastSquaresPCE
-        isModelSelectionPCE = result.isModelSelection()
-        isModelSelection = adaptiveStrategy.isModelSelection()
-        assert isModelSelection == isModelSelectionPCE
+        involvesModelSelectionPCE = result.involvesModelSelection()
+        involvesModelSelection = adaptiveStrategy.involvesModelSelection()
+        assert involvesModelSelection == involvesModelSelectionPCE
 
         # Post-process the results
         vector = ot.FunctionalChaosRandomVector(result)

--- a/python/test/t_IntegrationExpansion_std.py
+++ b/python/test/t_IntegrationExpansion_std.py
@@ -449,7 +449,7 @@ for doe in doeList:
     # Check the coefficients
     result = algo.getResult()
     assert not result.isLeastSquares()
-    assert not result.isModelSelection()
+    assert not result.involvesModelSelection()
     coeffs = result.getCoefficients().asPoint()
     ref = expectedCoefficientsLinear[: coeffs.getSize()]
     err = (coeffs - ref).norm()

--- a/python/test/t_IntegrationExpansion_std.py
+++ b/python/test/t_IntegrationExpansion_std.py
@@ -448,6 +448,8 @@ for doe in doeList:
     algo.run()
     # Check the coefficients
     result = algo.getResult()
+    assert not result.isLeastSquares()
+    assert not result.isModelSelection()
     coeffs = result.getCoefficients().asPoint()
     ref = expectedCoefficientsLinear[: coeffs.getSize()]
     err = (coeffs - ref).norm()

--- a/python/test/t_LeastSquaresExpansion_std.py
+++ b/python/test/t_LeastSquaresExpansion_std.py
@@ -456,6 +456,8 @@ for doe in doeList:
         algo.run()
         # Check the coefficients
         result = algo.getResult()
+        assert result.isLeastSquares()
+        assert not result.isModelSelection()
         coeffs = result.getCoefficients().asPoint()
         ref = expectedCoefficientsLinear[: coeffs.getSize()]
         err = (coeffs - ref).norm()

--- a/python/test/t_LeastSquaresExpansion_std.py
+++ b/python/test/t_LeastSquaresExpansion_std.py
@@ -457,7 +457,7 @@ for doe in doeList:
         # Check the coefficients
         result = algo.getResult()
         assert result.isLeastSquares()
-        assert not result.isModelSelection()
+        assert not result.involvesModelSelection()
         coeffs = result.getCoefficients().asPoint()
         ref = expectedCoefficientsLinear[: coeffs.getSize()]
         err = (coeffs - ref).norm()

--- a/python/test/t_LinearModelAlgorithm_std.expout
+++ b/python/test/t_LinearModelAlgorithm_std.expout
@@ -16,6 +16,7 @@ LinearModelResult
 - Cook's distances size=100
 - residuals variance=0.00991604
 - has intercept=true
+- is model selection=false
 
 
 trend coefficients =  [0.978992,0.110565,9.99924]
@@ -33,6 +34,7 @@ LinearModelResult
 - Cook's distances size=100
 - residuals variance=0.00991604
 - has intercept=true
+- is model selection=false
 
 
 [-2,4] 0 [0]

--- a/python/test/t_ProjectionStrategy_std.py
+++ b/python/test/t_ProjectionStrategy_std.py
@@ -26,6 +26,9 @@ print("leastSquaresStrategy (repr)")
 print(leastSquaresStrategy.__repr__())
 print("leastSquaresStrategy (html)")
 print(leastSquaresStrategy._repr_html_())
+assert leastSquaresStrategy.isLeastSquares()
+assert leastSquaresStrategy.isModelSelection()
+assert selectionAlgorithm.isModelSelection()
 
 enumerateFunction = basis.getEnumerateFunction()
 basisSize = enumerateFunction.getBasisSizeFromTotalDegree(totalDegree)
@@ -40,6 +43,7 @@ print("projectionStrategy (repr)")
 print(projectionStrategy.__repr__())
 print("projectionStrategy (html)")
 print(projectionStrategy._repr_html_())
+assert not adaptiveStrategy.isModelSelection()
 
 
 #
@@ -61,6 +65,7 @@ print("projectionStrategy (repr)")
 print(projectionStrategy.__repr__())
 print("projectionStrategy (html)")
 print(projectionStrategy._repr_html_())
+assert not integrationStrategy.isLeastSquares()
 
 #
 print("+ Compute flood model with large output dimension")

--- a/python/test/t_ProjectionStrategy_std.py
+++ b/python/test/t_ProjectionStrategy_std.py
@@ -27,8 +27,8 @@ print(leastSquaresStrategy.__repr__())
 print("leastSquaresStrategy (html)")
 print(leastSquaresStrategy._repr_html_())
 assert leastSquaresStrategy.isLeastSquares()
-assert leastSquaresStrategy.isModelSelection()
-assert selectionAlgorithm.isModelSelection()
+assert leastSquaresStrategy.involvesModelSelection()
+assert selectionAlgorithm.involvesModelSelection()
 
 enumerateFunction = basis.getEnumerateFunction()
 basisSize = enumerateFunction.getBasisSizeFromTotalDegree(totalDegree)
@@ -43,7 +43,7 @@ print("projectionStrategy (repr)")
 print(projectionStrategy.__repr__())
 print("projectionStrategy (html)")
 print(projectionStrategy._repr_html_())
-assert not adaptiveStrategy.isModelSelection()
+assert not adaptiveStrategy.involvesModelSelection()
 
 
 #


### PR DESCRIPTION
This PR creates new attributes that defines the way a linear model or a polynomial chaos expansion are computed. This makes it possible to know the kind of post-processing that we can apply on a given result. This is an essential information if we want to perform analytical cross-validation:
- This can be done only for a least squares problem (this is impossible if the coefficients are computed from quadrature),
- This can be done only when there is no model selection (otherwise the CV score is biased).

This PR leads to new methods:
- New `LeastSquaresMetaModelSelectionFactory.isModelSelection()`
- New `PenalizedLeastSquaresAlgorithmFactory.isModelSelection()`
- New `AdaptiveStrategy.isModelSelection()`
- New `ApproximationAlgorithm.isModelSelection()`

`ProjectionStrategy` class:
- New `isLeastSquares()`
- New `isModelSelection()`

`ApproximationAlgorithmImplementationFactory` class:
- New `ApproximationAlgorithmImplementationFactory.isModelSelection()`
- New `ApproximationAlgorithmImplementationFactory.build()` API help page. This is an undocumented method.

`LinearModelResult` class:
- New `isModelSelection()`

`FunctionalChaosResult` class:
- New `isLeastSquares()`
- New `isModelSelection()`
- New `getSampleResiduals()` : returns the residuals of the functional chaos metamodel.

The next table introduces the values of the parameters used in various classes.

| Class                                  | isModelSelection                   | isLeastSquares        |
| -------------------------------------- | ---------------------------------- | --------------------- |
| IntegrationStrategy                    | False                              | False                 |
| IntegrationExpansion                   | False                              | False                 |
| LeastSquaresStrategy                   | Depends on approximation           | True                  |
| LeastSquaresExpansion                  | True                               | False                 |
| FunctionalChaosResult                  | Default : True                     | Default : False       |
| CleaningStrategy                       | True                               | -                     |
| FixedStrategy                          | False                              |                       |
| FunctionalChaosAlgorithm               | Depends on adaptive and projection | Depends on projection |
| LinearModelStepwiseAlgorithm           | True                               | -                     |
| LeastSquaresMetaModel-SelectionFactory | True                               | -                     |
| PenalizedLeastSquaresAlgorithm         | False                              | -                     |
| PenalizedLeastSquares-AlgorithmFactory | False                              |                       |
| LinearModelResult                      | Default : False                    | -                     |
| LinearModelStepwiseAlgorithm           | True                               |                       |

**Table 1.** The values of the parameters used in various classes.

## New LinearModelResult.buildMethod method

New `buildMethod()`: returns the least squares method.

The least squares method from a `LinearModelResult` is necessary to compute the projection matrix in the K-Fold cross-validation.

```python
import openturns as ot

func = ot.SymbolicFunction(
    ['x1', 'x2', 'x3'],
    ['x1 + x2 + sin(x2 * 2 * pi_) / 5 + 1e-3 * x3^2']
)
dimension = 3
distribution = ot.JointDistribution([ot.Normal()] * dimension)
inputSample = distribution.getSample(20)
outputSample = func(inputSample)
algo = ot.LinearModelAlgorithm(inputSample, outputSample)
algo.run()
result = algo.getResult()

lsMethod = result.buildMethod()  // New!
projection = lsMethod.getH()
```

## Comments

~~This PR should not be merged before #2597 because lib/src/Uncertainty/Algorithm/MetaModel/LinearModel/LinearModelResult.cxx needs the `inverse()` method.~~ Edit (08/04/2024). This is not true anymore, now that I implemented `buildMethod()`.

This PR prepares for the integration of PR #2330.

PS
The computation of the Gram and projection matrix can be improved in `LeastSquaresMethod`. Here is a set of personal notes that explain how this may be done.

[Calcul matriciel en régression.pdf](https://github.com/openturns/openturns/files/14898572/Calcul.matriciel.en.regression.pdf)
