### PR TITLE
Create two C++ use cases for unit tests: Ishigami and GSobol

### DIFF
--- a/lib/include/openturns/GSobolUseCase.hxx
+++ b/lib/include/openturns/GSobolUseCase.hxx
@@ -1,0 +1,111 @@
+//                                               -*- C++ -*-
+/**
+ *  @brief The header file that defines the GSobol' Use Case
+ *
+ *  Copyright 2005-2024 Airbus-EDF-IMACS-ONERA-Phimeca
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef OPENTURNS_OTGSOBOLUSECASE_HXX
+#define OPENTURNS_OTGSOBOLUSECASE_HXX
+
+#include "openturns/OTconfig.hxx"
+#include "openturns/Distribution.hxx"
+#include "openturns/SymbolicFunction.hxx"
+#include "openturns/Function.hxx"
+
+BEGIN_NAMESPACE_OPENTURNS
+
+class GSobolUseCase
+{
+  public:
+    /* Default constructor */
+    GSobolUseCase(const UnsignedInteger & dimension, const Point & a) 
+    : dimension_(dimension)
+    , a_(a)
+    , mean_(1.0)
+    {
+      // Reference analytical values
+      ;
+      variance_ = 1.0;
+      // Create the gSobol function
+      Description inputVariables(dimension);
+      Description formula(1);
+      formula[0] = "1.0";
+      for (UnsignedInteger i = 0; i < dimension; ++i)
+      {
+        variance_ *= 1.0 + 1.0 / (3.0 * pow(1.0 + a[i], 2.0));
+        inputVariables[i] = (OSS() << "xi" << i);
+        formula[0] = (OSS() << formula[0] << " * (abs(4.0 * xi" << i << " - 2.0) + " << a[i] << ") / (1.0 + " << a[i] << ")");
+      }
+      --variance_;
+
+      model_ = SymbolicFunction(inputVariables, formula);
+
+      // Create the input distribution
+      Collection<Distribution> marginals(dimension, Uniform(0.0, 1.0));
+      inputDistribution_ = JointDistribution(marginals);
+    }
+    
+    Function getModel()
+    {
+      return model_;
+    }
+    
+    UnsignedInteger getDimension()
+    {
+      return dimension_;
+    }
+    
+    JointDistribution getInputDistribution()
+    {
+      return inputDistribution_;
+    }
+    
+    Scalar getMean()
+    {
+      return mean_;
+    }
+    
+    Scalar getVariance()
+    {
+      return variance_;
+    }
+    
+    // Get the first order Sobol’ index of a single input variable or the
+    // interaction (high order) index of a group of variables.
+    Scalar computeSobolIndex(const Indices & indices)
+    {
+      Scalar value = 1.0;
+      for (UnsignedInteger i = 0; i < indices.getSize(); ++i)
+      {
+        value *= 1.0 / (3.0 * pow(1.0 + a_[indices[i]], 2.0));
+      }
+      return value / variance_;
+    }
+    
+  private:
+    Function model_;
+    JointDistribution inputDistribution_;
+    UnsignedInteger dimension_;
+    Point a_;
+    Scalar mean_;
+    Scalar variance_;
+
+}; /* class GSobolUseCase */
+
+END_NAMESPACE_OPENTURNS
+
+#endif /* OPENTURNS_OTGSOBOLUSECASE_HXX */

--- a/lib/include/openturns/IshigamiUseCase.hxx
+++ b/lib/include/openturns/IshigamiUseCase.hxx
@@ -1,0 +1,184 @@
+//                                               -*- C++ -*-
+/**
+ *  @brief The header file that defines the Ishigami Use Case
+ *
+ *  Copyright 2005-2024 Airbus-EDF-IMACS-ONERA-Phimeca
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef OPENTURNS_OTISHIGAMIUSECASE_HXX
+#define OPENTURNS_OTISHIGAMIUSECASE_HXX
+
+#define _USE_MATH_DEFINES
+#include <cmath>          // For M_PI
+
+#include "openturns/OTconfig.hxx"
+#include "openturns/Distribution.hxx"
+#include "openturns/SymbolicFunction.hxx"
+#include "openturns/Function.hxx"
+
+BEGIN_NAMESPACE_OPENTURNS
+
+class IshigamiUseCase
+{
+  public:
+    /* Default constructor */
+    IshigamiUseCase()
+    {
+      // Create the Ishigami function
+      Description inputVariables = {"xi1","xi2", "xi3"};
+      Description formula(1);
+      formula[0] = (OSS() << "sin(xi1) + (" << a_ << ") * (sin(xi2)) ^ 2 + (" << b_ << ") * xi3^4 * sin(xi1)");
+      model_ = SymbolicFunction(inputVariables, formula);
+  
+      // Create the input distribution
+      Collection<Distribution> marginals(dimension_, Uniform(-M_PI, M_PI));
+      inputDistribution_ = JointDistribution(marginals);
+      
+      // Mean, variance
+      mean_ = a_ / 2;
+      variance_ = pow(b_, 2.0) * pow(M_PI, 8.0) / 18.0 \
+        + b_ * pow(M_PI, 4.0) / 5.0 + pow(a_, 2.0) / 8.0 + 1.0 / 2.0;
+      // Sobol' indices
+      // First order Sobol' index of X1
+      s1_ = (b_ * pow(M_PI, 4.0) / 5.0 + pow(b_, 2.0) * pow(M_PI, 8.0) / 50.0 \
+        + 1.0 / 2.0) /        variance_;
+      s2_ = (pow(a_, 2.0) / 8.0) / variance_;  // First order of X2
+      s3_ = 0.0;  // First order of X3
+      s12_ = 0.0;  // Interaction of (X1, X2)
+      // Interaction of (X1, X3)
+      s13_ = pow(b_, 2.0) * pow(M_PI, 8.0) * (1.0 / 9.0 - 1.0 / 25.0) / 2.0 / variance_;
+      s23_ = 0.0;  // Interaction of (X2, X3)
+      s123_ = 0.0;  // Interaction of (X1, X2, X3)
+      sT1_ = s1_ + s13_;  // Total of X1
+      sT2_ = s2_;  // Total of X2
+      sT3_ = s3_ + s13_;  // Total of X3
+    }
+
+    Function getModel()
+    {
+      return model_;
+    }
+    
+    UnsignedInteger getDimension()
+    {
+      return dimension_;
+    }
+    
+    Scalar getA()
+    {
+      return a_;
+    }
+    
+    Scalar getB()
+    {
+      return b_;
+    }
+    
+    JointDistribution getInputDistribution()
+    {
+      return inputDistribution_;
+    }
+    
+    Scalar getMean()
+    {
+      return mean_;
+    }
+    
+    Scalar getVariance()
+    {
+      return variance_;
+    }
+    
+    Point getFirstOrderSobolIndices()
+    {
+      const Point firstOrderIndices({s1_, s2_, s3_});
+      return firstOrderIndices;
+    }
+    
+    Point getTotalSobolIndices()
+    {
+      const Point totalIndices({sT1_, sT2_, sT3_});
+      return totalIndices;
+    }
+    
+    Scalar getFirstOrderInteractionSobolIndex(const Indices indices)
+    {
+      if (!indices.isIncreasing())
+        throw InvalidArgumentException(HERE) << "Provided quantiles are not increasing";
+      Scalar value = -1.0;
+      if (indices.getSize() == 2)
+      {
+        if (indices[0] == 0 && indices[1] == 1) value = s12_;
+        else if (indices[0] == 0 && indices[1] == 2) value = s13_;
+        else if (indices[0] == 1 && indices[1] == 2) value = s23_;
+        else
+          throw InvalidArgumentException(HERE) << "Inconsistent 2D indices = " << indices;
+      }
+      else if (indices.getSize() == 3)
+        if (indices[0] == 0 && indices[1] == 1 && indices[2] == 2) value = s123_;
+        else
+          throw InvalidArgumentException(HERE) << "Inconsistent 3D indices = " << indices;
+      else
+        throw InvalidArgumentException(HERE) << "Inconsistent dimension of indices = " << indices.getSize();
+      return value;
+    }
+    
+    Scalar getTotalInteractionSobolIndex(const Indices indices)
+    {
+      if (!indices.isIncreasing())
+        throw InvalidArgumentException(HERE) << "Provided quantiles are not increasing";
+      Scalar value = -1.0;
+      if (indices.getSize() == 2)
+      {
+        if (indices[0] == 0 && indices[1] == 1) value = s12_ + s123_;
+        else if (indices[0] == 0 && indices[1] == 2) value = s13_+ s123_;
+        else if (indices[0] == 1 && indices[1] == 2) value = s23_+ s123_;
+        else
+          throw InvalidArgumentException(HERE) << "Inconsistent 2D indices = " << indices;
+      }
+      else if (indices.getSize() == 3)
+        if (indices[0] == 0 && indices[1] == 1 && indices[2] == 2) value = s123_;
+        else
+          throw InvalidArgumentException(HERE) << "Inconsistent 3D indices = " << indices;
+      else
+        throw InvalidArgumentException(HERE) << "Inconsistent dimension of indices = " << indices.getSize();
+      return value;
+    }
+
+  private:
+    Function model_;
+    JointDistribution inputDistribution_;
+    UnsignedInteger dimension_ = 3;
+    Scalar a_ = 7.0;
+    Scalar b_ = 0.1;
+    Scalar mean_;
+    Scalar variance_;
+    Scalar s1_;
+    Scalar s2_;
+    Scalar s3_;
+    Scalar s12_;
+    Scalar s13_;
+    Scalar s23_;
+    Scalar s123_;
+    Scalar sT1_;
+    Scalar sT2_;
+    Scalar sT3_;
+
+}; /* class IshigamiUseCase */
+
+END_NAMESPACE_OPENTURNS
+
+#endif /* OPENTURNS_OTISHIGAMIUSECASE_HXX */

--- a/lib/test/t_FunctionalChaos_ishigami_database.expout
+++ b/lib/test/t_FunctionalChaos_ishigami_database.expout
@@ -15,9 +15,9 @@ Sobol index [0,1,2] =0.00172 absolute error=1.7e-03
 Sobol total index 0 =0.56386 absolute error=6.3e-03
 Sobol total index 1 =0.43790 absolute error=4.5e-03
 Sobol total index 2 =0.24631 absolute error=2.6e-03
-Sobol total index [0,1] =0.00005 absolute error=4.6e-05
-Sobol total index [0,2] =0.24416 absolute error=4.8e-04
-Sobol total index [1,2] =0.00044 absolute error=4.4e-04
+Sobol total index [0,1] =0.00176 absolute error=1.8e-03
+Sobol total index [0,2] =0.24588 absolute error=2.2e-03
+Sobol total index [1,2] =0.00215 absolute error=2.2e-03
 Sobol total index [0,1,2] =0.00172 absolute error=1.7e-03
 //////////////////////////////////////////////////////////////////////
 class=AdaptiveStrategy implementation=class=CleaningStrategy maximum size=20 significance factor=1e-06 derived from class=AdaptiveStrategyImplementation maximumDimension=84
@@ -57,9 +57,9 @@ Sobol index [0,1,2] =0.02263 absolute error=2.3e-02
 Sobol total index 0 =0.58644 absolute error=2.9e-02
 Sobol total index 1 =0.44488 absolute error=2.5e-03
 Sobol total index 2 =0.30105 absolute error=5.7e-02
-Sobol total index [0,1] =0.00932 absolute error=9.3e-03
-Sobol total index [0,2] =0.26319 absolute error=2.0e-02
-Sobol total index [1,2] =0.01461 absolute error=1.5e-02
+Sobol total index [0,1] =0.03195 absolute error=3.2e-02
+Sobol total index [0,2] =0.28582 absolute error=4.2e-02
+Sobol total index [1,2] =0.03724 absolute error=3.7e-02
 Sobol total index [0,1,2] =0.02263 absolute error=2.3e-02
 //////////////////////////////////////////////////////////////////////
 class=AdaptiveStrategy implementation=class=FixedStrategy derived from class=AdaptiveStrategyImplementation maximumDimension=84
@@ -78,9 +78,9 @@ Sobol index [0,1,2] =0.00549 absolute error=5.5e-03
 Sobol total index 0 =0.57120 absolute error=1.4e-02
 Sobol total index 1 =0.43703 absolute error=5.4e-03
 Sobol total index 2 =0.25963 absolute error=1.6e-02
-Sobol total index [0,1] =0.00315 absolute error=3.1e-03
-Sobol total index [0,2] =0.25121 absolute error=7.5e-03
-Sobol total index [1,2] =0.00252 absolute error=2.5e-03
+Sobol total index [0,1] =0.00864 absolute error=8.6e-03
+Sobol total index [0,2] =0.25670 absolute error=1.3e-02
+Sobol total index [1,2] =0.00801 absolute error=8.0e-03
 Sobol total index [0,1,2] =0.00549 absolute error=5.5e-03
 //////////////////////////////////////////////////////////////////////
 class=AdaptiveStrategy implementation=class=FixedStrategy derived from class=AdaptiveStrategyImplementation maximumDimension=84
@@ -99,9 +99,9 @@ Sobol index [0,1,2] =0.00205 absolute error=2.1e-03
 Sobol total index 0 =0.56488 absolute error=7.3e-03
 Sobol total index 1 =0.43718 absolute error=5.2e-03
 Sobol total index 2 =0.24893 absolute error=5.3e-03
-Sobol total index [0,1] =0.00000 absolute error=0.0e+00
-Sobol total index [0,2] =0.24688 absolute error=3.2e-03
-Sobol total index [1,2] =0.00000 absolute error=0.0e+00
+Sobol total index [0,1] =0.00205 absolute error=2.1e-03
+Sobol total index [0,2] =0.24893 absolute error=5.3e-03
+Sobol total index [1,2] =0.00205 absolute error=2.1e-03
 Sobol total index [0,1,2] =0.00205 absolute error=2.1e-03
 //////////////////////////////////////////////////////////////////////
 class=AdaptiveStrategy implementation=class=FixedStrategy derived from class=AdaptiveStrategyImplementation maximumDimension=84
@@ -120,7 +120,7 @@ Sobol index [0,1,2] =0.03026 absolute error=3.0e-02
 Sobol total index 0 =0.58898 absolute error=3.1e-02
 Sobol total index 1 =0.45271 absolute error=1.0e-02
 Sobol total index 2 =0.31226 absolute error=6.9e-02
-Sobol total index [0,1] =0.01430 absolute error=1.4e-02
-Sobol total index [0,2] =0.25857 absolute error=1.5e-02
-Sobol total index [1,2] =0.02058 absolute error=2.1e-02
+Sobol total index [0,1] =0.04455 absolute error=4.5e-02
+Sobol total index [0,2] =0.28883 absolute error=4.5e-02
+Sobol total index [1,2] =0.05083 absolute error=5.1e-02
 Sobol total index [0,1,2] =0.03026 absolute error=3.0e-02

--- a/lib/test/t_FunctionalChaos_ishigami_sparse.cxx
+++ b/lib/test/t_FunctionalChaos_ishigami_sparse.cxx
@@ -20,6 +20,7 @@
  *
  */
 #include "openturns/OT.hxx"
+#include "openturns/IshigamiUseCase.hxx"
 #include "openturns/OTtestcode.hxx"
 
 using namespace OT;
@@ -29,47 +30,12 @@ int main(int, char *[])
 {
   TESTPREAMBLE;
   OStream fullprint(std::cout);
-  //   Log::Show( Log::Flags() | Log::INFO );
 
   // Problem parameters
+  IshigamiUseCase ishigami;
   UnsignedInteger dimension = 3;
-  Scalar a = 7.0;
-  Scalar b = 0.1;
-  // Reference analytical values
-  Scalar covTh = (pow(b, 2.0) * pow(M_PI, 8.0)) / 18.0 + (b * pow(M_PI, 4.0)) / 5.0 + (pow(a, 2.0)) / 8.0 + 1.0 / 2.0;
-  Point sob_1(3);
-  sob_1[0] = (b * pow(M_PI, 4.0) / 5.0 + pow(b, 2.0) * pow(M_PI, 8.0) / 50.0 + 1.0 / 2.0) / covTh;
-  sob_1[1] = (pow(a, 2.0) / 8.0) / covTh;
-  sob_1[2] = 0.0;
-  Point sob_2(3);
-  sob_2[0] = 0.0;
-  sob_2[1] = (pow(b, 2.0) * pow(M_PI, 8.0) / 18.0 - pow(b, 2.0) * pow(M_PI, 8.0) / 50.0) / covTh;
-  sob_2[2] = 0.0;
-  Point sob_3(1, 0.0);
-  Point sob_T1(3);
-  sob_T1[0] = sob_1[0] + sob_2[0] + sob_2[1] + sob_3[0];
-  sob_T1[1] = sob_1[1] + sob_2[0] + sob_2[2] + sob_3[0];
-  sob_T1[2] = sob_1[2] + sob_2[1] + sob_2[2] + sob_3[0];
-  Point sob_T2(3);
-  sob_T2[0] = sob_2[0] + sob_2[1] + sob_3[0];
-  sob_T2[1] = sob_2[0] + sob_2[2] + sob_3[0];
-  sob_T2[2] = sob_2[1] + sob_2[2] + sob_3[0];
-  // Create the Ishigami function
-  Description inputVariables(dimension);
-  inputVariables[0] = "xi1";
-  inputVariables[1] = "xi2";
-  inputVariables[2] = "xi3";
-  Description formula(1);
-  formula[0] = (OSS() << "sin(xi1) + (" << a << ") * (sin(xi2)) ^ 2 + (" << b << ") * xi3^4 * sin(xi1)");
-  SymbolicFunction model(inputVariables, formula);
-
-  // Create the input distribution
-  Collection<Distribution> marginalX(dimension);
-  for ( UnsignedInteger i = 0; i < dimension; ++ i )
-  {
-    marginalX[i] = Uniform(-M_PI, M_PI);
-  }
-  JointDistribution distribution(marginalX);
+  Function model(ishigami.getModel());  // Create the Ishigami function
+  JointDistribution distribution(ishigami.getInputDistribution());  // Create the input distribution
 
   // Create the orthogonal basis
   Collection<OrthogonalUniVariatePolynomialFamily> polynomialCollection(dimension);


### PR DESCRIPTION
This PR creates two C++ use cases for unit tests: Ishigami and GSobol. The goal is to factor these two use cases which implementation is spread across several C++ unit tests.

The new `IshigamiUseCase` unit test class is created in OTtestcode.hxx. We can use this class to get the model, the input distribution and the Sobol' indices.
```cpp
IshigamiUseCase ishigami;
Function model(ishigami.getModel());
JointDistribution distribution(ishigami.getInputDistribution());
Scalar mean = ishigami.getMean();
Scalar variance = ishigami.getVariance();
Scalar S1 = ishigami.getFirstOrderSobolIndices();
Scalar S12 = ishigami.getFirstOrderInteractionSobolIndex({0, 1});
```

The new `GSobolUseCase` provides similar features.

```cpp
GSobolUseCase gsobol(dimension, a);
Function model(gsobol.getModel());
Scalar meanTh = gsobol.getMean();
Scalar covTh = gsobol.getVariance();
JointDistribution distribution(gsobol.getInputDistribution());
```

This is a part of #2330.
