### PR TITLE
IsotropicCovarianceModel throw if inputDimension=0

### DIFF
--- a/lib/src/Base/Stat/IsotropicCovarianceModel.cxx
+++ b/lib/src/Base/Stat/IsotropicCovarianceModel.cxx
@@ -37,6 +37,8 @@ IsotropicCovarianceModel::IsotropicCovarianceModel(const CovarianceModel & oneDi
     const UnsignedInteger inputDimension)
   : CovarianceModelImplementation(inputDimension)
 {
+  if (!inputDimension)
+    throw InvalidArgumentException(HERE) << "In IsotropicCovarianceModel, the supplied inputDimension must be nonzero.";
   setKernel(oneDimensional);
 }
 

--- a/lib/test/t_KrigingAlgorithm_isotropic_std.cxx
+++ b/lib/test/t_KrigingAlgorithm_isotropic_std.cxx
@@ -83,6 +83,16 @@ int main(int, char *[])
       assert_almost_equal(krigingFittedCovarianceModel.getAmplitude()[0], 6.65231, 0.0, 1e-4);
     }
 
+    try
+    {
+      IsotropicCovarianceModel(SquaredExponential(), 0);
+      throw InvalidDimensionException(HERE) << "Invalid IsotropicCovarianceModel should have thrown";
+    }
+    catch(const InvalidArgumentException &)
+    {
+      // nothing to do
+    }
+
   }
   catch (TestFailed & ex)
   {

--- a/python/test/t_KrigingAlgorithm_isotropic_std.py
+++ b/python/test/t_KrigingAlgorithm_isotropic_std.py
@@ -40,3 +40,9 @@ ott.assert_almost_equal(krigingFittedCovarianceModel.getScale()[0], 2.86427, 0.0
 ott.assert_almost_equal(
     krigingFittedCovarianceModel.getAmplitude()[0], 6.65231, 0.0, 1e-4
 )
+
+try:
+    ot.IsotropicCovarianceModel(ot.SquaredExponential(), 0)
+    raise ValueError("Invalid IsotropicCovarianceModel should have thrown")
+except TypeError:
+    pass


### PR DESCRIPTION
Everything is in the title. It was previously possible to construct an IsotropicCovarianceModel with null input dimension, which makes no sense.