### PR TITLE
Typo fixes in graph examples section

### DIFF
--- a/python/doc/examples/graphs/plot_graphs_basics.py
+++ b/python/doc/examples/graphs/plot_graphs_basics.py
@@ -11,7 +11,7 @@ A quick start guide to graphs
 # The `draw` method the `Graph` class
 # -----------------------------------
 #
-# The simplest way to create a graph is to use the `draw` method. The `Normal` distribution for example provides a method to draw the density function of the gaussian distribution.
+# The simplest way to create a graph is to use the `draw` method. The :class:`~openturns.Normal` distribution for example provides a method to draw the density function of the Gaussian distribution.
 
 # %%
 import openturns as ot
@@ -29,20 +29,20 @@ graph = n.drawPDF()
 view = viewer.View(graph)
 
 # %%
-# To configure the look of the plot, we can first observe the type of graph returned by the `drawPDF` method returns: it is a `Graph`.
+# To configure the look of the plot, we can first observe the type of graph returned by the `drawPDF` method returns: it is a :class:`~openturns.Graph`.
 
 # %%
 graph = n.drawPDF()
 type(graph)
 
 # %%
-# The `Graph` class provides several methods to configure the legends, the title and the colors.
-# Since a graph  can contain several sub-graphs, the `setColors` takes a list of colors as inputs argument: each item of the list corresponds to the sub-graphs.
+# The class:`~openturns.Graph` class provides several methods to configure the legends, the title and the colors.
+# Since a graph  can contain several sub-graphs, the `setColors` method takes a list of colors as inputs argument: each item of the list corresponds to the sub-graphs.
 
 # %%
 graph.setXTitle("N")
 graph.setYTitle("PDF")
-graph.setTitle("Probability density function of the standard gaussian distribution")
+graph.setTitle("Probability density function of the standard Gaussian distribution")
 graph.setLegends(["N"])
 graph.setColors(["blue"])
 view = viewer.View(graph)
@@ -74,7 +74,7 @@ view = viewer.View(graph)
 # Draw a cloud
 # ------------
 #
-# The `Cloud` class creates clouds of bidimensional points. To demonstrate it, let us create two gaussian distributions in two dimensions.
+# The :class:`~openturns.Cloud` class creates clouds of bidimensional points. To illustrate it, let us create two Gaussian distributions in two dimensions.
 
 # %%
 # Create a Funky distribution
@@ -108,7 +108,7 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-# We sometimes want to customize the graph by choosing the type of point (square, triangle, circle, etc...), of line (continuous, dashed, etc...) or another parameter.
+# We sometimes want to customize the graph by choosing the type of point (square, triangle, circle, etc.), of line (continuous, dashed, etc.) or another parameter.
 # We can know the list of possible values with the corresponding `getValid` method.
 #
 # For example, the following function returns the possible values of the `PointStyle` parameter.
@@ -137,7 +137,7 @@ view = viewer.View(graph)
 # Configure the style of points and the thickness of a curve
 # ----------------------------------------------------------
 #
-# Assume that we want to plot the sine curve from -2 to 2. The simplest way is to use the `draw` method of the function.
+# Assume that we want to plot the `sine` curve from -2 to 2. The simplest way is to use the `draw` method of the function.
 
 # %%
 g = ot.SymbolicFunction("x", "sin(x)")
@@ -147,14 +147,14 @@ graph = g.draw(-2, 2)
 view = viewer.View(graph)
 
 # %%
-# I would rather get a dashed curve: let us search for the available line styles.
+# One would rather get a dashed curve: let us search for the available line styles.
 
 # %%
 ot.Drawable.GetValidLineStyles()
 
 
 # %%
-# In order to use the `Curve` class, it will be easier if we have a method to generate a `Sample` containing points regularly spaced in an interval.
+# In order to use the :class:`~openturns.Curve` class, it will be easier if we have a method to generate a :class:`~openturns.Sample` containing points regularly spaced in an interval.
 
 
 # %%
@@ -216,9 +216,9 @@ view = viewer.View(graph)
 # Create matrices of graphs
 # -------------------------
 #
-# The library provides features to create a grid of graphs. However, we can use the `add_subplot` function from Matplotlib.
+# The library provides features to create a grid of graphs. However, we can use the `add_subplot` function from `Matplotlib`.
 #
-# Let us create two graphs of the PDF and CDF of the following gaussian distribution..
+# Let us create two graphs of the PDF and CDF of the following Gaussian distribution..
 
 # %%
 n = ot.Normal()
@@ -233,9 +233,9 @@ grid.setGraph(0, 1, myCDF)
 _ = viewer.View(grid)
 
 # %%
-# Another method is to create a figure with the `figure` function from Matplotlib,
+# Another method is to create a figure with the `figure` function from `Matplotlib`,
 # then add two graphs with the `add_subplot` function.
-# We use the `viewer.View` function to create the required Matplotlib object.
+# We use the `viewer.View` function to create the required `Matplotlib` object.
 # Since we are not interested by the output of the `View` function, we use the dummy variable `_` as output.
 # The title is finally configured with `suptitle`.
 
@@ -252,7 +252,7 @@ _ = fig.suptitle("The gaussian")
 # -----------------------
 
 # %%
-# The `View` class has a `save` method which saves the graph into an image.
+# The :class:`openturns.viewer` class has a `save` method which saves the graph into an image.
 
 # %%
 
@@ -269,13 +269,13 @@ view.save("normal.png")
 view.save("normal-100dpi.png", dpi=100)
 
 # %%
-# Configure the size of a graph with matplotlib
-# ---------------------------------------------
+# Configure the size of a graph with `matplotlib`
+# -----------------------------------------------
 
 # %%
 
 # %%
-# We first create a graph containing the PDF of a gaussian distribution
+# We first create a graph containing the PDF of a Gaussian distribution
 
 # %%
 n = ot.Normal()

--- a/python/doc/examples/graphs/plot_graphs_contour.py
+++ b/python/doc/examples/graphs/plot_graphs_contour.py
@@ -18,7 +18,7 @@ import openturns as ot
 import openturns.viewer as viewer
 
 # %%
-# We build a bidimensional function (function of x and y), define the study domain and the sample size
+# We build a bidimensional function (function of `x` and `y`), define the study domain and the sample size
 
 # %%
 f = ot.SymbolicFunction(["x", "y"], ["exp(-sin(cos(y)^2 * x^2 + sin(x)^2 * y^2))"])
@@ -37,14 +37,14 @@ graph = f.draw([YMin, YMin], [XMax, YMax], [NX, NY])
 view = viewer.View(graph)
 
 # %%
-# The graph contains an unique drawable whose implementation is of class `Contour`
+# The graph contains a unique drawable whose implementation is of class :class:`~openturns.Contour`
 
 # %%
 contour = graph.getDrawable(0).getImplementation()
 print(type(contour).__name__)
 
 # %%
-# Another way to build the contour is to build the data sample and give it to the constructor of the `Contour` class
+# Another way to build the contour is to build the data sample and give it to the constructor of the :class:`~openturns.Contour` class
 
 # %%
 inputData = ot.Box([NX, NY]).generate()
@@ -100,7 +100,7 @@ view = viewer.View(graph)
 # %%
 # When the function takes values very different in magnitude, it may be useful to change the norm which is
 # used to distribute the colors and to bound the color interval.
-# Here we will also let `matplotlib` calculate the levels by not giving any level to the contour
+# Here we will also let `Matplotlib` calculate the levels by not giving any level to the contour
 
 # %%
 contour.setColorMapNorm("log")
@@ -130,8 +130,8 @@ x_punk = ot.ComposedDistribution([x1, x2], copula)
 mixture = ot.Mixture([x_funk, x_punk], [0.5, 1.0])
 
 # %%
-# The constructed graph is composed of the superposition of a filled contour and iso lines
-# We also changed the thickness and style of the lines to show the effect although it is not useful here
+# The constructed graph is composed of the superposition of a filled contour and iso lines.
+# We also changed the thickness and style of the lines to show the effect although it is not useful here.
 
 # %%
 graph = mixture.drawPDF([-5.0, -5.0], [5.0, 5.0])

--- a/python/doc/examples/graphs/plot_graphs_fill_area.py
+++ b/python/doc/examples/graphs/plot_graphs_fill_area.py
@@ -16,7 +16,7 @@ from matplotlib import pylab as plt
 ot.Log.Show(ot.Log.NONE)
 
 # %%
-# We generate a sample from a standard gaussian distribution.
+# We generate a sample from the standard Normal distribution.
 
 # %%
 dist = ot.Normal()

--- a/python/doc/examples/graphs/plot_graphs_loglikelihood_contour.py
+++ b/python/doc/examples/graphs/plot_graphs_loglikelihood_contour.py
@@ -20,7 +20,7 @@ ot.ResourceMap.SetAsString("Contour-DefaultColorMap", "viridis")
 # -----------------
 
 # %%
-# We create a `TruncatedNormal` and generate a small sample.
+# We create a :class:`~openturns.TruncatedNormal` and generate a small sample.
 
 # %%
 a = -1
@@ -31,7 +31,7 @@ distribution = ot.TruncatedNormal(mu, sigma, a, b)
 sample = distribution.getSample(11)
 
 # %%
-# In order to see the distribution and the sample, we draw the PDF of the distribution and generate a clouds which X coordinates are the sample values.
+# In order to see the distribution and the sample, we draw the PDF of the distribution and generate a cloud which `X` coordinates are the sample values.
 
 # %%
 graph = distribution.drawPDF()
@@ -46,7 +46,7 @@ view = viewer.View(graph)
 
 
 # %%
-# The following function computes the log-likelihood of a `TruncatedNormal`
+# The following function computes the log-likelihood of a :class:`~openturns.TruncatedNormal`
 # which mean and standard deviations are given as input arguments.
 # The lower and upper bounds of the distribution are computed as minimum and maximum of the sample.
 
@@ -90,7 +90,7 @@ def logLikelihood(X):
 
 # %%
 # Draw the log-likelihood function with the `draw` method: this is much faster than using a `for` loop.
-# In order to print LaTeX X and Y labels, we use the `"r"` character in front of the string containing the LaTeX command.
+# In order to print LaTeX `X` and `Y` labels, we use the `"r"` character in front of the string containing the LaTeX command.
 
 # %%
 logLikelihoodFunction = ot.PythonFunction(2, 1, logLikelihood)
@@ -105,7 +105,7 @@ view = viewer.View(graphBasic)
 
 # %%
 # The level values are computed from the quantiles of the data, so that the contours are equally spaced.
-# We can configure the number of levels by setting the `Contour-DefaultLevelsNumber` key in the `ResourceMap`.
+# We can configure the number of levels by setting the `Contour-DefaultLevelsNumber` key in the :class:`~openturns.ResourceMap`.
 
 # %%
 ot.ResourceMap.SetAsUnsignedInteger("Contour-DefaultLevelsNumber", 5)
@@ -121,7 +121,7 @@ view = viewer.View(graphBasic)
 contour = graphBasic.getDrawable(0)
 
 # %%
-# To be able to use specific `Contour` methods like `buildDefaultLevels`, we need to use `getImplementation`.
+# To be able to use specific `Contour` methods like `buildDefaultLevels`, we need to use the method named `getImplementation`.
 
 contour = contour.getImplementation()
 contour.buildDefaultLevels(50)
@@ -133,8 +133,9 @@ view = viewer.View(manyLevelGraph)
 # %%
 # Using a rank-based normalization of the colors
 # ----------------------------------------------
+
 # %%
-# In the previous plots, there was little color variation for isolines corresponding to high log-likelihood values.
+# In the previous plots, there was little color variation for isolines corresponding to large log-likelihood values.
 # This is due to a steep cliff visible for low values of :math:`\sigma`.
 # To make the color variation clearer around -13, we use a normalization based on the rank of the level curve and not on its value.
 contour.setColorMapNorm("rank")
@@ -204,9 +205,9 @@ view = viewer.View(graphFineTune)
 # ----------------------------
 
 # %%
-# The `Contour` class does not allow us to manually set multiple colors.
+# The :class:`~openturns.Contour` class does not allow us to manually set multiple colors.
 # Here we show how to assign explicit colors to the different contour lines by passing keyword
-# arguments to the `viewer.View` class.
+# arguments to the class:` openturns.viewer` class.
 
 # Build a range of colors corresponding to the Tableau palette
 palette = ot.Drawable.BuildTableauPalette(len(levels))


### PR DESCRIPTION
This PR proposes to fix several typos and formatting issues of the examples contained in the Graph section.

![image](https://github.com/openturns/openturns/assets/26813843/c8a3a86c-27fb-46ba-a1cb-f4b6853658fc)
