### PR TITLE
Draw pairs between two samples

### DIFF
--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -298,25 +298,28 @@ GridLayout VisualTest::DrawPairs(const Sample & sample)
 }
 
 /* Draw 2-d projections of a multivariate sample */
-GridLayout VisualTest::DrawPairsXY(const Sample & inputSample, const Sample & outputSample)
+GridLayout VisualTest::DrawPairsXY(const Sample & sampleX, const Sample & sampleY)
 {
-  const UnsignedInteger inputDimension = inputSample.getDimension();
-  const UnsignedInteger outputDimension = outputSample.getDimension();
+  const UnsignedInteger sampleXDimension = sampleX.getDimension();
+  const UnsignedInteger sampleYDimension = sampleY.getDimension();
   
-  GridLayout grid(outputDimension, inputDimension);
-  const Description inputDescription(inputSample.getDescription());
-  const Description outputDescription(outputSample.getDescription());
+  GridLayout grid(sampleYDimension, sampleXDimension);
+  const Description sampleXDescription(sampleX.getDescription());
+  const Description sampleYDescription(sampleY.getDescription());
   
-  for (UnsignedInteger i = 0; i < outputDimension; ++ i)
+  if (sampleX.getSize() != sampleY.getSize())
+    throw InvalidRangeException(HERE) << "The two samples must have the same size.";
+  
+  for (UnsignedInteger i = 0; i < sampleYDimension; ++ i)
   {
-    for (UnsignedInteger j = 0; j < inputDimension; ++ j)
+    for (UnsignedInteger j = 0; j < sampleXDimension; ++ j)
     {
-      Cloud cloud(inputSample.getMarginal(j), outputSample.getMarginal(i));
+      Cloud cloud(sampleX.getMarginal(j), sampleY.getMarginal(i));
      
-      Graph graph("", i == outputDimension - 1 ? inputDescription[j] : "", j == 0 ? outputDescription[i] : "", true, "topright");
+      Graph graph("", i == sampleYDimension - 1 ? sampleXDescription[j] : "", j == 0 ? sampleYDescription[i] : "", true, "topright");
       graph.add(cloud);
       int location = GraphImplementation::TICKNONE;
-      if (i == outputDimension - 1)
+      if (i == sampleYDimension - 1)
         location |= GraphImplementation::TICKX;
       if (j == 0)
         location |= GraphImplementation::TICKY;

--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -311,7 +311,7 @@ GridLayout VisualTest::DrawPairs(const Sample & inputSample, const Sample & outp
   {
     for (UnsignedInteger j = 0; j < inputDimension; ++ j)
     {
-      Cloud cloud(inputSample.getMarginal({j}), outputSample.getMarginal({i}));
+      Cloud cloud(inputSample.getMarginal(j), outputSample.getMarginal(i));
      
       Graph graph("", i == outputDimension - 1 ? inputDescription[j] : "", j == 0 ? outputDescription[i] : "", true, "topright");
       graph.add(cloud);

--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -297,6 +297,36 @@ GridLayout VisualTest::DrawPairs(const Sample & sample)
   return grid;
 }
 
+/* Draw 2-d projections of a multivariate sample */
+GridLayout VisualTest::DrawPairs(const Sample & inputSample, const Sample & outputSample)
+{
+  const UnsignedInteger inputDimension = inputSample.getDimension();
+  const UnsignedInteger outputDimension = outputSample.getDimension();
+  
+  GridLayout grid(outputDimension, inputDimension);
+  const Description inputDescription(inputSample.getDescription());
+  const Description outputDescription(outputSample.getDescription());
+  
+  for (UnsignedInteger i = 0; i < outputDimension; ++ i)
+  {
+    for (UnsignedInteger j = 0; j < inputDimension; ++ j)
+    {
+      Cloud cloud(inputSample.getMarginal({j}), outputSample.getMarginal({i}));
+     
+      Graph graph("", i == outputDimension - 1 ? inputDescription[j] : "", j == 0 ? outputDescription[i] : "", true, "topright");
+      graph.add(cloud);
+      int location = GraphImplementation::TICKNONE;
+      if (i == outputDimension - 1)
+        location |= GraphImplementation::TICKX;
+      if (j == 0)
+        location |= GraphImplementation::TICKY;
+      graph.setTickLocation(static_cast<GraphImplementation::TickLocation>(location));
+      grid.setGraph(i, j, graph);
+    }
+  }
+  return grid;
+}
+
 
 /* Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
 GridLayout VisualTest::DrawPairsMarginals(const Sample & sample, const Distribution & distribution)

--- a/lib/src/Uncertainty/StatTests/VisualTest.cxx
+++ b/lib/src/Uncertainty/StatTests/VisualTest.cxx
@@ -298,7 +298,7 @@ GridLayout VisualTest::DrawPairs(const Sample & sample)
 }
 
 /* Draw 2-d projections of a multivariate sample */
-GridLayout VisualTest::DrawPairs(const Sample & inputSample, const Sample & outputSample)
+GridLayout VisualTest::DrawPairsXY(const Sample & inputSample, const Sample & outputSample)
 {
   const UnsignedInteger inputDimension = inputSample.getDimension();
   const UnsignedInteger outputDimension = outputSample.getDimension();

--- a/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
@@ -75,7 +75,7 @@ OT_API Graph DrawHenryLine(const Sample & sample,
 OT_API GridLayout DrawPairs(const Sample & sample);
 
 /** Draw 2-d projections of input / output sample */
-OT_API GridLayout DrawPairs(const Sample & inputSample, const Sample & outputSample);
+OT_API GridLayout DrawPairsXY(const Sample & sampleX, const Sample & sampleY);
 
 /** Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
 OT_API GridLayout DrawPairsMarginals(const Sample & sample, const Distribution & distribution);

--- a/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
+++ b/lib/src/Uncertainty/StatTests/openturns/VisualTest.hxx
@@ -74,6 +74,9 @@ OT_API Graph DrawHenryLine(const Sample & sample,
 /** Draw 2-d projections of a multivariate sample */
 OT_API GridLayout DrawPairs(const Sample & sample);
 
+/** Draw 2-d projections of input / output sample */
+OT_API GridLayout DrawPairs(const Sample & inputSample, const Sample & outputSample);
+
 /** Draw 2-d projections of a multivariate sample, plus marginals of a distribution */
 OT_API GridLayout DrawPairsMarginals(const Sample & sample, const Distribution & distribution);
 

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -9,6 +9,7 @@ Visualize pairs between two samples
 # This can be achieved by plotting the outputs versus the inputs.
 # When there are several inputs (which is the most often encountered case) and several outputs (which is less often).
 # The :meth:`~openturns.VisualTest.DrawPairs` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
+
 # %%
 import openturns as ot
 import openturns.viewer as viewer
@@ -36,4 +37,4 @@ output_sample = model(input_sample)
 graph = ot.VisualTest.DrawPairs(input_sample, output_sample)
 graph.setTitle("Clouds of input / output samples")
 view = viewer.View(graph)
-plt.show()
+viewer.View.ShowAll()

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -4,7 +4,7 @@ Visualize pairs between two samples
 """
 
 # %%
-# In this example we are going to a visualize the relationships between the marginal samples of two given samples.
+# In this example we visualize the relationships between the marginal samples of two given samples.
 # This is usual when we analyze the relationship of output sample of a model depending on input sample.
 # This can be achieved by plotting the outputs versus the inputs.
 # When there are several inputs (which is the most often encountered case) and several outputs (which is less often).

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -4,7 +4,7 @@ Visualize pairs between two samples
 """
 
 # %%
-# In this example we are going to a visualize the relationships between the marginal samples of two given samples. 
+# In this example we are going to a visualize the relationships between the marginal samples of two given samples.
 # This is usual when we analyze the relationship of output sample of a model depending on input sample.
 # This can be achieved by plotting the outputs versus the inputs.
 # When there are several inputs (which is the most often encountered case) and several outputs (which is less often).

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -8,7 +8,7 @@ Visualize pairs between two samples
 # This is usual when we analyze the relationship of output sample of a model depending on input sample.
 # This can be achieved by plotting the outputs versus the inputs.
 # When there are several inputs (which is the most often encountered case) and several outputs (which is less often).
-# The :meth:`~openturns.VisualTest.DrawPairs` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
+# The :meth:`~openturns.VisualTest.DrawPairsXY` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
 
 # %%
 import openturns as ot
@@ -33,7 +33,7 @@ input_sample = distribution.getSample(100)
 output_sample = model(input_sample)
 
 # %% Visualize the data
-graph = ot.VisualTest.DrawPairs(input_sample, output_sample)
+graph = ot.VisualTest.DrawPairsXY(input_sample, output_sample)
 graph.setTitle("Clouds of input / output samples")
 view = viewer.View(graph)
 viewer.View.ShowAll()

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -13,7 +13,6 @@ Visualize pairs between two samples
 # %%
 import openturns as ot
 import openturns.viewer as viewer
-from matplotlib import pylab as plt
 
 ot.Log.Show(ot.Log.NONE)
 

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -1,0 +1,37 @@
+"""
+Visualize pairs between two samples
+===================================
+"""
+
+# %%
+# In this example we are going to a visualize the relationships between the marginal samples of two given samples. This is usual when we analyze the relationship of output sample of a model depending on input sample.
+# This can be achieved by plotting the outputs versus the inputs.
+# When there are several inputs (which is the most often encountered case) and several outputs (which is less often), the :meth:`~openturns.VisualTest.DrawPairs` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
+# %%
+import openturns as ot
+import openturns.viewer as viewer
+from matplotlib import pylab as plt
+
+ot.Log.Show(ot.Log.NONE)
+
+# %%
+# Create the model
+model = ot.SymbolicFunction(
+    ["X0", "X1", "X2"],
+    ["1.0 + 2.0 * X0 - 1.0 * X1 + 4.0 * X2",
+     "-2.0 - 3.0 * X0 + 5.0 * X1 - 1.0 * X2"],)
+
+# %%
+# Create the input data to visualize
+distribution = ot.Normal(3)
+distribution.setDescription(model.getInputDescription())
+input_sample = distribution.getSample(100)
+
+# %% Create the output data to visualize
+output_sample = model(input_sample)
+
+# %% Visualize the data
+graph = ot.VisualTest.DrawPairs(input_sample, output_sample)
+graph.setTitle("Clouds of input / output samples")
+view = viewer.View(graph)
+plt.show()

--- a/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
+++ b/python/doc/examples/data_analysis/graphics/plot_visualize_input_output_sample.py
@@ -4,9 +4,11 @@ Visualize pairs between two samples
 """
 
 # %%
-# In this example we are going to a visualize the relationships between the marginal samples of two given samples. This is usual when we analyze the relationship of output sample of a model depending on input sample.
+# In this example we are going to a visualize the relationships between the marginal samples of two given samples. 
+# This is usual when we analyze the relationship of output sample of a model depending on input sample.
 # This can be achieved by plotting the outputs versus the inputs.
-# When there are several inputs (which is the most often encountered case) and several outputs (which is less often), the :meth:`~openturns.VisualTest.DrawPairs` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
+# When there are several inputs (which is the most often encountered case) and several outputs (which is less often).
+# The :meth:`~openturns.VisualTest.DrawPairs` method provides a tool to plot the pairs of input and output marginal samples and see the correlations graphically.
 # %%
 import openturns as ot
 import openturns.viewer as viewer

--- a/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_ishigami.py
+++ b/python/doc/examples/meta_modeling/polynomial_chaos_metamodel/plot_chaos_ishigami.py
@@ -47,30 +47,10 @@ outputSample = im.model(inputSample)
 
 
 # %%
-def plotXvsY(sampleX, sampleY):
-    dimX = sampleX.getDimension()
-    dimY = sampleY.getDimension()
-    descriptionX = sampleX.getDescription()
-    descriptionY = sampleY.getDescription()
-    grid = ot.GridLayout(dimY, dimX)
-    for i in range(dimY):
-        for j in range(dimX):
-            graph = ot.Graph("", descriptionX[j], descriptionY[i], True, "")
-            cloud = ot.Cloud(sampleX[:, j], sampleY[:, i])
-            graph.add(cloud)
-            if j == 0:
-                graph.setYTitle(descriptionY[i])
-            else:
-                graph.setYTitle("")
-            if i == dimY - 1:
-                graph.setXTitle(descriptionX[j])
-            else:
-                graph.setXTitle("")
-            grid.setGraph(i, j, graph)
-    return grid
+# Display relationships between the output and the inputs
 
-
-grid = plotXvsY(inputSample, outputSample)
+# %%
+grid = ot.VisualTest.DrawPairsXY(inputSample, outputSample)
 view = otv.View(grid, figure_kw={"figsize": (12.0, 4.0)})
 
 # %%

--- a/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_sobol.py
+++ b/python/doc/examples/reliability_sensitivity/sensitivity_analysis/plot_sensitivity_sobol.py
@@ -82,47 +82,11 @@ n = 10000
 sampleX = im.distributionX.getSample(n)
 sampleY = im.model(sampleX)
 
+# %%
+# Display relationships between the output and the inputs
 
 # %%
-def plotXvsY(sampleX, sampleY):
-    """
-    Plot a Y sample against a X sample on a grid.
-
-    Parameters
-    ----------
-    sampleX : ot.Sample(sampleSize, inputDimension)
-        The input sample.
-    sampleY : ot.Sample(sampleSize, outputDimension)
-        The output sample.
-
-    Returns
-    -------
-    grid: ot.GridLayout(outputDimension, inputDimension)
-        The grid of plots of all projections of Y vs X.
-    """
-    dimX = sampleX.getDimension()
-    dimY = sampleY.getDimension()
-    descriptionX = sampleX.getDescription()
-    descriptionY = sampleY.getDescription()
-    grid = ot.GridLayout(dimY, dimX)
-    for i in range(dimY):
-        for j in range(dimX):
-            graph = ot.Graph("", descriptionX[j], descriptionY[i], True, "")
-            cloud = ot.Cloud(sampleX[:, j], sampleY[:, i])
-            graph.add(cloud)
-            if j == 0:
-                graph.setYTitle(descriptionY[i])
-            else:
-                graph.setYTitle("")
-            if i == dimY - 1:
-                graph.setXTitle(descriptionX[j])
-            else:
-                graph.setXTitle("")
-            grid.setGraph(i, j, graph)
-    return grid
-
-
-grid = plotXvsY(sampleX, sampleY)
+grid = ot.VisualTest.DrawPairsXY(sampleX, sampleY)
 _ = ot.viewer.View(grid, figure_kw={"figsize": (10.0, 4.0)})
 
 # %%

--- a/python/doc/pyplots/DrawPairsXY.py
+++ b/python/doc/pyplots/DrawPairsXY.py
@@ -5,7 +5,7 @@ ot.RandomGenerator.SetSeed(0)
 
 sampleX = ot.Normal(2).getSample(100)
 
-f = ot.SymbolicFunction(['x1','x2'],['x1 + x2','2 * x1 - x2'])
+f = ot.SymbolicFunction(['x1', 'x2'], ['x1 + x2', '2 * x1 - x2'])
 
 sampleY = f(sampleX)
 

--- a/python/doc/pyplots/DrawPairsXY.py
+++ b/python/doc/pyplots/DrawPairsXY.py
@@ -1,0 +1,14 @@
+import openturns as ot
+from openturns.viewer import View
+
+ot.RandomGenerator.SetSeed(0)
+
+sampleX = ot.Normal(2).getSample(100)
+
+f = ot.SymbolicFunction(['x1','x2'],['x1 + x2','2 * x1 - x2'])
+
+sampleY = f(sampleX)
+
+graph = ot.VisualTest.DrawPairsXY(sampleX, sampleY)
+
+View(graph, figure_kw={"figsize": (6.0, 6.0)})

--- a/python/doc/user_manual/statistics_on_sample.rst
+++ b/python/doc/user_manual/statistics_on_sample.rst
@@ -223,6 +223,7 @@ Graphical tests
     :template: functionWithPlot.rst_t
 
     VisualTest.DrawPairs
+    VisualTest.DrawPairsXY
     VisualTest.DrawPairsMarginals
     VisualTest.DrawParallelCoordinates
     VisualTest.DrawHenryLine

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -520,23 +520,14 @@ Examples
 %feature("docstring") OT::VisualTest::DrawPairs
 "Draw 2-d projections of a multivariate sample.
 
-
-Available usages:
-    VisualTest.DrawPairs(*sample*)
-
-    VisualTest.DrawPairs(*inputSample, outputSample*);
-
 Parameters
 ----------
 sample : 2-d sequence of float
     Samples to draw.
-    
-inputSample, outputSample : 2-d sequence of float
-    Input and output samples to draw the relationships between inputs and outputs.
 
 Returns
 -------
-graph : :class:`~openturns.Graph`
+graph : :class:`~openturns.GridLayout`
     The graph object
 
 Notes
@@ -556,6 +547,45 @@ Examples
 >>> size = 100
 >>> sample = distribution.getSample(size)
 >>> clouds = ot.VisualTest.DrawPairs(sample)
+>>> View(clouds).show()"
+
+// ---------------------------------------------------------------------
+%feature("docstring") OT::VisualTest::DrawPairsXY
+"Draw 2-d projections between marginals of two samples.
+
+Parameters
+----------
+sampleX : 2-d sequence of float
+    First sample.
+sampleY : 2-d sequence of float
+    Second sample.
+
+Returns
+-------
+graph : :class:`~openturns.GridLayout`
+    The graph object
+
+Notes
+-----
+This method allows to draw the relationships between the margins of two samples.
+This consists of a collection of 2-d projections of the marginals of sampleY (in lines)
+with respect to the marginals of sampleX (in columns).
+The point style is given by the 'Drawable-DefaultPointStyle' key in the :class:`~openturns.ResourceMap`.
+The color is given by the first individual color in the default palette.
+
+Examples
+--------
+>>> import openturns as ot
+>>> from openturns.viewer import View
+>>> ot.RandomGenerator.SetSeed(0)
+>>> dim = 3
+>>> R = ot.CorrelationMatrix(dim)
+>>> R[0, 1] = 0.8
+>>> distribution = ot.Normal([3.0] * dim, [2.0]* dim, R)
+>>> size = 100
+>>> sampleX = distribution.getSample(size)
+>>> sampleY = distribution.getSample(size)
+>>> clouds = ot.VisualTest.DrawPairsXY(sampleX, sampleY)
 >>> View(clouds).show()"
 
 // ---------------------------------------------------------------------

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -558,7 +558,7 @@ Parameters
 sampleX : 2-d sequence of float
     First sample.
 sampleY : 2-d sequence of float
-    Second sample.
+    Second sample. It must have the same size as the first sample.
 
 Returns
 -------

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -520,10 +520,19 @@ Examples
 %feature("docstring") OT::VisualTest::DrawPairs
 "Draw 2-d projections of a multivariate sample.
 
+
+Available usages:
+    VisualTest.DrawPairs(*sample*)
+
+    VisualTest.DrawPairs(*inputSample, outputSample*);
+
 Parameters
 ----------
 sample : 2-d sequence of float
     Samples to draw.
+    
+inputSample, outputSample : 2-d sequence of float
+    Input and output samples to draw the relationships between inputs and outputs.
 
 Returns
 -------

--- a/python/src/VisualTest_doc.i.in
+++ b/python/src/VisualTest_doc.i.in
@@ -567,7 +567,7 @@ graph : :class:`~openturns.GridLayout`
 
 Notes
 -----
-This method allows to draw the relationships between the margins of two samples.
+This method allows one to draw the relationships between the margins of two samples.
 This consists of a collection of 2-d projections of the marginals of sampleY (in lines)
 with respect to the marginals of sampleX (in columns).
 The point style is given by the 'Drawable-DefaultPointStyle' key in the :class:`~openturns.ResourceMap`.


### PR DESCRIPTION
This PR closes #1749 

It is proposed a new usage of DrawPairs that depends on two samples `inputSample` and `outputSample`

This method draw pairs between the marginal samples of the two given sample. It could be useful to analyze the relationships between inputs and outputs of a code. 

An example of application is provided.
