### PR TITLE
modification of kernel to speed up EGO example and converge

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -270,8 +270,8 @@ Bibliography
     *Spectral methods for uncertainty quantification: with applications to computational fluid dynamics*. Springer Science & Business Media.
 .. [lemieux2009] Lemieux, C. (2009). *Monte Carlo and Quasi-Monte Carlo Sampling*.
     Springer. Springer Series in Statistics.
-.. [leriche2021] Le Riche, R., & Picheny, V. (2021). *ERevisiting Bayesian optimization in the
-    light of the COCO benchmark.* Structural and Multidisciplinary 
+.. [leriche2021] Le Riche, R., & Picheny, V. (2021). *Revisiting Bayesian optimization in the
+    light of the COCO benchmark.* Structural and Multidisciplinary
     Optimization, 64, 3063-3087.
 .. [liu2006] Liu, R., & Owen, A. B. (2006). *Estimating mean dimensionality of
     analysis of variance decompositions.* Journal of the American Statistical

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -270,6 +270,9 @@ Bibliography
     *Spectral methods for uncertainty quantification: with applications to computational fluid dynamics*. Springer Science & Business Media.
 .. [lemieux2009] Lemieux, C. (2009). *Monte Carlo and Quasi-Monte Carlo Sampling*.
     Springer. Springer Series in Statistics.
+.. [leriche2021] Le Riche, R., & Picheny, V. (2021). *ERevisiting Bayesian optimization in the
+    light of the COCO benchmark.* Structural and Multidisciplinary 
+    Optimization, 64, 3063-3087.
 .. [liu2006] Liu, R., & Owen, A. B. (2006). *Estimating mean dimensionality of
     analysis of variance decompositions.* Journal of the American Statistical
     Association, 101 (474), 712-721.

--- a/python/doc/examples/numerical_methods/optimization/plot_ego.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_ego.py
@@ -102,7 +102,7 @@ view = viewer.View(graph)
 # We use default settings (1.0) for the scale parameters of the covariance model, but configure the amplitude to 0.1, which better corresponds to the properties of the Ackley function.
 
 # %%
-covarianceModel = ot.SquaredExponential([1.0] * dim, [0.5])
+covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 1.5)
 basis = ot.ConstantBasisFactory(dim).build()
 kriging = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 kriging.run()
@@ -153,6 +153,8 @@ fexact
 
 # %%
 graph = result.drawOptimalValueHistory()
+optimum_curve = ot.Curve(ot.Sample([[0, fexact[0]], [9, fexact[0]]]))
+graph.add(optimum_curve)
 view = viewer.View(graph)
 
 # %%
@@ -260,7 +262,7 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-covarianceModel = ot.SquaredExponential([1.0] * dim, [1.0])
+covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 1.5)
 basis = ot.ConstantBasisFactory(dim).build()
 kriging = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 

--- a/python/doc/examples/numerical_methods/optimization/plot_ego.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_ego.py
@@ -102,7 +102,7 @@ view = viewer.View(graph)
 # We now create the kriging metamodel. We selected the :class:`~openturns.MaternModel` covariance model with a constant basis.
 
 # %%
-covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 1.5)
+covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 2.5)
 basis = ot.ConstantBasisFactory(dim).build()
 kriging = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 kriging.run()
@@ -243,7 +243,7 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 1.5)
+covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 2.5)
 basis = ot.ConstantBasisFactory(dim).build()
 kriging = ot.KrigingAlgorithm(inputSample, outputSample, covarianceModel, basis)
 

--- a/python/doc/examples/numerical_methods/optimization/plot_ego.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_ego.py
@@ -77,7 +77,7 @@ view = viewer.View(graph)
 # Before using the EGO algorithm, we must create an initial kriging.
 # In order to do this, we must create a design of experiment which fills the space.
 # In this situation, the :class:`~openturns.LHSExperiment` is a good place to start (but other design of experiments may allow one to better fill the space).
-# We use a uniform distribution in order to create a LHS design. 
+# We use a uniform distribution in order to create a LHS design.
 # The length of the first LHS is set to ten times the problem dimension as recommended in [jones1998]_.
 
 # %%

--- a/python/doc/examples/numerical_methods/optimization/plot_ego.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_ego.py
@@ -99,7 +99,8 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-# We now create the kriging metamodel. We selected the :class:`~openturns.MaternModel` covariance model with a constant basis.
+# We now create the kriging metamodel.
+# We selected the :class:`~openturns.MaternModel` covariance model with a constant basis as recommended in [leriche2021]_.
 
 # %%
 covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 2.5)

--- a/python/doc/examples/numerical_methods/optimization/plot_ego.py
+++ b/python/doc/examples/numerical_methods/optimization/plot_ego.py
@@ -3,7 +3,7 @@ EfficientGlobalOptimization examples
 ====================================
 """
 # %%
-# The EGO algorithm (Jones, 1998) is an adaptative optimization method based on
+# The EGO algorithm [jones1998]_ is an adaptative optimization method based on
 # kriging.
 #
 # An initial design of experiment is used to build a first metamodel.
@@ -14,7 +14,7 @@ EfficientGlobalOptimization examples
 # variance.
 #
 # Then the new point is evaluated using the original model and the metamodel is
-# relearnt on the extended design of experiment.
+# relearnt on the extended design of experiments.
 
 
 # %%
@@ -76,15 +76,16 @@ view = viewer.View(graph)
 #
 # Before using the EGO algorithm, we must create an initial kriging.
 # In order to do this, we must create a design of experiment which fills the space.
-# In this situation, the `LHSExperiment` is a good place to start (but other design of experiments may allow one to better fill the space).
-# We use a uniform distribution in order to create a LHS design with 50 points.
+# In this situation, the :class:`~openturns.LHSExperiment` is a good place to start (but other design of experiments may allow one to better fill the space).
+# We use a uniform distribution in order to create a LHS design. 
+# The length of the first LHS is set to ten times the problem dimension as recommended in [jones1998]_.
 
 # %%
 listUniformDistributions = [
     ot.Uniform(lowerbound[i], upperbound[i]) for i in range(dim)
 ]
 distribution = ot.JointDistribution(listUniformDistributions)
-sampleSize = 50
+sampleSize = 10 * dim
 experiment = ot.LHSExperiment(distribution, sampleSize)
 inputSample = experiment.generate()
 outputSample = model(inputSample)
@@ -98,8 +99,7 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-# We now create the kriging metamodel. We selected the `SquaredExponential` covariance model with a constant basis (the `MaternModel` may perform better in this case).
-# We use default settings (1.0) for the scale parameters of the covariance model, but configure the amplitude to 0.1, which better corresponds to the properties of the Ackley function.
+# We now create the kriging metamodel. We selected the :class:`~openturns.MaternModel` covariance model with a constant basis.
 
 # %%
 covarianceModel = ot.MaternModel([1.0] * dim, [0.5], 1.5)
@@ -111,7 +111,7 @@ kriging.run()
 # Create the optimization problem
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# We finally create the `OptimizationProblem` and solve it with `EfficientGlobalOptimization`.
+# We finally create the :class:`~openturns.OptimizationProblem` and solve it with class:`~openturns.EfficientGlobalOptimization`.
 
 # %%
 problem = ot.OptimizationProblem()
@@ -122,12 +122,12 @@ problem.setBounds(bounds)
 # %%
 # In order to show the various options, we configure them all, even if most could be left to default settings in this case.
 #
-# The most important method is `setMaximumCallsNumber` which limits the number of iterations that the algorithm can perform.
-# In the Ackley example, we choose to perform 10 iterations of the algorithm.
+# The most important method is :class:`~openturns.EfficientGlobalOptimization.setMaximumCallsNumber` which limits the number of iterations that the algorithm can perform.
+# In the Ackley example, we choose to perform 30 iterations of the algorithm.
 
 # %%
 algo = ot.EfficientGlobalOptimization(problem, kriging.getResult())
-algo.setMaximumCallsNumber(10)
+algo.setMaximumCallsNumber(30)
 algo.run()
 result = algo.getResult()
 
@@ -145,15 +145,15 @@ fexact
 
 # %%
 # Compared to the minimum function value, we see that the EGO algorithm
-# provides solution which is not very accurate.
-# However, the optimal point is in the neighbourhood of the exact solution,
+# provides solution which is accurate.
+# Indeed, the optimal point is in the neighbourhood of the exact solution,
 # and this is quite an impressive success given the limited amount of function
-# evaluations: only 60 evaluations for the initial DOE and 10 iterations of
-# the EGO algorithm, for a total equal to 70 function evaluations.
+# evaluations: only 20 evaluations for the initial DOE and 30 iterations of
+# the EGO algorithm, for a total equal to 50 function evaluations.
 
 # %%
 graph = result.drawOptimalValueHistory()
-optimum_curve = ot.Curve(ot.Sample([[0, fexact[0]], [9, fexact[0]]]))
+optimum_curve = ot.Curve(ot.Sample([[0, fexact[0]], [29, fexact[0]]]))
 graph.add(optimum_curve)
 view = viewer.View(graph)
 
@@ -176,25 +176,6 @@ view = viewer.View(graph)
 # %%
 # We see that the initial (black) points are dispersed in the whole domain,
 # while the solution points are much closer to the solution.
-#
-# However, the final solution produced by the EGO algorithm is not very accurate.
-# This is why we finalize the process by adding a local optimization step.
-
-# %%
-algo2 = ot.NLopt(problem, "LD_LBFGS")
-algo2.setStartingPoint(result.getOptimalPoint())
-algo2.run()
-result = algo2.getResult()
-
-# %%
-result.getOptimalPoint()
-
-# %%
-# The corrected solution is now extremely accurate.
-
-# %%
-graph = result.drawOptimalValueHistory()
-view = viewer.View(graph)
 
 # %%
 # Branin test-case
@@ -247,7 +228,7 @@ view = viewer.View(graph)
 
 # %%
 distribution = ot.JointDistribution([ot.Uniform(0.0, 1.0)] * dim)
-sampleSize = 50
+sampleSize = 10 * dim
 experiment = ot.LHSExperiment(distribution, sampleSize)
 inputSample = experiment.generate()
 outputSample = objectiveFunction(inputSample)
@@ -284,7 +265,7 @@ problem.setBounds(bounds)
 # %%
 # We configure the algorithm, with the model noise:
 algo = ot.EfficientGlobalOptimization(problem, kriging.getResult(), noise)
-algo.setMaximumCallsNumber(20)
+algo.setMaximumCallsNumber(30)
 
 # %%
 # We run the algorithm and get the result:
@@ -320,13 +301,13 @@ graph.add(cloud)
 view = viewer.View(graph)
 
 # %%
-# We see that the EGO algorithm found the second local minimum.
-# Given the limited number of function evaluations, the other local minimas have not been explored.
+# We see that the EGO algorithm reached the different optima locations.
 
 # %%
 graph = result.drawOptimalValueHistory()
+optimum_curve = ot.Curve(ot.Sample([[0, fexact[0][0]], [29, fexact[0][0]]]))
+graph.add(optimum_curve)
 view = viewer.View(graph, axes_kw={"xticks": range(0, result.getIterationNumber(), 5)})
-
 plt.show()
 
 # %%


### PR DESCRIPTION
This PR closes #1302.

The EGO example has been modified to enhance convergence of the algorithm without increasing the number of iteration. To do so, the kernel has been changed to Matern which is mored adapted than SquareExponential in order to deal with Ackley function.
