### PR TITLE
Replaced assert with assert_equal in C++ unit tests

### DIFF
--- a/lib/test/t_ExperimentIntegration_std.cxx
+++ b/lib/test/t_ExperimentIntegration_std.cxx
@@ -62,14 +62,14 @@ int main(int, char *[])
 
   fullprint << "Test integrate()" << std::endl;
   const Point ishigamiMeanComputed(integration.integrate(ishigamiFunction));
-  assert(ishigamiMeanComputed.getDimension() == 1);
+  assert_equal(ishigamiMeanComputed.getDimension(), (UnsignedInteger) 1);
   fullprint << "    ishigamiMeanComputed[0] = " << ishigamiMeanComputed[0] << std::endl;
   fullprint << "    mean = " << mean << std::endl;
   assert_almost_equal(ishigamiMeanComputed[0], mean, atolIntegrate);
 
   fullprint << "Test computeL2Norm()" << std::endl;
   const Point centeredIshigamiL2Norm(integration.computeL2Norm(centeredIshigami));
-  assert(centeredIshigamiL2Norm.getDimension() == 1);
+  assert_equal(centeredIshigamiL2Norm.getDimension(), (UnsignedInteger) 1);
   fullprint << "    centeredIshigamiL2Norm[0] = " << centeredIshigamiL2Norm[0] << std::endl;
   fullprint << "    exactL2Norm = " << exactL2Norm << std::endl;
   assert_almost_equal(centeredIshigamiL2Norm[0], exactL2Norm, atolIntegrate);
@@ -83,7 +83,7 @@ int main(int, char *[])
 
   fullprint << "Test computeL2Norm()" << std::endl;
   const Point ishigamiErrorComputed(integration.computeL2Norm(ishigamiFunction - ishigamiPartFunction));
-  assert(ishigamiErrorComputed.getDimension() == 1);
+  assert_equal(ishigamiErrorComputed.getDimension(), (UnsignedInteger) 1);
   Scalar errorExact = std::sqrt(0.5);
   fullprint << "    ishigamiErrorComputed[0] = " << ishigamiErrorComputed[0] << std::endl;
   fullprint << "    errorExact = " << errorExact << std::endl;

--- a/lib/test/t_MonteCarloExperiment_std.cxx
+++ b/lib/test/t_MonteCarloExperiment_std.cxx
@@ -37,9 +37,9 @@ int main(int, char *[])
   fullprint << "experiment = " << experiment << std::endl;
   Point weights(0);
   const Sample sample(experiment.generateWithWeights(weights));
-  assert(sample.getSize() == size);
-  assert(sample.getDimension() == 4);
-  assert(weights.getDimension() == size);
+  assert_equal(sample.getSize(), size);
+  assert_equal(sample.getDimension(), (UnsignedInteger) 4);
+  assert_equal(weights.getDimension(), size);
   const Scalar atol = 10.0 / std::sqrt(size);
   const Scalar rtol = 0.0;
   const Point meanExact(distribution.getMean());


### PR DESCRIPTION
When `assert` is used in C++ unit tests, it does not check anything. Using this may prevent from seeing actual bugs. This PR replaces `assert` with `assert_equal` in C++ unit tests