### PR TITLE
Improved JointByConditioningDistribution

### DIFF
--- a/lib/src/Uncertainty/Distribution/openturns/JointByConditioningDistribution.hxx
+++ b/lib/src/Uncertainty/Distribution/openturns/JointByConditioningDistribution.hxx
@@ -102,6 +102,21 @@ public:
   /** Parameters description accessor */
   Description getParameterDescription() const override;
 
+  /** Compute the PDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalPDF;
+  Scalar computeConditionalPDF(const Scalar x, const Point & y) const override;
+  Point computeSequentialConditionalPDF(const Point & x) const override;
+
+  /** Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalCDF;
+  Scalar computeConditionalCDF(const Scalar x, const Point & y) const override;
+  Point computeSequentialConditionalCDF(const Point & x) const override;
+
+  /** Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
+  using DistributionImplementation::computeConditionalQuantile;
+  Scalar computeConditionalQuantile(const Scalar q, const Point & y) const override;
+  Point computeSequentialConditionalQuantile(const Point & q) const override;
+
   /** Method save() stores the object through the StorageManager */
   void save(Advocate & adv) const override;
 

--- a/python/test/t_JointByConditioningDistribution_std.expout
+++ b/python/test/t_JointByConditioningDistribution_std.expout
@@ -23,3 +23,9 @@ anotherSample covariance= [[  0.0830803    0.000313403  0.0767514   ]
 Point point=  [0.5, 1.5, 1.0]  pdf=0.251589  cdf=0.181637
 Quantile= [0.982796,1.9828,3.87457]
 CDF(quantile)= 0.95
+conditional PDF=1.09340e-01
+conditional CDF=9.08789e-01
+conditional quantile=2.50000e+00
+sequential conditional PDF= [1,1,0.10934]
+sequential conditional CDF( [0.5, 1.5, 2.5] )= [0.5,0.5,0.908789]
+sequential conditional quantile( [0.5,0.5,0.908789] )= [0.5,1.5,2.5]

--- a/python/test/t_JointByConditioningDistribution_std.py
+++ b/python/test/t_JointByConditioningDistribution_std.py
@@ -56,6 +56,26 @@ quantile = distribution.computeQuantile(0.95)
 print("Quantile=", quantile)
 print("CDF(quantile)= %.12g" % distribution.computeCDF(quantile))
 
+x = 2.5
+y = [0.5, 1.5]
+print("conditional PDF=%.5e" % distribution.computeConditionalPDF(x, y))
+condCDF = distribution.computeConditionalCDF(x, y)
+print("conditional CDF=%.5e" % condCDF)
+q = condCDF
+print("conditional quantile=%.5e" % distribution.computeConditionalQuantile(q, y))
+pt = [i + 0.5 for i in range(dim)]
+print(
+    "sequential conditional PDF=", distribution.computeSequentialConditionalPDF(pt)
+)
+resCDF = distribution.computeSequentialConditionalCDF(pt)
+print("sequential conditional CDF(", pt, ")=", resCDF)
+print(
+    "sequential conditional quantile(",
+    resCDF,
+    ")=",
+    distribution.computeSequentialConditionalQuantile(resCDF),
+)
+
 ot.Log.Show(ot.Log.TRACE)
 checker = ott.DistributionChecker(distribution)
 checker.skipMoments()  # slow


### PR DESCRIPTION
Now, the compute[Sequential]Conditional[PDF|CDF[Quantile] methods have a dedicated implementation, resulting into a huge performance boost.

The main goal is to allow the use of JointByConditioningDistribution in FORM/SORM algorithms.