### PR TITLE
Doc of the EmpiricalBernsteinCopula and the BernsteinCopulaFactory

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -442,7 +442,7 @@ Bibliography
 .. [ScottStewart2011] W. F. Scott & B. Stewart.
     *Tables for the Lilliefors and Modified Cramer–von Mises Tests of Normality.*,
     Communications in Statistics - Theory and Methods. Volume 40, 2011 - Issue 4. Pages 726-730.
-.. [segers2016] J. Segers &  M. Sibuya &  H. TsukaharaSen (2016). *The Empirical Beta Copula*, 
+.. [segers2016] J. Segers &  M. Sibuya &  H. TsukaharaSen (2016). *The Empirical Beta Copula*,
    `pdf <https://arxiv.org/pdf/1607.04430>`__
 .. [sen1990] Sen, A., & Srivastava, M. (1990). *Regression analysis: theory, methods, and applications*.
     Springer.

--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -442,6 +442,8 @@ Bibliography
 .. [ScottStewart2011] W. F. Scott & B. Stewart.
     *Tables for the Lilliefors and Modified Cramer–von Mises Tests of Normality.*,
     Communications in Statistics - Theory and Methods. Volume 40, 2011 - Issue 4. Pages 726-730.
+.. [segers2016] J. Segers &  M. Sibuya &  H. TsukaharaSen (2016). *The Empirical Beta Copula*, 
+   `pdf <https://arxiv.org/pdf/1607.04430>`__
 .. [sen1990] Sen, A., & Srivastava, M. (1990). *Regression analysis: theory, methods, and applications*.
     Springer.
 .. [shao1993] Shao, J. (1993). *Linear model selection by cross-validation.*

--- a/python/doc/examples/calibration/least_squares_and_gaussian_calibration/plot_calibration_chaboche.py
+++ b/python/doc/examples/calibration/least_squares_and_gaussian_calibration/plot_calibration_chaboche.py
@@ -60,7 +60,7 @@ ot.Log.Show(ot.Log.NONE)
 # class.
 
 # %%
-RandomGenerator.SetSeed(0)
+ot.RandomGenerator.SetSeed(0)
 cm = chaboche_model.ChabocheModel()
 print(cm.data)
 observedStrain = cm.data[:, 0]

--- a/python/doc/examples/calibration/least_squares_and_gaussian_calibration/plot_calibration_chaboche.py
+++ b/python/doc/examples/calibration/least_squares_and_gaussian_calibration/plot_calibration_chaboche.py
@@ -60,6 +60,7 @@ ot.Log.Show(ot.Log.NONE)
 # class.
 
 # %%
+RandomGenerator.SetSeed(0)
 cm = chaboche_model.ChabocheModel()
 print(cm.data)
 observedStrain = cm.data[:, 0]

--- a/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
+++ b/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
@@ -51,8 +51,8 @@ def draw(dist, Y):
 #
 # .. math::
 #
-#      y_1 & = sin(u) / (1 + cos(u)^2) + 0.05 * v_1 \\
-#      y_2 & = sin(u) * cos(u) / (1 + cos(u)^2) + 0.05 * v_2
+#      y_1 & = \sin(u) / (1 + \cos(u)^2) + 0.05 * v_1 \\
+#      y_2 & = \sin(u) \cos(u) / (1 + \cos(u)^2) + 0.05 * v_2
 #
 # We define the following input random vector:
 #
@@ -109,6 +109,7 @@ view = viewer.View(draw(y_empBern, sample_Y))
 
 # %%
 # Now, we specify a bin number equal to the sample size: :math:`m = N` so that the built copula is very close to the sample.
+# With this parametrization, the empirical Bernstein copula is the *Beta copula* in the sens of [segers2016]_.
 # In that case, it manages to reproduce its specific feature.
 empBern_copula = ot.BernsteinCopulaFactory().build(sample_Y, N)
 y_empBern = ot.JointDistribution(marginals, empBern_copula)

--- a/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
+++ b/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
@@ -5,7 +5,7 @@ Model a singular multivariate distribution
 
 # %%
 # From time to time we need to model singular :math:`n_D` distributions
-# (e.g. the joint distribution of KL coefficients for curves resulting from the transport of a low dimensional random vector).
+# (e.g. the joint distribution of Karhunen Loeve coefficients for curves resulting from the transport of a low dimensional random vector).
 # A way to do that is to use an :class:`~openturns.EmpiricalBernsteinCopula` with a bin number equal to the sample size
 # (also called the empirical beta copula in this case).
 
@@ -41,29 +41,80 @@ def draw(dist, Y):
 
 
 # %%
-# Generate some multivariate data to estimate, with correlation.
+# We consider the function :math:`f: \Rset^3 \rightarrow \Rset` defined by:
+#
+# .. math::
+#
+#      f(u, v_1, v_2) = (y_1, y_2)
+#
+# where:
+#
+# .. math::
+#
+#      y_1 & = sin(u) / (1 + cos(u)^2) + 0.05 * v_1 \\
+#      y_2 & = sin(u) * cos(u) / (1 + cos(u)^2) + 0.05 * v_2
+#
+# We define the following input random vector:
+#
+# .. math::
+#
+#      U  \sim \cU(-0.85\pi, 0.85\pi) \\
+#      (V_1, V_2)  \sim \cN(\vect{\mu} = \vect{0}, \vect{\sigma} = \vect{1}, Id_2)\\
+#
+# with :math:`U` and :math:`\vect{V})` independent.
+#
+# We define the output random vector :math:`\vect{Y}` as:
+#
+# .. math::
+#
+#      \vect{Y} = f(U, V_1, V_2)
+
 f = ot.SymbolicFunction(
-    ["U", "xi1", "xi2"],
-    ["sin(U)/(1+cos(U)^2)+0.05*xi1", "sin(U)*cos(U)/(1+cos(U)^2)+0.05*xi2"],
+    ["U", "v1", "v2"],
+    ["sin(U)/(1+cos(U)^2)+0.05*v1", "sin(U)*cos(U)/(1+cos(U)^2)+0.05*v2"],
 )
 U = ot.Uniform(-0.85 * m.pi, 0.85 * m.pi)
-xi = ot.Normal(2)
-X = ot.BlockIndependentDistribution([U, xi])
+V = ot.Normal(2)
+X = ot.BlockIndependentDistribution([U, V])
+
+# %%
+# We generate a sample of the output random vector :math:`\vect{Y}` of size :math:`N`.
 N = 200
-Y = f(X.getSample(N))
+sample_Y = f(X.getSample(N))
 
 # %%
-# Estimation by multivariate kernel smoothing.
-multi_ks = ot.KernelSmoothing().build(Y)
-view = viewer.View(draw(multi_ks, Y))
+# We estimate the distribution of the output random vector :math:`\vect{Y}` by multivariate kernel smoothing.
+y_multi_ks = ot.KernelSmoothing().build(sample_Y)
+view = viewer.View(draw(y_multi_ks, sample_Y))
 
 # %%
-# Estimation by empirical beta copula.
-beta_copula = ot.EmpiricalBernsteinCopula(Y, len(Y))
+# Now, we estimate the distribution of :math:`\vect{Y}` splitting the estimation of the marginals
+# from the estimation of the copula:
+#
+# - the marginals are fitted by kernel smoothing,
+# - the copula is fitted using the Bernstein copula factory :class:`~openturns.BernsteinCopulaFactory` that builds
+#   an empirical Bernstein copula.
+#
+# First, we do not specify the bin number :math:`m`. It is equal to the value computed by the default method, which is the
+# LogLikelihood criteria. We get :math:`m=1`, which
+# means that one cell is created: the built copula is diffuse in :math:`[0,1]^2`. The estimated copula is
+# the independent copula.
+empBern_copula = ot.BernsteinCopulaFactory().buildAsEmpiricalBernsteinCopula(sample_Y)
+print('bin number computed m = ', empBern_copula.getBinNumber())
 marginals = [
-    ot.KernelSmoothing().build(Y.getMarginal(j)) for j in range(Y.getDimension())
+    ot.KernelSmoothing().build(sample_Y.getMarginal(j)) for j in range(sample_Y.getDimension())
 ]
-beta_dist = ot.JointDistribution(marginals, beta_copula)
-view = viewer.View(draw(beta_dist, Y))
+y_empBern = ot.JointDistribution(marginals, empBern_copula)
+view = viewer.View(draw(y_empBern, sample_Y))
+
+
+# %%
+# Now, we specify a bin number equal to the sample size: :math:`m = N` so that the built copula is very close to the sample.
+# In that case, it manages to reproduce its specific feature.
+empBern_copula = ot.BernsteinCopulaFactory().build(sample_Y, N)
+y_empBern = ot.JointDistribution(marginals, empBern_copula)
+view = viewer.View(draw(y_empBern, sample_Y))
+
+
 
 viewer.View.ShowAll()

--- a/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
+++ b/python/doc/examples/data_analysis/distribution_fitting/plot_model_singular_multivariate_distribution.py
@@ -107,14 +107,10 @@ marginals = [
 y_empBern = ot.JointDistribution(marginals, empBern_copula)
 view = viewer.View(draw(y_empBern, sample_Y))
 
-
 # %%
 # Now, we specify a bin number equal to the sample size: :math:`m = N` so that the built copula is very close to the sample.
 # In that case, it manages to reproduce its specific feature.
 empBern_copula = ot.BernsteinCopulaFactory().build(sample_Y, N)
 y_empBern = ot.JointDistribution(marginals, empBern_copula)
 view = viewer.View(draw(y_empBern, sample_Y))
-
-
-
 viewer.View.ShowAll()

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -3,7 +3,7 @@
 
 Notes
 -----
-This class provides a non parametric estimator of  the :class:`~openturns.EmpiricalBernsteinCopula`.
+This class builds an :class:`~openturns.EmpiricalBernsteinCopula`, which is a copula under some conditions.
 
 See also
 --------
@@ -12,7 +12,7 @@ DistributionFactory, EmpiricalBernsteinCopula"
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::BernsteinCopulaFactory::build
-"Build the nonparametric Bernstein interpolant based on the empirical copula.
+"Build the empirical Bernstein copula.
 
 **Available usages**:
 
@@ -39,17 +39,19 @@ m : int
 Returns
 -------
 core : :class:`~openturns.Distribution`
-    The estimated Bernstein interpolant as a generic distribution.
+    The empirical Bernstein copula as a generic distribution.
 
 Notes
 -----
-The estimated Bernstein interpolant based on the empirical copula is really a copula if :math:`m|N`. Otherwise, it is not a copula but
-still a valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
+Let :math:`\sampleSize` be the size of the sample. If :math:`m` divides :math:`\sampleSize`, then the
+:class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a 
+copula. Otherwise, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a core, i.e a
+multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::BernsteinCopulaFactory::buildAsEmpiricalBernsteinCopula
-"Build the nonparametric Bernstein interpolant based on the empirical copula.
+"Build the empirical Bernstein copula as native distribution.
 
 **Available usages**:
 
@@ -77,13 +79,15 @@ m : int
 
 Returns
 -------
-copula : :class:`~openturns.EmpiricalBernsteinCopula`
-    The estimated Bernstein interpolant as a :class:`~openturns.EmpiricalBernsteinCopula`.
+core : :class:`~openturns.EmpiricalBernsteinCopula`
+    The empirical Bernstein copula as a :class:`~openturns.EmpiricalBernsteinCopula`.
 
 Notes
 -----
-The estimated Bernstein interpolant based on the empirical copula is really a copula if :math:`m|N`. Otherwise, it is not a copula but
-still a valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
+Let :math:`\sampleSize` be the size of the sample. If :math:`m` divides :math:`\sampleSize`, then the
+:class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a 
+copula. Otherwise, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a core, i.e a
+multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 // ---------------------------------------------------------------------
 
@@ -105,6 +109,10 @@ leading to:
     m = 1+\left\lfloor \sampleSize^{\frac{2}{4+d}} \right\rfloor
 
 where :math:`\lfloor x \rfloor` is the largest integer less than or equal to :math:`x`, :math:`\sampleSize` the sample size and :math:`d` the sample dimension.
+
+Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
+Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
+valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 
 // ---------------------------------------------------------------------
@@ -137,6 +145,10 @@ If :math:`kFraction>1`, the bin number :math:`m` is given by:
 
 where :math:`\cE^V_k=\left\{\vect{x}_i\in\cE\,|\,i\equiv k \mod kFraction\right\}`
 and :math:`\cE^L_k=\cE \backslash \cE^V_k`.
+
+Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
+Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
+valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 
 // ---------------------------------------------------------------------
@@ -163,6 +175,10 @@ Let :math:`\cE=(\inputReal_1, \dots, \inputReal_\sampleSize)` be the given sampl
 
 where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample :math:`\cE` and the bin number :math:`M`, :math:`\hat{D}_f(c^{\cE}_{M})=\dfrac{1}{N}\sum_{j=1}^Nf\left(\dfrac{1}{\vect{u}_j}\right)` a Monte Carlo estimate of the Csiszar :math:`f` divergence, :math:`\rho_S(c^{\cE}_{M})` the exact Spearman correlation of the empirical Bernstein copula :math:`c^{\cE}_{M}` and :math:`\rho_S({\cE}_{M})` the empirical Spearman correlation of the sample :math:`{\cE}_{M}`.
 
-The parameter :math:`N` is controlled by the *'BernsteinCopulaFactory-SamplingSize'* key in :class:`~openturns.ResourceMap`.
+The parameter :math:`N` is controlled by the *BernsteinCopulaFactory-SamplingSize* key in :class:`~openturns.ResourceMap`.
+
+Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
+Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
+valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -3,7 +3,21 @@
 
 Notes
 -----
-This class builds an :class:`~openturns.EmpiricalBernsteinCopula`, which is a copula under some conditions.
+This class builds an :class:`~openturns.EmpiricalBernsteinCopula` which is a non parametric fitting of
+the copula of a multivariate distribution.
+
+The keys of :class:`~openturns.ResourceMap` related to the class are:
+
+- the key `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the default range of :math:`m` in the optimization
+  problems computing the optimal bin number according to a specified criteria,
+- the key `BernsteinCopulaFactory-BinNumberSelection` that defines the default criteria to compute the optimal bin number when it is not
+  specified,
+- the key `BernsteinCopulaFactory-KFraction` that specifies the fraction of the sample used for the validation in the
+  method :meth:`ComputeLogLikelihoodBinNumber`,
+- the key `BernsteinCopulaFactory-SamplingSize`  that defines the :math:`N` parameter used in the
+  method :meth:`ComputePenalizedCsiszarDivergenceBinNumber`.
+
+
 
 See also
 --------
@@ -20,38 +34,43 @@ DistributionFactory, EmpiricalBernsteinCopula"
 
     build(*sample*)
 
-    build(*sample, method, objective*)
-
     build(*sample, m*)
+
+    build(*sample, method, f*)
 
 Parameters
 ----------
 sample : 2-d sequence of float, of dimension :math:`d`
     The sample of size :math:`\sampleSize>0` from which the copula is estimated.
 method : str
-    The name of the bin number selection method. Possible choices are *AMISE*, *LogLikelihood* and *PenalizedCsiszarDivergence*. Default is *LogLikelihood*, given by the *'BernsteinCopulaFactory-BinNumberSelection'* entry of :class:`~openturns.ResourceMap`.
-m : int
-    The number of sub-intervals in which all the edges of the unit cube
+    The name of the bin number selection method. Possible choices are *AMISE*, *LogLikelihood* and *PenalizedCsiszarDivergence*.
+    
+    Default is *LogLikelihood*.
+f : :class:`~openturns.Function`
+    The function defining the Csiszar divergence of interest used by
+    the  *PenalizedCsiszarDivergence* method.
+    
+    Default is Function().
+m : int,:math:`1 \leq m \leq \sampleSize`,
+    The bin number, i.e. the number of sub-intervals in which all the edges of the unit cube
     :math:`[0, 1]^d` are regularly partitioned.
     
-    Default value is 1.
+    Default value is the value computed from the default bin number selection method.
 
 Returns
 -------
-core : :class:`~openturns.Distribution`
+copula : :class:`~openturns.Distribution`
     The empirical Bernstein copula as a generic distribution.
 
 Notes
 -----
-Let :math:`\sampleSize` be the size of the sample. If :math:`m` divides :math:`\sampleSize`, then the
-:class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a 
-copula. Otherwise, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a core, i.e a
-multivariate distribution whose range is included in :math:`[0,1]^d`.
+If the bin number :math:`m` is specified and does not divide the sample size :math:`\sampleSize`, then a part of the sample is
+removed for the result to be a copula. See :class:`~openturns.EmpiricalBernsteinCopula`.
 "
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::BernsteinCopulaFactory::buildAsEmpiricalBernsteinCopula
-"Build the empirical Bernstein copula as native distribution.
+"Build the empirical Bernstein copula as a native distribution.
 
 **Available usages**:
 
@@ -59,35 +78,40 @@ multivariate distribution whose range is included in :math:`[0,1]^d`.
 
     buildAsEmpiricalBernsteinCopula(*sample*)
 
-    buildAsEmpiricalBernsteinCopula(*sample, method, objective*)
-
     buildAsEmpiricalBernsteinCopula(*sample, m*)
 
+    buildAsEmpiricalBernsteinCopula(*sample, method, f*)
+
 Parameters
+    The fraction of the sample used for the validation. ComputeLogLikelihoodBinNumber
 ----------
 sample : 2-d sequence of float, of dimension *d*
     The sample of size :math:`\sampleSize>0` from which the copula is estimated.
 method : str
     The name of the bin number selection method. Possible choices are *AMISE*, *LogLikelihood* and
-    *PenalizedCsiszarDivergence*. Default is *LogLikelihood*, given by the *'BernsteinCopulaFactory-BinNumberSelection'*
-    entry of :class:`~openturns.ResourceMap`.
-m : int
-    The number of sub-intervals in which all the edges of the unit cube
+    *PenalizedCsiszarDivergence*.
+    
+    Default is *LogLikelihood*.
+f : :class:`~openturns.Function`
+    The function defining the Csiszar divergence of interest used by
+    the  *PenalizedCsiszarDivergence* method.
+    
+    Default is Function().
+m : int, :math:`1 \leq m \leq \sampleSize`,
+    The bin number, i.e. the number of sub-intervals in which all the edges of the unit cube
     :math:`[0, 1]^d` are regularly partitioned.
     
-    Default value is 1.
+    Default value is the value computed from the default bin number selection method.
 
 Returns
 -------
-core : :class:`~openturns.EmpiricalBernsteinCopula`
-    The empirical Bernstein copula as a :class:`~openturns.EmpiricalBernsteinCopula`.
+copula : :class:`~openturns.EmpiricalBernsteinCopula`
+    The empirical Bernstein copula as a native distribution.
 
 Notes
 -----
-Let :math:`\sampleSize` be the size of the sample. If :math:`m` divides :math:`\sampleSize`, then the
-:class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a 
-copula. Otherwise, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is a core, i.e a
-multivariate distribution whose range is included in :math:`[0,1]^d`.
+If the bin number :math:`m` is specified and does not divide the sample size :math:`\sampleSize`, then a part of the sample is
+removed for the result to be a copula a copula. See :class:`~openturns.EmpiricalBernsteinCopula`.
 "
 // ---------------------------------------------------------------------
 
@@ -111,8 +135,6 @@ leading to:
 where :math:`\lfloor x \rfloor` is the largest integer less than or equal to :math:`x`, :math:`\sampleSize` the sample size and :math:`d` the sample dimension.
 
 Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
-Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
-valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 
 // ---------------------------------------------------------------------
@@ -126,6 +148,8 @@ sample : 2-d sequence of float, of dimension 1
     The sample of size :math:`\sampleSize` from which the optimal log-likelihood bin number is computed.
 kFraction : int, :math:`0<kFraction<\sampleSize`
     The fraction of the sample used for the validation.
+    
+    Default value 2.
 
 Notes
 -----
@@ -147,8 +171,6 @@ where :math:`\cE^V_k=\left\{\vect{x}_i\in\cE\,|\,i\equiv k \mod kFraction\right\
 and :math:`\cE^L_k=\cE \backslash \cE^V_k`.
 
 Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
-Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
-valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 
 // ---------------------------------------------------------------------
@@ -173,12 +195,13 @@ Let :math:`\cE=(\inputReal_1, \dots, \inputReal_\sampleSize)` be the given sampl
 
     m = \argmin_{M\in\{1,\dots,\sampleSize\}}\left[\hat{D}_f(c^{\cE}_{M})-\dfrac{1}{\sampleSize}\sum_{\vect{x}_i\in\cE}f\left(\dfrac{1}{c^{\cE}_{M}(\vect{x}_i)}\right)\right]^2-[\rho_S(c^{\cE}_{M})-\rho_S({\cE}_{M})]^2
 
-where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample :math:`\cE` and the bin number :math:`M`, :math:`\hat{D}_f(c^{\cE}_{M})=\dfrac{1}{N}\sum_{j=1}^Nf\left(\dfrac{1}{\vect{u}_j}\right)` a Monte Carlo estimate of the Csiszar :math:`f` divergence, :math:`\rho_S(c^{\cE}_{M})` the exact Spearman correlation of the empirical Bernstein copula :math:`c^{\cE}_{M}` and :math:`\rho_S({\cE}_{M})` the empirical Spearman correlation of the sample :math:`{\cE}_{M}`.
+where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample
+:math:`\cE` and the bin number :math:`M`, :math:`\hat{D}_f(c^{\cE}_{M})=\dfrac{1}{N}\sum_{j=1}^Nf\left(\dfrac{1}{\vect{u}_j}\right)` a
+Monte Carlo estimate of the Csiszar :math:`f` divergence, :math:`\rho_S(c^{\cE}_{M})` the exact Spearman correlation of the empirical
+Bernstein copula :math:`c^{\cE}_{M}` and :math:`\rho_S({\cE}_{M})` the empirical Spearman correlation of the sample :math:`{\cE}_{M}`.
 
 The parameter :math:`N` is controlled by the *BernsteinCopulaFactory-SamplingSize* key in :class:`~openturns.ResourceMap`.
 
 Note that this optimal :math:`m` does not necessarily divide the sample size :math:`\sampleSize`.
-Then, the :class:`~openturns.EmpiricalBernsteinCopula` built from the sample is no longer a copula but still a
-valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -8,16 +8,15 @@ the copula of a multivariate distribution.
 
 The keys of :class:`~openturns.ResourceMap` related to the class are:
 
-- the keys `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the default range of :math:`m` in the optimization
+- the keys `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the range of :math:`m`
+  in the optimization
   problems computing the optimal bin number according to a specified criteria,
-- the key `BernsteinCopulaFactory-BinNumberSelection` that defines the default criteria to compute the optimal bin number when it is not
-  specified,
+- the key `BernsteinCopulaFactory-BinNumberSelection` that defines the  criteria to compute the optimal bin number
+  when it is not specified. The possible choices are 'AMISE', 'LogLikelihood', 'PenalizedCsiszarDivergence';
 - the key `BernsteinCopulaFactory-KFraction` that defines the fraction of the sample used for the validation in the
   method :meth:`ComputeLogLikelihoodBinNumber`,
 - the key `BernsteinCopulaFactory-SamplingSize`  that defines the :math:`N` parameter used in the
   method :meth:`ComputePenalizedCsiszarDivergenceBinNumber`.
-
-
 
 See also
 --------

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -1,9 +1,9 @@
 %feature("docstring") OT::BernsteinCopulaFactory
-"BernsteinCopula copula factory.
+"EmpiricalBernsteinCopula factory.
 
 Notes
 -----
-This class provides a non parametric estimator of a copula: the :class:`~openturns.EmpiricalBernsteinCopula`.
+This class provides a non parametric estimator of  the :class:`~openturns.EmpiricalBernsteinCopula`.
 
 See also
 --------
@@ -12,7 +12,7 @@ DistributionFactory, EmpiricalBernsteinCopula"
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::BernsteinCopulaFactory::build
-"Build the nonparametric Bernstein copula estimator based on the empirical copula.
+"Build the nonparametric Bernstein interpolant based on the empirical copula.
 
 **Available usages**:
 
@@ -26,24 +26,30 @@ DistributionFactory, EmpiricalBernsteinCopula"
 
 Parameters
 ----------
-sample : 2-d sequence of float, of dimension *d*
-    The sample of size :math:`n>0` from which the copula is estimated.
+sample : 2-d sequence of float, of dimension :math:`d`
+    The sample of size :math:`\sampleSize>0` from which the copula is estimated.
 method : str
     The name of the bin number selection method. Possible choices are *AMISE*, *LogLikelihood* and *PenalizedCsiszarDivergence*. Default is *LogLikelihood*, given by the *'BernsteinCopulaFactory-BinNumberSelection'* entry of :class:`~openturns.ResourceMap`.
 m : int
     The number of sub-intervals in which all the edges of the unit cube
     :math:`[0, 1]^d` are regularly partitioned.
+    
+    Default value is 1.
 
 Returns
 -------
-copula : :class:`~openturns.Distribution`
-    The estimated copula as a generic distribution.
+core : :class:`~openturns.Distribution`
+    The estimated Bernstein interpolant as a generic distribution.
 
+Notes
+-----
+The estimated Bernstein interpolant based on the empirical copula is really a copula if :math:`m|N`. Otherwise, it is not a copula but
+still a valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::BernsteinCopulaFactory::buildAsEmpiricalBernsteinCopula
-"Build the nonparametric Bernstein copula estimator based on the empirical copula.
+"Build the nonparametric Bernstein interpolant based on the empirical copula.
 
 **Available usages**:
 
@@ -58,7 +64,7 @@ copula : :class:`~openturns.Distribution`
 Parameters
 ----------
 sample : 2-d sequence of float, of dimension *d*
-    The sample of size :math:`n>0` from which the copula is estimated.
+    The sample of size :math:`\sampleSize>0` from which the copula is estimated.
 method : str
     The name of the bin number selection method. Possible choices are *AMISE*, *LogLikelihood* and
     *PenalizedCsiszarDivergence*. Default is *LogLikelihood*, given by the *'BernsteinCopulaFactory-BinNumberSelection'*
@@ -66,12 +72,18 @@ method : str
 m : int
     The number of sub-intervals in which all the edges of the unit cube
     :math:`[0, 1]^d` are regularly partitioned.
+    
+    Default value is 1.
 
 Returns
 -------
 copula : :class:`~openturns.EmpiricalBernsteinCopula`
-    The estimated copula as an empirical Bernstein copula.
+    The estimated Bernstein interpolant as a :class:`~openturns.EmpiricalBernsteinCopula`.
 
+Notes
+-----
+The estimated Bernstein interpolant based on the empirical copula is really a copula if :math:`m|N`. Otherwise, it is not a copula but
+still a valid core, i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 "
 // ---------------------------------------------------------------------
 
@@ -85,13 +97,14 @@ sample : 2-d sequence of float, of dimension 1
 
 Notes
 -----
-The number of bins is computed by minimizing the asymptotic mean integrated squared error (AMISE), leading to
+The bin number :math:`m` is computed by minimizing the asymptotic mean integrated squared error (AMISE),
+leading to:
 
 .. math::
 
-    m = 1+\left\lfloor n^{\dfrac{2}{4+d}} \right\rfloor
+    m = 1+\left\lfloor \sampleSize^{\frac{2}{4+d}} \right\rfloor
 
-where :math:`\lfloor x \rfloor` is the largest integer less than or equal to :math:`x`, :math:`n` the sample size and :math:`d` the sample dimension.
+where :math:`\lfloor x \rfloor` is the largest integer less than or equal to :math:`x`, :math:`\sampleSize` the sample size and :math:`d` the sample dimension.
 "
 
 // ---------------------------------------------------------------------
@@ -102,17 +115,17 @@ where :math:`\lfloor x \rfloor` is the largest integer less than or equal to :ma
 Parameters
 ----------
 sample : 2-d sequence of float, of dimension 1
-    The sample of size :math:`n` from which the optimal log-likelihood bin number is computed.
-kFraction : int, :math:`0<kFraction<n`
+    The sample of size :math:`\sampleSize` from which the optimal log-likelihood bin number is computed.
+kFraction : int, :math:`0<kFraction<\sampleSize`
     The fraction of the sample used for the validation.
 
 Notes
 -----
-Let :math:`\cE=\left\{\vect{X}_1,\dots,\vect{X}_n\right\}` be the given sample. If :math:`kFraction=1`, the bin number :math:`m` is given by:
+Let :math:`\cE= (\inputReal_1, \dots, \inputReal_\sampleSize)` be the given sample. If :math:`kFraction=1`, the bin number :math:`m` is given by:
 
 .. math::
 
-    m = \argmin_{M\in\{1,\dots,n\}}\dfrac{1}{n}\sum_{\vect{X}_i\in\cE}-\log c^{\cE}_{M}(\vect{X}_i)
+    m = \argmin_{M\in\{1,\dots,\sampleSize\}}\dfrac{1}{\sampleSize}\sum_{\vect{x}_i\in\cE}-\log c^{\cE}_{M}(\vect{x}_i)
 
 where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample :math:`\cE` and the bin number :math:`M`.
 
@@ -120,9 +133,10 @@ If :math:`kFraction>1`, the bin number :math:`m` is given by:
 
 .. math::
 
-    m = \argmin_{M\in\{1,\dots,n\}}\dfrac{1}{kFraction}\sum_{k=0}^{kFraction-1}\dfrac{1}{n}\sum_{\vect{X}_i\in\cE^V_k}-\log c^{\cE^L_k}_{M}(\vect{X}_i)
+    m = \argmin_{M\in\{1,\dots,\sampleSize\}}\dfrac{1}{kFraction}\sum_{k=0}^{kFraction-1}\dfrac{1}{\sampleSize}\sum_{\vect{x}_i\in\cE^V_k}-\log c^{\cE^L_k}_{M}(\vect{x}_i)
 
-where :math:`\cE^V_k=\left\{\vect{X}_i\in\cE\,|\,i\equiv k \mod kFraction\right\}` and :math:`\cE^L_k=\cE \backslash \cE^V_k`
+where :math:`\cE^V_k=\left\{\vect{x}_i\in\cE\,|\,i\equiv k \mod kFraction\right\}`
+and :math:`\cE^L_k=\cE \backslash \cE^V_k`.
 "
 
 // ---------------------------------------------------------------------
@@ -133,7 +147,7 @@ where :math:`\cE^V_k=\left\{\vect{X}_i\in\cE\,|\,i\equiv k \mod kFraction\right\
 Parameters
 ----------
 sample : 2-d sequence of float, of dimension 1
-    The sample of size :math:`n` from which the optimal AMISE bin number is computed.
+    The sample of size :math:`\sampleSize` from which the optimal AMISE bin number is computed.
 f : :class:`~openturns.Function`
     The function defining the Csiszar divergence of interest.
 alpha : float, :math:`\alpha\geq 0`
@@ -141,13 +155,13 @@ alpha : float, :math:`\alpha\geq 0`
 
 Notes
 -----
-Let :math:`\cE=\left\{\vect{X}_1,\dots,\vect{X}_n\right\}` be the given sample. The bin number :math:`m` is given by:
+Let :math:`\cE=(\inputReal_1, \dots, \inputReal_\sampleSize)` be the given sample. The bin number :math:`m` is given by:
 
 .. math::
 
-    m = \argmin_{M\in\{1,\dots,n\}}\left[\hat{D}_f(c^{\cE}_{M})-\dfrac{1}{n}\sum_{\vect{X}_i\in\cE}f\left(\dfrac{1}{c^{\cE}_{M}(\vect{X}_i)}\right)\right]^2-[\rho_S(c^{\cE}_{M})-\rho_S({\cE}_{M})]^2
+    m = \argmin_{M\in\{1,\dots,\sampleSize\}}\left[\hat{D}_f(c^{\cE}_{M})-\dfrac{1}{\sampleSize}\sum_{\vect{x}_i\in\cE}f\left(\dfrac{1}{c^{\cE}_{M}(\vect{x}_i)}\right)\right]^2-[\rho_S(c^{\cE}_{M})-\rho_S({\cE}_{M})]^2
 
-where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample :math:`\cE` and the bin number :math:`M`, :math:`\hat{D}_f(c^{\cE}_{M})=\dfrac{1}{N}\sum_{j=1}^Nf\left(\dfrac{1}{\vect{U}_j}\right)` a Monte Carlo estimate of the Csiszar :math:`f` divergence, :math:`\rho_S(c^{\cE}_{M})` the exact Spearman correlation of the empirical Bernstein copula :math:`c^{\cE}_{M}` and :math:`\rho_S({\cE}_{M})` the empirical Spearman correlation of the sample :math:`{\cE}_{M}`.
+where :math:`c_M^{\cE}` is the density function of the :class:`~openturns.EmpiricalBernsteinCopula` associated to the sample :math:`\cE` and the bin number :math:`M`, :math:`\hat{D}_f(c^{\cE}_{M})=\dfrac{1}{N}\sum_{j=1}^Nf\left(\dfrac{1}{\vect{u}_j}\right)` a Monte Carlo estimate of the Csiszar :math:`f` divergence, :math:`\rho_S(c^{\cE}_{M})` the exact Spearman correlation of the empirical Bernstein copula :math:`c^{\cE}_{M}` and :math:`\rho_S({\cE}_{M})` the empirical Spearman correlation of the sample :math:`{\cE}_{M}`.
 
 The parameter :math:`N` is controlled by the *'BernsteinCopulaFactory-SamplingSize'* key in :class:`~openturns.ResourceMap`.
 "

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -10,8 +10,8 @@ The keys of :class:`~openturns.ResourceMap` related to the class are:
 
 - the keys `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the range of :math:`m`
   in the optimization
-  problems computing the optimal bin number according to a specified criteria,
-- the key `BernsteinCopulaFactory-BinNumberSelection` that defines the  criteria to compute the optimal bin number
+  problems computing the optimal bin number according to a specified criterion,
+- the key `BernsteinCopulaFactory-BinNumberSelection` that defines the  criterion to compute the optimal bin number
   when it is not specified. The possible choices are 'AMISE', 'LogLikelihood', 'PenalizedCsiszarDivergence';
 - the key `BernsteinCopulaFactory-KFraction` that defines the fraction of the sample used for the validation in the
   method :meth:`ComputeLogLikelihoodBinNumber`,

--- a/python/src/BernsteinCopulaFactory_doc.i.in
+++ b/python/src/BernsteinCopulaFactory_doc.i.in
@@ -8,11 +8,11 @@ the copula of a multivariate distribution.
 
 The keys of :class:`~openturns.ResourceMap` related to the class are:
 
-- the key `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the default range of :math:`m` in the optimization
+- the keys `BernsteinCopulaFactory-MinM` and `BernsteinCopulaFactory-MaxM` that define the default range of :math:`m` in the optimization
   problems computing the optimal bin number according to a specified criteria,
 - the key `BernsteinCopulaFactory-BinNumberSelection` that defines the default criteria to compute the optimal bin number when it is not
   specified,
-- the key `BernsteinCopulaFactory-KFraction` that specifies the fraction of the sample used for the validation in the
+- the key `BernsteinCopulaFactory-KFraction` that defines the fraction of the sample used for the validation in the
   method :meth:`ComputeLogLikelihoodBinNumber`,
 - the key `BernsteinCopulaFactory-SamplingSize`  that defines the :math:`N` parameter used in the
   method :meth:`ComputePenalizedCsiszarDivergenceBinNumber`.
@@ -83,7 +83,6 @@ removed for the result to be a copula. See :class:`~openturns.EmpiricalBernstein
     buildAsEmpiricalBernsteinCopula(*sample, method, f*)
 
 Parameters
-    The fraction of the sample used for the validation. ComputeLogLikelihoodBinNumber
 ----------
 sample : 2-d sequence of float, of dimension *d*
     The sample of size :math:`\sampleSize>0` from which the copula is estimated.

--- a/python/src/EmpiricalBernsteinCopula_doc.i.in
+++ b/python/src/EmpiricalBernsteinCopula_doc.i.in
@@ -1,32 +1,78 @@
 %feature("docstring") OT::EmpiricalBernsteinCopula
-"EmpiricalBernstein copula.
+"Bernstein interpolant based on the empirical copula.
 
 Parameters
 ----------
 sample : :class:`~openturns.Sample`
-    The sample of size :math:`N>0` and dimension :math:`d` from which the empirical copula sample is extracted.
+    A sample of size :math:`\sampleSize>0` and dimension :math:`d`.
     
     Default value is [[0.0], [0.0]].
-binNumber : int, :math:`0<binNumber\leq N`
-    The number of cells into which each dimension of the unit cube :math:`[0, 1]^d` is divided to cluster the empirical copula sample.
+m : int, :math:`0 < m \leq \sampleSize`
+    The number of sub-intervals in which all the edges of the unit cube
+    :math:`[0, 1]^d` are regularly partitioned.
     
     Default value is 1.
-isCopulaSample : bool
-    Flag to tell if the given sample is already an empirical copula sample.
+isRankSample : bool
+    Flag to tell if the given sample is already a normalized rank sample.
     
     Default value is False.
 
 Notes
 -----
-The empirical Bernstein copula is a copula based on the Bernstein approximation built upon a clustering of the empirical copula. It is defined by:
+Let :math:`(\inputReal_1, \dots, \inputReal_\sampleSize)` a sample. Let :math:`m` be the bin number.
+
+Case 1: :math:`isRankSample == False`.
+
+In that case, if :math:`m|\sampleSize` is not verified, then a part of the sample is
+removed in order to get a new size :math:`\tilde{\sampleSize}` such that :math:`m|\tilde{\sampleSize}`. At most, :math:`m-1` points are removed from the initial sample. This condition guarantees that the Bernstein interpolant based on the empirical copula is really a copula.
+
+We still denote by  :math:`\sampleSize` the size of the sample used to create the Bernstein interpolant based on the empirical copula.
+
+Let :math:`(\vect{v}_1, \dots, \vect{v}_\sampleSize)` be the associated normalized rank sample defined  by:
 
 .. math::
 
-    C(\vect{u}) = \dfrac{1}{N}\sum_{i=1}^N\prod_{j=1}^d I_{r_j^i,s_j^i}(u_j)
+     \vect{v}_i = \dfrac{1}{\sampleSize} rank(\inputReal_i)
 
-for :math:`\vect{u}\in[0,1]^d`, where :math:`r_j^i=\lceil binNumber U_j^i \rceil`, :math:`binNumber - r_j^i + 1`, :math:`(\vect{U}_i)_{i=1,\dots,N}` is the empirical copula sample associated to *sample* and :math:`I_{a,b}(x)` is the value of the regularized incomplete beta function of parameters :math:`a` and :math:`b` at :math:`x`, see :meth:`~openturns.SpecFunc.RegularizedIncompleteBeta`.
+for all :math:`1 \leq i \leq \sampleSize` where the rank of a vector is the vector of the rank of the components.
 
-This construction leads to an actual copula if and only if :math:`N` is a multiple of :math:`binNumber`. If it is not the case, the last points of the sample are dropped in order to fulfill this condition.
+Let :math:`r_i^j` and :math:`s_i^j` defined by:
+
+.. math::
+
+     r_i^j & = \lfloor m v_i^j \rfloor \\
+     s_i^j & = m-r_i^j+1
+
+for all :math:`1 \leq i \leq \sampleSize` and :math:`1 \leq j \leq d` and where :math:`\lfloor x \rfloor` is
+the largest integer less than or equal to :math:`x`.
+
+Let :math:`B(r_i^j , s_i^j, 0, 1)` be a
+:class:`~openturns.Beta` distribution defined on :math:`[0,1]` parametrized by the shape parameters :math:`r_i^j` and
+:math:`s_i^j`. We denote by :math:`F_{B(r_i^j, s_i^j, 0, 1)}` its cumulated distribution function.
+
+Then the Bernstein interpolant based on the empirical copula is defined by:
+
+.. math::
+    :label: defEmpCopBernstein
+
+    C(\vect{u}) = \dfrac{1}{\sampleSize}\sum_{i=1}^\sampleSize\prod_{j=1}^d F_{B(r_i^j, s_i^j, 0, 1)}(u^j)
+
+for :math:`\vect{u}\in[0,1]^d`.
+
+Case 2: :math:`isRankSample == True`.
+
+In that case, the given sample is assumed to be already a normalized rank sample.
+Even if the bin number :math:`m` does not divide :math:`\sampleSize`, the whole sample is used. The
+Bernstein interpolant based on the empirical copula is still defined by :eq:`defEmpCopBernstein` where :math:`r_i^j`
+and :math:`s_i^j` are computed on the initial sample:
+
+.. math::
+
+     r_i^j & = \lfloor m x_i^j \rfloor \\
+     s_i^j & = m-r_i^j+1
+
+If the condition :math:`m|N` is not verified, then :math:`C` is no longer a copula but still a valid core,
+i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 
 See also
 --------
@@ -37,11 +83,11 @@ Examples
 Create a distribution:
 
 >>> import openturns as ot
->>> copula = ot.EmpiricalBernsteinCopula(ot.Normal(2).getSample(10), 2, False)
+>>> empBernsteinCop = ot.EmpiricalBernsteinCopula(ot.Normal(2).getSample(10), 2, False)
 
 Draw a sample:
 
->>> sample = copula.getSample(5)"
+>>> sample = empBernsteinCop.getSample(5)"
 
 // ---------------------------------------------------------------------
 
@@ -51,36 +97,40 @@ Draw a sample:
 Returns
 -------
 sample : :class:`~openturns.Sample`
-    The empirical copula sample of the copula."
+    The empirical copula sample."
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::EmpiricalBernsteinCopula::setCopulaSample
-"Set the sample of the copula.
+"Set the sample.
 
 Parameters
 ----------
 sample : 2-d sequence of float
     The sample from which the empirical copula sample is deduced.
-isEmpiricalCopulaSample : bool
-    Flag telling if the given sample is already an empirical copula sample. The default value is *False*."
+isRankSample : bool
+    Flag telling if the given sample is already a normalized rank sample.
+    
+    Default value is *False*."
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::EmpiricalBernsteinCopula::getBinNumber
-"Get the bin number of the copula.
+"Get the bin number :math:`m`.
 
 Returns
 -------
-binNumber : int
-    The bin number of the copula."
+m : int, :math:`0 < m \leq \sampleSize`
+    The number of sub-intervals in which all the edges of the unit cube
+    :math:`[0, 1]^d` are regularly partitioned."
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::EmpiricalBernsteinCopula::setBinNumber
-"Set the bin number of the copula.
+"Set the bin number :math:`m`.
 
 Parameters
 ----------
-binNumber : int
-    The bin number of the copula. It must be positive and not greater than the copula sample size."
+m : int, :math:`0 < m \leq \sampleSize`
+    The number of sub-intervals in which all the edges of the unit cube
+    :math:`[0, 1]^d` are regularly partitioned."

--- a/python/src/EmpiricalBernsteinCopula_doc.i.in
+++ b/python/src/EmpiricalBernsteinCopula_doc.i.in
@@ -21,7 +21,7 @@ Notes
 -----
 Let :math:`(\inputReal_1, \dots, \inputReal_\sampleSize)` a sample. Let :math:`m` be the bin number.
 Note that when :math:`m=1`, the empirical Bernstein copula is the independent copula. When :math:`m=\sampleSize`, the empirical Bernstein
-copula is also called *the beta copula* (see [segers2016]_).
+copula is also called the *Beta copula* (see [segers2016]_).
 
 **Case 1:** :math:`isRankSample = False`.
 

--- a/python/src/EmpiricalBernsteinCopula_doc.i.in
+++ b/python/src/EmpiricalBernsteinCopula_doc.i.in
@@ -1,5 +1,5 @@
 %feature("docstring") OT::EmpiricalBernsteinCopula
-"Bernstein interpolant based on the empirical copula.
+"Empirical Bernstein copula.
 
 Parameters
 ----------
@@ -21,18 +21,18 @@ Notes
 -----
 Let :math:`(\inputReal_1, \dots, \inputReal_\sampleSize)` a sample. Let :math:`m` be the bin number.
 
-Case 1: :math:`isRankSample == False`.
+Case 1: :math:`isRankSample = False`.
 
 In that case, if :math:`m|\sampleSize` is not verified, then a part of the sample is
-removed in order to get a new size :math:`\tilde{\sampleSize}` such that :math:`m|\tilde{\sampleSize}`. At most, :math:`m-1` points are removed from the initial sample. This condition guarantees that the Bernstein interpolant based on the empirical copula is really a copula.
+removed in order to get a new size :math:`\tilde{\sampleSize}` such that :math:`m|\tilde{\sampleSize}`. At most, :math:`m-1` points are removed from the initial sample. This condition guarantees that the Bernstein interpolant based on the empirical copula is a copula.
 
-We still denote by  :math:`\sampleSize` the size of the sample used to create the Bernstein interpolant based on the empirical copula.
+We still denote by  :math:`\sampleSize` the size of the sample used to create the empirical Bernstein interpolant copula.
 
 Let :math:`(\vect{v}_1, \dots, \vect{v}_\sampleSize)` be the associated normalized rank sample defined  by:
 
 .. math::
 
-     \vect{v}_i = \dfrac{1}{\sampleSize} rank(\inputReal_i)
+     \vect{v}_k = \dfrac{1}{\sampleSize} rank(\inputReal_k)
 
 for all :math:`1 \leq i \leq \sampleSize` where the rank of a vector is the vector of the rank of the components.
 
@@ -50,28 +50,28 @@ Let :math:`B(r_i^j , s_i^j, 0, 1)` be a
 :class:`~openturns.Beta` distribution defined on :math:`[0,1]` parametrized by the shape parameters :math:`r_i^j` and
 :math:`s_i^j`. We denote by :math:`F_{B(r_i^j, s_i^j, 0, 1)}` its cumulated distribution function.
 
-Then the Bernstein interpolant based on the empirical copula is defined by:
+Then the empirical Bernstein copula is defined by:
 
 .. math::
     :label: defEmpCopBernstein
 
-    C(\vect{u}) = \dfrac{1}{\sampleSize}\sum_{i=1}^\sampleSize\prod_{j=1}^d F_{B(r_i^j, s_i^j, 0, 1)}(u^j)
+    C^B_\sampleSize(\vect{u}) = \dfrac{1}{\sampleSize}\sum_{i=1}^\sampleSize\prod_{j=1}^d F_{B(r_i^j, s_i^j, 0, 1)}(u^j)
 
 for :math:`\vect{u}\in[0,1]^d`.
 
-Case 2: :math:`isRankSample == True`.
+Case 2: :math:`isRankSample = True`.
 
 In that case, the given sample is assumed to be already a normalized rank sample.
 Even if the bin number :math:`m` does not divide :math:`\sampleSize`, the whole sample is used. The
-Bernstein interpolant based on the empirical copula is still defined by :eq:`defEmpCopBernstein` where :math:`r_i^j`
-and :math:`s_i^j` are computed on the initial sample:
+empirical Bernstein copula is still defined by :eq:`defEmpCopBernstein` where :math:`r_i^j`
+and :math:`s_i^j` are computed on the initial sample :math:`(\inputReal_1, \dots, \inputReal_\sampleSize)`:
 
 .. math::
 
      r_i^j & = \lfloor m x_i^j \rfloor \\
      s_i^j & = m-r_i^j+1
 
-If the condition :math:`m|N` is not verified, then :math:`C` is no longer a copula but still a valid core,
+If the condition :math:`m|N` is not verified, then :math:`C^B_\sampleSize` is no longer a copula but still a valid core,
 i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
 
 See also

--- a/python/src/EmpiricalBernsteinCopula_doc.i.in
+++ b/python/src/EmpiricalBernsteinCopula_doc.i.in
@@ -7,7 +7,7 @@ sample : :class:`~openturns.Sample`
     A sample of size :math:`\sampleSize>0` and dimension :math:`d`.
     
     Default value is [[0.0], [0.0]].
-m : int, :math:`0 < m \leq \sampleSize`
+m : int, :math:`1 \leq m \leq \sampleSize`
     The number of sub-intervals in which all the edges of the unit cube
     :math:`[0, 1]^d` are regularly partitioned.
     
@@ -20,13 +20,16 @@ isRankSample : bool
 Notes
 -----
 Let :math:`(\inputReal_1, \dots, \inputReal_\sampleSize)` a sample. Let :math:`m` be the bin number.
+Note that when :math:`m=1`, the empirical Bernstein copula is the independent copula. When :math:`m=\sampleSize`, the empirical Bernstein
+copula is also called *the beta copula* (see [segers2016]_).
 
-Case 1: :math:`isRankSample = False`.
+**Case 1:** :math:`isRankSample = False`.
 
-In that case, if :math:`m|\sampleSize` is not verified, then a part of the sample is
-removed in order to get a new size :math:`\tilde{\sampleSize}` such that :math:`m|\tilde{\sampleSize}`. At most, :math:`m-1` points are removed from the initial sample. This condition guarantees that the Bernstein interpolant based on the empirical copula is a copula.
+In that case, if :math:`m` does not divide :math:`\sampleSize`, then a part of the sample is
+removed in order to get a new size :math:`\tilde{\sampleSize}` such that :math:`m` divides :math:`\tilde{\sampleSize}`. At most, :math:`m-1` points are removed from the initial sample. This condition guarantees that the :class:`~openturns.EmpiricalBernsteinCopula`
+built is a copula.
 
-We still denote by  :math:`\sampleSize` the size of the sample used to create the empirical Bernstein interpolant copula.
+We still denote by  :math:`\sampleSize` the size of the sample used to create the empirical Bernstein copula.
 
 Let :math:`(\vect{v}_1, \dots, \vect{v}_\sampleSize)` be the associated normalized rank sample defined  by:
 
@@ -34,7 +37,7 @@ Let :math:`(\vect{v}_1, \dots, \vect{v}_\sampleSize)` be the associated normaliz
 
      \vect{v}_k = \dfrac{1}{\sampleSize} rank(\inputReal_k)
 
-for all :math:`1 \leq i \leq \sampleSize` where the rank of a vector is the vector of the rank of the components.
+for all :math:`1 \leq i \leq \sampleSize` where the rank of a vector is the vector of the component ranks.
 
 Let :math:`r_i^j` and :math:`s_i^j` defined by:
 
@@ -50,7 +53,7 @@ Let :math:`B(r_i^j , s_i^j, 0, 1)` be a
 :class:`~openturns.Beta` distribution defined on :math:`[0,1]` parametrized by the shape parameters :math:`r_i^j` and
 :math:`s_i^j`. We denote by :math:`F_{B(r_i^j, s_i^j, 0, 1)}` its cumulated distribution function.
 
-Then the empirical Bernstein copula is defined by:
+Then the empirical Bernstein copula :math:`C^B_\sampleSize` is defined by:
 
 .. math::
     :label: defEmpCopBernstein
@@ -59,7 +62,7 @@ Then the empirical Bernstein copula is defined by:
 
 for :math:`\vect{u}\in[0,1]^d`.
 
-Case 2: :math:`isRankSample = True`.
+**Case 2:** :math:`isRankSample = True`.
 
 In that case, the given sample is assumed to be already a normalized rank sample.
 Even if the bin number :math:`m` does not divide :math:`\sampleSize`, the whole sample is used. The
@@ -71,8 +74,11 @@ and :math:`s_i^j` are computed on the initial sample :math:`(\inputReal_1, \dots
      r_i^j & = \lfloor m x_i^j \rfloor \\
      s_i^j & = m-r_i^j+1
 
-If the condition :math:`m|N` is not verified, then :math:`C^B_\sampleSize` is no longer a copula but still a valid core,
-i.e a multivariate distribution whose range is included in :math:`[0,1]^d`.
+If :math:`m` does not divide :math:`\sampleSize`, then :math:`C^B_\sampleSize` is no longer a copula but still a valid core,
+i.e a multivariate distribution whose range is included in :math:`[0,1]^d`. As a matter of fact, the marginals are not necessarily
+uniform because some cells may have more points than others.
+
+We still use the term *copula* even if it is not a copula.
 
 See also
 --------
@@ -83,7 +89,9 @@ Examples
 Create a distribution:
 
 >>> import openturns as ot
->>> empBernsteinCop = ot.EmpiricalBernsteinCopula(ot.Normal(2).getSample(10), 2, False)
+>>> sampleNormal = ot.Normal(2).getSample(10)
+>>> m = 2
+>>> empBernsteinCop = ot.EmpiricalBernsteinCopula(sampleNormal, m)
 
 Draw a sample:
 

--- a/python/src/InverseChiSquare_doc.i.in
+++ b/python/src/InverseChiSquare_doc.i.in
@@ -18,7 +18,7 @@ Its probability density function is defined as:
 
 .. math::
 
-    f_X(x) = \dfrac{\exp \left( -\dfrac{1}{2 x}\right)}{\Gamma \left(\dfrac{\nu}{2}\right)\lambda^{\frac{\nu}{2}}x^{\frac{\nu}{2}+1}}, \quad x \in [0; +\infty[
+    f_X(x) = \dfrac{2^{-\nu/2}}{\Gamma \left(\dfrac{\nu}{2}\right)}  x^{-\left(\frac{\nu}{2}+1 \right)} \exp \left( -\dfrac{1}{2 x}\right), \quad x \in [0; +\infty[
 
 with :math:`\nu > 0`.
 

--- a/python/src/KernelMixture_doc.i.in
+++ b/python/src/KernelMixture_doc.i.in
@@ -13,7 +13,7 @@ sample : 2-d sequence of float
 
 Notes
 -----
-A *KernelMixture* is a particular *Mixture*: all the weights are identical and
+A :class:`~openturns.KernelMixture` is a particular :class:`~openturns.Mixture`: all the weights are identical and
 all the kernels of the combination are of the same
 family. The kernels are centered on the sample points. The multivariate kernel
 is a tensorized product of the same univariate kernel.


### PR DESCRIPTION
I modified the doc of the : 

1. EmpiricalBernsteinCopula: I gave the expression of the empirical Bernstein copula  as a Mixture of multivariate beta distributions. I precised that it is not always a copula (it is a copula only if the bin number divides the sample size). I detailed the argument isRankSample.
2. BernsteinCopulaFactory: I improved the doc to explain all the arguments. As it is implemented, it is always produce a copula.
3. I improved the example 'Model a singular multivariate distribution' in order to better explain the use of the EmpiricalBernsteinCopula.
4. I added the reference to the reference paper of Segers on the empirical Bernstein copula.
5. I fixed two typos in the InverseChiSquare and KernelMixture documentations.
