### PR TITLE
Fix the distribution definition in stiffened panel

### DIFF
--- a/python/doc/usecases/use_case_stiffened_panel.rst
+++ b/python/doc/usecases/use_case_stiffened_panel.rst
@@ -35,7 +35,7 @@ This use-case implements a simplified model of buckling for a stiffened panel (s
     **Figure 3.** Parameterization of the stiffened panel.
 
 
-This test case is composed of nine random variables:
+This test case is composed of ten random variables:
 
 - :math:`E\sim\mathcal{TN}(\num{110.0e9}, \num{55.0e9}, \num{99.0e9}, \num{121.0e9})` : Young modulus (:math:`\unit{\Pa}`)
 


### PR DESCRIPTION
This PR offers a minor correction to the stiffened panel usecase.

Model description specifies a dependence between f1 and f2 variables with Spearman coefficient of -0.8.
Added fields are:
  - the correlation matrix of dimension 10;
  - the Normal copula used for the input variables;
  - the input distribution with the dependence;
  - an independent distribution if needed

It also fixes some typos in class documentation.