### PR TITLE
Fix nonlinear leastsquares and Gaussian calibration

### DIFF
--- a/lib/src/Uncertainty/Bayesian/openturns/LinearLeastSquaresCalibration.hxx
+++ b/lib/src/Uncertainty/Bayesian/openturns/LinearLeastSquaresCalibration.hxx
@@ -40,6 +40,10 @@ class OT_API LinearLeastSquaresCalibration
   : public CalibrationAlgorithmImplementation
 {
   CLASSNAME
+
+    /** The NonLinearLeastSquaresCalibration class is closely related with the LinearLeastSquaresCalibration class */
+    friend class NonLinearLeastSquaresCalibration;
+
 public:
 
   /** Default constructor */
@@ -89,6 +93,13 @@ public:
   void load(Advocate & adv) override;
 
 private:
+  /* Compute the posterior and error distributions */
+  static Distribution ComputePosteriorAndErrorDistribution(const Point & thetaStar,
+							   const Point & r,
+							   const SquareMatrix & gramInverse,
+							   const UnsignedInteger outputDimension,
+							   Distribution & error);
+
   /* The model observations */
   Sample modelObservations_;
 


### PR DESCRIPTION
The posterior distribution was not centered at the MAP when using the Laplace approximation. It was due to the fact that a new linear least squares or linear Gaussian calibration was triggered and the posterior distribution was built using this new MAP.

See #2890 for the details.