### PR TITLE
Fix extrapolation of PieceWise Hermite and Linear Evaluation

### DIFF
--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -72,7 +72,7 @@
   
   <!-- OT::PiecewiseHermiteEvaluation parameters -->
   <PiecewiseLinearEvaluation-EpsilonRegular value_float="1.0e-12" />
-   <PiecewiseLinearEvaluation-DefaultEnableExtrapolation value_bool="true"/>
+  <PiecewiseLinearEvaluation-DefaultEnableExtrapolation value_bool="true"/>
     
   <!-- OT::UniVariatePolynomialImplementation parameters -->
   <UniVariatePolynomial-SmallDegree value_int="400" />

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -72,7 +72,8 @@
   
   <!-- OT::PiecewiseHermiteEvaluation parameters -->
   <PiecewiseLinearEvaluation-EpsilonRegular value_float="1.0e-12" />
-  
+   <PiecewiseLinearEvaluation-DefaultEnableExtrapolation value_bool="true"/>
+    
   <!-- OT::UniVariatePolynomialImplementation parameters -->
   <UniVariatePolynomial-SmallDegree value_int="400" />
 

--- a/lib/etc/openturns.conf.in
+++ b/lib/etc/openturns.conf.in
@@ -69,7 +69,8 @@
 
   <!-- OT::PiecewiseHermiteEvaluation parameters -->
   <PiecewiseHermiteEvaluation-EpsilonRegular value_float="1.0e-12" />
-  
+  <PiecewiseHermiteEvaluation-DefaultEnableExtrapolation value_bool="true"/>
+   
   <!-- OT::PiecewiseHermiteEvaluation parameters -->
   <PiecewiseLinearEvaluation-EpsilonRegular value_float="1.0e-12" />
   <PiecewiseLinearEvaluation-DefaultEnableExtrapolation value_bool="true"/>

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -723,7 +723,8 @@ void ResourceMap::loadDefaultConfiguration()
 
   // PiecewiseLinearEvaluation parameters //
   addAsScalar("PiecewiseLinearEvaluation-EpsilonRegular", 1.0e-12);
-
+  addAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation", true);
+  
   // UniVariatePolynomialImplementation parameters //
   addAsUnsignedInteger("UniVariatePolynomial-SmallDegree", 400);
 

--- a/lib/src/Base/Common/ResourceMap.cxx
+++ b/lib/src/Base/Common/ResourceMap.cxx
@@ -719,6 +719,7 @@ void ResourceMap::loadDefaultConfiguration()
 
   // PiecewiseHermiteEvaluation parameters //
   addAsScalar("PiecewiseHermiteEvaluation-EpsilonRegular", 1.0e-12);
+  addAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation", true);
 
   // PiecewiseLinearEvaluation parameters //
   addAsScalar("PiecewiseLinearEvaluation-EpsilonRegular", 1.0e-12);

--- a/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
@@ -364,8 +364,7 @@ void PiecewiseHermiteEvaluation::save(Advocate & adv) const
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
   adv.saveAttribute( "derivatives_", derivatives_ );
-  if (adv.hasAttribute("enableExtrapolation_"))
-    adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 
@@ -376,7 +375,9 @@ void PiecewiseHermiteEvaluation::load(Advocate & adv)
   adv.loadAttribute( "locations_", locations_ );
   adv.loadAttribute( "values_", values_ );
   adv.loadAttribute( "derivatives_", derivatives_ );
-  adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  if (adv.hasAttribute("enableExtrapolation_"))
+    adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
+
   isRegular_ = PiecewiseLinearEvaluation::IsRegular(locations_, ResourceMap::GetAsScalar("PiecewiseHermiteEvaluation-EpsilonRegular"));
 }
 

--- a/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
@@ -43,10 +43,9 @@ PiecewiseHermiteEvaluation::PiecewiseHermiteEvaluation()
 /* Parameters constructor */
 PiecewiseHermiteEvaluation::PiecewiseHermiteEvaluation(const Point & locations,
     const Point & values,
-    const Point & derivatives,
-    const Bool enableExtrapolation)
+    const Point & derivatives)
   : EvaluationImplementation(),
-    enableExtrapolation_(enableExtrapolation)
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
 {
   const UnsignedInteger sizeValues = values.getSize();
   SampleImplementation sampleValues(sizeValues, 1);
@@ -63,10 +62,9 @@ PiecewiseHermiteEvaluation::PiecewiseHermiteEvaluation(const Point & locations,
 /* Parameters constructor */
 PiecewiseHermiteEvaluation::PiecewiseHermiteEvaluation(const Point & locations,
     const Sample & values,
-    const Sample & derivatives,
-    const Bool enableExtrapolation)
+    const Sample & derivatives)
   : EvaluationImplementation(),
-    enableExtrapolation_(enableExtrapolation)
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
 {
   // Check the input
   setLocationsValuesAndDerivatives(locations, values, derivatives);
@@ -112,7 +110,7 @@ Point PiecewiseHermiteEvaluation::operator () (const Point & inP) const
     }
     else
     {
-       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the design of experiments=" << locations_[iLeft];
+       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the locations=" << locations_[iLeft];
     }
   }
 
@@ -125,7 +123,7 @@ Point PiecewiseHermiteEvaluation::operator () (const Point & inP) const
     }
     else
     {
-       throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the design of experiments=" << values_[iRight];
+       throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the locations=" << values_[iRight];
     }
   }
 
@@ -163,7 +161,7 @@ Sample PiecewiseHermiteEvaluation::operator () (const Sample & inSample) const
       }
       else
       {
-        throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the design of experiments=" << locations_[0];
+        throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the locations=" << locations_[0];
       }
     }
     
@@ -176,7 +174,7 @@ Sample PiecewiseHermiteEvaluation::operator () (const Sample & inSample) const
       }
       else
       {
-        throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the design of experiments=" << locations_[iRight];
+        throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the locations=" << locations_[iRight];
       }
     }
     
@@ -208,7 +206,7 @@ Point PiecewiseHermiteEvaluation::derivate(const Point & inP) const
     }
     else
     {
-       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the design of experiments=" << locations_[iLeft];
+       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the locations=" << locations_[iLeft];
     }
   }
   
@@ -222,7 +220,7 @@ Point PiecewiseHermiteEvaluation::derivate(const Point & inP) const
     }
     else
     {
-      throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the design of experiments=" << locations_[iRight];
+      throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the locations=" << locations_[iRight];
     }
   }
   iLeft = PiecewiseLinearEvaluation::FindSegmentIndex(locations_, x, 0, isRegular_);
@@ -289,6 +287,18 @@ void PiecewiseHermiteEvaluation::setValues(const Sample & values)
   values_ = values;
 }
 
+/* enableExtrapolation accessor */
+Bool PiecewiseHermiteEvaluation::getEnableExtrapolation() const
+{
+  return enableExtrapolation_;
+}
+
+void PiecewiseHermiteEvaluation::setEnableExtrapolation(const Bool & enableExtrapolation)
+{
+  enableExtrapolation_ = enableExtrapolation;
+}
+ 
+
 /* Derivatives accessor */
 Sample PiecewiseHermiteEvaluation::getDerivatives() const
 {
@@ -354,6 +364,7 @@ void PiecewiseHermiteEvaluation::save(Advocate & adv) const
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
   adv.saveAttribute( "derivatives_", derivatives_ );
+  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 
@@ -364,6 +375,7 @@ void PiecewiseHermiteEvaluation::load(Advocate & adv)
   adv.loadAttribute( "locations_", locations_ );
   adv.loadAttribute( "values_", values_ );
   adv.loadAttribute( "derivatives_", derivatives_ );
+  adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
   isRegular_ = PiecewiseLinearEvaluation::IsRegular(locations_, ResourceMap::GetAsScalar("PiecewiseHermiteEvaluation-EpsilonRegular"));
 }
 

--- a/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseHermiteEvaluation.cxx
@@ -364,7 +364,8 @@ void PiecewiseHermiteEvaluation::save(Advocate & adv) const
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
   adv.saveAttribute( "derivatives_", derivatives_ );
-  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  if (adv.hasAttribute("enableExtrapolation_"))
+    adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -41,10 +41,9 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation()
 
 /* Parameters constructor */
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
-    const Point & values,
-    const Bool enableExtrapolation)
+    const Point & values)
   : EvaluationImplementation(),
-    enableExtrapolation_(enableExtrapolation)
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
 {
   // Convert the values into a sample
   const UnsignedInteger size = values.getSize();
@@ -56,10 +55,9 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
 
 /* Parameters constructor */
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
-    const Sample & values,
-    const Bool enableExtrapolation)
+    const Sample & values)
   : EvaluationImplementation(),
-    enableExtrapolation_(enableExtrapolation)
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
 {
   setLocationsAndValues(locations, values);
 }
@@ -149,7 +147,7 @@ Point PiecewiseLinearEvaluation::operator () (const Point & inP) const
     }
     else
     {
-       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the design of experiments=" << locations_[iLeft];
+       throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the locations=" << locations_[iLeft];
     }
   }
   
@@ -162,7 +160,7 @@ Point PiecewiseLinearEvaluation::operator () (const Point & inP) const
     }
     else
     {
-       throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the design of experiments=" << values_[iRight];
+       throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the locations=" << values_[iRight];
     }
   }
   iLeft = FindSegmentIndex(locations_, x, 0, isRegular_);
@@ -200,7 +198,7 @@ Sample PiecewiseLinearEvaluation::operator () (const Sample & inSample) const
       }
       else
       {
-        throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the design of experiments=" << locations_[0];
+        throw InvalidArgumentException(HERE) << "Error : input point is less than the lower bound of the locations=" << locations_[0];
       }
     }
     
@@ -214,7 +212,7 @@ Sample PiecewiseLinearEvaluation::operator () (const Sample & inSample) const
       }
       else
       {
-        throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the design of experiments=" << locations_[iRight];
+        throw InvalidArgumentException(HERE) << "Error : input point is greater than the upper bound of the locations=" << locations_[iRight];
       }
     }
     iLeft = FindSegmentIndex(locations_, x, iLeft, isRegular_);
@@ -321,6 +319,16 @@ UnsignedInteger PiecewiseLinearEvaluation::getOutputDimension() const
   return values_.getDimension();
 }
 
+/* enableExtrapolation accessor */
+Bool PiecewiseHermiteEvaluation::getEnableExtrapolation() const
+{
+  return enableExtrapolation_;
+}
+
+void PiecewiseHermiteEvaluation::setEnableExtrapolation(const Bool & enableExtrapolation)
+{
+  enableExtrapolation_ = enableApproximation;
+}
 
 /* Method save() stores the object through the StorageManager */
 void PiecewiseLinearEvaluation::save(Advocate & adv) const
@@ -328,6 +336,7 @@ void PiecewiseLinearEvaluation::save(Advocate & adv) const
   EvaluationImplementation::save(adv);
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
+  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 
@@ -337,6 +346,7 @@ void PiecewiseLinearEvaluation::load(Advocate & adv)
   EvaluationImplementation::load(adv);
   adv.loadAttribute( "locations_", locations_ );
   adv.loadAttribute( "values_", values_ );
+  adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
   isRegular_ = IsRegular(locations_, ResourceMap::GetAsScalar("PiecewiseLinearEvaluation-EpsilonRegular"));
 }
 

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -41,7 +41,8 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation()
 
 /* Parameters constructor */
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
-    const Point & values)
+    const Point & values,
+    const Bool enableExtrapolation)
   : EvaluationImplementation(),
     enableExtrapolation_(enableExtrapolation)
 {
@@ -55,7 +56,8 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
 
 /* Parameters constructor */
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
-    const Sample & values)
+    const Sample & values,
+    const Bool enableExtrapolation)
   : EvaluationImplementation(),
     enableExtrapolation_(enableExtrapolation)
 {

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -336,7 +336,8 @@ void PiecewiseLinearEvaluation::save(Advocate & adv) const
   EvaluationImplementation::save(adv);
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
-  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  if (adv.hasAttribute("enableExtrapolation_"))
+    adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -43,7 +43,7 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation()
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
     const Point & values)
   : EvaluationImplementation(),
-    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"))
 {
   // Convert the values into a sample
   const UnsignedInteger size = values.getSize();
@@ -57,7 +57,7 @@ PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
 PiecewiseLinearEvaluation::PiecewiseLinearEvaluation(const Point & locations,
     const Sample & values)
   : EvaluationImplementation(),
-    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"))
+    enableExtrapolation_(ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"))
 {
   setLocationsAndValues(locations, values);
 }
@@ -320,14 +320,14 @@ UnsignedInteger PiecewiseLinearEvaluation::getOutputDimension() const
 }
 
 /* enableExtrapolation accessor */
-Bool PiecewiseHermiteEvaluation::getEnableExtrapolation() const
+Bool PiecewiseLinearEvaluation::getEnableExtrapolation() const
 {
   return enableExtrapolation_;
 }
 
-void PiecewiseHermiteEvaluation::setEnableExtrapolation(const Bool & enableExtrapolation)
+void PiecewiseLinearEvaluation::setEnableExtrapolation(const Bool & enableExtrapolation)
 {
-  enableExtrapolation_ = enableApproximation;
+  enableExtrapolation_ = enableExtrapolation;
 }
 
 /* Method save() stores the object through the StorageManager */

--- a/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
+++ b/lib/src/Base/Func/PiecewiseLinearEvaluation.cxx
@@ -336,8 +336,7 @@ void PiecewiseLinearEvaluation::save(Advocate & adv) const
   EvaluationImplementation::save(adv);
   adv.saveAttribute( "locations_", locations_ );
   adv.saveAttribute( "values_", values_ );
-  if (adv.hasAttribute("enableExtrapolation_"))
-    adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  adv.saveAttribute( "enableExtrapolation_", enableExtrapolation_ );
 }
 
 
@@ -348,6 +347,8 @@ void PiecewiseLinearEvaluation::load(Advocate & adv)
   adv.loadAttribute( "locations_", locations_ );
   adv.loadAttribute( "values_", values_ );
   adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
+  if (adv.hasAttribute("enableExtrapolation_"))
+    adv.loadAttribute( "enableExtrapolation_", enableExtrapolation_ );
   isRegular_ = IsRegular(locations_, ResourceMap::GetAsScalar("PiecewiseLinearEvaluation-EpsilonRegular"));
 }
 

--- a/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
@@ -43,14 +43,12 @@ public:
   /** Parameter constructor */
   PiecewiseHermiteEvaluation(const Point & locations,
                              const Point & values,
-                             const Point & derivatives,
-                             const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"));
+                             const Point & derivatives);
 
   /** Parameter constructor */
   PiecewiseHermiteEvaluation(const Point & locations,
                              const Sample & values,
-                             const Sample & derivatives,
-                             const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"));
+                             const Sample & derivatives);
   
   /** Virtual constructor */
   PiecewiseHermiteEvaluation * clone() const override;
@@ -70,7 +68,11 @@ public:
   /** Locations accessor */
   Point getLocations() const;
   void setLocations(const Point & locations);
-
+  
+  /** enableExtrapolation accessor */
+  Bool getEnableExtrapolation() const;
+  void setEnableExtrapolation(const Bool & enableExtrapolation);
+  
   /** Values accessor */
   Sample getValues() const;
   void setValues(const Sample & values);

--- a/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseHermiteEvaluation.hxx
@@ -43,13 +43,15 @@ public:
   /** Parameter constructor */
   PiecewiseHermiteEvaluation(const Point & locations,
                              const Point & values,
-                             const Point & derivatives);
+                             const Point & derivatives,
+                             const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"));
 
   /** Parameter constructor */
   PiecewiseHermiteEvaluation(const Point & locations,
                              const Sample & values,
-                             const Sample & derivatives);
-
+                             const Sample & derivatives,
+                             const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseHermiteEvaluation-DefaultEnableExtrapolation"));
+  
   /** Virtual constructor */
   PiecewiseHermiteEvaluation * clone() const override;
 
@@ -94,10 +96,14 @@ public:
   /** Method load() reloads the object from the StorageManager */
   void load(Advocate & adv) override;
 
-
+    
 protected:
 
 private:
+
+  /** Enable extrapolation */
+  Bool enableExtrapolation_;
+  
   // The locations
   Point locations_;
 

--- a/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
@@ -45,13 +45,11 @@ public:
 
   /** Parameter constructor */
   PiecewiseLinearEvaluation(const Point & locations,
-                            const Point & values,
-                            const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"));
+                            const Point & values);
 
   /** Parameter constructor */
   PiecewiseLinearEvaluation(const Point & locations,
-                            const Sample & values,
-                            const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"));
+                            const Sample & values);
 
   /** Virtual constructor */
   PiecewiseLinearEvaluation * clone() const override;
@@ -69,6 +67,10 @@ public:
   Point getLocations() const;
   void setLocations(const Point & locations);
 
+  /** enableExtrapolation accessor */
+  Bool getEnableExtrapolation() const;
+  void setEnableExtrapolation(const Bool & enableExtrapolation);
+  
   /** Values accessor */
   Sample getValues() const;
   void setValues(const Point & values);

--- a/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
+++ b/lib/src/Base/Func/openturns/PiecewiseLinearEvaluation.hxx
@@ -45,11 +45,13 @@ public:
 
   /** Parameter constructor */
   PiecewiseLinearEvaluation(const Point & locations,
-                            const Point & values);
+                            const Point & values,
+                            const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"));
 
   /** Parameter constructor */
   PiecewiseLinearEvaluation(const Point & locations,
-                            const Sample & values);
+                            const Sample & values,
+                            const Bool enableExtrapolation = ResourceMap::GetAsBool("PiecewiseLinearEvaluation-DefaultEnableExtrapolation"));
 
   /** Virtual constructor */
   PiecewiseLinearEvaluation * clone() const override;
@@ -100,6 +102,9 @@ protected:
                                           const Bool isRegular);
 
 private:
+  /** Enable extrapolation */
+  Bool enableExtrapolation_;
+  
   // The locations
   Point locations_;
 

--- a/python/src/PiecewiseHermiteEvaluation_doc.i.in
+++ b/python/src/PiecewiseHermiteEvaluation_doc.i.in
@@ -18,8 +18,8 @@ Notes
 -----
 The evaluation returns constant values for data outside the bounds of the design of experiments.
 Thus, the approximation should not be used outside the range of the design of experiments.
-The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is `True`, see :class:`~openturns.ResourceMap`). 
-If this parameter is set to `False`, an error message is retrieved for evaluations outside the design of experiments.
+The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is *True*, see :class:`~openturns.ResourceMap`). 
+If this parameter is set to *False*, an error message is retrieved for evaluations outside the design of experiments.
 
 Examples
 --------
@@ -128,7 +128,7 @@ derivative : :class:`~openturns.Point`
 
 Parameters
 ----------
-boolean : :class:`~openturns.Bool`
+enableExtrapolation : bool
     Parameter for extrapolation."
     
 // ---------------------------------------------------------------------
@@ -138,5 +138,5 @@ boolean : :class:`~openturns.Bool`
 
 Returns
 -------
-boolean : :class:`~openturns.Bool`
+enableExtrapolation : bool
     Parameter for extrapolation."

--- a/python/src/PiecewiseHermiteEvaluation_doc.i.in
+++ b/python/src/PiecewiseHermiteEvaluation_doc.i.in
@@ -9,8 +9,6 @@ values : 1-d or 2-d sequence of float
     Values at each location
 derivatives : 1-d or 2-d sequence of float
     Derivatives at each location
-enableExtrapolation : boolean, optional
-    Boolean that enables extrapolation of the model outside the design of experiments, default value is True.
 
 See also
 --------
@@ -20,6 +18,8 @@ Notes
 -----
 The evaluation returns constant values for data outside the bounds of the design of experiments.
 Thus, the approximation should not be used outside the range of the design of experiments.
+The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is `True`, see :class:`~openturns.ResourceMap`). 
+If this parameter is set to `False`, an error message is retrieved for evaluations outside the design of experiments.
 
 Examples
 --------
@@ -91,7 +91,7 @@ Parameters
 ----------
 derivatives : :class:`~openturns.Sample`
     Derivatives of the function at the locations."
-
+        
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::PiecewiseHermiteEvaluation::setLocationsValuesAndDerivatives
@@ -120,3 +120,23 @@ Returns
 -------
 derivative : :class:`~openturns.Point`
     The derivative of the function at the given point."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::PiecewiseHermiteEvaluation::setEnableExtrapolation
+"Accessor to the parameters allowing extrapolation outside the design of experiments.
+
+Parameters
+----------
+boolean : :class:`~openturns.Bool`
+    Parameter for extrapolation."
+    
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::PiecewiseHermiteEvaluation::getEnableExtrapolation
+"Accessor to the parameters allowing extrapolation outside the design of experiments.
+
+Returns
+-------
+boolean : :class:`~openturns.Bool`
+    Parameter for extrapolation."

--- a/python/src/PiecewiseHermiteEvaluation_doc.i.in
+++ b/python/src/PiecewiseHermiteEvaluation_doc.i.in
@@ -9,7 +9,7 @@ values : 1-d or 2-d sequence of float
     Values at each location
 derivatives : 1-d or 2-d sequence of float
     Derivatives at each location
-enableExtrapolation : Bool, optional
+enableExtrapolation : boolean, optional
     Boolean that enables extrapolation of the model outside the design of experiments, default value is True.
 
 See also

--- a/python/src/PiecewiseHermiteEvaluation_doc.i.in
+++ b/python/src/PiecewiseHermiteEvaluation_doc.i.in
@@ -9,6 +9,8 @@ values : 1-d or 2-d sequence of float
     Values at each location
 derivatives : 1-d or 2-d sequence of float
     Derivatives at each location
+enableExtrapolation : Bool, optional
+    Boolean that enables extrapolation of the model outside the design of experiments, default value is True.
 
 See also
 --------

--- a/python/src/PiecewiseLinearEvaluation_doc.i.in
+++ b/python/src/PiecewiseLinearEvaluation_doc.i.in
@@ -7,8 +7,6 @@ locations : sequence of float
     Locations
 values : 1-d or 2-d sequence of float
     Values at each location
-enableExtrapolation : boolean, optional
-    Boolean that enables extrapolation of the model outside the design of experiments, default value is True.
 
 See also
 --------
@@ -18,6 +16,8 @@ Notes
 -----
 The evaluation returns constant values for data outside the bounds of the design of experiments.
 Thus, the approximation should not be used outside the range of the design of experiments.
+The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is `True`, see :class:`~openturns.ResourceMap`). 
+If this parameter is set to `False`, an error message is retrieved for evaluations outside the design of experiments.
 
 Examples
 --------
@@ -80,3 +80,23 @@ locations : :class:`~openturns.Point`
     Locations.
 values : :class:`~openturns.Sample`
     Values of the function at the locations."
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::PiecewiseHermiteEvaluation::setEnableExtrapolation
+"Accessor to the parameters allowing extrapolation outside the design of experiments.
+
+Parameters
+----------
+boolean : :class:`~openturns.Bool`
+    Parameter for extrapolation."
+    
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::PiecewiseHermiteEvaluation::getEnableExtrapolation
+"Accessor to the parameters allowing extrapolation outside the design of experiments.
+
+Returns
+-------
+boolean : :class:`~openturns.Bool`
+    Parameter for extrapolation."

--- a/python/src/PiecewiseLinearEvaluation_doc.i.in
+++ b/python/src/PiecewiseLinearEvaluation_doc.i.in
@@ -7,6 +7,8 @@ locations : sequence of float
     Locations
 values : 1-d or 2-d sequence of float
     Values at each location
+enableExtrapolation : boolean, optional
+    Boolean that enables extrapolation of the model outside the design of experiments, default value is True.
 
 See also
 --------

--- a/python/src/PiecewiseLinearEvaluation_doc.i.in
+++ b/python/src/PiecewiseLinearEvaluation_doc.i.in
@@ -16,8 +16,8 @@ Notes
 -----
 The evaluation returns constant values for data outside the bounds of the design of experiments.
 Thus, the approximation should not be used outside the range of the design of experiments.
-The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is `True`, see :class:`~openturns.ResourceMap`). 
-If this parameter is set to `False`, an error message is retrieved for evaluations outside the design of experiments.
+The possibility of extrapolation can be changed using :meth:`setEnableExtrapolation` (default value is *True*, see :class:`~openturns.ResourceMap`). 
+If this parameter is set to *False*, an error message is retrieved for evaluations outside the design of experiments.
 
 Examples
 --------
@@ -88,7 +88,7 @@ values : :class:`~openturns.Sample`
 
 Parameters
 ----------
-boolean : :class:`~openturns.Bool`
+enableExtrapolation : bool
     Parameter for extrapolation."
     
 // ---------------------------------------------------------------------
@@ -98,5 +98,5 @@ boolean : :class:`~openturns.Bool`
 
 Returns
 -------
-boolean : :class:`~openturns.Bool`
+enableExtrapolation : bool
     Parameter for extrapolation."

--- a/python/src/PiecewiseLinearEvaluation_doc.i.in
+++ b/python/src/PiecewiseLinearEvaluation_doc.i.in
@@ -83,7 +83,7 @@ values : :class:`~openturns.Sample`
 
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::PiecewiseHermiteEvaluation::setEnableExtrapolation
+%feature("docstring") OT::PiecewiseLinearEvaluation::setEnableExtrapolation
 "Accessor to the parameters allowing extrapolation outside the design of experiments.
 
 Parameters
@@ -93,7 +93,7 @@ enableExtrapolation : bool
     
 // ---------------------------------------------------------------------
 
-%feature("docstring") OT::PiecewiseHermiteEvaluation::getEnableExtrapolation
+%feature("docstring") OT::PiecewiseLinearEvaluation::getEnableExtrapolation
 "Accessor to the parameters allowing extrapolation outside the design of experiments.
 
 Returns

--- a/python/test/t_PiecewiseHermiteEvaluation_std.py
+++ b/python/test/t_PiecewiseHermiteEvaluation_std.py
@@ -21,3 +21,17 @@ for x in X:
     print("f( %.12g )=" % x[0], evaluation(x), ", ref=", ref(x))
 Y = evaluation(X)
 print(Y)
+
+# Test exception enableExtrapolation
+locations = [1.0, 2.0, 3.0, 4.0, 5.0]
+values = [-2.0, 2.0, 1.0, 3.0, 5.0]
+derivatives = [0.0]*5
+evaluation = ot.PiecewiseHermiteEvaluation(locations, values, derivatives)
+evaluation.setEnableExtrapolation(False)
+f = ot.Function(evaluation)
+try:
+    f([-12.5])
+except Exception:
+    pass
+else:
+    raise ValueError("test fails because no exception was raised")

--- a/python/test/t_PiecewiseHermiteEvaluation_std.py
+++ b/python/test/t_PiecewiseHermiteEvaluation_std.py
@@ -25,7 +25,7 @@ print(Y)
 # Test exception enableExtrapolation
 locations = [1.0, 2.0, 3.0, 4.0, 5.0]
 values = [-2.0, 2.0, 1.0, 3.0, 5.0]
-derivatives = [0.0]*5
+derivatives = [0.0] * 5
 evaluation = ot.PiecewiseHermiteEvaluation(locations, values, derivatives)
 evaluation.setEnableExtrapolation(False)
 f = ot.Function(evaluation)

--- a/python/test/t_PiecewiseLinearEvaluation_std.py
+++ b/python/test/t_PiecewiseLinearEvaluation_std.py
@@ -17,3 +17,16 @@ print("evaluation=", evaluation)
 for i in range(2 * size):
     x = [-1.0 + 12.0 * i / (2.0 * size - 1.0)]
     print("f( %.12g )=" % x[0], evaluation(x), ", ref=", ref(x))
+    
+# Test exception enableExtrapolation
+locations = [1.0, 2.0, 3.0, 4.0, 5.0]
+values = [-2.0, 2.0, 1.0, 3.0, 5.0]
+evaluation = ot.PiecewiseLinearEvaluation(locations, values)
+evaluation.setEnableExtrapolation(False)
+f = ot.Function(evaluation)
+try:
+    f([-12.5])
+except Exception:
+    pass
+else:
+    raise ValueError("test fails because no exception was raised")

--- a/python/test/t_PiecewiseLinearEvaluation_std.py
+++ b/python/test/t_PiecewiseLinearEvaluation_std.py
@@ -17,7 +17,7 @@ print("evaluation=", evaluation)
 for i in range(2 * size):
     x = [-1.0 + 12.0 * i / (2.0 * size - 1.0)]
     print("f( %.12g )=" % x[0], evaluation(x), ", ref=", ref(x))
-    
+
 # Test exception enableExtrapolation
 locations = [1.0, 2.0, 3.0, 4.0, 5.0]
 values = [-2.0, 2.0, 1.0, 3.0, 5.0]


### PR DESCRIPTION
This PR closes #2856 

A boolean has been added to enable (or not) the extrapolation of PieceWiseEvaluation algorithms. If this boolean is set to False, a documented error is retrieved.
