### PR TITLE
modification of kriging example to use GPR

### DIFF
--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_branin_function.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_branin_function.py
@@ -1,6 +1,6 @@
 """
-Kriging: metamodel of the Branin-Hoo function
-==============================================
+Gaussian Process fitter : metamodel of the Branin-Hoo function
+==============================================================
 """
 
 # %%
@@ -14,6 +14,7 @@ import openturns as ot
 import openturns.viewer as otv
 from openturns.usecases import branin_function
 from matplotlib import pylab as plt
+import openturns.experimental as otexp
 
 
 # %%
@@ -62,10 +63,10 @@ print(bm.objectiveFunction(sample1))
 
 
 # %%
-# Definition of the Kriging metamodel
-# -----------------------------------
+# Definition of the Gaussian Process fitter (GP) metamodel
+# --------------------------------------------------------
 #
-# We use the :class:`~openturns.KrigingAlgorithm` class to perform the Kriging analysis.
+# We use the :class:`~openturns.experimental.GaussianProcessFitter` class to perform the GP fitter analysis.
 # We first generate a design of experiments with LHS and store the input training points in `xdata`
 experiment = ot.LHSExperiment(
     ot.JointDistribution([ot.Uniform(0.0, 1.0), ot.Uniform(0.0, 1.0)]),
@@ -90,23 +91,27 @@ basis = ot.ConstantBasisFactory(dimension).build()
 covarianceModel = ot.SquaredExponential([0.1] * dimension, [1.0])
 
 # %%
-# We have all the components to build a Kriging algorithm and run it :
-algo = ot.KrigingAlgorithm(xdata, ydata, covarianceModel, basis)
-algo.run()
-
-# %%
-# We get the result of the Kriging analysis with :
-result = algo.getResult()
+# We have all the components to build a GP fitter  algorithm and run it :
+fitter_algo = otexp.GaussianProcessFitter(xdata, ydata, covarianceModel, basis)
+fitter_algo.setOptimizeParameters(True)
+fitter_algo.run()
+fitter_result = fitter_algo.getResult()
+gpr_algo = otexp.GaussianProcessRegression(fitter_result)
+gpr_algo.run()
+gpr_result = gpr_algo.getResult()
+print(gpr_result)
 
 # %%
 # Metamodel visualization
 # -----------------------
 #
-# We draw the Kriging metamodel of the Branin function. It is the mean of the random process.
-metamodel = result.getMetaModel()
+# We get the metamodel (mean of the conditioned Gaussian Process) and the variance estimation.
+# We draw the GP fitter metamodel of the Branin function.
+gprMetamodel = gpr_result.getMetaModel()
+gccc = otexp.GaussianProcessConditionalCovariance(gpr_result)
 
 
-graphBasic = metamodel.draw([0.0, 0.0], [1.0, 1.0], [100] * 2)
+graphBasic = gprMetamodel.draw([0.0, 0.0], [1.0, 1.0], [100] * 2)
 # Take the first drawable as the only contour with multiple levels
 contours = graphBasic.getDrawable(0).getImplementation()
 contours.setColorBarPosition("")  # Hide the color bar
@@ -130,7 +135,7 @@ view = otv.View(graphFineTune)
 
 # %%
 # We evaluate the metamodel at the minima locations :
-print(metamodel(sample1))
+print(gprMetamodel(sample1))
 
 # %%
 # Graphically, both the metamodel and the exact function look the same. The metamodel also has three
@@ -152,7 +157,7 @@ inputData = ot.Box([N, N]).generate()
 
 # %%
 # We compute the conditional variance of the model and take the square root to get the deviation :
-condCov = result.getConditionalMarginalVariance(inputData, 0)
+condCov = gccc.getConditionalMarginalVariance(inputData, 0)
 condCovSd = sqrt(condCov)
 
 # %%
@@ -176,10 +181,10 @@ view = otv.View(graphFineTune)
 # We observe that the standard deviation is small in the center of the domain where we have enough
 # data to learn the model.
 # We can print the value of the variance at the first 5 training points (they all behave similarly) :
-print(result.getConditionalMarginalVariance(xdata, 0)[0:5])
+print(gccc.getConditionalMarginalVariance(xdata, 0)[0:5])
 
 # %%
-# These values are nearly zero which is expected as the Kriging interpolates data. The value being
+# These values are nearly zero which is expected as the GP fitter interpolates data. The value being
 # known it is not random anymore and the variance ought to be zero.
 
 # %%

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_multioutput_firesatellite.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_multioutput_firesatellite.py
@@ -1,22 +1,23 @@
 """
-Example of multi output Kriging on the fire satellite model
-===========================================================
+Example of multi output Gaussian Process Fitter on the fire satellite model
+===========================================================================
 """
 
 # %%
-# This example aims to illustrate Kriging metamodel with several outputs on the fire satellite model.
+# This example aims to illustrate Gaussian Process Fitter (Kriging) metamodel with several outputs on the fire satellite model.
 
 
 # %%
 # Loading of the model
 # --------------------
 # This model involves 9 input variables and 3 output variables.
-# We load the :ref:`Fire satellite use case<use-case-fire-satellite>`.
+# We load the :ref:`Fire satellite use case<use-case-firesatellite>`.
 
 # %%
 import openturns as ot
 from openturns.usecases.fire_satellite import FireSatelliteModel
 from openturns.viewer import View
+import openturns.experimental as otexp
 
 ot.Log.Show(ot.Log.NONE)
 
@@ -76,7 +77,7 @@ myCov3 = ot.MaternModel([1.0] * m.dim, 2.5)
 covarianceModel = ot.TensorizedCovarianceModel([myCov1, myCov2, myCov3])
 
 # %%
-# The scaling of the data is really important when dealing with Kriging,
+# The scaling of the data is really important when dealing with GP fitter,
 # especially considering the domain definition of the input variables (the
 # altitude varies in order of :math:`10^7` whereas the drag coefficient is around 1).
 # We thus define appropriate bounds for the training algorithm based on the
@@ -89,16 +90,23 @@ scaleOptimizationBounds = ot.Interval(
 )
 
 # %%
-# We can now define the scaled version of Kriging model.
-algo = ot.KrigingAlgorithm(inputTrainingSet, outputTrainingSet, covarianceModel, basis)
-algo.setOptimizationBounds(scaleOptimizationBounds)
-algo.setOptimizeParameters(True)
+# We can now define the scaled version of with GP fitter model.
+# First, we need to initialize the covariance model's parameters in accordance with the optimization bounds.
+covarianceModelParameters = 0.5 * (scaleOptimizationBounds.getUpperBound() - scaleOptimizationBounds.getLowerBound()) + scaleOptimizationBounds.getLowerBound()
+covarianceModel.setParameter(covarianceModelParameters)
+fitter_algo = otexp.GaussianProcessFitter(inputTrainingSet, outputTrainingSet, covarianceModel, basis)
+fitter_algo.setOptimizationBounds(scaleOptimizationBounds)
+fitter_algo.setOptimizeParameters(True)
 
 # %%
 # We run the algorithm and get the metamodel.
-algo.run()
-result = algo.getResult()
-krigingMetamodel = result.getMetaModel()
+fitter_algo.run()
+fitter_result = fitter_algo.getResult()
+gpr_algo = otexp.GaussianProcessRegression(fitter_result)
+gpr_algo.run()
+gpr_result = gpr_algo.getResult()
+
+gprMetamodel = gpr_result.getMetaModel()
 
 # %%
 # Validation of metamodel
@@ -113,7 +121,7 @@ outputTestSet = model(inputTestSet)
 
 # %%
 # Then, we use the :class:`~openturns.MetaModelValidation` class to validate the metamodel.
-metamodelPredictions = krigingMetamodel(inputTestSet)
+metamodelPredictions = gprMetamodel(inputTestSet)
 val = ot.MetaModelValidation(outputTestSet, metamodelPredictions)
 
 r2Score = val.computeR2Score()
@@ -129,3 +137,4 @@ for i in range(3):
     graph.setYTitle("Metamodel prediction")
     graph.setTitle(label[i])
     View(graph)
+View.ShowAll()

--- a/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_sequential.py
+++ b/python/doc/examples/meta_modeling/kriging_metamodel/plot_kriging_sequential.py
@@ -1,10 +1,10 @@
 """
-Sequentially adding new points to a Kriging
-===========================================
+Sequentially adding new points to a Gaussian Process fitter
+===========================================================
 """
 
 # %%
-# In this example, we show how to sequentially add new points to a Kriging in order to improve the predictivity of the metamodel.
+# In this example, we show how to sequentially add new points to a  Gaussian Process fitter (Kriging) in order to improve the predictivity of the metamodel.
 # In order to create simple graphics, we consider a 1-d function.
 
 # %%
@@ -54,7 +54,7 @@ view = viewer.View(graph)
 
 
 # %%
-def createMyBasicKriging(X, Y):
+def createMyBasicGPfitter(X, Y):
     """
     Create a kriging from a pair of X and Y samples.
     We use a 3/2 Matérn covariance model and a constant trend.
@@ -87,15 +87,15 @@ sqrt = ot.SymbolicFunction(["x"], ["sqrt(x)"])
 
 
 # %%
-def plotMyBasicKriging(gprResult, xMin, xMax, X, Y, level=0.95):
+def plotMyBasicGPfitter(gprResult, xMin, xMax, X, Y, level=0.95):
     """
-    Given a kriging result, plot the data, the kriging metamodel
+    Given a kriging result, plot the data, the GP fitter metamodel
     and a confidence interval.
     """
     samplesize = X.getSize()
     meta = gprResult.getMetaModel()
     graphKriging = meta.draw(xMin, xMax)
-    graphKriging.setLegends(["Kriging"])
+    graphKriging.setLegends(["Gaussian Process fitter"])
     # Create a grid of points and evaluate the function and the kriging
     nbpoints = 50
     xGrid = linearSample(xMin, xMax, nbpoints)
@@ -151,11 +151,11 @@ def plotMyBasicKriging(gprResult, xMin, xMax, X, Y, level=0.95):
 
 
 # %%
-# We start by creating the initial Kriging metamodel on the 4 points in the design of experiments.
+# We start by creating the initial GP fitter metamodel on the 4 points in the design of experiments.
 
 # %%
-gprResult = createMyBasicKriging(X, Y)
-graph = plotMyBasicKriging(gprResult, xMin, xMax, X, Y)
+gprResult = createMyBasicGPfitter(X, Y)
+graph = plotMyBasicGPfitter(gprResult, xMin, xMax, X, Y)
 view = viewer.View(graph)
 
 
@@ -200,13 +200,13 @@ X.add(xNew)
 Y.add(yNew)
 
 # %%
-# We now plot the updated Kriging.
+# We now plot the updated GP fitter.
 
 # %%
 # sphinx_gallery_thumbnail_number = 3
-gprResult = createMyBasicKriging(X, Y)
-graph = plotMyBasicKriging(gprResult, xMin, xMax, X, Y)
-graph.setTitle("Kriging #0")
+gprResult = createMyBasicGPfitter(X, Y)
+graph = plotMyBasicGPfitter(gprResult, xMin, xMax, X, Y)
+graph.setTitle("GP fitter #0")
 view = viewer.View(graph)
 
 # %%
@@ -218,9 +218,9 @@ for krigingStep in range(5):
     yNew = g(xNew)
     X.add(xNew)
     Y.add(yNew)
-    gprResult = createMyBasicKriging(X, Y)
-    graph = plotMyBasicKriging(gprResult, xMin, xMax, X, Y)
-    graph.setTitle("Kriging #%d " % (krigingStep + 1) + graph.getTitle())
+    gprResult = createMyBasicGPfitter(X, Y)
+    graph = plotMyBasicGPfitter(gprResult, xMin, xMax, X, Y)
+    graph.setTitle("GP fitter #%d " % (krigingStep + 1) + graph.getTitle())
     View(graph)
 
 # %%


### PR DESCRIPTION
As requested in technical committee of 05/07, the following three examples have been updated to use GPR instead of Kriging :

- [Kriging: metamodel of the Branin-Hoo function](https://openturns.github.io/openturns/latest/auto_meta_modeling/kriging_metamodel/plot_kriging_branin_function.html?highlight=brani+kriging)
-  [Example of multi output Kriging on the fire satellite model](https://openturns.github.io/openturns/latest/auto_meta_modeling/kriging_metamodel/plot_kriging_multioutput_firesatellite.html?highlight=multioutput+satellite)
- [Sequentially adding new points to a Kriging](https://openturns.github.io/openturns/latest/auto_meta_modeling/kriging_metamodel/plot_kriging_sequential.html?highlight=sequential)