### PR TITLE
Gaussian Process Regression: doc and examples

### DIFF
--- a/python/doc/theory/probabilistic_modeling/covariance_model.rst
+++ b/python/doc/theory/probabilistic_modeling/covariance_model.rst
@@ -53,14 +53,14 @@ where:
     \mat{L}_{\rho}(\vect{s}, \vect{t})\,\Tr{\mat{L}_{\rho}(\vect{s}, \vect{t})}
     = \mat{\rho}(\vect{s}, \vect{t})
 
-The correlation function :math:`\mat{\rho}` may depend on additional
+where :math:`\mat{\rho}` is the correlation function: it may depend on additional
 specific parameters which are not made explicit here.
 
 The global correlation is given by two separate correlations:
 
     - the spatial correlation between the components of :math:`X_{\vect{t}}`
       which is given by the correlation matrix
-      :math:`\mat{R} \in \cS_{\inputDim}^+(\Rset)` and the vector of marginal variances
+      :math:`\mat{R} \in \cS_{\inputDim}^+(\Rset)` and the vector of marginal standard deviations
       :math:`\vect{\sigma} \in \Rset^{\inputDim}`.
       The spatial correlation does not depend on :math:`\vect{t} \in \cD`.
       For each  :math:`\vect{t}`, it links together the components of

--- a/python/doc/theory/probabilistic_modeling/probabilistic_modeling.rst
+++ b/python/doc/theory/probabilistic_modeling/probabilistic_modeling.rst
@@ -22,6 +22,7 @@ Stochastic process
 .. toctree::
 
     process_definitions
+    covariance_model
 
 Transformation of fields
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,7 +46,6 @@ Normal processes
 
 .. toctree::
 
-    covariance_model
     stationary_covariance_model
     estimate_stationary_covariance_model
     estimate_non_stationary_covariance_model


### PR DESCRIPTION
I did the following modifications: 


1. 'Covariance models' theory file:

      -  I moved the 'Covariance models' theory file from the 'Normal process' section into the 'Stochastic process' section:
      - I corrected some typos in the 'Covariance models' theory file 

2. GaussianProcessFitter and GaussianProcessFitterResult: I improved and corrected the doc, made it coherent
3. GaussianProcessRegression and GaussianProcessRegressionResult: I improved and corrected the doc, made it coherent
