### PR TITLE
Change of QMC reliability example

### DIFF
--- a/python/doc/examples/reliability_sensitivity/reliability/plot_estimate_probability_randomized_qmc.py
+++ b/python/doc/examples/reliability_sensitivity/reliability/plot_estimate_probability_randomized_qmc.py
@@ -4,24 +4,24 @@ Use a randomized QMC algorithm
 """
 
 # %%
-# In this example we are going to estimate a failure probability on the :ref:`cantilever beam <use-case-cantilever-beam>`.
+# In this example we are going to estimate a failure probability on the :ref:`stressed beam <use-case-stressed-beam>`.
 
 # %%
-from openturns.usecases import cantilever_beam
+from openturns.usecases import stressed_beam
 import openturns as ot
 
 
 # %%
 # We load the data class containing the probabilistic modeling of the beam.
-cb = cantilever_beam.CantileverBeam()
+sm = stressed_beam.AxialStressedBeam()
 
 # %%
 # We load the joint probability distribution of the input parameters :
-distribution = cb.distribution
+distribution = sm.distribution
 
 # %%
 # We load the model as well,
-model = cb.model
+model = sm.model
 
 # %%
 # We create the event whose probability we want to estimate.
@@ -29,7 +29,7 @@ model = cb.model
 # %%
 vect = ot.RandomVector(distribution)
 G = ot.CompositeRandomVector(model, vect)
-event = ot.ThresholdEvent(G, ot.Greater(), 0.3)
+event = ot.ThresholdEvent(G, ot.Less(), 0.0)
 
 # %%
 # Define the low discrepancy sequence.
@@ -45,7 +45,7 @@ experiment = ot.LowDiscrepancyExperiment(sequence, 1)
 experiment.setRandomize(True)
 algo = ot.ProbabilitySimulationAlgorithm(event, experiment)
 algo.setMaximumCoefficientOfVariation(0.05)
-algo.setMaximumOuterSampling(int(1e5))
+algo.setMaximumOuterSampling(int(1e4))
 algo.run()
 
 # %%


### PR DESCRIPTION
Hi,

This PR proposes a slight change of the [Use a randomized QMC algorithm](https://openturns.github.io/openturns/latest/auto_reliability_sensitivity/reliability/plot_estimate_probability_randomized_qmc.html?highlight=qmc) example.

Indeed, the current example describes the use of QMC for reliability on the cantilever beam example. However, since the target probability of this reliability example is very low (around 1e-7), the algorithm fails  with the considered simulation budget and retrieves 0.


<img width="825" height="152" alt="image" src="https://github.com/user-attachments/assets/a5c06ce9-a843-4f97-96b3-d14856c056fe" />


In this PR, the test case is switched to the simple beam example with a target probability of  around 0.03. With this test case, the QMC reliability method succeeds to estimate the failure probability with a reasonable budget.

<img width="726" height="131" alt="image" src="https://github.com/user-attachments/assets/f0732008-a57f-49a7-a4ec-d834aafe1d29" />
