### PR TITLE
Fix formatting of outputDim in documentation

### DIFF
--- a/python/src/GaussianProcessRegression_doc.i
+++ b/python/src/GaussianProcessRegression_doc.i
@@ -39,7 +39,7 @@ In all cases, no estimation of the underlying Gaussian process approximation :ma
 
     \vect{Y}(\omega, \vect{x}) = \vect{\mu}(\vect{x}) + \vect{W}(\omega, \vect{x})
 
-where :math:`\vect{\mu} : \Rset^\inputDim \rightarrow \Rset^outputDim` is the trend function and :math:`\vect{W}` is a Gaussian process of dimension :math:`\outputDim` with zero mean and a specified covariance function.
+where :math:`\vect{\mu} : \Rset^\inputDim \rightarrow \Rset^{\outputDim}` is the trend function and :math:`\vect{W}` is a Gaussian process of dimension :math:`\outputDim` with zero mean and a specified covariance function.
 
 The Gaussian Process Regression denoted by :math:`\vect{Z}` is the Gaussian process :math:`\vect{Y}` conditioned to the data
 set:


### PR DESCRIPTION
This fixes:

https://openturns.github.io/openturns/latest/user_manual/_generated/openturns.experimental.GaussianProcessRegression.html#openturns.experimental.GaussianProcessRegression

<img width="1202" height="202" alt="image" src="https://github.com/user-attachments/assets/685948a3-6656-4114-8ba1-f9ba060a7002" />
