### PR TITLE
Update JOSS paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,13 +1,13 @@
 @Inbook{baudin2016,
-  author="Baudin, Micha{\"e}l and Dutfoy, Anne and Iooss, Bertrand and Popelin, Anne-Laure",
-  title="{OpenTURNS}: An Industrial Software for Uncertainty Quantification in Simulation. In: Ghanem R., Higdon D., Owhadi H. (eds) Handbook of Uncertainty Quantification.",
-  year="2016",
-  publisher="Springer International Publishing",
-  address="Cham",
-  pages="1--38",
-  isbn="978-3-319-11259-6",
-  doi="10.1007/978-3-319-11259-6_64-1",
-  url="https://doi.org/10.1007/978-3-319-11259-6_64-1"
+  author={Baudin, Micha{\"e}l and Dutfoy, Anne and Iooss, Bertrand and Popelin, Anne-Laure},
+  title={{OpenTURNS: An Industrial Software for Uncertainty Quantification in Simulation. In: Ghanem R., Higdon D., Owhadi H. (eds) Handbook of Uncertainty Quantification.}},
+  year={2016},
+  publisher={Springer International Publishing},
+  address={Cham},
+  pages={1--38},
+  isbn={978-3-319-11259-6},
+  doi={10.1007/978-3-319-11259-6_64-1},
+  url={https://doi.org/10.1007/978-3-319-11259-6_64-1}
 }
 
 @article{dutfoy2023,
@@ -15,27 +15,30 @@
   year = {2023},
   title = {Uncertainty on estimated magnitudes: a new approach based on a {Poisson} point process of dimension 2},
   journal = {Pure Appl. Geophys.},
-  volume = {180 (10)},
+  volume = {180},
+  number = {10},
   pages = {919-933},
   url = {https://doi.org/10.1007/s00024-022-03222-6},
+  doi = {10.1007/s00024-022-03222-6}
 }
 
 @misc{openturns_forum,
   title        = {{OpenTURNS}'s forum},
   howpublished = {\url{https://openturns.discourse.group/}},
+  year = {2020}
 }
 
 @misc{persalys,
-  title = {Persalys: Graphical User Interface for Uncertainty Quantification},
+  title = {{Persalys: Graphical User Interface for Uncertainty Quantification}},
   author = {{EDF} and {Phimeca Engineering}},
   year = {2016},
   howpublished = {\url{https://www.persalys.fr/}}
 }
 
 @article{pedregosa2011scikit,
-  title={{Scikit-learn}: {Machine} learning in {Python}},
+  title={{Scikit-learn: Machine learning in Python}},
   author={Pedregosa, Fabian and Varoquaux, Ga{\"e}l and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and others},
-  journal={the Journal of machine Learning research},
+  journal={The Journal of Machine Learning Research},
   volume={12},
   pages={2825--2830},
   year={2011},
@@ -43,10 +46,12 @@
 }
 
 @inproceedings{seabold2010statsmodels,
-  title={statsmodels: Econometric and statistical modeling with {Python}},
+  title={{Statsmodels: Econometric and statistical modeling with Python}},
   author={Seabold, Skipper and Perktold, Josef},
-  booktitle={9th Python in Science Conference},
+  booktitle={{9th Python in Science Conference}},
   year={2010},
+  doi = {10.25080/majora-92bf1922-011},
+  url = {https://doi.org/10.25080/majora-92bf1922-011}
 }
 
 @article{Wicaksono2023,
@@ -55,23 +60,25 @@
   year = {2023}, publisher = {The Open Journal}, 
   volume = {8}, number = {90}, pages = {5671}, 
   author = {Wicaksono, Damar and Hecht, Michael}, 
-  title = {UQTestFuns: A Python3 library of uncertainty quantification (UQ) test functions}, 
+  title = {{UQTestFuns: A Python3 library of uncertainty quantification (UQ) test functions}}, 
   journal = {Journal of Open Source Software}
 }
 
 @article{roy2023quasi,
-  title={Quasi-monte carlo methods in python},
+  title={{Quasi-monte carlo methods in Python}},
   author={Roy, Pamphile and Owen, Art B. and Balandat, Maximilian and Haberland, Matt},
   journal={Journal of Open Source Software},
   volume={8},
   number={84},
   pages={5309},
-  year={2023}
+  year={2023},
+  url = {https://doi.org/10.21105/joss.05309},
+  doi = {10.21105/joss.05309}
 }
 
 @article{virtanen2020scipy,
   author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and others},
-  title   = {{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in {Python}},
+  title   = {{SciPy 1.0: Fundamental Algorithms for Scientific Computing in Python}},
   journal = {Nature Methods},
   volume  = {17},
   pages   = {261--272},
@@ -81,26 +88,30 @@
 }
 
 @Article{espoeys2025multifidelity,
-  title={Multifidelity Bayesian Sequential Optimization and Reliability Assessment for Aerospace Systems Design},
+  title={Multifidelity {Bayesian} Sequential Optimization and Reliability Assessment for Aerospace Systems Design},
   author={Espoeys, Romain and Brevault, Loic and Balesdent, Mathieu and Ricci, Sophie and Mycek, Paul},
   journal={Journal of Aerospace Information Systems},
   pages={1--24},
   year={2025},
-  publisher={American Institute of Aeronautics and Astronautics}
+  publisher={American Institute of Aeronautics and Astronautics},
+  doi = {10.2514/1.I011614},
+  url={https://doi.org/10.2514/1.I011614}
 }
 
 @article{faure2024impact,
-  title={Impact of time resolution on estimation of energy savings using a copula-based calibration in UBEM},
+  title={Impact of time resolution on estimation of energy savings using a copula-based calibration in {UBEM}},
   author={Faure, Xavier and Lebrun, R{\'e}gis and Pasichnyi, Oleksii},
   journal={Energy and Buildings},
   volume={311},
   pages={114134},
   year={2024},
-  publisher={Elsevier}
+  publisher={Elsevier},
+  url = {https://doi.org/10.1016/j.enbuild.2024.114134},
+  doi = {10.1016/j.enbuild.2024.114134}
 }
 
 @manual{salome_platform,
-  title        = {{SALOME}: The Open Source Platform for Pre- and Post-Processing for Numerical Simulation},
+  title        = {{SALOME: The Open Source Platform for Pre- and Post-Processing for Numerical Simulation}},
   author       = {{SALOME Consortium}},
   year         = {2026},
   url          = {https://www.salome-platform.org/},
@@ -108,9 +119,30 @@
 }
 
 @manual{pseven,
-  title        = {pSeven: Design Space Exploration and Predictive Modeling Framework},
+  title        = {{pSeven: Design Space Exploration and Predictive Modeling Framework}},
   author       = {{pSeven SAS}},
   year         = {2026},
   url          = {https://www.pseven.io/product/pseven-core/},
   note         = {Accessed: 2026-02-26}
+}
+
+@manual{gemseo,
+  title        = {{GEMSEO: Generic Engine for Multidisciplinary Scenarios, Exploration and Optimization}},
+  author       = {{IRT Saint Exupéry}},
+  year         = {2026},
+  url          = {https://gemseo.readthedocs.io/},
+  note         = {Accessed: 2026-02-26}
+}
+
+@article{Roy2018,
+  doi = {10.21105/joss.00493},
+  url = {https://doi.org/10.21105/joss.00493},
+  year = {2018},
+  publisher = {The Open Journal},
+  volume = {3},
+  number = {21},
+  pages = {493},
+  author = {Pamphile T. Roy and Sophie Ricci and Romain Dupuis and Robin Campet and Jean-Christophe Jouhaud and Cyril Fournier},
+  title = {{BATMAN: Statistical analysis for expensive computer codes made easy}},
+  journal = {Journal of Open Source Software}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -235,6 +235,8 @@ multiple science and engineering domains
 The Persalys graphical user interface [@persalys], built on top of OpenTURNS,
 enables users to perform UQ analyses with no (or minimal) Python
 programming.
+OpenTURNS is a requirement for several other tools including [@gemseo] 
+and [@Roy2018] for example.
 
 An annual Users’ Day has been held since 2008, fostering collaboration
 and knowledge exchange among researchers, engineers, and educators.


### PR DESCRIPTION
This is the next step of the PR #2939. After the initial PR was merged, I was able to use the editorial bot. The DOI check by JOSS produced the following report.

### Reference check summary (note 'MISSING' DOIs are suggestions that need verification):

✅ OK DOIs

- 10.1007/978-3-319-11259-6_64-1 is OK
- 10.21105/joss.05671 is OK
- 10.1038/s41592-019-0686-2 is OK

🟡 SKIP DOIs

- No DOI given, and none found for title: OpenTURNS’s forum
- No DOI given, and none found for title: Persalys: Graphical User Interface for Uncertainty...
- No DOI given, and none found for title: Scikit-learn: Machine learning in Python
- No DOI given, and none found for title: Quasi-monte carlo methods in python
- No DOI given, and none found for title: Impact of time resolution on estimation of energy ...
- No DOI given, and none found for title: SALOME: The Open Source Platform for Pre- and Post...
- No DOI given, and none found for title: pSeven: Design Space Exploration and Predictive Mo...

❌ MISSING DOIs

- 10.1007/s00024-022-03222-6 may be a valid DOI for title: Uncertainty on estimated magnitudes: a new approac...
- 10.25080/majora-92bf1922-011 may be a valid DOI for title: statsmodels: Econometric and statistical modeling ...
- 10.2514/1.i011614 may be a valid DOI for title: Multifidelity Bayesian Sequential Optimization and...

The main goal of this PR is to fix these issues, so that we can go to the review step.

## Significant commits of this PR

- Added libraries which depend on OpenTURNS
- Fixed DOIs.
- Fixed case in .bib.

The result is: [paper.pdf](https://github.com/user-attachments/files/25873788/paper.pdf)

 After this PR, all lights will turn green.
