### PR TITLE
Fix formatting of mathematical equations in documentation

### DIFF
--- a/python/src/TriangularFactory_doc.i
+++ b/python/src/TriangularFactory_doc.i
@@ -9,9 +9,9 @@ The parameters are estimated by method of moments:
     :nowrap:
 
     \begin{eqnarray*}
-      \displaystyle\Hat{a}_n=(1-\mathrm{sign}(x_{(1,n)})/(2+n))x_{(1,n)}\\
-      \displaystyle\Hat{b}_n=(1+\mathrm{sign}(x_{(n,n)})/(2+n))x_{(n,n)}\\
-      \displaystyle\Hat{m}_n=3\bar{x}_n-\Hat{a}_n-\Hat{b}_n
+      \Hat{a}_n & = \frac{1 - \mathrm{sign}(x_{(1,n)})}{2 + n} x_{(1,n)} \\
+      \Hat{b}_n & = \frac{1 + \mathrm{sign}(x_{(n,n)})}{2 + n} x_{(n,n)} \\
+      \Hat{m}_n & = 3\bar{x}_n - \Hat{a}_n - \Hat{b}_n
     \end{eqnarray*}
 
 See also

--- a/python/src/TriangularFactory_doc.i
+++ b/python/src/TriangularFactory_doc.i
@@ -8,11 +8,11 @@ The parameters are estimated by method of moments:
 .. math::
     :nowrap:
 
-    \begin{eqnarray*}
-      \Hat{a}_n & = \frac{1 - \mathrm{sign}(x_{(1,n)})}{2 + n} x_{(1,n)} \\
-      \Hat{b}_n & = \frac{1 + \mathrm{sign}(x_{(n,n)})}{2 + n} x_{(n,n)} \\
-      \Hat{m}_n & = 3\bar{x}_n - \Hat{a}_n - \Hat{b}_n
-    \end{eqnarray*}
+    \begin{align*}
+      \Hat{a}_n & = \left(1 - \frac{\mathrm{sign}\left(x_{(1,n)}\right)}{2 + n}\right) x_{(1,n)}\\
+      \Hat{b}_n & = \left(1 + \frac{\mathrm{sign}\left(x_{(n,n)}\right)}{2 + n}\right) x_{(n,n)}\\
+      \Hat{m}_n & = 3 \overline{x}_n - \Hat{a}_n - \Hat{b}_n
+    \end{align*}
 
 See also
 --------


### PR DESCRIPTION

<img width="821" height="168" alt="image" src="https://github.com/user-attachments/assets/29cfaaf8-efa8-4f07-9a53-cd5f9320040b" />

**Figure 1.** Before the commits.

<img width="876" height="301" alt="image" src="https://github.com/user-attachments/assets/45a2c213-8f58-4e7c-9c03-c9b7c3461c96" />

**Figure 2.** After the commits.