### PR TITLE
Fix formatting in GaussianProcessFitter_doc.i

### DIFF
--- a/python/doc/theory/meta_modeling/gaussian_process_regression.rst
+++ b/python/doc/theory/meta_modeling/gaussian_process_regression.rst
@@ -123,6 +123,8 @@ where :math:`\mat{C}_{ij} = C_{\vect{p}}(\vect{x}_i, \vect{x}_j)\in \cS_{\output
 
 The likelihood of the Gaussian process on the data set is defined by:
 
+.. _logLikelihoodGP:
+
 .. math::
     :label: logLikelihoodGPgen
 

--- a/python/src/GaussianProcessFitter_doc.i
+++ b/python/src/GaussianProcessFitter_doc.i
@@ -50,7 +50,7 @@ where :math:`\vect{p}` is the vector of the parameters of the covariance model  
 :class:`openturns.CovarianceModel` to get details on the activation of the estimation of the other
 parameters.
 
-The estimation is done by maximizing the *reduced* log-likelihood of the mode, defined in :eq:`logLikelihoodGP`.
+The estimation is done by maximizing the :ref:`reduced log-likelihood of the model<logLikelihoodGP>`.
 
 The default optimizer is :class:`~openturns.Cobyla` and can be changed thanks to the
 :meth:`setOptimizationAlgorithm` method.
@@ -68,17 +68,17 @@ It is also possible to proceed as follows:
 * set the optimal parameter value into the covariance model used in the *GaussianProcessFitter*,
 * tell the algorithm not to optimize the parameter using the :meth:`setOptimizeParameters` method.
 
-A centered Gaussian noise :math:`\mat{\Sigma}_i^{noise} \in \cM_{\outputDim \times \outputDim}(\Rset)`
+A centered Gaussian noise :math:`\mat{\Sigma}_i^{\text{noise}} \in \cM_{\outputDim \times \outputDim}(\Rset)`
 can be taken into account for each output value with :func:`setNoise()`:
 
 .. math::
     :label: noise
 
-    \vect{Y}_i = \vect{y}_i^{true} + \vect{\varepsilon}, \quad
-    \vect{\varepsilon} \sim \cN \left(\vect{0}, \mat{\Sigma}_i^{noise}\right)
+    \vect{Y}_i = \vect{y}_i^{\text{true}} + \vect{\varepsilon}, \quad
+    \vect{\varepsilon} \sim \cN \left(\vect{0}, \mat{\Sigma}_i^{\text{noise}}\right)
 
 
-where :math:`\vect{y}_i^{true}` is the true (and unknown) value of the model at :math:`\vect{x}_i`. Refer to
+where :math:`\vect{y}_i^{\text{true}}` is the true (and unknown) value of the model at :math:`\vect{x}_i`. Refer to
 :doc:`/auto_surrogate_modeling/gaussian_process_regression/plot_gpr_noise` to get an example.
 
 The behaviour of the reduction is controlled by the following keys in :class:`~openturns.ResourceMap`:


### PR DESCRIPTION
The goal of this PR is to fix this sentence. It lets the user thinks that the equation (1) is inside the current `GaussianProcessFitter` help page, but it is not: the actual equation is located inside a theory help page.

<img width="987" height="242" alt="image" src="https://github.com/user-attachments/assets/b742fa79-0f53-4cd7-b1b1-c4c078eeb9b8" />

**Figure 1.** Before the commit.

<img width="983" height="201" alt="image" src="https://github.com/user-attachments/assets/c211763e-9c9f-459c-9637-49ad75bb835b" />

**Figure 2.** After the commit.
