### PR TITLE
Fix mathematical notation for argmin in documentation

### DIFF
--- a/python/src/Analytical_doc.i
+++ b/python/src/Analytical_doc.i
@@ -60,7 +60,7 @@ constrained optimization problem :
 
 .. math::
 
-    \vect{u}^* = argmin \{||\vect{u}|| \, | \, G(\vect{u}) = 0 \}
+    \vect{u}^* = \argmin \{||\vect{u}|| \, | \, G(\vect{u}) = 0 \}
 
 Then the limit state surface is approximated in the standard space by a linear
 surface (:class:`~openturns.FORM`) or by a quadratic surface


### PR DESCRIPTION
<img width="1080" height="283" alt="image" src="https://github.com/user-attachments/assets/8dcec783-0f82-4105-b2a7-e0dccaa0643d" />

**Figure 1.** Before the commit.

<img width="991" height="245" alt="image" src="https://github.com/user-attachments/assets/09170511-912d-4c68-8b80-96a531a5e5f4" />

**Figure 2.** After the commit.
