### PR TITLE
Improved [LeastSquares|Integration]Expansion

### DIFF
--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/IntegrationExpansion.cxx
@@ -27,6 +27,8 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/DistributionTransformation.hxx"
 #include "openturns/IdentityFunction.hxx"
+#include "openturns/FixedStrategy.hxx"
+#include "openturns/IntegrationStrategy.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -88,7 +90,7 @@ IntegrationExpansion::IntegrationExpansion(const Sample & inputSample,
     const Distribution & distribution,
     const OrthogonalBasis & basis,
     const UnsignedInteger basisSize)
-  : FunctionalChaosAlgorithm(inputSample, weights, outputSample, distribution)
+  : FunctionalChaosAlgorithm(inputSample, weights, outputSample, distribution, FixedStrategy(basis, basisSize), IntegrationStrategy())
   , basis_(basis)
   , basisSize_(basisSize)
 {
@@ -117,6 +119,7 @@ void IntegrationExpansion::run()
   {
     const Distribution measure(basis_.getMeasure());
     Sample transformedInputSample;
+    LOGINFO("Build transformation");
     if (distribution_ == measure)
     {
       transformation_ = IdentityFunction(distribution_.getDimension());
@@ -130,6 +133,7 @@ void IntegrationExpansion::run()
       transformedInputSample = transformation_(inputSample_);
     }
     FunctionCollection functions(basisSize_);
+    LOGINFO("Build basis");
     for (UnsignedInteger i = 0; i < basisSize_; ++i)
       functions[i] = basis_.build(i);
     designProxy_ = DesignProxy(transformedInputSample, functions);
@@ -157,6 +161,7 @@ void IntegrationExpansion::run()
   // As they will be used as a Sample of size activeFunctions_.getSize() and
   // dimension outputDimension, it is better to compute them in a transposed
   // form and copy the internal representation
+  LOGINFO(OSS() << "Compute all the coefficients");
   Matrix coefficientsAsMatrix(weightedOutput * designMatrix);
   SampleImplementation coefficients(activeFunctions_.getSize(), outputDimension);
   coefficients.setData(*coefficientsAsMatrix.getImplementation());

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
@@ -29,6 +29,8 @@
 #include "openturns/DistributionTransformation.hxx"
 #include "openturns/LeastSquaresMethod.hxx"
 #include "openturns/IdentityFunction.hxx"
+#include "openturns/FixedStrategy.hxx"
+#include "openturns/LeastSquaresStrategy.hxx"
 
 BEGIN_NAMESPACE_OPENTURNS
 
@@ -94,7 +96,7 @@ LeastSquaresExpansion::LeastSquaresExpansion(const Sample & inputSample,
     const OrthogonalBasis & basis,
     const UnsignedInteger basisSize,
     const String & methodName)
-  : FunctionalChaosAlgorithm(inputSample, weights, outputSample, distribution)
+  : FunctionalChaosAlgorithm(inputSample, weights, outputSample, distribution, FixedStrategy(basis, basisSize), LeastSquaresStrategy())
   , basis_(basis)
   , basisSize_(basisSize)
   , methodName_(methodName)
@@ -124,6 +126,7 @@ void LeastSquaresExpansion::run()
   {
     const Distribution measure(basis_.getMeasure());
     Sample transformedInputSample;
+    LOGINFO("Build transformation");
     if (distribution_ == measure)
     {
       transformation_ = IdentityFunction(distribution_.getDimension());
@@ -137,6 +140,7 @@ void LeastSquaresExpansion::run()
       transformedInputSample = transformation_(inputSample_);
     }
     FunctionCollection functions(basisSize_);
+    LOGINFO("Build basis");
     for (UnsignedInteger i = 0; i < basisSize_; ++i)
       functions[i] = basis_.build(i);
     designProxy_ = DesignProxy(transformedInputSample, functions);
@@ -147,8 +151,10 @@ void LeastSquaresExpansion::run()
   SampleImplementation coefficients(activeFunctions_.getSize(), outputDimension);
   for (UnsignedInteger j = 0; j < outputDimension; ++j)
   {
+    LOGINFO(OSS() << "Work on output marginal j=" << j);
     const Sample marginalOutputSample(outputSample_.getMarginal(j));
     const Point rhs(marginalOutputSample.asPoint());
+    LOGINFO(OSS() << "Solve problem using method=" << leastSquaresMethod);
     const Point coeffsJ(leastSquaresMethod.solve(rhs));
     for (UnsignedInteger i = 0; i < activeFunctions_.getSize(); ++i)
       coefficients(i, j) = coeffsJ[i];


### PR DESCRIPTION
When all the parameters are given to the constructor of these classes, there is no need to call a constructor of the base class which trigger the construction of costly objects. It is fixed now.