### PR TITLE
Fixed CompositeDistribution

### DIFF
--- a/lib/src/Uncertainty/Distribution/CompositeDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/CompositeDistribution.cxx
@@ -367,7 +367,7 @@ Scalar CompositeDistribution::computePDF(const Point & point) const
         const Matrix gradient(function_.gradient(fInvX));
         if (!(gradient.getNbRows() == 1 && gradient.getNbColumns() == 1)) throw InternalException(HERE) << "Error: the given function has no actual gradient. Consider using finite differences.";
         const Scalar denominator = std::abs(function_.gradient(fInvX)(0, 0));
-        if (std::isfinite(denominator)) pdf += numerator / denominator;
+        if (std::isfinite(denominator) && (denominator != 0.0)) pdf += numerator / denominator;
         LOGDEBUG(OSS() << "i=" << i << ", a=" << a << ", fA=" << fA << ", x=" << x << ", b=" << b << ", fB=" << fB << ", fInvX=" << fInvX << ", numerator=" << numerator << ", denominator=" << denominator << ", pdf=" << pdf);
       }
     }

--- a/python/test/t_CompositeDistribution_std.py
+++ b/python/test/t_CompositeDistribution_std.py
@@ -131,3 +131,7 @@ validation.skipMinimumVolumeInterval()  # wrong proba
 validation.skipMinimumVolumeLevelSet()  # slow
 validation.skipPDFAtLowerBound()  # Testing that the PDF is null at its lower bound if finite is a complex task
 validation.run()
+
+# Check that the PDF is zero where it is given by a fraction with null denominator
+pdf = ot.Uniform(-5.0, 5.0).sqr().computePDF(0.0)
+assert pdf == 0.0, f"Expected a zero value for the PDF, got PDF={pdf}"


### PR DESCRIPTION
The computePDF() method generates nan/inf when evaluated at a point where the function derivative is exactly zero.