### PR TITLE
Various fixes

### DIFF
--- a/lib/src/Base/Func/LinearEnumerateFunction.cxx
+++ b/lib/src/Base/Func/LinearEnumerateFunction.cxx
@@ -92,7 +92,7 @@ UnsignedInteger LinearEnumerateFunction::findBinomialCoefficient(const UnsignedI
    compute recursively the complement by looping over the degree of the remainder.
    For a given index I, we have:
    I = Binomial(n_1, d) + ... + Binomial(n_{d-1}, 1)
-   where Binomial(n_1, d_1) is
+   where Binomial(n_1, d_1) is the binomial coefficient d_1 / (n_1! * (d_1 - n_1)!)
 */
 Indices LinearEnumerateFunction::operator() (const UnsignedInteger index) const
 {

--- a/lib/src/Base/Func/NormInfEnumerateFunction.cxx
+++ b/lib/src/Base/Func/NormInfEnumerateFunction.cxx
@@ -130,19 +130,15 @@ UnsignedInteger NormInfEnumerateFunction::inverse(const Indices & indices) const
 
 
 /* The cardinal of the given strata
- * = strataIndex^dimension-(strataIndex-1)^dimension
+ * = 1 for strataIndex=0
+ * = (strataIndex+1)^dimension-strataIndex^dimension
  */
 UnsignedInteger NormInfEnumerateFunction::getStrataCardinal(const UnsignedInteger strataIndex) const
 {
-  const UnsignedInteger dimension = getDimension();
-  for (UnsignedInteger j = 0; j < dimension; ++ j)
-    if (strataIndex > upperBound_[j])
-      throw NotYetImplementedException(HERE) << "in NormInfEnumerateFunction::getStrataCardinal";
-
+  UnsignedInteger cardinal = getStrataCumulatedCardinal(strataIndex);
   if (strataIndex > 0)
-    return getStrataCumulatedCardinal(strataIndex) - getStrataCumulatedCardinal(strataIndex - 1);
-  else
-    return 1;
+    cardinal -= getStrataCumulatedCardinal(strataIndex - 1);
+  return cardinal;
 }
 
 /* The cardinal of the cumulated strata less or equal to the given strata
@@ -151,11 +147,17 @@ UnsignedInteger NormInfEnumerateFunction::getStrataCardinal(const UnsignedIntege
 UnsignedInteger NormInfEnumerateFunction::getStrataCumulatedCardinal(const UnsignedInteger strataIndex) const
 {
   const UnsignedInteger dimension = getDimension();
+  UnsignedInteger cardinal = 1;
+  Bool isSaturated = false;
   for (UnsignedInteger j = 0; j < dimension; ++ j)
-    if (strataIndex > upperBound_[j])
-      throw NotYetImplementedException(HERE) << "in NormInfEnumerateFunction::getStrataCumulatedCardinal";
+  {
+    isSaturated = isSaturated && (upperBound_[j] < strataIndex);
+    cardinal *= std::max(strataIndex + 1, upperBound_[j] + 1);
+  }
+  if (isSaturated)
+    throw NotDefinedException(HERE) << "in NormInfEnumerateFunction::getStrataCumulatedCardinal, no strata of index=" << strataIndex;
 
-  return std::pow(1.0 * strataIndex, 1.0 * dimension);
+  return cardinal;
 }
 
 /* The index of the strata of degree max < degree */

--- a/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/FunctionalChaos/LeastSquaresExpansion.cxx
@@ -166,7 +166,11 @@ Indices LeastSquaresExpansion::getActiveFunctions() const
 
 void LeastSquaresExpansion::setActiveFunctions(const Indices & activeFunctions)
 {
-  if (!activeFunctions.check(basisSize_)) throw InvalidArgumentException(HERE) << "Error: the active functions must have indices less than " << basisSize_;
+  if (!activeFunctions.check(basisSize_))
+  {
+    basisSize_ = activeFunctions.normInf() + 1;
+    designProxy_ = DesignProxy();
+  }
   activeFunctions_ = activeFunctions;
 }
 

--- a/lib/src/Uncertainty/Distribution/AliMikhailHaqCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/AliMikhailHaqCopula.cxx
@@ -290,11 +290,14 @@ Scalar AliMikhailHaqCopula::computeConditionalCDF(const Scalar x, const Point & 
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
   // Special case for no conditioning or independent copula
-  if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
+  if ((conditioningDimension == 0) || (hasIndependentCopula())) return SpecFunc::Clip01(x);
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u < 1.0))) return 0.0;
   const Scalar v = x;
+  if (!(v > 0.0)) return 0.0;
+  if (!(v < 1.0)) return 1.0;
   // If we are in the support
-  return v * (1.0 - theta_ * (1.0 - v)) / std::pow(1.0 - theta_ * (1.0 - u) * (1.0 - v), 2);
+  return SpecFunc::Clip01(v * (1.0 - theta_ * (1.0 - v)) / std::pow(1.0 - theta_ * (1.0 - u) * (1.0 - v), 2));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -302,7 +305,7 @@ Scalar AliMikhailHaqCopula::computeConditionalQuantile(const Scalar q, const Poi
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   if (q == 0.0) return 0.0;
   if (q == 1.0) return 1.0;
   // Initialize the conditional quantile with the quantile of the i-th marginal distribution
@@ -310,6 +313,7 @@ Scalar AliMikhailHaqCopula::computeConditionalQuantile(const Scalar q, const Poi
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   // Optimized code given by Maple 13
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning component outside of [0, 1]";
   const Scalar qTheta = q * theta_;
   const Scalar theta2 = theta_ * theta_;
   const Scalar qTheta2 = q * theta2;
@@ -319,7 +323,7 @@ Scalar AliMikhailHaqCopula::computeConditionalQuantile(const Scalar q, const Poi
   const Scalar tmp1 = 2.0 * qThetaU;
   const Scalar tmp2 = 4.0 * qTheta2 * u;
   const Scalar tmp3 = std::sqrt(1.0 + theta2 + 4.0 * qThetaU - tmp2 + 4.0 * qTheta2U2 - 2.0 * theta_);
-  return -0.5 * (theta_ + 2.0 * qTheta - 2.0 * qTheta2 - 2.0 * qTheta2U2 - tmp1 - 1.0 + tmp2 + tmp3) / (theta_ * (-1.0 + qTheta - tmp1 + qTheta * u2));
+  return SpecFunc::Clip01(-0.5 * (theta_ + 2.0 * qTheta - 2.0 * qTheta2 - 2.0 * qTheta2U2 - tmp1 - 1.0 + tmp2 + tmp3) / (theta_ * (-1.0 + qTheta - tmp1 + qTheta * u2)));
 }
 
 /* Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/BlockIndependentCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/BlockIndependentCopula.cxx
@@ -513,7 +513,7 @@ Point BlockIndependentCopula::computeSequentialConditionalCDF(const Point & x) c
   Point result(dimension_);
   if (hasIndependentCopula())
     for (UnsignedInteger i = 0; i < dimension_; ++i)
-      result[i] = (x[i] < 0.0 ? 0.0 : x[i] > 1.0 ? 1.0 : x[i]);
+      result[i] = SpecFunc::Clip01(x[i]);
   else
   {
     const UnsignedInteger size = copulaCollection_.getSize();
@@ -539,7 +539,7 @@ Scalar BlockIndependentCopula::computeConditionalQuantile(const Scalar q, const 
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension == 0) return q;
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q=" << q << " outside of [0, 1]";
   if (q == 0.0) return 0.0;
   if (q == 1.0) return 1.0;
   if (conditioningDimension == 0) return q;
@@ -567,7 +567,10 @@ Point BlockIndependentCopula::computeSequentialConditionalQuantile(const Point &
   Point result(dimension_);
   if (hasIndependentCopula())
     for (UnsignedInteger i = 0; i < dimension_; ++i)
-      result[i] = (q[i] < 0.0 ? 0.0 : q[i] > 1.0 ? 1.0 : q[i]);
+      {
+	if (!((q[i] >= 0.0) && (q[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
+	result[i] = q[i];
+      }
   else
   {
     const UnsignedInteger size = copulaCollection_.getSize();

--- a/lib/src/Uncertainty/Distribution/BlockIndependentDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/BlockIndependentDistribution.cxx
@@ -441,7 +441,7 @@ Scalar BlockIndependentDistribution::computeConditionalQuantile(const Scalar q, 
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   if (q == 0.0) return getRange().getLowerBound()[y.getDimension()];
   if (q == 1.0) return getRange().getUpperBound()[y.getDimension()];
   if (conditioningDimension == 0) return getMarginal(0).computeQuantile(q)[0];

--- a/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
@@ -403,34 +403,35 @@ Point ClaytonCopula::computeQuantile(const Scalar prob,
 /* Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
 Scalar ClaytonCopula::computeConditionalCDF(const Scalar x, const Point & y) const
 {
-  std::cerr << "In computeConditionalCDF" << std::endl;
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
   // Special case for no conditioning
-  if (conditioningDimension == 0) return SpecFunc::Clip01(x);
+  if ((conditioningDimension == 0) || (hasIndependentCopula())) return SpecFunc::Clip01(x);
   const Scalar u = y[0];
-  if ((u <= 0.0) || (u > 1.0)) return 0.0;
-  const Scalar v = SpecFunc::Clip01(x);
+  if (!((u >= 0.0) && (u < 1.0))) return 0.0;
+  const Scalar v = x;
+  if (!(v > 0.0)) return 0.0;
+  if (!(v < 1.0)) return 1.0;
   // If we are in the support
   const Scalar factor = std::pow(u, -theta_) + std::pow(v, -theta_) - 1.0;
-  if (factor <= 0.0) return 0.0;
-  return std::pow(factor, -1.0 - 1.0 / theta_) * std::pow(u, -1.0 - theta_);
+  if (!(factor > 0.0)) return 0.0;
+  return SpecFunc::Clip01(std::pow(factor, -1.0 - 1.0 / theta_) * std::pow(u, -1.0 - theta_));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
 Scalar ClaytonCopula::computeConditionalQuantile(const Scalar q, const Point & y) const
 {
-  std::cerr << "In computeConditionalQuantile" << std::endl;
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   // Special case for no conditioning or independent copula
   if ((q == 0.0) || (q == 1.0)) return q;
   // Initialize the conditional quantile with the quantile of the i-th marginal distribution
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   const Scalar z = y[0];
-  return z * std::pow(std::pow(q, -theta_ / (1.0 + theta_)) - 1.0 + std::pow(z, theta_), -1.0 / theta_);
+  if (!((z >= 0.0) && (z <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning component outside of [0, 1]";
+  return SpecFunc::Clip01(z * std::pow(std::pow(q, -theta_ / (1.0 + theta_)) - 1.0 + std::pow(z, theta_), -1.0 / theta_));
 }
 
 /* Tell if the distribution has independent copula */

--- a/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ClaytonCopula.cxx
@@ -403,12 +403,14 @@ Point ClaytonCopula::computeQuantile(const Scalar prob,
 /* Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
 Scalar ClaytonCopula::computeConditionalCDF(const Scalar x, const Point & y) const
 {
+  std::cerr << "In computeConditionalCDF" << std::endl;
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
-  // Special case for no conditioning or independent copula
-  if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
+  // Special case for no conditioning
+  if (conditioningDimension == 0) return SpecFunc::Clip01(x);
   const Scalar u = y[0];
-  const Scalar v = x;
+  if ((u <= 0.0) || (u > 1.0)) return 0.0;
+  const Scalar v = SpecFunc::Clip01(x);
   // If we are in the support
   const Scalar factor = std::pow(u, -theta_) + std::pow(v, -theta_) - 1.0;
   if (factor <= 0.0) return 0.0;
@@ -418,6 +420,7 @@ Scalar ClaytonCopula::computeConditionalCDF(const Scalar x, const Point & y) con
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
 Scalar ClaytonCopula::computeConditionalQuantile(const Scalar q, const Point & y) const
 {
+  std::cerr << "In computeConditionalQuantile" << std::endl;
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
   if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";

--- a/lib/src/Uncertainty/Distribution/Dirichlet.cxx
+++ b/lib/src/Uncertainty/Distribution/Dirichlet.cxx
@@ -330,7 +330,7 @@ Scalar Dirichlet::computeConditionalPDF(const Scalar x,
   if (sumY <= 0.0 || sumY >= 1.0) return 0.0;
   s -= sumThetaConditioning;
   const Scalar z = x / (1.0 - sumY);
-  if (z <= 0.0 || z >= 1.0) return 0.0;
+  if (!((z > 0.0) && (z < 1.0))) return 0.0;
   return std::exp(-SpecFunc::LogBeta(r, s) + (r - 1.0) * std::log(z) + (s - 1.0) * log1p(-z)) / (1.0 - sumY);
 }
 
@@ -351,7 +351,7 @@ Point Dirichlet::computeSequentialConditionalPDF(const Point & x) const
     s -= r;
     r = theta_[conditioningDimension];
     z = x[conditioningDimension] / (1.0 - sumY);
-    if (z <= 0.0 || z >= 1.0) break;
+    if (!((z > 0.0) & (z < 1.0))) break;
     result[conditioningDimension] = std::exp(- SpecFunc::LogBeta(r, s) + (r - 1.0) * std::log(z) + (s - 1.0) * log1p(-z)) / (1.0 - sumY);
   }
   return result;
@@ -373,8 +373,8 @@ Scalar Dirichlet::computeConditionalCDF(const Scalar x,
     sumThetaConditioning += theta_[i];
     sumY += y[i];
   }
-  if (sumY <= 0.0) return 0.0;
-  if (sumY >= 1.0) return 1.0;
+  if (!(sumY > 0.0)) return 0.0;
+  if (!(sumY < 1.0)) return 1.0;
   s -= sumThetaConditioning;
   return DistFunc::pBeta(r, s, x / (1.0 - sumY));
 }
@@ -392,7 +392,7 @@ Point Dirichlet::computeSequentialConditionalCDF(const Point & x) const
   for (UnsignedInteger conditioningDimension = 1; conditioningDimension < dimension; ++conditioningDimension)
   {
     sumY += x[conditioningDimension - 1];
-    if (sumY <= 0.0 || sumY >= 1.0) return result;
+    if (!((sumY > 0.0) && (sumY < 1.0))) return result;
     s -= r;
     r = theta_[conditioningDimension];
     z = x[conditioningDimension] / (1.0 - sumY);
@@ -407,11 +407,12 @@ Scalar Dirichlet::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q=" << q << " outside of [0, 1]";
   Scalar sumThetaConditioning = 0.0;
   Scalar sumY = 0.0;
   for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
   {
+    if (!((y[i] >= 0.0) && (y[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning point outside of the conditioning distribution range";
     sumThetaConditioning += theta_[i];
     sumY += y[i];
   }
@@ -432,7 +433,7 @@ Point Dirichlet::computeSequentialConditionalQuantile(const Point & q) const
   for (UnsignedInteger conditioningDimension = 1; conditioningDimension < dimension; ++conditioningDimension)
   {
     sumY += result[conditioningDimension - 1];
-    if (sumY <= 0.0 || sumY >= 1.0) return result;
+    if (!((sumY > 0.0) & (sumY < 1.0))) return result;
     s -= r;
     r = theta_[conditioningDimension];
     result[conditioningDimension] = (1.0 - sumY) * DistFunc::qBeta(r, s, q[conditioningDimension]);

--- a/lib/src/Uncertainty/Distribution/DistFunc.cxx
+++ b/lib/src/Uncertainty/Distribution/DistFunc.cxx
@@ -1186,6 +1186,7 @@ Scalar DistFunc::pNormal3D(const Scalar x1,
 Scalar DistFunc::qNormal(const Scalar p,
                          const Bool tail)
 {
+  if ((p < 0.0) || (p > 1.0)) throw InvalidArgumentException(HERE) << "Error: expected a probability level in [0, 1] for qNormal, got p=" << p;
   if (p == 0.0) return (tail ? 8.125890664701906 : -37.5193793471445);
   if (p == 1.0) return (tail ? -37.5193793471445 :  8.125890664701906);
 
@@ -1285,6 +1286,7 @@ Point DistFunc::qNormal(const Point & p,
   for (UnsignedInteger i = 0; i < size; ++i)
   {
     prob = p[i];
+    if ((prob < 0.0) || (prob > 1.0)) throw InvalidArgumentException(HERE) << "Error: expected a probability level in [0, 1] for qNormal, got p[" << i << "]=" << prob;
     if (prob == 0.0)
     {
       result[i] = (tail ? 8.125890664701906 : -8.125890664701906);

--- a/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/EmpiricalBernsteinCopula.cxx
@@ -458,7 +458,7 @@ Scalar EmpiricalBernsteinCopula::computeConditionalCDF(const Scalar x,
   if (x <= 0.0) return 0.0;
   if (x >= 1.0) return 1.0;
   for (UnsignedInteger i = 0; i < y.getDimension(); ++i)
-    if (y[i] <= 0.0 || y[i] >= 1.0) return 0.0;
+    if ((y[i] <= 0.0) || (y[i] >= 1.0)) return 0.0;
   const UnsignedInteger size = copulaSample_.getSize();
   // Special case for no conditioning or independent copula
   if ((conditioningDimension == 0) || (hasIndependentCopula()))
@@ -468,7 +468,7 @@ Scalar EmpiricalBernsteinCopula::computeConditionalCDF(const Scalar x,
     Scalar conditionalCDF = 1.0;
     for (UnsignedInteger i = 0; i < size; ++i)
       conditionalCDF += SpecFunc::RegularizedIncompleteBeta(logFactors_(i, j), binNumber_ - logFactors_(i, j) + 1.0, x);
-    return conditionalCDF / size;
+    return SpecFunc::Clip01(conditionalCDF / size);
   } // (conditioningDimension == 0) || (hasIndependentCopula())
   // Case with conditioning. The PDFs are computed up to an 1/n factor, which simplifies during the division.
   Point allConditioningAtomPDF(size);
@@ -489,7 +489,7 @@ Scalar EmpiricalBernsteinCopula::computeConditionalCDF(const Scalar x,
   Scalar conditionedCDF = 0.0;
   for (UnsignedInteger i = 0; i < size; ++i)
     conditionedCDF += SpecFunc::RegularizedIncompleteBeta(logFactors_(i, conditioningDimension), binNumber_ - logFactors_(i, conditioningDimension) + 1.0, x) * allConditioningAtomPDF[i];
-  return conditionedCDF / conditioningPDF;
+  return SpecFunc::Clip01(conditionedCDF / conditioningPDF);
 }
 
 Point EmpiricalBernsteinCopula::computeSequentialConditionalCDF(const Point & x) const
@@ -500,11 +500,16 @@ Point EmpiricalBernsteinCopula::computeSequentialConditionalCDF(const Point & x)
   // Special case for no conditioning or independent copula
   if (hasIndependentCopula())
   {
-    if (isCopula()) return Point(dimension_, 1.0);
+    if (isCopula())
+    {
+      for (UnsignedInteger j = 0; j < dimension_; ++j)
+	result[j] = SpecFunc::Clip01(x[j]);
+      return result;
+    } // isCopula
     for (UnsignedInteger j = 0; j < dimension_; ++j)
     {
-      if (x[j] <= 0.0) result[j] = 0.0;
-      else if (x[j] >= 1.0) result[j] = 1.0;
+      if (!(x[j] > 0.0)) result[j] = 0.0;
+      else if (!(x[j] < 1.0)) result[j] = 1.0;
       else
       {
         Scalar conditionalPDF = 0.0;
@@ -522,7 +527,7 @@ Point EmpiricalBernsteinCopula::computeSequentialConditionalCDF(const Point & x)
   {
     Scalar conditionedPDF = 0.0;
     Scalar conditionedCDF = 0.0;
-    if ((x[j] > 0.0) && (x[j] < 1.0) && conditioningPDF > 0.0)
+    if ((x[j] > 0.0) && (x[j] < 1.0) && (conditioningPDF > 0.0))
     {
       const Scalar logX = std::log(x[j]);
       const Scalar log1mX = std::log1p(-x[j]);
@@ -535,7 +540,7 @@ Point EmpiricalBernsteinCopula::computeSequentialConditionalCDF(const Point & x)
       }
     } // 0<x<1
     else return result;
-    result[j] = conditionedCDF / conditioningPDF;
+    result[j] = SpecFunc::Clip01(conditionedCDF / conditioningPDF);
     conditioningPDF = conditionedPDF;
   } // j
   return result;

--- a/lib/src/Uncertainty/Distribution/ExtremeValueCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/ExtremeValueCopula.cxx
@@ -120,7 +120,7 @@ Scalar ExtremeValueCopula::computePDF(const Point & point) const
   const Scalar u = point[0];
   const Scalar v = point[1];
   // A copula has a null PDF outside of ]0, 1[^2
-  if ((u <= 0.0) || (u >= 1.0) || (v <= 0.0) || (v >= 1.0))
+  if (!((u > 0.0) && (u < 1.0) && (v > 0.0) && (v < 1.0)))
   {
     return 0.0;
   }
@@ -143,7 +143,7 @@ Scalar ExtremeValueCopula::computeLogPDF(const Point & point) const
   const Scalar u = point[0];
   const Scalar v = point[1];
   // A copula has a null PDF outside of ]0, 1[^2
-  if ((u <= 0.0) || (u >= 1.0) || (v <= 0.0) || (v >= 1.0))
+  if (!((u > 0.0) && (u < 1.0) && (v > 0.0) && (v < 1.0)))
   {
     return SpecFunc::LowestScalar;
   }
@@ -169,22 +169,22 @@ Scalar ExtremeValueCopula::computeCDF(const Point & point) const
   const Scalar u = point[0];
   const Scalar v = point[1];
   // If we are outside of the support, in the lower parts
-  if ((u <= 0.0) || (v <= 0.0))
+  if (!((u > 0.0) && (v > 0.0)))
   {
     return 0.0;
   }
   // If we are outside of the support, in the upper part
-  if ((u >= 1.0) && (v >= 1.0))
+  if (!((u < 1.0) || (v < 1.0)))
   {
     return 1.0;
   }
   // If we are outside of the support for u, in the upper part
-  if (u >= 1.0)
+  if (!(u < 1.0))
   {
     return v;
   }
   // If we are outside of the support for v, in the upper part
-  if (v >= 1.0)
+  if (!(v < 1.0))
   {
     return u;
   }
@@ -216,13 +216,16 @@ public:
 
   Point operator() (const Point & point) const override
   {
+    if (!((u_ >= 0.0) && (u_ < 1.0))) return Point(1, 0.0);
     const Scalar v = point[0];
+    if (!(v > 0.0)) return Point(1, 0.0);
+    if (!(v < 1.0)) return Point(1, 1.0);
     const Scalar logV = std::log(v);
     const Scalar logUV = std::log(u_ * v);
     const Point ratio(1, logV / logUV);
     const Scalar A = pickandFunction_(ratio)[0];
     const Scalar dA = pickandFunction_.gradient(ratio)(0, 0);
-    const Scalar conditionalCDF = (A - dA * ratio[0]) * std::exp(logUV * A) / u_;
+    const Scalar conditionalCDF = SpecFunc::Clip01((A - dA * ratio[0]) * std::exp(logUV * A) / u_);
     return Point(1, conditionalCDF);
   }
 

--- a/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/FarlieGumbelMorgensternCopula.cxx
@@ -189,8 +189,8 @@ Point FarlieGumbelMorgensternCopula::computePDFGradient(const Point & point) con
 
   const Scalar u = point[0];
   const Scalar v = point[1];
-  // A copula has a null PDF outside of ]0, 1[^2
-  if ((u <= 0.0) || (u >= 1.0) || (v <= 0.0) || (v >= 1.0))
+  // A copula has a null PDF outside of [0, 1[^2
+  if (!((u >= 0.0) && (u < 1.0) && (v >= 0.0) && (v < 1.0)))
   {
     return Point(1, 0.0);
   }
@@ -205,7 +205,7 @@ Point FarlieGumbelMorgensternCopula::computeCDFGradient(const Point & point) con
 
   const Scalar u = point[0];
   const Scalar v = point[1];
-  if ((u <= 0.0) || (u >= 1.0) || (v <= 0.0) || (v >= 1.0))
+  if (!((u >= 0.0) && (u < 1.0) && (v >= 0.0) && (v < 1.0)))
   {
     return Point(1, 0.0);
   }
@@ -219,11 +219,14 @@ Scalar FarlieGumbelMorgensternCopula::computeConditionalCDF(const Scalar x,
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
   // Special case for no conditioning or independent copula
-  if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
+  if ((conditioningDimension == 0) || (hasIndependentCopula())) return SpecFunc::Clip01(x);
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u < 1.0))) return 0.0;
   const Scalar v = x;
+  if (!(v >= 0.0)) return 0.0;
+  if (!(v < 1.0)) return 1.0;
   // If we are in the support
-  return v * (1.0 + theta_ * (v - 1.0) * (2.0 * u - 1.0));
+  return SpecFunc::Clip01(v * (1.0 + theta_ * (v - 1.0) * (2.0 * u - 1.0)));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -232,15 +235,17 @@ Scalar FarlieGumbelMorgensternCopula::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   // Special case for no conditioning or independent copula
   if ((q == 0.0) || (q == 1.0)) return q;
   // Initialize the conditional quantile with the quantile of the i-th marginal distribution
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
-  const Scalar alpha = theta_ * (1.0 - 2.0 * y[0]);
+  const Scalar u = y[0];
+  if (!((u >= 0.0) && (u <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning component outside of [0, 1]";
+  const Scalar alpha = theta_ * (1.0 - 2.0 * u);
   const Scalar alpha1 = 1.0 + alpha;
-  return 2.0 * q / (alpha1 + std::sqrt(alpha1 * alpha1 - 4.0 * q * alpha));
+  return SpecFunc::Clip01(2.0 * q / (alpha1 + std::sqrt(alpha1 * alpha1 - 4.0 * q * alpha)));
 }
 
 /* Tell if the distribution has an elliptical copula */

--- a/lib/src/Uncertainty/Distribution/FrankCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/FrankCopula.cxx
@@ -278,13 +278,16 @@ Scalar FrankCopula::computeConditionalCDF(const Scalar x, const Point & y) const
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
   // Special case for no conditioning or independent copula
-  if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
+  if ((conditioningDimension == 0) || (hasIndependentCopula())) return SpecFunc::Clip01(x);
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u <= 1.0))) return 0.0;
   const Scalar v = x;
+  if (!(v > 0.0)) return 0.0;
+  if (!(v < 1.0)) return 1.0;
   // If we are in the support
   const Scalar alpha = std::exp(-theta_ * v);
   const Scalar beta = std::exp(-theta_ * u) * (alpha - 1.0);
-  return -beta / (alpha - std::exp(-theta_) - beta);
+  return SpecFunc::Clip01(-beta / (alpha - std::exp(-theta_) - beta));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -292,15 +295,16 @@ Scalar FrankCopula::computeConditionalQuantile(const Scalar q, const Point & y) 
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   if (q == 0.0) return 0.0;
   if (q == 1.0) return 1.0;
   // Initialize the conditional quantile with the quantile of the i-th marginal distribution
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning value outside of [0, 1]";
   const Scalar factor = (q - 1.0) * std::exp(-theta_ * u);
-  return 1.0 + std::log((factor - q) / (factor * std::exp(theta_) - q)) / theta_;
+  return SpecFunc::Clip01(1.0 + std::log((factor - q) / (factor * std::exp(theta_) - q)) / theta_);
 }
 
 /* Compute the archimedean generator of the archimedean copula, i.e.

--- a/lib/src/Uncertainty/Distribution/GumbelCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/GumbelCopula.cxx
@@ -267,13 +267,15 @@ Scalar GumbelCopula::computeConditionalCDF(const Scalar x, const Point & y) cons
   // Special case for no conditioning or independent copula
   if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
   const Scalar u = y[0];
+  if ((u <= 0.0) || (u > 1.0)) return 0.0;
   const Scalar v = x;
+  if (v <= 0.0) return 0.0;
   // If we are in the support
   const Scalar minusLogU = -std::log(u);
   const Scalar minusLogUPowTheta = std::pow(minusLogU, theta_);
   const Scalar minusLogVPowTheta = std::pow(-std::log(v), theta_);
   const Scalar sum = minusLogUPowTheta + minusLogVPowTheta;
-  return std::pow(sum, -1.0 + 1.0 / theta_) * minusLogUPowTheta * std::exp(-std::pow(sum, 1.0 / theta_)) / (u * minusLogU);
+  return SpecFunc::Clip01(std::pow(sum, -1.0 + 1.0 / theta_) * minusLogUPowTheta * std::exp(-std::pow(sum, 1.0 / theta_)) / (u * minusLogU));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -281,18 +283,19 @@ Scalar GumbelCopula::computeConditionalQuantile(const Scalar q, const Point & y)
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q <= 0.0) || (q >= 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q > 0.0) && (q < 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   if (q == 0.0) return 0.0;
   if (q == 1.0) return 1.0;
   // Initialize the conditional quantile with the quantile of the i-th marginal distribution
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning component outside of [0, 1]";
   const Scalar inverseThetaMinusOne = 1.0 / (theta_ - 1.0);
   const Scalar minusLogU = -std::log(u);
   const Scalar minusLogUPowTheta = std::pow(minusLogU, theta_);
   const Scalar factor = minusLogUPowTheta / (u * q * minusLogU);
-  return std::exp(-std::pow(std::exp(theta_ * (std::log(factor) / (theta_ - 1.0) - SpecFunc::LambertW(std::pow(factor, inverseThetaMinusOne) * inverseThetaMinusOne))) - minusLogUPowTheta, 1.0 / theta_));
+  return SpecFunc::Clip01(std::exp(-std::pow(std::exp(theta_ * (std::log(factor) / (theta_ - 1.0) - SpecFunc::LambertW(std::pow(factor, inverseThetaMinusOne) * inverseThetaMinusOne))) - minusLogUPowTheta, 1.0 / theta_)));
 }
 
 /* Get the Kendall concordance of the distribution */

--- a/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/IndependentCopula.cxx
@@ -261,9 +261,8 @@ Scalar IndependentCopula::computeConditionalPDF(const Scalar x, const Point & y)
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional PDF with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if (x < 0.0) return 0.0;
-  if (x < 1.0) return 1.0;
-  return 0.0;
+  if (!(x >= 0.0) || !(x < 1.0)) return 0.0;
+  return 1.0;
 }
 
 /* Compute the CDF of Xi | X1, ..., Xi-1. x = Xi, y = (X1,...,Xi-1) */
@@ -271,9 +270,9 @@ Scalar IndependentCopula::computeConditionalCDF(const Scalar x, const Point & y)
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if (x < 0.0) return 0.0;
-  if (x < 1.0) return x;
-  return 1.0;
+  for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
+    if (!((y[i] >= 0.0) && (y[i] < 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile when the conditioning point y=" << y << " is not in [0, 1]";    
+  return SpecFunc::Clip01(x);
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -282,7 +281,9 @@ Scalar IndependentCopula::computeConditionalQuantile(const Scalar q, const Point
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
   if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
-  return q;
+  for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
+    if (!((y[i] >= 0.0) && (y[i] < 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile when the conditioning point y=" << y << " is not in [0, 1]";    
+  return SpecFunc::Clip01(q);
 }
 
 /* Get the isoprobabilist transformation */

--- a/lib/src/Uncertainty/Distribution/JointByConditioningDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/JointByConditioningDistribution.cxx
@@ -591,7 +591,7 @@ Scalar JointByConditioningDistribution::computeConditionalQuantile(const Scalar 
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   // Special case for a conditioning only in the conditioning part
   const UnsignedInteger conditioningDistributionDimension = conditioningDistribution_.getDimension();
   if ((conditioningDimension < conditioningDistributionDimension))

--- a/lib/src/Uncertainty/Distribution/JointDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/JointDistribution.cxx
@@ -844,7 +844,8 @@ Point JointDistribution::computeSequentialConditionalCDF(const Point & x) const
   for (UnsignedInteger i = 0; i < dimension_; ++i)
     u[i] = distributionCollection_[i].computeCDF(x[i]);
   if (core_.isCopula() && hasIndependentCopula()) return u;
-  return core_.computeSequentialConditionalCDF(u);
+  const Point result(core_.computeSequentialConditionalCDF(u));
+  return result;
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -860,7 +861,11 @@ Scalar JointDistribution::computeConditionalQuantile(const Scalar q,
   if (core_.isCopula() && ((conditioningDimension == 0) || hasIndependentCopula())) return distributionCollection_[conditioningDimension].computeScalarQuantile(q);
   // General case
   Point u(conditioningDimension);
-  for (UnsignedInteger i = 0; i < conditioningDimension; ++i) u[i] = distributionCollection_[i].computeCDF(y[i]);
+  for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
+    {
+      if (!((y[i] >= range_.getLowerBound()[i]) && (y[i] <= range_.getUpperBound()[i]))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning point outside of the conditioning distribution range";
+      u[i] = distributionCollection_[i].computeCDF(y[i]);
+    }
   return distributionCollection_[conditioningDimension].computeScalarQuantile(core_.computeConditionalQuantile(q, u));
 }
 

--- a/lib/src/Uncertainty/Distribution/KernelMixture.cxx
+++ b/lib/src/Uncertainty/Distribution/KernelMixture.cxx
@@ -505,7 +505,7 @@ Scalar KernelMixture::computeConditionalPDF(const Scalar x,
     marginalPDF += marginalAtomPDF;
     jointPDF += marginalAtomPDF * p_kernel_->computePDF((x - sample_(i, conditioningDimension)) * bandwidthInverse_[conditioningDimension]);
   }
-  if (marginalPDF <= 0.0) return 0.0;
+  if (!(marginalPDF > 0.0)) return 0.0;
   return bandwidthInverse_[conditioningDimension] * jointPDF / marginalPDF;
 }
 
@@ -526,7 +526,7 @@ Point KernelMixture::computeSequentialConditionalPDF(const Point & x) const
   for (UnsignedInteger conditioningDimension = 1; conditioningDimension < dimension_; ++conditioningDimension)
   {
     // Return the result as soon as a conditional pdf is zero
-    if (pdfConditioning == 0) return result;
+    if (!(pdfConditioning > 0.0)) return result;
     currentX = x[conditioningDimension];
     Scalar pdfConditioned = 0.0;
     for (UnsignedInteger i = 0; i < size; ++i)
@@ -561,7 +561,7 @@ Scalar KernelMixture::computeConditionalCDF(const Scalar x,
     marginalPDF += marginalAtomPDF;
     jointCDF += marginalAtomPDF * p_kernel_->computeCDF((x - sample_(i, conditioningDimension)) / h);
   }
-  if (marginalPDF <= 0.0) return 0.0;
+  if (!(marginalPDF > 0.0)) return 0.0;
   // No need to normalize by 1/h as it simplifies
   return SpecFunc::Clip01(jointCDF / marginalPDF);
 }
@@ -594,7 +594,7 @@ Point KernelMixture::computeSequentialConditionalCDF(const Point & x) const
   for (UnsignedInteger conditioningDimension = 1; conditioningDimension < dimension_; ++conditioningDimension)
   {
     // Return the result as soon as a conditional pdf is zero
-    if (pdfConditioning == 0) return result;
+    if (!(pdfConditioning > 0.0)) return result;
     currentX = x[conditioningDimension];
     currentH = bandwidth_[conditioningDimension];
     pdfConditioned = 0.0;
@@ -605,7 +605,7 @@ Point KernelMixture::computeSequentialConditionalCDF(const Point & x) const
       atomsValues[i] *= p_kernel_->computePDF((currentX - sample_(i, conditioningDimension)) / currentH) / currentH;
       pdfConditioned += atomsValues[i];
     }
-    result[conditioningDimension] = cdfConditioned / pdfConditioning;
+    result[conditioningDimension] = SpecFunc::Clip01(cdfConditioned / pdfConditioning);
     pdfConditioning = pdfConditioned;
   } // conditioningDimension
   return result;

--- a/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/MaximumEntropyOrderStatisticsDistribution.cxx
@@ -625,7 +625,7 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalPDF (const S
   const Scalar aK = getRange().getLowerBound()[k];
   const Scalar bK = getRange().getUpperBound()[k];
   // If x is outside of the range of the kth marginal, the conditional PDF is zero
-  if ((x <= aK) || (x > bK)) return 0.0;
+  if (!((x > aK) && (x <= bK))) return 0.0;
   // The conditional PDF depends only on the last component of the conditioning vector
   const Scalar xKm1 = y[k - 1];
   // If the conditioning component is greater than the argument the conditional PDF is zero
@@ -633,7 +633,7 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalPDF (const S
   // If the conditioning component is outside of the (k-1)th marginal range
   const Scalar aKm1 = getRange().getLowerBound()[k - 1];
   const Scalar bKm1 = getRange().getUpperBound()[k - 1];
-  if ((xKm1 <= aKm1) || (xKm1 > bKm1)) return 0.0;
+  if (!((xKm1 > aKm1) && (xKm1 <= bKm1))) return 0.0;
   // Here we have something to do
   // If x is independent of the previous components
   if (partition_.contains(k - 1)) return distributionCollection_[k].computePDF(x);
@@ -661,26 +661,26 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalCDF (const S
   const Scalar aK = getRange().getLowerBound()[k];
   const Scalar bK = getRange().getUpperBound()[k];
   // If x is less than the lower bound of its associated marginal, the conditional CDF is zero
-  if (x <= aK)
+  if (!(x > aK))
   {
     return 0.0;
   }
   // If x is greater than the upper bound of its associated marginal, the conditional CDF is one
-  if (x > bK)
+  if (!(x <= bK))
   {
     return 1.0;
   }
   // The conditional CDF depends only on the last component of the conditioning vector
   const Scalar xKm1 = y[k - 1];
   // If the conditioning component is greater than the argument the conditional CDF is zero
-  if (xKm1 > x)
+  if (!(xKm1 <= x))
   {
     return 1.0;
   }
   // If the conditioning component is outside of the (k-1)th marginal range
   const Scalar aKm1 = getRange().getLowerBound()[k - 1];
   const Scalar bKm1 = getRange().getUpperBound()[k - 1];
-  if ((xKm1 <= aKm1) || (xKm1 > bKm1))
+  if (!((xKm1 > aKm1) && (xKm1 <= bKm1)))
   {
     return 0.0;
   }
@@ -695,7 +695,7 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalCDF (const S
   // CDF(x|xKm1) = 1 - exp(-\int_{xKm1}^x\phi(s)ds)
   const Scalar factor = computeFactor(k, xKm1, x);
   const Scalar value = -expm1(-factor);
-  return value;
+  return SpecFunc::Clip01(value);
 }
 
 
@@ -705,7 +705,7 @@ Scalar MaximumEntropyOrderStatisticsDistribution::computeConditionalQuantile(con
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
 
   if (conditioningDimension == 0) return distributionCollection_[0].computeQuantile(q)[0];
   const UnsignedInteger k = conditioningDimension;

--- a/lib/src/Uncertainty/Distribution/Mixture.cxx
+++ b/lib/src/Uncertainty/Distribution/Mixture.cxx
@@ -471,7 +471,7 @@ Scalar Mixture::computeConditionalCDF(const Scalar x,
     if (weightedMarginalAtomPDF > 0.0)
       conditionedCDF += distributionCollection_[i].computeConditionalCDF(x, y) * weightedMarginalAtomPDF;
   }
-  if (conditioningPDF <= 0.0) return 0.0;
+  if (!(conditioningPDF > 0.0)) return 0.0;
   // No need to normalize by 1/h as it simplifies
   return SpecFunc::Clip01(conditionedCDF / conditioningPDF);
 }
@@ -514,14 +514,14 @@ Point Mixture::computeSequentialConditionalCDF(const Point & x) const
       const Scalar wI = weights[i];
       const Distribution marginalAtom(distributionCollection_[i].getMarginal(conditioning));
       const Scalar weightedMarginalAtomPDF = wI * marginalAtom.computePDF(currentX);
-      if (weightedMarginalAtomPDF > 0.0)
+      if (!(weightedMarginalAtomPDF <= 0.0))
       {
         pdfConditioned += weightedMarginalAtomPDF;
         cdfConditioned += marginalAtom.computeConditionalCDF(xConditioned, y) * weightedAtomsPDF[i];
         weightedAtomsPDF[i] = weightedMarginalAtomPDF;
       } // atomMarginalPDF > 0.0
     } // i
-    result[conditioningDimension] = cdfConditioned / pdfConditioning;
+    result[conditioningDimension] = SpecFunc::Clip01(cdfConditioned / pdfConditioning);
     pdfConditioning = pdfConditioned;
   } // conditioningDimension
   return result;

--- a/lib/src/Uncertainty/Distribution/Multinomial.cxx
+++ b/lib/src/Uncertainty/Distribution/Multinomial.cxx
@@ -587,7 +587,7 @@ Scalar Multinomial::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   // Special case when no contitioning or independent copula
   if (conditioningDimension == 0) return Binomial(n_, p_[0]).computeQuantile(q)[0];
   // General case

--- a/lib/src/Uncertainty/Distribution/Normal.cxx
+++ b/lib/src/Uncertainty/Distribution/Normal.cxx
@@ -638,7 +638,7 @@ Scalar Normal::computeConditionalQuantile(const Scalar q,
   const UnsignedInteger conditioningDimension = y.getDimension();
 
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   // Special case when no conditioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return mean_[conditioningDimension] + sigma_[conditioningDimension] * DistFunc::qNormal(q);
   // General case
@@ -654,6 +654,8 @@ Scalar Normal::computeConditionalQuantile(const Scalar q,
 Point Normal::computeSequentialConditionalQuantile(const Point & q) const
 {
   if (q.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute sequential conditional quantile with an argument of dimension=" << q.getDimension() << " different from distribution dimension=" << dimension_;
+  for (UnsignedInteger i = 0; i < dimension_; ++i)
+    if (!((q[i] >= 0.0) && (q[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
   if (hasIndependentCopula())
   {
     Point result(dimension_);

--- a/lib/src/Uncertainty/Distribution/NormalCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/NormalCopula.cxx
@@ -430,8 +430,8 @@ Point NormalCopula::computeConditionalPDF(const Point & x,
     Point result(size, 1.0);
     for (UnsignedInteger i = 0; i < size; ++i)
     {
-      if (x[i]  < 0.0) result[i] = 0.0;
-      if (x[i] >= 1.0) result[i] = 0.0;
+      if (!(x[i] >= 0.0)) result[i] = 0.0;
+      if (!(x[i] <= 1.0)) result[i] = 0.0;
     }
     return result;
   }
@@ -458,7 +458,10 @@ Point NormalCopula::computeSequentialConditionalPDF(const Point & x) const
   Point result(dimension_);
   if (hasIndependentCopula())
     for (UnsignedInteger i = 0; i < dimension_; ++i)
-      result[i] = (x[i] >= 0.0 && x[i] < 1.0 ? 1.0 : 0.0);
+    {
+      if (!((x[i] < 0.0) || (x[i] >= 1.0)))
+	result[i] = 1.0;
+    }
   else
   {
     const TriangularMatrix inverseCholesky(normal_.getInverseCholesky());
@@ -478,7 +481,7 @@ Scalar NormalCopula::computeConditionalCDF(const Scalar x,
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional CDF with a conditioning point of dimension greater or equal to the distribution dimension.";
   // Special case for no conditioning or independent copula
   if ((conditioningDimension == 0) || (hasIndependentCopula()))
-    return (x <= 0.0 ? 0.0 : (x >= 1.0 ? 1.0 : x));
+    return (!(x > 0.0) ? 0.0: !(x < 1.0) ? 1.0 : x);
   // General case
   const TriangularMatrix inverseCholesky(normal_.getInverseCholesky());
   Scalar meanRos = 0.0;
@@ -496,7 +499,7 @@ Point NormalCopula::computeSequentialConditionalCDF(const Point & x) const
   {
     Point result(dimension_);
     for (UnsignedInteger i = 0; i < dimension_; ++i)
-      result[i] = (x[i] <= 0.0 ? 0.0 : (x[i] >= 1.0 ? 1.0 : x[i]));
+      result[i] = (!((x[i] > 0.0) && (x[i] < 1.0)) ? 0.0 : 1.0);
     return result;
   }
   return DistFunc::pNormal(normal_.getInverseCholesky() * DistFunc::qNormal(x));
@@ -508,7 +511,9 @@ Scalar NormalCopula::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  for (UnsignedInteger i = 0; i < conditioningDimension; ++i)
+    if (!((y[i] >= 0.0) && (y[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning point outside of the conditioning distribution range";
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   // General case
@@ -526,6 +531,8 @@ Scalar NormalCopula::computeConditionalQuantile(const Scalar q,
 Point NormalCopula::computeSequentialConditionalQuantile(const Point & q) const
 {
   if (q.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute sequential conditional quantile with an argument of dimension=" << q.getDimension() << " different from distribution dimension=" << dimension_;
+  for (UnsignedInteger i = 0; i < dimension_; ++i)
+    if (!((q[i] >= 0.0) && (q[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
   if (hasIndependentCopula()) return q;
   return DistFunc::pNormal(normal_.getCholesky() * DistFunc::qNormal(q));
 }

--- a/lib/src/Uncertainty/Distribution/PlackettCopula.cxx
+++ b/lib/src/Uncertainty/Distribution/PlackettCopula.cxx
@@ -246,7 +246,7 @@ Scalar PlackettCopula::computeConditionalCDF(const Scalar x, const Point & y) co
   if ((conditioningDimension == 0) || (hasIndependentCopula())) return x;
   const Scalar u = y[0];
   const Scalar v = x;
-  return 0.5 * (1.0 + (2.0 * v + thetaMinus1_ * (v - u) - 1.0) / std::sqrt(1.0 + std::pow(thetaMinus1_ * (u - v), 2.0) + thetaMinus1_ * (2.0 * v + u * (2.0 - 4.0 * v))));
+  return SpecFunc::Clip01(0.5 * (1.0 + (2.0 * v + thetaMinus1_ * (v - u) - 1.0) / std::sqrt(1.0 + std::pow(thetaMinus1_ * (u - v), 2.0) + thetaMinus1_ * (2.0 * v + u * (2.0 - 4.0 * v)))));
 }
 
 /* Compute the quantile of Xi | X1, ..., Xi-1, i.e. x such that CDF(x|y) = q with x = Xi, y = (X1,...,Xi-1) */
@@ -254,12 +254,13 @@ Scalar PlackettCopula::computeConditionalQuantile(const Scalar q, const Point & 
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
   if (q == 0.0) return 0.0;
   if (q == 1.0) return 1.0;
   // Special case when no contitioning or independent copula
   if ((conditioningDimension == 0) || hasIndependentCopula()) return q;
   const Scalar u = y[0];
+  if (!((u >= 0.0) && (u < 1.0))) return 0.0;
   const Scalar a = thetaMinus1_;
   const Scalar t1 = a * a;
   const Scalar t2 = q * q;
@@ -285,9 +286,8 @@ Scalar PlackettCopula::computeConditionalQuantile(const Scalar q, const Point & 
   const Scalar B = (4.0 * t12 * u - 4.0 * t16 * u - a - 2.0 * t10 - 2.0 * t12 + 2.0 * t16 + 2.0 * t8 - 1.0);
   const Scalar C = std::sqrt(t56 + t70);
   if (q <= 0.5)
-    return A * (B + C);
-  else
-    return A * (B - C);
+    return SpecFunc::Clip01(A * (B + C));
+  return SpecFunc::Clip01(A * (B - C));
 }
 
 /* Parameters value accessor */

--- a/lib/src/Uncertainty/Distribution/Student.cxx
+++ b/lib/src/Uncertainty/Distribution/Student.cxx
@@ -507,7 +507,7 @@ Scalar Student::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= getDimension()) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q=" << q << " outside of [0, 1]";
   // Special case when no contitioning or independent copula
   if (conditioningDimension == 0) return mean_[0] + sigma_[0] * DistFunc::qStudent(nu_, q);
   // General case

--- a/lib/src/Uncertainty/Distribution/UniformOrderStatistics.cxx
+++ b/lib/src/Uncertainty/Distribution/UniformOrderStatistics.cxx
@@ -233,7 +233,7 @@ Point UniformOrderStatistics::computeSequentialConditionalPDF(const Point & x) c
     // If at one step the components of x are not in nondecreasing order, all the subsequent conditional PDF
     // will be zero
     const Scalar xKm1 = x[k - 1];
-    if ((x[k] < xKm1) || (x[k] >= 1.0)) return result;
+    if (!((x[k] >= xKm1) && (x[k] < 1.0))) return result;
     result[k] = (dimension_ - k) * std::pow((1.0 - x[k]) / (1.0 - xKm1), dimension_ - k - 1.0) / (1.0 - xKm1);
   }
   return result;
@@ -245,14 +245,14 @@ Scalar UniformOrderStatistics::computeConditionalCDF(const Scalar x,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional PDF with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if (x < 0.0) return 0.0;
-  if (conditioningDimension == 0) return (x >= 1.0 ? 1.0 : 1.0 - std::pow(1.0 - x, dimension_));
+  if (!(x > 0.0)) return 0.0;
+  if (conditioningDimension == 0) return (!(x < 1.0) ? 1.0 : 1.0 - std::pow(1.0 - x, dimension_));
   // The conditioning values must be in nondecreasing order
   if (!y.isNonDecreasing()) return 0.0;
   const UnsignedInteger k = y.getDimension();
   const Scalar xKm1 = y[k - 1];
-  if (x < xKm1) return 0.0;
-  if (x >= 1.0) return 1.0;
+  if (!(x > xKm1)) return 0.0;
+  if (!(x < 1.0)) return 1.0;
   return 1.0 - std::pow((1.0 - x) / (1.0 - xKm1), dimension_ - k);
 }
 
@@ -260,15 +260,15 @@ Point UniformOrderStatistics::computeSequentialConditionalCDF(const Point & x) c
 {
   if (x.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute a sequential conditional CDF at a point of dimension=" << x.getDimension() << " not equal to the distribution dimension=" << dimension_;
   Point result(dimension_);
-  if (x[0] <= 0) return result;
+  if (!(x[0] > 0)) return result;
   result[0] = 1.0 - std::pow(1.0 - x[0], dimension_);
   for (UnsignedInteger k = 1; k < dimension_; ++k)
   {
     // If at one step the components of x are not in nondecreasing order, all the subsequent conditional PDF
     // will be zero
     const Scalar xKm1 = x[k - 1];
-    if (x[k] < xKm1) return result;
-    if (x[k] >= 1.0) result[k] = 1.0;
+    if (!(x[k] > xKm1)) return result;
+    if (!(x[k] < 1.0)) result[k] = 1.0;
     result[k] = 1.0 - std::pow((1.0 - x[k]) / (1.0 - xKm1), dimension_ - k);
   }
   return result;
@@ -280,25 +280,26 @@ Scalar UniformOrderStatistics::computeConditionalQuantile(const Scalar q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  if ((q < 0.0) || (q > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q >= 0.0) && (q <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q=" << q << " outside of [0, 1]";
   if (conditioningDimension == 0) return 1.0 - std::pow(1.0 - q, 1.0 / dimension_);
   // The conditioning values must be in nondecreasing order
   if (!y.isNonDecreasing()) return 0.0;
   const UnsignedInteger k = y.getDimension();
-  const Scalar xKm1 = y[k - 1];
-  return 1.0 - (1.0 - xKm1) * std::pow(1.0 - q, 1.0 / (dimension_ - k));
+  const Scalar yKm1 = y[k - 1];
+  if (!((yKm1 >= 0.0) && (yKm1 <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a conditioning point outside of the conditioning distribution range";
+  return SpecFunc::Clip01(1.0 - (1.0 - yKm1) * std::pow(1.0 - q, 1.0 / (dimension_ - k)));
 }
 
 Point UniformOrderStatistics::computeSequentialConditionalQuantile(const Point & q) const
 {
   if (q.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute a sequential conditional PDF at a quantile level vector of dimension=" << q.getDimension() << " not equal to the distribution dimension=" << dimension_;
-  if ((q[0] < 0.0) || (q[0] > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
+  if (!((q[0] >= 0.0) && (q[0] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[0]=" << q[0] << " outside of [0, 1]";
   Point result(dimension_);
-  result[0] = 1.0 - std::pow(1.0 - q[0], 1.0 / dimension_);
+  result[0] = SpecFunc::Clip01(1.0 - std::pow(1.0 - q[0], 1.0 / dimension_));
   for (UnsignedInteger k = 1; k < dimension_; ++k)
   {
-    if ((q[k] < 0.0) || (q[k] > 1.0)) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level outside of [0, 1]";
-    result[k] = 1.0 - (1.0 - result[k - 1]) * std::pow(1.0 - q[k], 1.0 / (dimension_ - k));
+    if (!((q[k] >= 0.0) && (q[k] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << k << "]=" << q[k] << " outside of [0, 1]";
+    result[k] = SpecFunc::Clip01(1.0 - (1.0 - result[k - 1]) * std::pow(1.0 - q[k], 1.0 / (dimension_ - k)));
   }
   return result;
 }

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2409,8 +2409,8 @@ Point DistributionImplementation::computeConditionalCDF(const Point & x,
   for (UnsignedInteger i = 0; i < size; ++i)
     if (pdfConditioning(i, 0) > 0.0)
     {
-      if (x[i] >= xMax) result[i] = 1.0;
-      else if (x[i] > xMin)
+      if (!(x[i] < xMax)) result[i] = 1.0;
+      else if (!(x[i] <= xMin))
       {
         // Numerical integration with respect to x
         p_conditionalPDFWrapper->setParameter(y[i]);
@@ -2433,11 +2433,13 @@ Scalar DistributionImplementation::computeConditionalQuantile(const Scalar q,
 Point DistributionImplementation::computeSequentialConditionalQuantile(const Point & q) const
 {
   if (q.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Cannot compute sequential conditional quantile from an argument of dimension=" << q.getDimension() << ", expected " << dimension_;
+  for (UnsignedInteger i = 0; i < dimension_; ++i)
+    if (!((q[i] >= 0.0) && (q[i] <= 1.0))) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
   // Special case for bidimensional copulas (most copulas)
   Point result(0);
   if (isCopula() && (dimension_ == 2))
   {
-    result.add(SpecFunc::Clip01(q[0]));
+    result.add(q[0]);
     result.add(computeConditionalQuantile(q[1], {result[0]}));
     return result;
   } // (isCopula() && (dimension_ == 2)
@@ -2452,17 +2454,13 @@ Point DistributionImplementation::computeConditionalQuantile(const Point & q,
 {
   const UnsignedInteger conditioningDimension = y.getDimension();
   if (conditioningDimension >= dimension_) throw InvalidArgumentException(HERE) << "Error: cannot compute a conditional quantile with a conditioning point of dimension greater or equal to the distribution dimension.";
-  const UnsignedInteger size = q.getDimension();
-  for (UnsignedInteger i = 0; i < size; ++i)
-  {
-    if ((q[i] < 0.0) || (q[i] > 1.0)) throw InvalidArgumentException(HERE) << "Error: point=" << i << ", cannot compute a conditional quantile for a probability level q[" << i << "]=" << q[i] << " outside of [0, 1]";
-  }
   // Special case for no conditioning or independent copula
   if ((conditioningDimension == 0) || (hasIndependentCopula()))
     return getMarginal(conditioningDimension).computeQuantile(q).getImplementation()->getData();
   // General case
   const Scalar xMin = range_.getLowerBound()[conditioningDimension];
   const Scalar xMax = range_.getUpperBound()[conditioningDimension];
+  const UnsignedInteger size = y.getSize();
   Point result(size);
   // Here we recreate a ConditionalCDFWrapper only if none has been created or if the parameter dimension has changed
   Pointer<ConditionalCDFWrapper> p_conditionalCDFWrapper = new ConditionalCDFWrapper(this);

--- a/lib/src/Uncertainty/Model/DistributionImplementation.cxx
+++ b/lib/src/Uncertainty/Model/DistributionImplementation.cxx
@@ -2241,6 +2241,16 @@ Point DistributionImplementation::computeSequentialConditionalPDF(const Point & 
 {
   if (x.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: expected a point of dimension=" << dimension_ << ", got dimension=" << x.getDimension();
   Point result(dimension_);
+  // Special case for bidimensional copulas (most copulas)
+  if (isCopula() && (dimension_ == 2))
+  {
+    if ((x[0] >= 0.0) && (x[1] < 1.0))
+      {
+	result[0] = 1.0;
+	result[1] = computePDF(x);
+      }
+    return result;
+  } // (isCopula() && (dimension_ == 2)
   Indices conditioning(1, 0);
   Implementation conditioningDistribution(getMarginal(conditioning).getImplementation());
   Point currentX(1, x[0]);
@@ -2324,6 +2334,13 @@ Point DistributionImplementation::computeSequentialConditionalCDF(const Point & 
 {
   if (x.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Error: expected a point of dimension=" << dimension_ << ", got dimension=" << x.getDimension();
   Point result(dimension_);
+  // Special case for bidimensional copulas (most copulas)
+  if (isCopula() && (dimension_ == 2))
+  {
+    result[0] = SpecFunc::Clip01(x[0]);
+    result[1] = computeConditionalCDF(x[1], {x[0]});
+    return result;
+  } // (isCopula() && (dimension_ == 2)
   Indices conditioning(1, 0);
   Implementation conditioningDistribution(getMarginal(conditioning).getImplementation());
   Point currentX(1, x[0]);
@@ -2351,10 +2368,12 @@ Point DistributionImplementation::computeSequentialConditionalCDF(const Point & 
       Pointer<ConditionalPDFWrapper> p_conditionalPDFWrapper = new ConditionalPDFWrapper(conditioningDistribution);
       p_conditionalPDFWrapper->setParameter(currentX);
       const Scalar cdfConditioned = algo.integrate(UniVariateFunction(p_conditionalPDFWrapper), xMin, std::min(x[conditioningDimension], xMax));
-      result[conditioningDimension] = cdfConditioned / pdfConditioning;
+      result[conditioningDimension] = SpecFunc::Clip01(cdfConditioned / pdfConditioning);
     }
     currentX.add(x[conditioningDimension]);
-    pdfConditioning = conditioningDistribution->computePDF(currentX);
+    // If we are not at the last component, compute the conditioning PDF
+    if (conditioningDimension < dimension_ - 1)
+      pdfConditioning = conditioningDistribution->computePDF(currentX);
   } // conditioningDimension
   return result;
 }
@@ -2414,7 +2433,14 @@ Scalar DistributionImplementation::computeConditionalQuantile(const Scalar q,
 Point DistributionImplementation::computeSequentialConditionalQuantile(const Point & q) const
 {
   if (q.getDimension() != dimension_) throw InvalidArgumentException(HERE) << "Cannot compute sequential conditional quantile from an argument of dimension=" << q.getDimension() << ", expected " << dimension_;
+  // Special case for bidimensional copulas (most copulas)
   Point result(0);
+  if (isCopula() && (dimension_ == 2))
+  {
+    result.add(SpecFunc::Clip01(q[0]));
+    result.add(computeConditionalQuantile(q[1], {result[0]}));
+    return result;
+  } // (isCopula() && (dimension_ == 2)
   for (UnsignedInteger i = 0; i < dimension_; ++i)
     result.add(computeConditionalQuantile(q[i], result));
   return result;

--- a/lib/src/Uncertainty/Model/SklarCopula.cxx
+++ b/lib/src/Uncertainty/Model/SklarCopula.cxx
@@ -133,7 +133,7 @@ Point SklarCopula::computeDDF(const Point & point) const
   for (UnsignedInteger i = 0; i < dimension; ++i)
   {
     const Scalar ui = point[i];
-    if ((ui <= 0.0) || ui >= 1.0) return Point(dimension, 0.0);
+    if (!((ui > 0.0) && (ui < 1.0))) return Point(dimension, 0.0);
     const Point xi(marginalCollection_[i].computeQuantile(ui));
     x[i] = xi[0];
     pdfX[i] = marginalCollection_[i].computePDF(xi);

--- a/python/test/t_LeastSquaresExpansion_std.py
+++ b/python/test/t_LeastSquaresExpansion_std.py
@@ -518,3 +518,13 @@ for doe in doeList:
         rtol = 1.0e-2
         atol = 1.0e-2
         assert_almost_equal(err, 0.0, rtol, atol)
+
+# Check the setActiveFunctions method
+size = 10
+algo = ot.LeastSquaresExpansion(inputSample, outputSample, distribution, productBasis, size)
+# The active functions are within the current basis/basis size
+algo.setActiveFunctions(range(8))
+assert algo.getActiveFunctions() == range(8)
+# The active functions are not within the current basis/basis size
+algo.setActiveFunctions(range(12))
+assert algo.getActiveFunctions() == range(12)

--- a/python/test/t_NormInfEnumerateFunction_std.expout
+++ b/python/test/t_NormInfEnumerateFunction_std.expout
@@ -1,8 +1,10 @@
+Strata 3 cardinal= 1
 First 4 values for dimension 1
 i= 0 f(i)= [0]
 i= 1 f(i)= [1]
 i= 2 f(i)= [2]
 i= 3 f(i)= [3]
+Strata 3 cardinal= 7
 First 16 values for dimension 2
 i= 0 f(i)= [0,0]
 i= 1 f(i)= [1,0]
@@ -20,6 +22,7 @@ i= 12 f(i)= [0,3]
 i= 13 f(i)= [1,3]
 i= 14 f(i)= [2,3]
 i= 15 f(i)= [3,3]
+Strata 3 cardinal= 37
 First 64 values for dimension 3
 i= 0 f(i)= [0,0,0]
 i= 1 f(i)= [1,0,0]

--- a/python/test/t_NormInfEnumerateFunction_std.py
+++ b/python/test/t_NormInfEnumerateFunction_std.py
@@ -4,10 +4,11 @@ import openturns as ot
 
 ot.TESTPREAMBLE()
 
-stratas = 4
+stratas = 3
 for dimension in range(1, 4):
     f = ot.NormInfEnumerateFunction(dimension)
     size = f.getStrataCumulatedCardinal(stratas)
+    print("Strata", stratas, "cardinal=", f.getStrataCardinal(stratas))
     print("First", size, "values for dimension", dimension)
     for i in range(size):
         print("i=", i, "f(i)=", f(i))


### PR DESCRIPTION
This PR provides the following features:
  *  Improved computeConditional[CDF|Quantile]
      Now the argument are checked wrt their natural bounds and the CDF values are cliped to [0, 1] when numerical
      roundoff could produce values slightly out of this interval.
  * Improved DistributionImplementation
     Now, the computeSequentialConditional[PDF|CDF|Quantile] methods have a specific implementation for the
    common case of bidimensional copulas.
  * Fixed NormInfEnumerateFunction
     The strata cardinals were wrong, with a shift of 1 in the index. The bounds are now properly taken into account in
     the cardinal computations.