### PR TITLE
Improve truncated distribution

### DIFF
--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -31,6 +31,8 @@
 #include "openturns/JointDistribution.hxx"
 #include "openturns/BlockIndependentDistribution.hxx"
 #include "openturns/BlockIndependentCopula.hxx"
+#include "openturns/KernelMixture.hxx"
+#include "openturns/Mixture.hxx"
 #include "openturns/Dirichlet.hxx"
 #include "openturns/Beta.hxx"
 
@@ -180,7 +182,27 @@ Distribution TruncatedDistribution::dispatchTruncation(const Collection<Distribu
 /* Get the simplified version (or clone the distribution) */
 Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) const
 {
+  // Delve into the antecedents until we get something which is not a truncated distribution
+  Distribution localDistribution(distribution_);
+  String kind(localDistribution.getImplementation()->getClassName());
+  UnsignedInteger level = 1;
+  while (kind == "TruncatedDistribution")
+  {
+    const TruncatedDistribution * truncatedDistribution = dynamic_cast<const TruncatedDistribution *>(localDistribution.getImplementation().get());
+    localDistribution = truncatedDistribution->getDistribution();
+    kind = localDistribution.getImplementation()->getClassName();
+    ++ level;
+    // nested truncation intervals have already been intersected during the nested range computations
+  }
   // n-D case
+  // If no truncation
+  const Interval range(getRange());
+  if ((localDistribution.getRange().getLowerBound() == range.getLowerBound()) &&
+      (localDistribution.getRange().getUpperBound() == range.getUpperBound()))
+  {
+    simplified = localDistribution;
+    return true;
+  }
   JointDistribution *p_joint = dynamic_cast<JointDistribution *>(distribution_.getImplementation().get());
   if (p_joint && p_joint->hasIndependentCopula())
   {
@@ -208,26 +230,61 @@ Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) cons
     return true;
   }
 
-  // Simplification of the 1D case
-  Distribution localDistribution(distribution_);
-  String kind(localDistribution.getImplementation()->getClassName());
-  // Delve into the antecedents until we get something which is not a truncated distribution
-  UnsignedInteger level = 1;
-  while (kind == "TruncatedDistribution")
+  // If KernelMixture
+  KernelMixture *p_kernelMixture = dynamic_cast<KernelMixture *>(distribution_.getImplementation().get());
+  if (p_kernelMixture)
   {
-    const TruncatedDistribution * truncatedDistribution = dynamic_cast<const TruncatedDistribution *>(localDistribution.getImplementation().get());
-    localDistribution = truncatedDistribution->getDistribution();
-    kind = localDistribution.getImplementation()->getClassName();
-    ++ level;
-    // nested truncation intervals have already been intersected during the nested range computations
-  }
-  // If no truncation
-  const Interval range(getRange());
-  if (localDistribution.getRange() == range)
-  {
-    simplified = localDistribution;
+    const Sample sample(p_kernelMixture->getInternalSample());
+    // No need to simplify in dimension < 3
+    if (sample.getDimension() < 3)
+      return false;
+    const Distribution kernel(p_kernelMixture->getKernel());
+    const Point bandwidth(p_kernelMixture->getBandwidth());
+    const UnsignedInteger size = sample.getSize();
+    Collection<Distribution> atoms(0);
+    Point weights(0);
+    const Point lb(bounds_.getLowerBound());
+    const Point ub(bounds_.getUpperBound());
+    Collection<Distribution> components(dimension_);
+    for (UnsignedInteger i = 0; i < size; ++i)
+    {
+      // Try to build the truncated atom associated with the current point
+      // It fails if the intersection between the bounds and the atom range is empty
+      try
+      {
+	// Many ways to define the atoms
+	// A JointDistribution with truncated RandomMixture marginals
+	// with simplification of the RandomMixture:
+	// dim=3, size=10000, creation=0.57s mean=1.36s cov=1.5s
+	// without simplification of the RandomMixture:
+	// dim=3, size=10000, creation=0.44s mean=1.35s cov=1.47s
+	// A JointDistribution with truncated KernelMixture marginals
+	// dim=3, size=10000, creation=0.37s mean=1.24s cov=1.37s
+	// A BlockIndependentDistribution with truncated RandomMixture blocks
+	// dim=3, size=10000, creation=0.44s mean=1.39s cov=3.16s
+	// A BlockIndependentDistribution with truncated KernelMixture blocks
+	// dim=3, size=10000, creation=0.38s mean=1.31s cov=2.68s
+	Scalar wI = normalizationFactor_;
+	for (UnsignedInteger j = 0; j < dimension_; ++j)
+	  {
+	    const TruncatedDistribution componentJ(KernelMixture(kernel, Point(1, bandwidth[j]), Sample(1, Point(1, sample(i, j)))), lb[j], ub[j]);
+	    wI /= componentJ.normalizationFactor_;
+	    components[j] = componentJ.getSimplifiedVersion();
+	  }
+	atoms.add(JointDistribution(components));
+	weights.add(wI);
+      }
+      catch (InvalidArgumentException & )
+      {
+	// Nothing to do
+      }
+    } // for i
+    const UnsignedInteger atomsNumber = atoms.getSize();
+    if (atomsNumber == 0) throw InternalException(HERE) << "Error: all the truncated atoms have been rejected";
+    simplified = Mixture(atoms, weights);
     return true;
   }
+  
   // If UserDefined
   if (kind == "UserDefined")
   {
@@ -248,6 +305,7 @@ Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) cons
     return true;
   }
   // At this point, no more simplification in the multivariate case
+  // Simplification of the 1D case
   if (getDimension() == 1)
   {
     // Now, the 1D simplifications
@@ -319,6 +377,7 @@ void TruncatedDistribution::computeRange()
   else
   {
     const Interval range(distributionRange.intersect(bounds_));
+    if (range.isEmpty()) throw InvalidArgumentException(HERE) << "Error: the truncation interval does not contain a non-empty part of the support of the distribution";
     setRange(range);
     const Scalar probability = distribution_.computeProbability(range);
     if (!(probability > 0.0)) throw InvalidArgumentException(HERE) << "Error: the truncation interval does not contain a non-empty part of the support of the distribution";

--- a/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
+++ b/lib/src/Uncertainty/Distribution/TruncatedDistribution.cxx
@@ -31,6 +31,8 @@
 #include "openturns/JointDistribution.hxx"
 #include "openturns/BlockIndependentDistribution.hxx"
 #include "openturns/BlockIndependentCopula.hxx"
+#include "openturns/KernelMixture.hxx"
+#include "openturns/Mixture.hxx"
 #include "openturns/Dirichlet.hxx"
 #include "openturns/Beta.hxx"
 
@@ -180,7 +182,26 @@ Distribution TruncatedDistribution::dispatchTruncation(const Collection<Distribu
 /* Get the simplified version (or clone the distribution) */
 Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) const
 {
+  // Delve into the antecedents until we get something which is not a truncated distribution
+  Distribution localDistribution(distribution_);
+  String kind(localDistribution.getImplementation()->getClassName());
+  UnsignedInteger level = 1;
+  while (kind == "TruncatedDistribution")
+  {
+    const TruncatedDistribution * truncatedDistribution = dynamic_cast<const TruncatedDistribution *>(localDistribution.getImplementation().get());
+    localDistribution = truncatedDistribution->getDistribution();
+    kind = localDistribution.getImplementation()->getClassName();
+    ++ level;
+    // nested truncation intervals have already been intersected during the nested range computations
+  }
   // n-D case
+  // If no truncation
+  const Interval range(getRange());
+  if (localDistribution.getRange() == range)
+  {
+    simplified = localDistribution;
+    return true;
+  }
   JointDistribution *p_joint = dynamic_cast<JointDistribution *>(distribution_.getImplementation().get());
   if (p_joint && p_joint->hasIndependentCopula())
   {
@@ -208,26 +229,61 @@ Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) cons
     return true;
   }
 
-  // Simplification of the 1D case
-  Distribution localDistribution(distribution_);
-  String kind(localDistribution.getImplementation()->getClassName());
-  // Delve into the antecedents until we get something which is not a truncated distribution
-  UnsignedInteger level = 1;
-  while (kind == "TruncatedDistribution")
+  // If KernelMixture
+  KernelMixture *p_kernelMixture = dynamic_cast<KernelMixture *>(distribution_.getImplementation().get());
+  if (p_kernelMixture)
   {
-    const TruncatedDistribution * truncatedDistribution = dynamic_cast<const TruncatedDistribution *>(localDistribution.getImplementation().get());
-    localDistribution = truncatedDistribution->getDistribution();
-    kind = localDistribution.getImplementation()->getClassName();
-    ++ level;
-    // nested truncation intervals have already been intersected during the nested range computations
-  }
-  // If no truncation
-  const Interval range(getRange());
-  if (localDistribution.getRange() == range)
-  {
-    simplified = localDistribution;
+    const Sample sample(p_kernelMixture->getInternalSample());
+    // No need to simplify in dimension < 3
+    if (sample.getDimension() < 3)
+      return false;
+    const Distribution kernel(p_kernelMixture->getKernel());
+    const Point bandwidth(p_kernelMixture->getBandwidth());
+    const UnsignedInteger size = sample.getSize();
+    Collection<Distribution> atoms(0);
+    Point weights(0);
+    const Point lb(bounds_.getLowerBound());
+    const Point ub(bounds_.getUpperBound());
+    Collection<Distribution> components(dimension_);
+    for (UnsignedInteger i = 0; i < size; ++i)
+    {
+      // Try to build the truncated atom associated with the current point
+      // It fails if the intersection between the bounds and the atom range is empty
+      try
+      {
+	// Many ways to define the atoms
+	// A JointDistribution with truncated RandomMixture marginals
+	// with simplification of the RandomMixture:
+	// dim=3, size=10000, creation=0.57s mean=1.36s cov=1.5s
+	// without simplification of the RandomMixture:
+	// dim=3, size=10000, creation=0.44s mean=1.35s cov=1.47s
+	// A JointDistribution with truncated KernelMixture marginals
+	// dim=3, size=10000, creation=0.37s mean=1.24s cov=1.37s
+	// A BlockIndependentDistribution with truncated RandomMixture blocks
+	// dim=3, size=10000, creation=0.44s mean=1.39s cov=3.16s
+	// A BlockIndependentDistribution with truncated KernelMixture blocks
+	// dim=3, size=10000, creation=0.38s mean=1.31s cov=2.68s
+	Scalar wI = normalizationFactor_;
+	for (UnsignedInteger j = 0; j < dimension_; ++j)
+	  {
+	    const TruncatedDistribution componentJ(KernelMixture(kernel, Point(1, bandwidth[j]), Sample(1, Point(1, sample(i, j)))), lb[j], ub[j]);
+	    wI /= componentJ.normalizationFactor_;
+	    components[j] = componentJ.getSimplifiedVersion();
+	  }
+	atoms.add(JointDistribution(components));
+	weights.add(wI);
+      }
+      catch (InvalidArgumentException & )
+      {
+	// Nothing to do
+      }
+    } // for i
+    const UnsignedInteger atomsNumber = atoms.getSize();
+    if (atomsNumber == 0) throw InternalException(HERE) << "Error: all the truncated atoms have been rejected";
+    simplified = Mixture(atoms, weights);
     return true;
   }
+  
   // If UserDefined
   if (kind == "UserDefined")
   {
@@ -248,6 +304,7 @@ Bool TruncatedDistribution::hasSimplifiedVersion(Distribution & simplified) cons
     return true;
   }
   // At this point, no more simplification in the multivariate case
+  // Simplification of the 1D case
   if (getDimension() == 1)
   {
     // Now, the 1D simplifications
@@ -319,6 +376,7 @@ void TruncatedDistribution::computeRange()
   else
   {
     const Interval range(distributionRange.intersect(bounds_));
+    if (range.isEmpty()) throw InvalidArgumentException(HERE) << "Error: the truncation interval does not contain a non-empty part of the support of the distribution";
     setRange(range);
     const Scalar probability = distribution_.computeProbability(range);
     if (!(probability > 0.0)) throw InvalidArgumentException(HERE) << "Error: the truncation interval does not contain a non-empty part of the support of the distribution";

--- a/python/test/t_TruncatedDistribution_std.expout
+++ b/python/test/t_TruncatedDistribution_std.expout
@@ -260,7 +260,7 @@ conditional PDF=0.540165
 sequential conditional PDF=[0.540165,0.540165]
 conditional CDF=0.543689
 sequential conditional CDF=[0.543689,0.543689]
-Distribution  TruncatedDistribution(WeibullMin(beta = 2, alpha = 3, gamma = 0), bounds = [0, (6.36519) +inf[)
+Distribution  WeibullMin(beta = 2, alpha = 3, gamma = 0)
 Elliptical =  False
 Continuous =  True
 oneRealization= class=Point name=Unnamed dimension=1 values=[2.23016]
@@ -275,8 +275,8 @@ pdf (ref)=0.553345
 cdf=0.344184
 ccdf=0.655816
 cdf (ref)=0.344184
-pdf gradient      = class=Point name=Unnamed dimension=4 values=[-0.479854,0.0924181,-0.270908,0]
-cdf gradient      = class=Point name=Unnamed dimension=4 values=[-0.415009,-0.0795937,-0.553345,0]
+pdf gradient      = class=Point name=Unnamed dimension=3 values=[-0.479854,0.0924181,-0.270908]
+cdf gradient      = class=Point name=Unnamed dimension=3 values=[-0.415009,-0.0795937,-0.553345]
 quantile= class=Point name=Unnamed dimension=1 values=[2.88313]
 quantile= class=Point name=Unnamed dimension=1 values=[2.88313]
 cdf(quantile)=0.950000
@@ -286,7 +286,7 @@ entropy=0.979345
 Minimum volume interval= [0.53717, 3.0308]
 threshold= [0.95]
 Minimum volume level set= {x | f(x) <= 2.24308} with f=
-MinimumVolumeLevelSetEvaluation(TruncatedDistribution(WeibullMin(beta = 2, alpha = 3, gamma = 0), bounds = [0, (6.36519) +inf[))
+MinimumVolumeLevelSetEvaluation(WeibullMin(beta = 2, alpha = 3, gamma = 0))
 beta= [0.106131]
 Bilateral confidence interval= [0.587271, 3.09026]
 beta= [0.95]
@@ -304,10 +304,10 @@ kurtosis      = class=Point name=Unnamed dimension=1 values=[2.72946]
 kurtosis (ref)= class=Point name=Unnamed dimension=1 values=[2.72946]
 covariance      = class=CovarianceMatrix dimension=1 implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[0.421332]
 covariance (ref)= class=CovarianceMatrix dimension=1 implementation=class=MatrixImplementation name=Unnamed rows=1 columns=1 values=[0.421332]
-parameters      = [class=PointWithDescription name=X0 dimension=4 description=[beta,alpha,gamma,lowerBound] values=[2,3,0,0]]
+parameters      = [class=PointWithDescription name=X0 dimension=3 description=[beta,alpha,gamma] values=[2,3,0]]
 parameters (ref)= [class=PointWithDescription name=X0 dimension=3 description=[beta,alpha,gamma] values=[2,3,0]]
-parameter       = class=Point name=Unnamed dimension=4 values=[2,3,0,0]
-parameter desc  = [beta,alpha,gamma,lowerBound]
+parameter       = class=Point name=Unnamed dimension=3 values=[2,3,0]
+parameter desc  = [beta,alpha,gamma]
 marginal 0      = class=WeibullMin name=WeibullMin dimension=1 beta=2 alpha=3 gamma=0
 Standard representative= WeibullMin(beta = 1, alpha = 3, gamma = 0)
 conditional PDF=0.586847
@@ -336,11 +336,9 @@ d= TruncatedDistribution(BlockIndependentCopula(NormalCopula(R = [[ 1 0 ]
  [ 0 1 ]])), bounds = [0, 1]
 [0, 1]
 [0, 1]
-[0, 1]) simplified= BlockIndependentDistribution(TruncatedDistribution(NormalCopula(R = [[ 1 0 ]
- [ 0 1 ]]), bounds = [0, 1]
-[0, 1]), TruncatedDistribution(NormalCopula(R = [[ 1 0 ]
- [ 0 1 ]]), bounds = [0, 1]
-[0, 1]))
+[0, 1]) simplified= BlockIndependentCopula(NormalCopula(R = [[ 1 0 ]
+ [ 0 1 ]]), NormalCopula(R = [[ 1 0 ]
+ [ 0 1 ]]))
 d= TruncatedDistribution(Dirichlet(theta = [0.7,0.3]), bounds = [0.2, 2.4]) simplified= Beta(alpha = 0.7, beta = 0.3, a = 0.2, b = 1)
 d= TruncatedDistribution(TruncatedDistribution(Normal(mu = 0, sigma = 1), bounds = [-1, 1]), bounds = [-1, 1]) simplified= TruncatedNormal(mu = 0, sigma = 1, a = -1, b = 1)
 after setbounds q@0.9= [29.628]

--- a/python/test/t_TruncatedDistribution_std.expout
+++ b/python/test/t_TruncatedDistribution_std.expout
@@ -336,11 +336,9 @@ d= TruncatedDistribution(BlockIndependentCopula(NormalCopula(R = [[ 1 0 ]
  [ 0 1 ]])), bounds = [0, 1]
 [0, 1]
 [0, 1]
-[0, 1]) simplified= BlockIndependentDistribution(TruncatedDistribution(NormalCopula(R = [[ 1 0 ]
- [ 0 1 ]]), bounds = [0, 1]
-[0, 1]), TruncatedDistribution(NormalCopula(R = [[ 1 0 ]
- [ 0 1 ]]), bounds = [0, 1]
-[0, 1]))
+[0, 1]) simplified= BlockIndependentCopula(NormalCopula(R = [[ 1 0 ]
+ [ 0 1 ]]), NormalCopula(R = [[ 1 0 ]
+ [ 0 1 ]]))
 d= TruncatedDistribution(Dirichlet(theta = [0.7,0.3]), bounds = [0.2, 2.4]) simplified= Beta(alpha = 0.7, beta = 0.3, a = 0.2, b = 1)
 d= TruncatedDistribution(TruncatedDistribution(Normal(mu = 0, sigma = 1), bounds = [-1, 1]), bounds = [-1, 1]) simplified= TruncatedNormal(mu = 0, sigma = 1, a = -1, b = 1)
 after setbounds q@0.9= [29.628]

--- a/python/test/t_TruncatedDistribution_std.py
+++ b/python/test/t_TruncatedDistribution_std.py
@@ -54,7 +54,7 @@ distribution.append(truncatedKS)
 referenceDistribution.append(ks)  # N/A
 # Add a non-truncated example
 weibull = ot.WeibullMin(2.0, 3.0)
-distribution.append(ot.TruncatedDistribution(weibull, weibull.getRange()))
+distribution.append(weibull)
 referenceDistribution.append(weibull)
 ot.RandomGenerator.SetSeed(0)
 
@@ -264,3 +264,39 @@ normal = ot.Normal([0.0] * 2, [1.0] * 2, R)
 trunc = ot.TruncatedDistribution(normal, ot.Interval([-0.5] * 2, [1.0] * 2))
 marginal0 = trunc.getMarginal(0)
 ott.assert_almost_equal(marginal0.getMean(), [0.220527])
+
+# simplification for KernelMixture in dimension >= 3
+dim = 3
+kernelMixture = ot.KernelMixture(
+    ot.Normal(), [0.2] * dim, ot.Normal(dim).getSample(1000)
+)
+bounds = ot.Interval([-1.0] * dim, [0.5] * dim)
+trunc = ot.TruncatedDistribution(kernelMixture, bounds)
+assert trunc.getSimplifiedVersion().getImplementation().getClassName() == "Mixture"
+mean = trunc.getMean()
+ott.assert_almost_equal(mean, [-0.207172, -0.193878, -0.186422])
+cov = trunc.getCovariance()
+ott.assert_almost_equal(
+    cov,
+    ot.CovarianceMatrix(
+        3,
+        [
+            0.173185,
+            -0.0152049,
+            0.000857313,
+            -0.0152049,
+            0.164721,
+            -9.17347e-05,
+            0.000857313,
+            -9.17347e-05,
+            0.170059,
+        ],
+    ),
+)
+# check simplification logic only checks numerical range
+dist = ot.Gumbel(1.0, 0.0)
+numericalRange = ot.Interval(
+    dist.getRange().getLowerBound(), dist.getRange().getUpperBound()
+)
+truncated = ot.TruncatedDistribution(dist, numericalRange)
+assert truncated.getSimplifiedVersion() == dist

--- a/python/test/t_TruncatedDistribution_std.py
+++ b/python/test/t_TruncatedDistribution_std.py
@@ -264,3 +264,32 @@ normal = ot.Normal([0.0] * 2, [1.0] * 2, R)
 trunc = ot.TruncatedDistribution(normal, ot.Interval([-0.5] * 2, [1.0] * 2))
 marginal0 = trunc.getMarginal(0)
 ott.assert_almost_equal(marginal0.getMean(), [0.220527])
+
+# simplification for KernelMixture in dimension >= 3
+dim = 3
+kernelMixture = ot.KernelMixture(
+    ot.Normal(), [0.2] * dim, ot.Normal(dim).getSample(1000)
+)
+bounds = ot.Interval([-1.0] * dim, [0.5] * dim)
+trunc = ot.TruncatedDistribution(kernelMixture, bounds)
+assert trunc.getSimplifiedVersion().getImplementation().getClassName() == "Mixture"
+mean = trunc.getMean()
+ott.assert_almost_equal(mean, [-0.207172, -0.193878, -0.186422])
+cov = trunc.getCovariance()
+ott.assert_almost_equal(
+    cov,
+    ot.CovarianceMatrix(
+        3,
+        [
+            0.173185,
+            -0.0152049,
+            0.000857313,
+            -0.0152049,
+            0.164721,
+            -9.17347e-05,
+            0.000857313,
+            -9.17347e-05,
+            0.170059,
+        ],
+    ),
+)


### PR DESCRIPTION
Now, the simplification algorithm takes into account the KernelMixture case.
It improves things only if the dimension is greater than or equal to 3.
It fixes #3162.
