### PR TITLE
Update confidence interval of a quantile: doc and code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,8 @@
  * LOLAVoronoi moved out of experimental
  * Deprecated GaussianProcessConditionalCovariance::operator() for getMarginalDistribution
  * Deprecated ProcessSample.setField(Field, int) in favor ProcessSample.setField(int, Field)
+ * Deprecated QuantileConfidence.computeUnilateralConfidenceIntervalWithCoverage(Sample) in favor of QuantileConfidence.computeUnilateralCoverage(UnsignedInteger, UnsignedInteger, Bool)
+ * Deprecated QuantileConfidence.computeBilateralConfidenceIntervalWithCoverage(Sample) in favor of computeBilateralCoverage(UnsignedInteger, UnsignedInteger, UnsignedInteger)
 
 === Documentation ===
 

--- a/lib/src/Uncertainty/Algorithm/Simulation/QuantileConfidence.cxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/QuantileConfidence.cxx
@@ -53,10 +53,12 @@ QuantileConfidence::QuantileConfidence(const Scalar alpha, const Scalar beta)
   , alpha_(alpha)
   , beta_(beta)
 {
-  if (!(alpha >= 0.0) || !(alpha <= 1.0))
-    throw InvalidArgumentException(HERE) << "Quantile level must be in [0, 1]";
-  if (!(beta >= 0.0) || !(beta <= 1.0))
-    throw InvalidArgumentException(HERE) << "Confidence level must be in [0, 1]";
+  if (!(alpha >= 0.0 && alpha <= 1.0))
+    throw InvalidArgumentException(HERE)
+      << "Quantile level must be in [0, 1], but alpha = " << alpha;
+  if (!(beta >= 0.0 && beta <= 1.0))
+    throw InvalidArgumentException(HERE)
+      << "Confidence level must be in [0, 1], but beta = " << beta;
 }
 
 /* Virtual constructor */
@@ -79,28 +81,34 @@ String QuantileConfidence::__str__(const String & /*offset*/) const
 }
 
 // compute rank k given by the beta-level quantile of B(n, alpha)
-UnsignedInteger QuantileConfidence::computeUnilateralRank(const UnsignedInteger size, const Bool tail) const
+UnsignedInteger QuantileConfidence::computeUnilateralRank(const UnsignedInteger size, const Bool lowerBounded) const
 {
-  const UnsignedInteger minimumSize = computeUnilateralMinimumSampleSize(0, tail);
+  const UnsignedInteger minimumSize = computeUnilateralMinimumSampleSize(0, lowerBounded);
   if (size < minimumSize)
-    throw InvalidArgumentException(HERE) << "Cannot compute unilateral rank as size (" << size << ") is lower than minimum size (" << minimumSize << ")";
+    throw InvalidArgumentException(HERE) 
+        << "Cannot compute unilateral rank as size (" << size 
+        << ") is lower than minimum size (" << minimumSize << ")";
 
   const Binomial binomial(size, alpha_);
-  const Scalar p = tail ? 1.0 - std::pow(alpha_, 1.0 * size) : 1.0 - std::pow(1.0 - alpha_, 1.0 * size);
+  const Scalar p = lowerBounded ? 1.0 - std::pow(1.0 - alpha_, 1.0 * size) : 1.0 - std::pow(alpha_, 1.0 * size);
 
   if (p < beta_)
   {
-    if (tail)
-      throw InvalidArgumentException(HERE) << "Cannot compute rank as parameters do not satisfy 1 - alpha^n >= beta";
+    if (lowerBounded)
+      throw InvalidArgumentException(HERE)
+          << "Cannot compute rank as parameters do not satisfy 1 - (1 - alpha)^n >= beta. "
+          << "Increase the size, or decrease the confidence level.";
     else
-      throw InvalidArgumentException(HERE) << "Cannot compute rank as parameters do not satisfy 1 - (1 - alpha)^n >= beta";
+      throw InvalidArgumentException(HERE)
+          << "Cannot compute rank as parameters do not satisfy 1 - alpha^n >= beta. "
+          << "Increase the size, or decrease the confidence level.";
   }
-
-  const UnsignedInteger rank = binomial.computeQuantile(beta_, tail)[0];
+  const UnsignedInteger rank = binomial.computeQuantile(beta_, lowerBounded)[0];
   return rank;
 }
 
 // compute argmin (k1, k2) P_Xd(]k1, k2]) under constraint P_Xd(]k1, k2])>=beta, with Xd~B(n, alpha)
+// and 1 <= k1 <= k2 <= n
 Indices QuantileConfidence::computeBilateralRank(const UnsignedInteger size) const
 {
   const UnsignedInteger minimumSize = computeBilateralMinimumSampleSize();
@@ -141,36 +149,40 @@ Indices QuantileConfidence::computeBilateralRank(const UnsignedInteger size) con
 }
 
 // compute interval of the form [X_k; +inf[ or ]-inf; X_k] from unilateral rank k
-Interval QuantileConfidence::computeUnilateralConfidenceInterval(const Sample & sample, const Bool tail) const
+Interval QuantileConfidence::computeUnilateralConfidenceInterval(const Sample & sample, const Bool lowerBounded) const
 {
   Scalar coverageOut = -1.0;
-  return computeUnilateralConfidenceIntervalWithCoverage(sample, coverageOut, tail);
+  return computeUnilateralConfidenceIntervalWithCoverage(sample, coverageOut, lowerBounded);
 }
 
 // compute interval of the form [X_k; +inf[ or ]-inf; X_k] from unilateral rank k and the actual coverage
-Interval QuantileConfidence::computeUnilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut, const Bool tail) const
+Interval QuantileConfidence::computeUnilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut, const Bool lowerBounded) const
 {
+  LOGWARN("QuantileConfidence.computeUnilateralConfidenceIntervalWithCoverage(Sample) is deprecated, use QuantileConfidence.computeUnilateralCoverage(UnsignedInteger, UnsignedInteger, Bool)");
+  if (sample.getSize() == 0)
+    throw InvalidArgumentException(HERE)
+      << "Expected a non-empty sample, but size is zero";
   if (sample.getDimension() != 1)
-    throw InvalidArgumentException(HERE) << "Expected a sample of dimension 1";
+    throw InvalidArgumentException(HERE)
+      << "Expected a sample of dimension 1, but dimension = "
+      << sample.getDimension();
   Point lowerBound(1, -SpecFunc::MaxScalar);
   Point upperBound(1, SpecFunc::MaxScalar);
   Interval::BoolCollection finiteLowerBound(1, false);
   Interval::BoolCollection finiteUpperBound(1, false);
   const Sample sortedSample(sample.sort());
-  const UnsignedInteger k = computeUnilateralRank(sample.getSize(), tail);
-  const Binomial binomial(sample.getSize(), getAlpha());
-  if (tail)
+  const UnsignedInteger k = computeUnilateralRank(sample.getSize(), lowerBounded);
+  if (lowerBounded)
   {
     lowerBound[0] = sortedSample(k, 0);
     finiteLowerBound[0] = true;
-    coverageOut = binomial.computeComplementaryCDF(k);
   }
   else
   {
     upperBound[0] = sortedSample(k, 0);
     finiteUpperBound[0] = true;
-    coverageOut = binomial.computeCDF(k);
   }
+  coverageOut = computeUnilateralCoverage(sample.getSize(), k, lowerBounded);
   return Interval(lowerBound, upperBound, finiteLowerBound, finiteUpperBound);
 }
 
@@ -184,15 +196,61 @@ Interval QuantileConfidence::computeBilateralConfidenceInterval(const Sample & s
 // compute interval of the form [X_k1; X_k2] from bilateral ranks k1, k2 with actual coverage
 Interval QuantileConfidence::computeBilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut) const
 {
+  LOGWARN("QuantileConfidence.computeBilateralConfidenceIntervalWithCoverage(Sample) is deprecated, use QuantileConfidence.computeBilateralCoverage(UnsignedInteger, UnsignedInteger, UnsignedInteger)");
+  if (sample.getSize() == 0)
+    throw InvalidArgumentException(HERE)
+      << "Expected a non-empty sample, but size is zero";
   if (sample.getDimension() != 1)
-    throw InvalidArgumentException(HERE) << "Expected a sample of dimension 1";
+    throw InvalidArgumentException(HERE)
+      << "Expected a sample of dimension 1 but dimension = "
+      << sample.getDimension();
   const Indices rank(computeBilateralRank(sample.getSize()));
-  const Binomial binomial(sample.getSize(), getAlpha());
-  coverageOut = binomial.computeCDF(rank[1]) - binomial.computeCDF(rank[0]);
+  coverageOut = computeBilateralCoverage(sample.getSize(), rank[0], rank[1]);
   const Sample sortedSample(sample.sort());
   return Interval(Point({sortedSample(rank[0], 0)}), Point({sortedSample(rank[1], 0)}));
 }
 
+Scalar QuantileConfidence::computeUnilateralCoverage(const UnsignedInteger size, const UnsignedInteger rank, const Bool lowerBounded) const
+{
+  if (rank >= size)
+    throw InvalidArgumentException(HERE)
+        << "The rank must be strictly less than the sample size, but rank = "
+        << rank << ", size = " << size;
+
+  // Y ~ Binomial(size, alpha)
+  Binomial binomial(size, alpha_);  
+  Scalar cdf;
+
+  if (lowerBounded)
+    // Lower bound coverage: 1 - P(Y <= rank)
+    cdf = binomial.computeComplementaryCDF(rank);
+  else
+    // Upper bound coverage: P(Y <= rank)
+    cdf = binomial.computeCDF(rank);
+  
+  return cdf;
+}
+
+Scalar QuantileConfidence::computeBilateralCoverage(const UnsignedInteger size, const UnsignedInteger rank1, const UnsignedInteger rank2) const
+{
+  if (rank1 > rank2)
+    throw InvalidArgumentException(HERE)
+      << "The lower rank (" << rank1 
+      << ") must be less than or equal to the upper rank (" << rank2 << ").";
+  if (rank2 >= size)
+    throw InvalidArgumentException(HERE)
+      << "The upper rank (" << rank2 
+      << ") must be strictly less than the sample size (" << size << ").";
+
+  // Y ~ Binomial(size, alpha)
+  Binomial binomial(size, alpha_);
+  
+  // P(k1 + 1 <= Y <= k2) = P(Y <= k2) - P(Y <= k1)
+  Scalar cdf_upper = binomial.computeCDF(rank2);
+  Scalar cdf_lower = binomial.computeCDF(rank1);
+  
+  return cdf_upper - cdf_lower;
+}
 
 namespace
 {
@@ -201,11 +259,11 @@ class QuantileConfidenceEvaluation: public EvaluationImplementation
 public:
   QuantileConfidenceEvaluation(const Scalar alpha,
                                const UnsignedInteger rank,
-                               const Bool tail)
+                               const Bool lowerBounded)
     : EvaluationImplementation()
     , alpha_(alpha)
     , rank_(rank)
-    , tail_(tail)
+    , lowerBounded_(lowerBounded)
   {
     // Nothing to do
   }
@@ -217,7 +275,7 @@ public:
 
   Point operator() (const Point & point) const override
   {
-    return {DistFunc::pBeta(rank_ + 1, point[0] - rank_, tail_ ? 1.0 - alpha_ : alpha_)};
+    return {DistFunc::pBeta(rank_ + 1, point[0] - rank_, lowerBounded_ ? alpha_ : 1.0 - alpha_)};
   }
 
   UnsignedInteger getInputDimension() const override
@@ -233,12 +291,12 @@ public:
 private:
   Scalar alpha_ = 0.0;
   UnsignedInteger rank_ = 0;
-  Bool tail_ = true;
+  Bool lowerBounded_ = true;
 }; // class QuantileConfidenceEvaluation
 } // Anonymous namespace
 
 
-UnsignedInteger QuantileConfidence::computeUnilateralMinimumSampleSize(const UnsignedInteger rank, const Bool tail) const
+UnsignedInteger QuantileConfidence::computeUnilateralMinimumSampleSize(const UnsignedInteger tail_rank, const Bool lowerBounded) const
 {
   // Here we have to find the minimal value of N such that
   // 1-\sum_{i=N-r}^N Binomial(i, N)\alpha^i(1-\alpha)^{N-i}>=\beta
@@ -250,13 +308,13 @@ UnsignedInteger QuantileConfidence::computeUnilateralMinimumSampleSize(const Uns
   // Binomial(N, alpha) distribution.
   // Easy case: rank=0, the quantile bound is given by the largest upper statistics. The equation to solve is N=\min{n|1-\alpha^n>=\beta}
   Scalar nApprox = 0.0;
-  const Function wilksConstraint(QuantileConfidenceEvaluation(alpha_, rank, tail).clone());
-  if (rank == 0)
+  const Function wilksConstraint(QuantileConfidenceEvaluation(alpha_, tail_rank, lowerBounded).clone());
+  if (tail_rank == 0)
   {
-    if (tail)
-      nApprox = std::log1p(-beta_) / std::log(alpha_);
-    else
+    if (lowerBounded)
       nApprox = std::log1p(-beta_) / std::log1p(-alpha_);
+    else
+      nApprox = std::log1p(-beta_) / std::log(alpha_);
   }
   else
   {
@@ -267,18 +325,19 @@ UnsignedInteger QuantileConfidence::computeUnilateralMinimumSampleSize(const Uns
     // We compute a reasonable guess for n using a Normal approximation:
     // n*alpha+q_beta*sqrt(n*alpha*(1-alpha))=n-r:
     const Scalar aBeta = DistFunc::qNormal(beta_);
-    UnsignedInteger nMax = static_cast<UnsignedInteger>((rank + 0.5 * (alpha_ * aBeta * aBeta + std::abs(aBeta) * std::sqrt(alpha_ * (4.0 * rank + alpha_ * aBeta * aBeta)))) / (1.0 - alpha_));
+    UnsignedInteger nMax = static_cast<UnsignedInteger>((tail_rank + 0.5 * (alpha_ * aBeta * aBeta + std::abs(aBeta) * std::sqrt(alpha_ * (4.0 * tail_rank + alpha_ * aBeta * aBeta)))) / (1.0 - alpha_));
     // This loop must end as wilksConstraint->1 when n->inf
     while (wilksConstraint(Point({0.0 + nMax}))[0] < beta_)
       // At the beginning of the loop nMax is >= 1 so it increases strictly
       nMax += nMax;
-    nApprox = Brent().solve(wilksConstraint, beta_, rank, nMax);
+    nApprox = Brent().solve(wilksConstraint, beta_, tail_rank, nMax);
   } // rank > 0
   // Here, nApprox can be very close to an integer (in the sense of: the value of the constraint evaluated at the nearest integer is very close to beta_), in which case the correct answer is round(nApprox), or the answer is the next integer value
-  const UnsignedInteger nInf = std::round(std::max(1.0 * rank, nApprox));
+  const UnsignedInteger nInf = std::round(std::max(1.0 * (tail_rank + 1), nApprox));
   const Scalar constraintInf = wilksConstraint(Point({0.0 + nInf}))[0];
   if (std::abs(constraintInf - beta_) < std::sqrt(SpecFunc::Precision)) return nInf;
-  return std::ceil(nApprox);
+  const UnsignedInteger minimumSampleSize = std::max(tail_rank + 1, static_cast<UnsignedInteger>(std::ceil(nApprox)));
+  return minimumSampleSize;
 }
 
 // Find the minimal value of N such that 1 - alpha^n - (1 - alpha)^n >= beta
@@ -308,11 +367,17 @@ Indices QuantileConfidence::computeAsymptoticBilateralRank(const UnsignedInteger
 // compute interval of the form [X_k1; X_k2] from asymptotic bilateral ranks k1, k2
 Interval QuantileConfidence::computeAsymptoticBilateralConfidenceInterval(const Sample & sample) const
 {
+  if (sample.getSize() == 0)
+    throw InvalidArgumentException(HERE)
+      << "Expected a non-empty sample, but size is zero";
+  if (sample.getDimension() != 1)
+    throw InvalidArgumentException(HERE)
+      << "Expected a sample of dimension 1, but dimension = "
+      << sample.getDimension();
   const Indices rank(computeAsymptoticBilateralRank(sample.getSize()));
   const Sample sortedSample(sample.sort());
   return Interval(Point({sortedSample(rank[0], 0)}), Point({sortedSample(rank[1], 0)}));
 }
-
 
 /* Quantile level accessor */
 void QuantileConfidence::setAlpha(const Scalar alpha)

--- a/lib/src/Uncertainty/Algorithm/Simulation/openturns/QuantileConfidence.hxx
+++ b/lib/src/Uncertainty/Algorithm/Simulation/openturns/QuantileConfidence.hxx
@@ -47,17 +47,22 @@ public:
   QuantileConfidence * clone() const override;
 
   /** Compute ranks */
-  UnsignedInteger computeUnilateralRank(const UnsignedInteger size, const Bool tail = false) const;
+  UnsignedInteger computeUnilateralRank(const UnsignedInteger size, const Bool lowerBounded = false) const;
   Indices computeBilateralRank(const UnsignedInteger size) const;
 
   /** Compute confidence intervals */
-  Interval computeUnilateralConfidenceInterval(const Sample & sample, const Bool tail = false) const;
-  Interval computeUnilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut, const Bool tail = false) const;
+  Interval computeUnilateralConfidenceInterval(const Sample & sample, const Bool lowerBounded = false) const;
+  Interval computeUnilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut, const Bool lowerBounded = false) const;
   Interval computeBilateralConfidenceInterval(const Sample & sample) const;
   Interval computeBilateralConfidenceIntervalWithCoverage(const Sample & sample, Scalar & coverageOut) const;
 
+  /** Compute probability of coverage for a given size and rank */
+  Scalar computeUnilateralCoverage(const UnsignedInteger size, const UnsignedInteger rank, const Bool lowerBounded = false) const;
+  /** Compute probability of coverage for a bilateral interval given size and ranks */
+  Scalar computeBilateralCoverage(const UnsignedInteger size, const UnsignedInteger rank1, const UnsignedInteger rank2) const;
+  
   /** Compute minimum sample size */
-  UnsignedInteger computeUnilateralMinimumSampleSize(const UnsignedInteger rank = 0, const Bool tail = false) const;
+  UnsignedInteger computeUnilateralMinimumSampleSize(const UnsignedInteger rank = 0, const Bool lowerBounded = false) const;
   UnsignedInteger computeBilateralMinimumSampleSize() const;
 
   /** Asymptotic confidence */

--- a/python/src/QuantileConfidence_doc.i
+++ b/python/src/QuantileConfidence_doc.i
@@ -6,79 +6,94 @@ Refer to :any:`quantile_confidence_estimation`.
 Parameters
 ----------
 alpha : float
-    Quantile level
+    Quantile level.
 beta : float, optional
-    Confidence level. Default value is 0.95
+    Confidence level. Default value is 0.95.
 
 Notes
 -----
-This class estimates bounds of the quantile of level :math:`\alpha \in [0,1]` of the random variable :math:`X`
+This class estimates bounds of the quantile of level
+:math:`\alpha \in [0,1]` of the random variable :math:`X`
 with a confidence greater than :math:`\beta` using order statistics.
 
-Let :math:`x_{\alpha}` be the unknown quantile of level :math:`\alpha` of the random variable :math:`X` of dimension 1.
-Let :math:`(X_0, \dots, X_{\sampleSize-1})` be a sample of independent and identically distributed variables according to :math:`X`.
+Let :math:`x_{\alpha}` be the unknown quantile of level :math:`\alpha`
+of the random variable :math:`X` of dimension 1.
+Let :math:`(X_0, \dots, X_{\sampleSize - 1})` be independent
+copies of :math:`X`.
 
-The bounds of the interval are computed from order statistics that we now introduce.
-Let :math:`X_{(k)}` be the :math:`k+1` -th order statistics of :math:`(X_0, \dots, X_{\sampleSize-1})` for :math:`0 \leq k \leq \sampleSize -1`.
-For example, :math:`X_{(0)} = \min (X_0, \dots, X_{\sampleSize-1})`
-and :math:`X_{(\sampleSize -1)} = \max (X_0, \dots, X_{\sampleSize-1})`.
+We now introduce the order statistics used to compute the quantile bounds.
+Let :math:`X_{(k)}` be the :math:`k+1` -th order statistics of
+:math:`(X_0, \dots, X_{\sampleSize - 1})` for :math:`0 \leq k \leq \sampleSize - 1`.
+For example, :math:`X_{(0)} = \min (X_0, \dots, X_{\sampleSize - 1})`
+and :math:`X_{(\sampleSize - 1)} = \max (X_0, \dots, X_{\sampleSize - 1})`.
 
-We have:
+By definition of order statistics, we have:
 
 .. math::
 
-    X_{(0)} \leq X_{(1)} \leq \dots \leq X_{(\sampleSize -1)}
+    X_{(0)} \leq X_{(1)} \leq \dots \leq X_{(\sampleSize - 1)}.
 
-Care: Python enumeration begins at 0 so that the mathematical :math:`X_{(k)}` order statistics of the theoretical file
-:any:`quantile_confidence_estimation` where :math:`1 \leq k \leq n` corresponds to the order statistics :math:`X_{(k-1)}` given by the library
-with this class `QuantileConfidence`.
-
+Note: Python uses 0-based indexing.
+In textbook notation, order statistics often use 1-based indexing where
+:math:`X_{(k)}` with :math:`1 \leq k \leq \sampleSize` denotes the k-th smallest value.
+In this class, we use 0-based indexing where the textbook's :math:`X_{(k)}`
+corresponds to :math:`X_{(k - 1)}` in our notation.
 
 Examples
 --------
+In the following example, we compute a confidence interval
+for the quantile of level 95% with confidence 95%.
+More precisely, we compute an upper bound of this quantile.
+
 >>> import openturns as ot
->>> alpha = 0.05
+>>> ot.RandomGenerator.SetSeed(0)
+>>> alpha = 0.95
 >>> beta = 0.95
 >>> sample = ot.Gumbel().getSample(100)
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> ci = algo.computeUnilateralConfidenceInterval(sample)
+>>> upper_bound = ci.getUpperBound()[0]
+>>> print(upper_bound)
+3.999...
 )RAW"
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::QuantileConfidence::computeUnilateralRank
-R"RAW(Evaluate the rank of a quantile lower bound.
+R"RAW(Evaluate the rank of a quantile lower or upper bound.
 
-The lower rank :math:`k_{low}` is the largest rank :math:`k`  with :math:`0 \leq k \leq \sampleSize -1` such that:
+If `lowerBounded` is `True`, the lower rank :math:`k_{low}` is the largest rank :math:`k` with
+:math:`0 \leq k < \sampleSize` such that:
 
 .. math::
 
     \Prob{X_{(k)} \leq x_{\alpha}} \geq \beta.
 
-In other words, the interval :math:`\left[ X_{(k_{low})}, +\infty\right[` is a unilateral confidence
-interval for the quantile :math:`x_\alpha` with confidence :math:`\beta`.
+In other words, the interval :math:`\left[ X_{(k_{low})}, +\infty\right)` is a
+unilateral confidence interval for the quantile :math:`x_\alpha` with
+confidence :math:`\beta`.
 
-The upper rank :math:`k_{up}` is the smallest rank :math:`k` with :math:`0 \leq k \leq \sampleSize -1` such that:
+If `lowerBounded` is `False`, the upper rank :math:`k_{up}` is the smallest rank :math:`k` with
+:math:`0 \leq k < \sampleSize` such that:
 
 .. math::
 
     \Prob{x_{\alpha} \leq X_{(k)}} \geq \beta.
 
-In other words, the interval :math:`\left]-\infty, X_{(k_{up})}\right]` is a unilateral confidence
-interval for the quantile :math:`x_\alpha` with confidence :math:`\beta`.
+In other words, the interval :math:`\left(-\infty, X_{(k_{up})}\right]` is a
+unilateral confidence interval for the quantile :math:`x_\alpha` with confidence
+:math:`\beta`.
 
-See  :any:`quantile_confidence_estimation`
-to get the conditions of the existence of a solution and the solution for each case.
+Refer to :any:`quantile_confidence_estimation` for the conditions under
+which a solution exists, and the solution itself.
 
 Parameters
 ----------
 size : int
-    Sample size
-lower_bounded : bool, optional
-    True indicates the interval is bounded by a lower value.
-
-    False indicates the interval is bounded by an upper value.
-
+    Sample size :math:`\sampleSize`.
+lowerBounded : bool, optional
+    False to compute the upper bound of the quantile,
+    True for the lower bound.
     Default value is False.
 
 Returns
@@ -88,13 +103,20 @@ rank : int
 
 Examples
 --------
+In the following example, we consider a sample of size 100.
+We compute the rank of the observation such that :math:`x_{(k)}`
+is a lower bound of the quantile of order :math:`\alpha`, with confidence
+:math:`\beta`.
+See [meeker2017]_, Table J.11, page 548 for comparison.
+
 >>> import openturns as ot
 >>> alpha = 0.05
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
->>> rank = algo.computeUnilateralRank(100)
+>>> lowerBounded = True
+>>> rank = algo.computeUnilateralRank(300, lowerBounded)
 >>> print(rank)
-9
+8
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -102,21 +124,23 @@ Examples
 %feature("docstring") OT::QuantileConfidence::computeBilateralRank
 R"RAW(Evaluate the ranks of a quantile bilateral bound.
 
-The ranks :math:`k_1, k_2` with :math:`0 \leq k_1, k_2 \leq \sampleSize -1` are defined by:
+The ranks :math:`k_1, k_2` with :math:`0 \leq k_1 \leq k_2 < \sampleSize`
+are defined by:
 
 .. math::
 
     \begin{array}{ll}
-    (k_1, k_2) = & \argmin \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}\\
-                 & \mbox{s.t.} \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
+    (k_1, k_2) = 
+    & \argmin \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}\\
+    & \mbox{s.t.} \; \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
     \end{array}
 
-In other words, the interval :math:`\left[ X_{(k_1)}, X_{(k_2)} \right[` is a bilateral confidence
-interval for the quantile :math:`x_\alpha` with confidence :math:`\beta`.
+In other words, the interval :math:`\left[ X_{(k_1)}, X_{(k_2)} \right]` is a
+bilateral confidence interval for the quantile :math:`x_\alpha` with confidence
+:math:`\beta`.
 
-See  :any:`quantile_confidence_estimation`
-to get the conditions of the existence of a solution and the solution.
- 
+Refer to :any:`quantile_confidence_estimation` for the conditions under
+which a solution exists, and the solution itself.
 
 Parameters
 ----------
@@ -142,45 +166,47 @@ Examples
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::QuantileConfidence::computeUnilateralConfidenceInterval
-R"RAW(Evaluate an unilateral confidence interval of a quantile.
+R"RAW(Evaluate a unilateral confidence interval of a quantile.
 
-The lower bounded confidence interval  is given by the order statistics:
-
-.. math::
-
-    [X_{(k_{low})}, +\infty[
-
-where :math:`k_{low}` is the largest rank with :math:`0 \leq k_{low} \leq \sampleSize - 1` so that:
+If `lowerBounded` is `True`, the lower-bounded confidence interval is given
+by the order statistic:
 
 .. math::
 
-    \Prob{X_{(k_{low})} \leq x_{\alpha}} \geq \beta.
+    \left[X_{(k)}, +\infty\right)
 
-The upper bounded confidence interval :
-
-.. math::
-
-    ]-\infty, X_{(k_{up})}]
-
-where :math:`k_{up}` is the smallest rank with :math:`0 \leq k_{up} \leq \sampleSize - 1` so that:
+where :math:`k` is the largest rank such that
+:math:`0 \leq k < \sampleSize` and:
 
 .. math::
 
-    \Prob{x_{\alpha} \leq X_{(k_{up})}} \geq \beta
+    \Prob{X_{(k)} \leq x_{\alpha}} \geq \beta.
 
-The lower or upper ranks :math:`k_{low}` and :math:`k_{up}` are given by :meth:`computeUnilateralRank`.
+If `lowerBounded` is `False`, the upper-bounded confidence interval is given
+by the order statistic:
 
-The statistics values are evaluated from the given sample.
+.. math::
+
+    \left(-\infty, X_{(k)}\right]
+
+where :math:`k` is the smallest rank such that
+:math:`0 \leq k < \sampleSize` and:
+
+.. math::
+
+    \Prob{x_{\alpha} \leq X_{(k)}} \geq \beta.
+
+The rank :math:`k` is evaluated by :meth:`computeUnilateralRank`.
+
+The order statistic is computed from the provided sample.
 
 Parameters
 ----------
 sample : 2-d sequence of float
-    Quantile level
-lower_bounded : bool, optional
-    True indicates the interval is bounded by a lower value.
-
-    False indicates the interval is bounded by an upper value.
-
+    Sample of the variable :math:`X`.
+lowerBounded : bool, optional
+    False to compute the upper bound of the quantile,
+    True to compute its lower bound.
     Default value is False.
 
 Returns
@@ -190,28 +216,33 @@ ci : :class:`~openturns.Interval`
 
 Examples
 --------
+In the following example, we compute a confidence interval
+for the quantile of level 95% with confidence 95%.
+More precisely, we compute an upper bound of this quantile.
+
 >>> import openturns as ot
->>> alpha = 0.05
+>>> ot.RandomGenerator.SetSeed(0)
+>>> alpha = 0.95
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> sample = ot.Gumbel().getSample(100)
 >>> ci = algo.computeUnilateralConfidenceInterval(sample)
+>>> print(ci.getUpperBound()[0])
+3.999...
 )RAW"
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::QuantileConfidence::computeUnilateralConfidenceIntervalWithCoverage
-R"RAW(Evaluate an unilateral confidence interval of a quantile.
-
-Refer to :func:`computeUnilateralConfidenceInterval()`
+R"RAW(Evaluate a unilateral confidence interval of a quantile.
 
 Parameters
 ----------
 sample : 2-d sequence of float
-    Quantile level
-lower_bounded : bool, optional
-    True indicates the interval is bounded by a lower value.
-    False indicates the interval is bounded by an upper value.
+    Sample of the variable :math:`X`.
+lowerBounded : bool, optional
+    False to compute the upper bound of the quantile,
+    True to compute its lower bound.
     Default value is False.
 
 Returns
@@ -220,23 +251,27 @@ ci : :class:`~openturns.Interval`
     Quantile confidence interval.
 
 coverage : float
-    If `lower_bounded` is True, then the `coverage` is the value of :math:`\Prob{X_{(k_1)} \leq x_{\alpha} })`.
-    Otherwise, the `coverage` is the value of :math:`\Prob{x_{\alpha} \leq X_{(k_2)}}`.
-    In both cases, the coverage is guaranteed to be greater or equal to :math:`\beta`.
+    If `lowerBounded` is True, then the `coverage` is the value of
+    :math:`\Prob{X_{(k)} \leq x_{\alpha}}`.
+    Otherwise, the `coverage` is the value of :math:`\Prob{x_{\alpha} \leq X_{(k)}}`.
+    In both cases, the coverage is guaranteed to be greater or equal to
+    :math:`\beta`.
 
 Notes
 -----
-Refer to :func:`computeUnilateralConfidenceInterval()`. In addition to the confidence interval,
-the method returns the supremum of :math:`\beta` for the confidence interval.
+Refer to :func:`computeUnilateralConfidenceInterval()`.
 
 Examples
 --------
 >>> import openturns as ot
->>> alpha = 0.05
+>>> ot.RandomGenerator.SetSeed(0)
+>>> alpha = 0.95
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> sample = ot.Gumbel().getSample(100)
 >>> ci, coverage = algo.computeUnilateralConfidenceIntervalWithCoverage(sample)
+>>> print(coverage)
+0.962...
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -244,19 +279,22 @@ Examples
 %feature("docstring") OT::QuantileConfidence::computeBilateralConfidenceInterval
 R"RAW(Evaluate a bilateral confidence interval of a quantile.
 
-The confidence interval for the quantile of level :math:`\alpha` is given by the order statistics:
+The confidence interval for the quantile of level :math:`\alpha` is given by
+the order statistics:
 
 .. math::
 
     [X_{(k_1)}, X_{(k_2)}]
 
-where :math:`(k_1, k_2)`  are the ranks with :math:`0 \leq k_1 \leq k_2 \leq n - 1` defined by:
+where :math:`(k_1, k_2)`  are the ranks with
+:math:`0 \leq k_1 \leq k_2 < \sampleSize` defined by:
 
 .. math::
 
     \begin{array}{ll}
-    (k_1, k_2) = & \argmin \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}\\
-                 & \mbox{s.t.} \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
+    (k_1, k_2) = 
+    & \argmin \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}\\
+    & \mbox{s.t.} \; \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
     \end{array}
 
 The ranks :math:`(k_1, k_2)` are given by :meth:`computeBilateralRank`.
@@ -276,11 +314,14 @@ ci : :class:`~openturns.Interval`
 Examples
 --------
 >>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
 >>> alpha = 0.05
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> sample = ot.Gumbel().getSample(60)
 >>> ci = algo.computeBilateralConfidenceInterval(sample)
+>>> print(ci)
+[-1.310..., -0.532...]
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -301,22 +342,25 @@ ci : :class:`~openturns.Interval`
     Quantile confidence interval.
 
 coverage : float
-    The `coverage` is the value of :math:`\Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}`.
+    The `coverage` is the value of
+    :math:`\Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}`.
     The coverage is guaranteed to be greater or equal to :math:`\beta`.
 
 Notes
 -----
-Refer to :func:`computeBilateralConfidenceInterval()`. In addition to the confidence interval,
-the method returns the supremum of :math:`\beta` for the confidence interval.
+Refer to :func:`computeBilateralConfidenceInterval()`.
 
 Examples
 --------
 >>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
 >>> alpha = 0.05
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> sample = ot.Gumbel().getSample(60)
 >>> ci, coverage = algo.computeBilateralConfidenceIntervalWithCoverage(sample)
+>>> print(coverage)
+0.9510...
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -324,80 +368,140 @@ Examples
 %feature("docstring") OT::QuantileConfidence::computeUnilateralMinimumSampleSize
 R"RAW(Evaluate the minimum sample size for the unilateral confidence interval.
 
-The rank :math:`k \geq 0` is specified. The method computes the smallest sample size :math:`n` so that:
+Let :math:`k \geq 0` be the given (tail) rank using 0-based indexing.
+The method computes the smallest sample size :math:`\sampleSize` required to
+guarantee a confidence level :math:`\beta` for the specified unilateral
+confidence interval of the quantile :math:`x_\alpha`.
+
+If `lowerBounded` is `True`, the condition to satisfy for the lower-bounded
+confidence interval :math:`\left[ X_{(k)}, +\infty\right)` is:
 
 .. math::
 
-    \Prob{X_{(k)} \leq x_{\alpha}} \geq \beta
+    \Prob{X_{(k)} \leq x_{\alpha}} \geq \beta.
 
-in the case of a lower bound of the quantile of order :math:`\alpha`, and:
+If `lowerBounded` is `False`, the condition to satisfy for the upper-bounded
+confidence interval :math:`\left(-\infty, X_{(\sampleSize - k - 1)} \right]` is:
 
 .. math::
 
-    \Prob{x_{\alpha} \leq X_{(n-k-1)}} \geq \beta.
+    \Prob{x_{\alpha} \leq X_{(\sampleSize - k - 1)}} \geq \beta.
 
-in the case of an upper bound.
+Notice that the actual rank used for the upper bound is
+:math:`\sampleSize - k - 1`.
 
-In other words, the interval :math:`\left] -\infty, X_{(k)} \right]` or :math:`\left[ X_{(k)}, +\infty \right[` is a unilateral confidence
-interval for the quantile :math:`x_\alpha` with confidence :math:`\beta`. The statistics values are evaluated from the sample.
+A notable feature of this method is its use of the tail rank to compute the
+minimum sample size.
+This allows the evaluation of an arbitrary order statistic, rather than being
+restricted to the extreme observations, i.e.,
+:math:`X_{(0)}` or :math:`X_{(\sampleSize - 1)}`.
+While this is straightforward when computing the lower confidence bound,
+computing the upper confidence bound requires the adjusted rank
+:math:`\sampleSize - k - 1`. This corresponds to the rank counted from the
+largest observation in the sample.
 
-See  :any:`quantile_confidence_estimation`
-to get the conditions of the existence of a solution and the solution.
+Refer to :any:`quantile_confidence_estimation` for the conditions under
+which a solution exists, and the solution itself.
 
 Parameters
 ----------
-k : int, optional, :math:`k \geq 0`
-    Rank of the quantile.
-
+tail_rank : int, optional, :math:`k \geq 0`
+    The (tail) rank of the quantile, using 0-based indexing.
     Default value is 0.
-lower_bounded : bool, optional
-    True indicates the interval is bounded by a lower value.
-
-    False indicates the interval is bounded by an upper value.
-
+lowerBounded : bool, optional
+    False to compute the upper bound of the quantile,
+    True for the lower bound.
     Default value is False.
 
 Returns
 -------
 size : int
-    Minimum sample size :math:`n`.
+    Minimum sample size :math:`\sampleSize`.
 
 Examples
 --------
+In the following example, we compute the smallest sample size such that the
+largest observation in the sample, i.e. :math:`x_{(\sampleSize - 1)}`, is an
+upper bound of the quantile of order :math:`\alpha`, with confidence
+:math:`\beta`.
+See [meeker2017]_, Table J.13, page 549 for comparison.
+
 >>> import openturns as ot
->>> alpha = 0.05
+>>> alpha = 0.95
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> size = algo.computeUnilateralMinimumSampleSize(0)
 >>> print(size)
 59
+
+Consider an upper confidence bound based on a given tail rank, for instance
+:math:`k = 10`.
+The goal is to verify that the condition
+:math:`\Prob{x_{\alpha} \leq X_{(\sampleSize - k - 1)}} \geq \beta` is satisfied.
+Note that because we are evaluating an upper bound, the actual rank must be
+computed from the tail rank as :math:`\sampleSize - k - 1`.
+
+>>> alpha = 0.95
+>>> beta = 0.95
+>>> algo = ot.QuantileConfidence(alpha, beta)
+>>> lowerBounded = False
+>>> tail_rank = 10
+>>> size = algo.computeUnilateralMinimumSampleSize(tail_rank, lowerBounded)
+>>> print(size)
+336
+>>> rank = size - tail_rank - 1
+>>> coverage = algo.computeUnilateralCoverage(size, rank, lowerBounded)
+>>> print(coverage)
+0.9503...
+>>> print(coverage >= beta)
+True
+
+Consider a lower confidence bound based on a given tail rank, for instance
+:math:`k = 10`.
+The goal is to verify that the condition
+:math:`\Prob{X_{(k)} \leq x_{\alpha}} \geq \beta` is satisfied.
+Note that because we are evaluating a lower bound, the actual rank used for the
+order statistic is exactly the tail rank :math:`k`.
+
+>>> alpha = 0.05
+>>> beta = 0.95
+>>> algo = ot.QuantileConfidence(alpha, beta)
+>>> lowerBounded = True
+>>> tail_rank = 10
+>>> size = algo.computeUnilateralMinimumSampleSize(tail_rank, lowerBounded)
+>>> print(size)
+336
+>>> rank = tail_rank
+>>> coverage = algo.computeUnilateralCoverage(size, rank, lowerBounded)
+>>> print(coverage)
+0.9503...
+>>> print(coverage >= beta)
+True
 )RAW"
 
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::QuantileConfidence::computeBilateralMinimumSampleSize
-R"RAW(Evaluate the minimum size of the sample for the bilateral min - max confidence interval.
+R"RAW(Evaluate the minimum size of the sample for the bilateral confidence interval.
 
-The method determines the smallest sample size :math:`n` so that:
+The method determines the smallest sample size :math:`\sampleSize` such that:
 
 .. math::
 
-    \Prob{X_{(0)} \leq x_{\alpha} \leq X_{(n-1)}} \geq \beta.
+    \Prob{X_{(0)} \leq x_{\alpha} \leq X_{(\sampleSize - 1)}} \geq \beta.
 
-In other words, the interval :math:`\left[X_{(0)}, X_{(n-1)} \right]` is a bilateral  confidence
-interval for the quantile :math:`x_\alpha` with confidence :math:`\beta`, where
-:math:`X_{(0)} = \min(X_1, \dots, X_{n-1})`
-and :math:`X_{(n-1)} = \max(X_1, \dots, X_{n-1})`.
+In other words, the interval :math:`\left[X_{(0)}, X_{(\sampleSize - 1)} \right]`
+is a bilateral confidence interval for the quantile :math:`x_\alpha` with
+confidence :math:`\beta`, where :math:`X_{(0)} = \min(X_0, \dots, X_{\sampleSize - 1})`
+and :math:`X_{(\sampleSize - 1)} = \max(X_0, \dots, X_{\sampleSize - 1})`.
 
-The statistics values are evaluated from the sample.
-
-See  :any:`quantile_confidence_estimation`
-to get the conditions of the existence of a solution and the solution.
+Refer to :any:`quantile_confidence_estimation` for the conditions under
+which a solution exists, and the solution itself.
 
 Returns
 -------
 size : int
-    Minimum sample size :math:`n`.
+    Minimum sample size :math:`\sampleSize`.
 
 Examples
 --------
@@ -415,21 +519,33 @@ Examples
 %feature("docstring") OT::QuantileConfidence::computeAsymptoticBilateralRank
 R"RAW(Evaluate the asymptotic bilateral rank of a quantile.
 
-This method computes two integers :math:`(k_1, k_2)` such that:
-
-.. math::
-    \lim_{n \rightarrow \infty} \Prob{X_{(k_1)} \leq x_\alpha \leq X_{(k_2)}} = \beta, \quad 0 \leq k_1 \leq k_2 \leq n - 1
-
-In other words, the interval :math:`\left[X_{(k_1)}, X_{(k_2)} \right]` is an asymptotic
-confidence interval for :math:`x_\alpha` with asymptotic confidence :math:`\beta`.
-The asymptotic bilateral ranks :math:`k_1, k_2 \in \llbracket 0, n - 1 \rrbracket` are estimated from:
+This method computes two integers :math:`(k_1, k_2)` such that
+:math:`0 \leq k_1 \leq k_2 \leq \sampleSize - 1` and:
 
 .. math::
 
-    k_1 & = \left\lfloor n \alpha - \sqrt{n} z_{1-\beta/2} \sqrt{\alpha (1 - \alpha)} \right\rfloor - 1 \\
-    k_2 & = \left\lfloor n \alpha + \sqrt{n} z_{1-\beta/2} \sqrt{\alpha (1 - \alpha)} \right\rfloor - 1
+    \lim_{\sampleSize \rightarrow \infty} \Prob{X_{(k_1)} \leq x_\alpha \leq X_{(k_2)}}
+    = \beta.
 
-with :math:`z_{1-\beta/2}` the standard Gaussian quantile of order :math:`1-\beta/2`, see [delmas2006]_ proposition 12.2.13 page 257.
+In other words, the interval :math:`\left[X_{(k_1)}, X_{(k_2)} \right]` is an
+asymptotic confidence interval for :math:`x_\alpha` with asymptotic confidence
+:math:`\beta`.
+The ranks :math:`k_1, k_2 \in \llbracket 0, \sampleSize - 1 \rrbracket` are
+estimated from:
+
+.. math::
+
+    k_1 & = \left\lfloor \sampleSize \alpha - z_{\gamma} \sqrt{\sampleSize \alpha (1 - \alpha)} \right\rfloor - 1 \\
+    k_2 & = \left\lfloor \sampleSize \alpha + z_{\gamma} \sqrt{\sampleSize \alpha (1 - \alpha)} \right\rfloor - 1
+
+where :math:`\gamma \in [0,1]` is defined as:
+
+.. math::
+
+    \gamma = 1 - \frac{1 - \beta}{2}
+
+where :math:`z_{\gamma}` is the standard Gaussian quantile of order :math:`\gamma`.
+See [delmas2006]_ proposition 12.2.13 page 257 for more details on this topic.
 
 Parameters
 ----------
@@ -439,7 +555,8 @@ size : int
 Returns
 -------
 ranks : :class:`~openturns.Indices` of size 2
-    Pair of lower and upper ranks :math:`(k_1, k_2)` with :math:`0 \leq k_1 \leq k_2 \leq n-1`.
+    Pair of lower and upper ranks :math:`(k_1, k_2)` with
+    :math:`0 \leq k_1 \leq k_2 \leq \sampleSize - 1`.
 
 Examples
 --------
@@ -448,8 +565,8 @@ Examples
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> k1, k2 = algo.computeAsymptoticBilateralRank(100)
->>> print(k1, k2)
-0 8
+>>> print((k1, k2))
+(0, 8)
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -467,28 +584,33 @@ so that:
 
 .. math::
 
-    \lim_{n \rightarrow \infty} \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
+    \lim_{\sampleSize \rightarrow \infty}
+    \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}} \geq \beta
 
-where the ranks :math:`0 \leq k_1 \leq k_2 \leq n - 1` are given by :meth:`computeAsymptoticBilateralRank`.
+where the ranks :math:`0 \leq k_1 \leq k_2 \leq \sampleSize - 1` are given by
+:meth:`computeAsymptoticBilateralRank`.
 
 Parameters
 ----------
 sample : 2-d sequence of float
-    Sample of the variable :math:`X`
+    Sample of the variable :math:`X`.
 
 Returns
 -------
 ci : :class:`~openturns.Interval`
-    Quantile confidence interval
+    Quantile confidence interval.
 
 Examples
 --------
 >>> import openturns as ot
+>>> ot.RandomGenerator.SetSeed(0)
 >>> alpha = 0.05
 >>> beta = 0.95
 >>> algo = ot.QuantileConfidence(alpha, beta)
 >>> sample = ot.Gumbel().getSample(60)
 >>> ci = algo.computeAsymptoticBilateralConfidenceInterval(sample)
+>>> print(ci)
+[-1.310..., -0.898...]
 )RAW"
 
 // ---------------------------------------------------------------------
@@ -499,7 +621,7 @@ Examples
 Parameters
 ----------
 alpha : float
-    Quantile level
+    Quantile level.
 "
 
 // ---------------------------------------------------------------------
@@ -510,7 +632,7 @@ alpha : float
 Returns
 -------
 alpha : float
-    Quantile level
+    Quantile level.
 "
 
 // ---------------------------------------------------------------------
@@ -521,7 +643,7 @@ alpha : float
 Parameters
 ----------
 beta : float
-    Confidence level
+    Confidence level.
 "
 
 // ---------------------------------------------------------------------
@@ -532,5 +654,96 @@ beta : float
 Returns
 -------
 beta : float
-    Confidence level
+    Confidence level.
 "
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::QuantileConfidence::computeUnilateralCoverage
+R"RAW(Evaluate the coverage probability of a unilateral confidence interval.
+
+This method computes the exact probability that the true quantile of level
+:math:`\alpha` belongs to the unilateral confidence interval defined by the
+order statistic of the given rank. The computation relies on the Binomial
+distribution and does not require a sample.
+
+If `lowerBounded` is True, the method computes:
+
+.. math::
+
+    \Prob{X_{(k)} \leq x_{\alpha}}
+
+If `lowerBounded` is False, the method computes:
+
+.. math::
+
+    \Prob{x_{\alpha} \leq X_{(k)}}
+
+Parameters
+----------
+size : int
+    Sample size :math:`\sampleSize`.
+rank : int
+    Rank :math:`k` of the order statistic.
+lowerBounded : bool, optional
+    False to consider the upper bound of the quantile,
+    True to consider its lower bound.
+    Default value is False.
+
+Returns
+-------
+coverage : float
+    Probability of coverage.
+
+Examples
+--------
+>>> import openturns as ot
+>>> alpha = 0.05
+>>> beta = 0.95
+>>> algo = ot.QuantileConfidence(alpha, beta)
+>>> lowerBounded = True
+>>> coverage = algo.computeUnilateralCoverage(300, 8, lowerBounded)
+>>> print(coverage)
+0.9659...
+)RAW"
+
+// ---------------------------------------------------------------------
+
+%feature("docstring") OT::QuantileConfidence::computeBilateralCoverage
+R"RAW(Evaluate the coverage probability of a bilateral confidence interval.
+
+This method computes the exact probability that the true quantile of level
+:math:`\alpha` belongs to the bilateral confidence interval defined by the
+order statistics of the given ranks. The computation relies on the Binomial
+distribution and does not require a sample.
+
+The method computes:
+
+.. math::
+
+    \Prob{X_{(k_1)} \leq x_{\alpha} \leq X_{(k_2)}}
+
+Parameters
+----------
+size : int
+    Sample size :math:`\sampleSize`.
+rank1 : int
+    Lower rank :math:`k_1`.
+rank2 : int
+    Upper rank :math:`k_2`.
+
+Returns
+-------
+coverage : float
+    Probability of coverage.
+
+Examples
+--------
+>>> import openturns as ot
+>>> alpha = 0.05
+>>> beta = 0.95
+>>> algo = ot.QuantileConfidence(alpha, beta)
+>>> coverage = algo.computeBilateralCoverage(100, 1, 10)
+>>> print(coverage)
+0.9514...
+)RAW"

--- a/python/test/t_QuantileConfidence_std.py
+++ b/python/test/t_QuantileConfidence_std.py
@@ -3,598 +3,897 @@
 import openturns as ot
 import openturns.testing as ott
 
-alpha = 0.05
-beta = 0.95
-algo = ot.QuantileConfidence(alpha, beta)
-print(algo)
-print(repr(algo))
-algo.setAlpha(alpha)
-algo.setBeta(beta)
-assert algo.getAlpha() == alpha
-assert algo.getBeta() == beta
+
+def check_basic():
+    print("check_basic ...")
+    alpha = 0.05
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    print(algo)
+    print(repr(algo))
+    algo.setAlpha(alpha)
+    algo.setBeta(beta)
+    assert algo.getAlpha() == alpha
+    assert algo.getBeta() == beta
+    # Check exceptions in the constructor
+    alpha = -0.5
+    beta = 0.95
+    with ott.assert_raises(TypeError):
+        algo = ot.QuantileConfidence(alpha, beta)
+    alpha = 1.5
+    beta = 0.95
+    with ott.assert_raises(TypeError):
+        algo = ot.QuantileConfidence(alpha, beta)
+    alpha = 0.95
+    beta = -0.5
+    with ott.assert_raises(TypeError):
+        algo = ot.QuantileConfidence(alpha, beta)
+    alpha = 0.95
+    beta = 1.5
+    with ott.assert_raises(TypeError):
+        algo = ot.QuantileConfidence(alpha, beta)
+
 
 # lower rank
-print("lower rank ...")
-k_ref = {
-    59: 0,
-    93: 1,
-    124: 2,
-    153: 3,
-    181: 4,
-    208: 5,
-    311: 9,
-    410: 13,
-    506: 17,
-    717: 26,
-    809: 30,
-    900: 34,
-    1036: 40,
-}
-for i in range(991, 1013):
-    k_ref[i] = 38
-k_ref[1013] = 39
-for n in k_ref.keys():
-    ll = algo.computeUnilateralRank(n, True)
-    p = ot.Binomial(n, alpha).computeComplementaryCDF(ll)
-    print(f"n={n} l={ll} ref={k_ref[n]} p={p}")
-    assert ll == k_ref[n]
-    assert p >= beta
+def get_lower_rank_ref():
+    k_ref = {
+        59: 0,
+        93: 1,
+        124: 2,
+        153: 3,
+        181: 4,
+        208: 5,
+        311: 9,
+        410: 13,
+        506: 17,
+        717: 26,
+        809: 30,
+        900: 34,
+        1036: 40,
+    }
+    for i in range(991, 1013):
+        k_ref[i] = 38
+    k_ref[1013] = 39
+    return k_ref
+
+
+# lower rank
+def check_lower_rank():
+    print("check_lower_rank ...")
+    alpha = 0.05
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    # lower rank
+    k_ref = get_lower_rank_ref()
+    lower_bounded = True
+    for n in k_ref.keys():
+        ll = algo.computeUnilateralRank(n, lower_bounded)
+        p = algo.computeUnilateralCoverage(n, ll, lower_bounded)
+        print(f"n={n} l={ll} ref={k_ref[n]} p={p}")
+        assert ll == k_ref[n]
+        assert p >= beta
+    # Check exceptions
+    # N is lower than the minimum sample size
+    with ott.assert_raises(TypeError):
+        n = 58
+        ll = algo.computeUnilateralRank(n, lower_bounded)
+    # The rank is larger or equal to the size
+    with ott.assert_raises(TypeError):
+        n = 59
+        ll = 59
+        p = algo.computeUnilateralCoverage(n, ll, lower_bounded)
+
 
 # upper rank
-print("upper rank ...")
-algo.setAlpha(0.95)
-k_ref = {
-    59: 58,
-    93: 91,
-    124: 121,
-    153: 149,
-    181: 176,
-    208: 202,
-    311: 301,
-    410: 396,
-    506: 488,
-    601: 579,
-    717: 690,
-    809: 778,
-    900: 865,
-    1013: 973,
-    1036: 995,
-}
-for n in k_ref.keys():
-    u = algo.computeUnilateralRank(n)
-    p = ot.Binomial(n, alpha).computeCDF(u)
-    print(f"n={n} u={u} ref={k_ref[n]} p={p}")
-    assert u == k_ref[n]
-    assert p >= beta
+def get_upper_rank_ref():
+    k_ref = {
+        59: 58,
+        93: 91,
+        124: 121,
+        153: 149,
+        181: 176,
+        208: 202,
+        311: 301,
+        410: 396,
+        506: 488,
+        601: 579,
+        717: 690,
+        809: 778,
+        900: 865,
+        1013: 973,
+        1036: 995,
+    }
+    return k_ref
+
+
+# upper rank
+def check_upper_rank():
+    print("check_upper_rank ...")
+    alpha = 0.95
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    # upper rank
+    k_ref = get_upper_rank_ref()
+    for n in k_ref.keys():
+        u = algo.computeUnilateralRank(n)
+        p = algo.computeUnilateralCoverage(n, u)
+        print(f"n={n} u={u} ref={k_ref[n]} p={p}")
+        assert u == k_ref[n]
+        assert p >= beta
+    # Check exceptions
+    # N is lower than the minimum sample size
+    with ott.assert_raises(TypeError):
+        n = 58
+        ll = algo.computeUnilateralRank(n)
+    # The rank is larger or equal to the size
+    with ott.assert_raises(TypeError):
+        n = 59
+        ll = 59
+        p = algo.computeUnilateralCoverage(n, ll)
+
 
 # bilateral ranks
-print("bilateral ranks ...")
-algo.setAlpha(0.05)
-algo = ot.QuantileConfidence(alpha, beta)
-k_ref = {
-    59: (0, 9),
-    60: (0, 8),
-    70: (0, 8),
-    80: (0, 8),
-    90: (0, 8),
-    100: (1, 10),
-    150: (1, 12),
-    200: (2, 15),
-    250: (3, 18),
-    300: (4, 21),
-    400: (11, 28),
-    500: (12, 33),
-    600: (19, 40),
-    700: (25, 50),
-    800: (22, 50),
-    900: (34, 69),
-    1000: (36, 63),
-    10000: (437, 536),
-    100000: (4879, 5160),
-}
-for n in k_ref.keys():
-    k1, k2 = algo.computeBilateralRank(n)
-    binom = ot.Binomial(n, alpha)
-    p = binom.computeCDF(k2) - binom.computeCDF(k1)
-    print(f"n={n} k1={k1} k2={k2} p={p:.6f}")
-    assert (k1, k2) == k_ref[n]
-    assert p >= beta
+def get_bilateral_rank_ref():
+    k_ref = {
+        59: (0, 9),
+        60: (0, 8),
+        70: (0, 8),
+        80: (0, 8),
+        90: (0, 8),
+        100: (1, 10),
+        150: (1, 12),
+        200: (2, 15),
+        250: (3, 18),
+        300: (4, 21),
+        400: (11, 28),
+        500: (12, 33),
+        600: (19, 40),
+        700: (25, 50),
+        800: (22, 50),
+        900: (34, 69),
+        1000: (36, 63),
+        10000: (437, 536),
+        100000: (4879, 5160),
+    }
+    return k_ref
 
-    # we can also make sure by exploring all combinations (costly)
-    if n > 100:
-        continue
-    bestP = 2
-    for i1 in range(n):
-        for i2 in range(i1, n):
-            # we compute P(k1<X<=k2)=P(k1+1<=X<=k2), CDF(k2)-CDF(k1) also works
-            p = binom.computeCDF(i2) - binom.computeCDF(i1)
-            if (p >= beta) and (p < bestP):
-                bestP = p
-                bestK1K2 = i1, i2
-    print(n, (k1, k2), bestK1K2, bestP)
-    assert (k1, k2) == bestK1K2
+
+# bilateral ranks
+def check_bilateral_rank():
+    print("check_bilateral_rank ...")
+    alpha = 0.05
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    #
+    # bilateral ranks
+    k_ref = get_bilateral_rank_ref()
+
+    for n in k_ref.keys():
+        k1, k2 = algo.computeBilateralRank(n)
+        print(f"n={n} k1={k1} k2={k2}")
+        p = algo.computeBilateralCoverage(n, k1, k2)
+        print(f"coverage={p}")
+        assert (k1, k2) == k_ref[n]
+        assert p >= beta
+
+        # we can also make sure by exploring all combinations (costly)
+        if n > 100:
+            continue
+        bestP = 2
+        bestK1K2 = None
+        for i1 in range(n):
+            for i2 in range(i1, n):
+                # we compute P(k1<X<=k2)=P(k1+1<=X<=k2), CDF(k2)-CDF(k1) also works
+                p = algo.computeBilateralCoverage(n, i1, i2)
+                if (p >= beta) and (p < bestP):
+                    bestP = p
+                    bestK1K2 = i1, i2
+        # print(n, bestK1K2, bestP)
+        assert bestK1K2 is not None, f"No valid (k1, k2) pair found for n={n}"
+        assert (k1, k2) == bestK1K2
+
+    # Check exceptions
+    # N is lower than the minimum sample size
+    with ott.assert_raises(TypeError):
+        n = 58
+        k1, k2 = algo.computeBilateralRank(n)
+    # The rank k1 is larger than k2
+    with ott.assert_raises(TypeError):
+        n = 59
+        k1 = 10
+        k2 = 9
+        p = algo.computeBilateralCoverage(n, k1, k2)
+    # The rank k2 is larger or equal to the size
+    with ott.assert_raises(TypeError):
+        n = 59
+        k1 = 0
+        k2 = 59
+        p = algo.computeBilateralCoverage(n, k1, k2)
+
 
 # validate confidence intervals by probability estimation
-n = 100
-distribution = ot.Gumbel()
-nreps = 3000
-p1 = 0.0
-p2 = 0.0
-p3 = 0.0
-for r in range(nreps):
-    sample = distribution.getSample(n)
-    interval1 = algo.computeUnilateralConfidenceInterval(sample)
-    interval1_bis, coverage1 = algo.computeUnilateralConfidenceIntervalWithCoverage(
-        sample
+def check_validate_empirical_coverage():
+    print("check_validate_empirical_coverage ...")
+    # validate confidence intervals by probability estimation
+    # Estimate the probability that the interval contains the true quantile
+    # by Monte Carlo sampling.
+    # Then the computed probability should be close to the expected
+    # coverage.
+    alpha = 0.95
+    beta = 0.90
+    algo = ot.QuantileConfidence(alpha, beta)
+    size = 100
+    distribution = ot.Normal()
+    quantile_alpha = distribution.computeQuantile(alpha)
+    # This should be as large as possible (but is limited by CPU time)
+    number_of_repetitions = 3000
+    count_upper = 0
+    count_lower = 0
+    count_bilateral = 0
+    for _ in range(number_of_repetitions):
+        sample = distribution.getSample(size)
+        interval_upper = algo.computeUnilateralConfidenceInterval(sample)
+        interval_lower = algo.computeUnilateralConfidenceInterval(sample, True)
+        interval_bilateral = algo.computeBilateralConfidenceInterval(sample)
+
+        if interval_upper.contains(quantile_alpha):
+            count_upper += 1
+        if interval_lower.contains(quantile_alpha):
+            count_lower += 1
+        if interval_bilateral.contains(quantile_alpha):
+            count_bilateral += 1
+
+    estimated_coverage_upper = count_upper / number_of_repetitions
+    estimated_coverage_lower = count_lower / number_of_repetitions
+    estimated_coverage_bilateral = count_bilateral / number_of_repetitions
+    print(f"estimated_coverage_upper={estimated_coverage_upper}")
+    print(f"estimated_coverage_lower={estimated_coverage_lower}")
+    print(f"estimated_coverage_bilateral={estimated_coverage_bilateral}")
+
+    upper_rank = algo.computeUnilateralRank(size)
+    lower_rank = algo.computeUnilateralRank(size, True)
+    bilateral_k1, bilateral_k2 = algo.computeBilateralRank(size)
+    exact_coverage_upper = algo.computeUnilateralCoverage(size, upper_rank)
+    exact_coverage_lower = algo.computeUnilateralCoverage(size, lower_rank, True)
+    exact_coverage_bilateral = algo.computeBilateralCoverage(
+        size, bilateral_k1, bilateral_k2
     )
-    interval2 = algo.computeUnilateralConfidenceInterval(sample, True)
-    interval2_bis, coverage2 = algo.computeUnilateralConfidenceIntervalWithCoverage(
-        sample, True
+    print(f"exact_coverage_upper={exact_coverage_upper}")
+    print(f"exact_coverage_lower={exact_coverage_lower}")
+    print(f"exact_coverage_bilateral={exact_coverage_bilateral}")
+
+    ott.assert_almost_equal(estimated_coverage_upper, exact_coverage_upper, 0.01, 0.0)
+    ott.assert_almost_equal(estimated_coverage_lower, exact_coverage_lower, 0.01, 0.0)
+    ott.assert_almost_equal(
+        estimated_coverage_bilateral, exact_coverage_bilateral, 0.01, 0.0
     )
-    interval3 = algo.computeBilateralConfidenceInterval(sample)
-    interval3_bis, coverage3 = algo.computeBilateralConfidenceIntervalWithCoverage(
-        sample
-    )
-
-    assert interval1 == interval1_bis
-    assert interval2 == interval2_bis
-    assert interval3 == interval3_bis
-
-    assert coverage1 >= beta
-    assert coverage2 >= beta
-    assert coverage3 >= beta
-
-    ott.assert_almost_equal(coverage1, 0.97, 0.005, 0.0)
-    ott.assert_almost_equal(coverage2, 0.96, 0.005, 0.0)
-    ott.assert_almost_equal(coverage3, 0.95, 0.005, 0.0)
-
-    q = distribution.computeQuantile(alpha)
-    if interval1.contains(q):
-        p1 += 1.0 / nreps
-    if interval2.contains(q):
-        p2 += 1.0 / nreps
-    if interval3.contains(q):
-        p3 += 1.0 / nreps
-
-print(f"p1={p1:.6f} p2={p2:.6f} p3={p3:.6f}")
-assert p1 >= beta
-assert p2 >= beta
-assert p3 >= beta
-
-ott.assert_almost_equal(p1, coverage1, 0.005, 0.0)
-ott.assert_almost_equal(p2, coverage2, 0.01, 0.0)
-ott.assert_almost_equal(p3, coverage3, 0.005, 0.0)
 
 
 # minimum size
-print("minimum size ...")
-ref_a = {}  # dict of reference size values for different (alpha, beta) pairs
-ref_a[(0.01, 0.99)] = 459
-ref_a[(0.01, 0.95)] = 299
-ref_a[(0.01, 0.9)] = 230
-ref_a[(0.05, 0.99)] = 90
-ref_a[(0.05, 0.95)] = 59
-ref_a[(0.05, 0.9)] = 45
-ref_a[(0.1, 0.99)] = 44
-ref_a[(0.1, 0.95)] = 29
-ref_a[(0.1, 0.9)] = 22
-ref_a[(0.75, 0.99)] = 4
-ref_a[(0.75, 0.95)] = 3
-ref_a[(0.75, 0.9)] = 2
-ref_a[(0.9, 0.99)] = 2
-ref_a[(0.9, 0.95)] = 2
-ref_a[(0.9, 0.9)] = 1
-ref_a[(0.95, 0.99)] = 2
-ref_a[(0.95, 0.95)] = 1
-ref_a[(0.95, 0.9)] = 1
-ref_a[(0.99, 0.99)] = 1
-ref_a[(0.99, 0.95)] = 1
-ref_a[(0.99, 0.9)] = 1
+def get_minimum_sample_size_lower():
+    ref_minimum_sample_size_lower = {
+        (0.01, 0.99): 459,
+        (0.01, 0.95): 299,
+        (0.01, 0.9): 230,
+        (0.05, 0.99): 90,
+        (0.05, 0.95): 59,
+        (0.05, 0.9): 45,
+        (0.1, 0.99): 44,
+        (0.1, 0.95): 29,
+        (0.1, 0.9): 22,
+        (0.75, 0.99): 4,
+        (0.75, 0.95): 3,
+        (0.75, 0.9): 2,
+        (0.9, 0.99): 2,
+        (0.9, 0.95): 2,
+        (0.9, 0.9): 1,
+        (0.95, 0.99): 2,
+        (0.95, 0.95): 1,
+        (0.95, 0.9): 1,
+        (0.99, 0.99): 1,
+        (0.99, 0.95): 1,
+        (0.99, 0.9): 1,
+    }
+    return ref_minimum_sample_size_lower
 
-ref_b = {}
-ref_b[(0.01, 0.9)] = 1
-ref_b[(0.01, 0.95)] = 1
-ref_b[(0.01, 0.99)] = 1
-ref_b[(0.05, 0.9)] = 1
-ref_b[(0.05, 0.95)] = 1
-ref_b[(0.05, 0.99)] = 2
-ref_b[(0.1, 0.9)] = 1
-ref_b[(0.1, 0.95)] = 2
-ref_b[(0.1, 0.99)] = 2
-ref_b[(0.25, 0.9)] = 2
-ref_b[(0.25, 0.95)] = 3
-ref_b[(0.25, 0.99)] = 4
-ref_b[(0.75, 0.9)] = 9
-ref_b[(0.75, 0.95)] = 11
-ref_b[(0.75, 0.99)] = 17
-ref_b[(0.9, 0.9)] = 22
-ref_b[(0.9, 0.95)] = 29
-ref_b[(0.9, 0.99)] = 44
-ref_b[(0.95, 0.9)] = 45
-ref_b[(0.95, 0.95)] = 59
-ref_b[(0.95, 0.99)] = 90
-ref_b[(0.99, 0.9)] = 230
-ref_b[(0.99, 0.95)] = 299
-ref_b[(0.99, 0.99)] = 459
 
-ref_c = {}
-ref_c[(0.01, 0.9)] = 230
-ref_c[(0.01, 0.95)] = 299
-ref_c[(0.01, 0.99)] = 459
-ref_c[(0.05, 0.9)] = 45
-ref_c[(0.05, 0.95)] = 59
-ref_c[(0.05, 0.99)] = 90
-ref_c[(0.1, 0.9)] = 22
-ref_c[(0.1, 0.95)] = 29
-ref_c[(0.1, 0.99)] = 44
-ref_c[(0.25, 0.9)] = 9
-ref_c[(0.25, 0.95)] = 11
-ref_c[(0.25, 0.99)] = 17
-ref_c[(0.75, 0.9)] = 9
-ref_c[(0.75, 0.95)] = 11
-ref_c[(0.75, 0.99)] = 17
-ref_c[(0.9, 0.9)] = 22
-ref_c[(0.9, 0.95)] = 29
-ref_c[(0.9, 0.99)] = 44
-ref_c[(0.95, 0.9)] = 45
-ref_c[(0.95, 0.95)] = 59
-ref_c[(0.95, 0.99)] = 90
-ref_c[(0.99, 0.9)] = 230
-ref_c[(0.99, 0.95)] = 299
-ref_c[(0.99, 0.99)] = 459
+def get_minimum_sample_size_upper():
+    ref_minimum_sample_size_upper = {
+        (0.01, 0.9): 1,
+        (0.01, 0.95): 1,
+        (0.01, 0.99): 1,
+        (0.05, 0.9): 1,
+        (0.05, 0.95): 1,
+        (0.05, 0.99): 2,
+        (0.1, 0.9): 1,
+        (0.1, 0.95): 2,
+        (0.1, 0.99): 2,
+        (0.25, 0.9): 2,
+        (0.25, 0.95): 3,
+        (0.25, 0.99): 4,
+        (0.75, 0.9): 9,
+        (0.75, 0.95): 11,
+        (0.75, 0.99): 17,
+        (0.9, 0.9): 22,
+        (0.9, 0.95): 29,
+        (0.9, 0.99): 44,
+        (0.95, 0.9): 45,
+        (0.95, 0.95): 59,
+        (0.95, 0.99): 90,
+        (0.99, 0.9): 230,
+        (0.99, 0.95): 299,
+        (0.99, 0.99): 459,
+    }
+    return ref_minimum_sample_size_upper
 
-for alpha in [0.01, 0.05, 0.10, 0.25, 0.75, 0.90, 0.95, 0.99]:
-    for beta in [0.90, 0.95, 0.99]:
-        algo = ot.QuantileConfidence(alpha, beta)
-        # lower
-        for r in range(5):
-            n = algo.computeUnilateralMinimumSampleSize(r)
-            p = ot.Binomial(n, alpha).computeComplementaryCDF(r)
-            pPrev = ot.Binomial(n - 1, alpha).computeComplementaryCDF(r)
+
+def get_minimum_sample_size_bilateral():
+    ref_minimum_sample_size_bilateral = {
+        (0.01, 0.9): 230,
+        (0.01, 0.95): 299,
+        (0.01, 0.99): 459,
+        (0.05, 0.9): 45,
+        (0.05, 0.95): 59,
+        (0.05, 0.99): 90,
+        (0.1, 0.9): 22,
+        (0.1, 0.95): 29,
+        (0.1, 0.99): 44,
+        (0.25, 0.9): 9,
+        (0.25, 0.95): 11,
+        (0.25, 0.99): 17,
+        (0.75, 0.9): 9,
+        (0.75, 0.95): 11,
+        (0.75, 0.99): 17,
+        (0.9, 0.9): 22,
+        (0.9, 0.95): 29,
+        (0.9, 0.99): 44,
+        (0.95, 0.9): 45,
+        (0.95, 0.95): 59,
+        (0.95, 0.99): 90,
+        (0.99, 0.9): 230,
+        (0.99, 0.95): 299,
+        (0.99, 0.99): 459,
+    }
+    return ref_minimum_sample_size_bilateral
+
+
+# minimum size
+def check_minimum_sample_size():
+    print("check_minimum_sample_size ...")
+    # minimum size
+    # dict of reference size values for different (alpha, beta) pairs
+    ref_minimum_sample_size_lower = get_minimum_sample_size_lower()
+    ref_minimum_sample_size_upper = get_minimum_sample_size_upper()
+    ref_minimum_sample_size_bilateral = get_minimum_sample_size_bilateral()
+
+    for alpha in [0.01, 0.05, 0.10, 0.25, 0.75, 0.90, 0.95, 0.99]:
+        for beta in [0.90, 0.95, 0.99]:
+            algo = ot.QuantileConfidence(alpha, beta)
+            # lower
+            lower_bound = True
+            for r in range(5):
+                n = algo.computeUnilateralMinimumSampleSize(r, lower_bound)
+                p = ot.Binomial(n, alpha).computeComplementaryCDF(r)
+                pPrev = ot.Binomial(n - 1, alpha).computeComplementaryCDF(r)
+                print(
+                    f"alpha={alpha:.3f} beta={beta:.3f} r={r} n={n} p={p:.6f} pPrev={pPrev:.6f}"
+                )
+                assert p >= beta
+                assert pPrev < beta
+                if r == 0 and (alpha, beta) in ref_minimum_sample_size_lower:
+                    assert n == ref_minimum_sample_size_lower[(alpha, beta)]
+
+            # upper
+            # lower_bound = False is the default value
+            for r in range(5):
+                n = algo.computeUnilateralMinimumSampleSize(r)
+                p = ot.Binomial(n, alpha).computeCDF(n - 1 - r)
+                pPrev = ot.Binomial(n - 1, alpha).computeCDF((n - 1) - 1 - r)
+                print(
+                    f"alpha={alpha:.3f} beta={beta:.3f} r={r} n={n} p={p:.6f} pPrev={pPrev:.6f}"
+                )
+                assert p >= beta
+                assert pPrev < beta
+                if r == 0 and (alpha, beta) in ref_minimum_sample_size_upper:
+                    assert n == ref_minimum_sample_size_upper[(alpha, beta)]
+
+            # bilateral
+            n = algo.computeBilateralMinimumSampleSize()
+            p = 1 - alpha**n - (1 - alpha) ** n
+            pPrev = 1 - alpha ** (n - 1) - (1 - alpha) ** (n - 1)
             print(
                 f"alpha={alpha:.3f} beta={beta:.3f} r={r} n={n} p={p:.6f} pPrev={pPrev:.6f}"
             )
             assert p >= beta
             assert pPrev < beta
-            if r == 0 and (alpha, beta) in ref_a:
-                assert n == ref_a[(alpha, beta)]
+            if (alpha, beta) in ref_minimum_sample_size_bilateral:
+                assert n == ref_minimum_sample_size_bilateral[(alpha, beta)]
 
-        # upper
-        for r in range(5):
-            n = algo.computeUnilateralMinimumSampleSize(r, True)
-            p = ot.Binomial(n, alpha).computeCDF(n - 1 - r)
-            pPrev = ot.Binomial(n - 1, alpha).computeCDF((n - 1) - 1 - r)
-            print(
-                f"alpha={alpha:.3f} beta={beta:.3f} r={r} n={n} p={p:.6f} pPrev={pPrev:.6f}"
-            )
-            assert p >= beta
-            assert pPrev < beta
-            if r == 0 and (alpha, beta) in ref_b:
-                assert n == ref_b[(alpha, beta)]
-
-        # bilateral
-        n = algo.computeBilateralMinimumSampleSize()
-        p = 1 - alpha**n - (1 - alpha) ** n
-        pPrev = 1 - alpha ** (n - 1) - (1 - alpha) ** (n - 1)
-        print(
-            f"alpha={alpha:.3f} beta={beta:.3f} r={r} n={n} p={p:.6f} pPrev={pPrev:.6f}"
-        )
-        assert p >= beta
-        assert pPrev < beta
-        if (alpha, beta) in ref_c:
-            assert n == ref_c[(alpha, beta)]
 
 # table J13 from Meeker2017
-for alpha in [
-    0.5,
-    0.55,
-    0.6,
-    0.65,
-    0.7,
-    0.75,
-    0.8,
-    0.85,
-    0.9,
-    0.95,
-    0.96,
-    0.97,
-    0.98,
-    0.99,
-    0.995,
-    0.999,
-]:
-    print(f"{alpha:.3f} | ", end=" ")
-    for beta in [0.5, 0.75, 0.9, 0.95, 0.98, 0.99, 0.999]:
-        algo = ot.QuantileConfidence(alpha, beta)
-        n = algo.computeUnilateralMinimumSampleSize(0, True)
-        if alpha == 0.5 and beta == 0.75:
-            print(f"alpha={alpha} beta={beta} n={n}")
-        print(f"{n: >6}", end=" ")
-    print("")
+def check_print_minimum_unilateral_sample_size_meeker():
+    print("check_print_minimum_unilateral_sample_size_meeker ...")
+    # table J13 from Meeker2017
+    for alpha in [
+        0.5,
+        0.55,
+        0.6,
+        0.65,
+        0.7,
+        0.75,
+        0.8,
+        0.85,
+        0.9,
+        0.95,
+        0.96,
+        0.97,
+        0.98,
+        0.99,
+        0.995,
+        0.999,
+    ]:
+        print(f"{alpha:.3f} | ", end=" ")
+        for beta in [0.5, 0.75, 0.9, 0.95, 0.98, 0.99, 0.999]:
+            algo = ot.QuantileConfidence(alpha, beta)
+            n = algo.computeUnilateralMinimumSampleSize(0, True)
+            if alpha == 0.5 and beta == 0.75:
+                print(f"alpha={alpha} beta={beta} n={n}")
+            print(f"{n: >6}", end=" ")
+        print("")
 
-n_ref = {}
-n_ref[(0.5, 0.5)] = 1
-n_ref[(0.5, 0.75)] = 2
-n_ref[(0.5, 0.9)] = 4
-n_ref[(0.5, 0.95)] = 5
-n_ref[(0.5, 0.98)] = 6
-n_ref[(0.5, 0.99)] = 7
-n_ref[(0.5, 0.999)] = 10
 
-n_ref[(0.55, 0.5)] = 2
-n_ref[(0.55, 0.75)] = 3
-n_ref[(0.55, 0.9)] = 4
-n_ref[(0.55, 0.95)] = 6
-n_ref[(0.55, 0.98)] = 7
-n_ref[(0.55, 0.99)] = 8
-n_ref[(0.55, 0.999)] = 12
+def get_minimum_unilateral_sample_size_ref():
+    # See Meeker2017, table J.13
+    # In Meeker2017, beta is the quantile level, 1 - alpha is the confidence level
+    n_ref = {
+        (0.5, 0.5): 1,
+        (0.5, 0.75): 2,
+        (0.5, 0.9): 4,
+        (0.5, 0.95): 5,
+        (0.5, 0.98): 6,
+        (0.5, 0.99): 7,
+        (0.5, 0.999): 10,
+        (0.55, 0.5): 2,
+        (0.55, 0.75): 3,
+        (0.55, 0.9): 4,
+        (0.55, 0.95): 6,
+        (0.55, 0.98): 7,
+        (0.55, 0.99): 8,
+        (0.55, 0.999): 12,
+        (0.6, 0.5): 2,
+        (0.6, 0.75): 3,
+        (0.6, 0.9): 5,
+        (0.6, 0.95): 6,
+        (0.6, 0.98): 8,
+        (0.6, 0.99): 10,
+        (0.6, 0.999): 14,
+        (0.65, 0.5): 2,
+        (0.65, 0.75): 4,
+        (0.65, 0.9): 6,
+        (0.65, 0.95): 7,
+        (0.65, 0.98): 10,
+        (0.65, 0.99): 11,
+        (0.65, 0.999): 17,
+        (0.7, 0.5): 2,
+        (0.7, 0.75): 4,
+        (0.7, 0.9): 7,
+        (0.7, 0.95): 9,
+        (0.7, 0.98): 11,
+        (0.7, 0.99): 13,
+        (0.7, 0.999): 20,
+        (0.75, 0.5): 3,
+        (0.75, 0.75): 5,
+        (0.75, 0.9): 9,
+        (0.75, 0.95): 11,
+        (0.75, 0.98): 14,
+        (0.75, 0.99): 17,
+        (0.75, 0.999): 25,
+        (0.8, 0.5): 4,
+        (0.8, 0.75): 7,
+        (0.8, 0.9): 11,
+        (0.8, 0.95): 14,
+        (0.8, 0.98): 18,
+        (0.8, 0.99): 21,
+        (0.8, 0.999): 31,
+        (0.85, 0.5): 5,
+        (0.85, 0.75): 9,
+        (0.85, 0.9): 15,
+        (0.85, 0.95): 19,
+        (0.85, 0.98): 25,
+        (0.85, 0.99): 29,
+        (0.85, 0.999): 43,
+        (0.9, 0.5): 7,
+        (0.9, 0.75): 14,
+        (0.9, 0.9): 22,
+        (0.9, 0.95): 29,
+        (0.9, 0.98): 38,
+        (0.9, 0.99): 44,
+        (0.9, 0.999): 66,
+        (0.95, 0.5): 14,
+        (0.95, 0.75): 28,
+        (0.95, 0.9): 45,
+        (0.95, 0.95): 59,
+        (0.95, 0.98): 77,
+        (0.95, 0.99): 90,
+        (0.95, 0.999): 135,
+        (0.96, 0.5): 17,
+        (0.96, 0.75): 34,
+        (0.96, 0.9): 57,
+        (0.96, 0.95): 74,
+        (0.96, 0.98): 96,
+        (0.96, 0.99): 113,
+        (0.96, 0.999): 170,
+        (0.97, 0.5): 23,
+        (0.97, 0.75): 46,
+        (0.97, 0.9): 76,
+        (0.97, 0.95): 99,
+        (0.97, 0.98): 129,
+        (0.97, 0.99): 152,
+        (0.97, 0.999): 227,
+        (0.98, 0.5): 35,
+        (0.98, 0.75): 69,
+        (0.98, 0.9): 114,
+        (0.98, 0.95): 149,
+        (0.98, 0.98): 194,
+        (0.98, 0.99): 228,
+        (0.98, 0.999): 342,
+        (0.99, 0.5): 69,
+        (0.99, 0.75): 138,
+        (0.99, 0.9): 230,
+        (0.99, 0.95): 299,
+        (0.99, 0.98): 390,
+        (0.99, 0.99): 459,
+        (0.99, 0.999): 688,
+        (0.995, 0.5): 139,
+        (0.995, 0.75): 277,
+        (0.995, 0.9): 460,
+        (0.995, 0.95): 598,
+        (0.995, 0.98): 781,
+        (0.995, 0.99): 919,
+        (0.995, 0.999): 1379,
+        (0.999, 0.5): 693,
+        (0.999, 0.75): 1386,
+        (0.999, 0.9): 2302,
+        (0.999, 0.95): 2995,
+        (0.999, 0.98): 3911,
+        (0.999, 0.99): 4603,
+        (0.999, 0.999): 6905,
+    }
+    return n_ref
 
-n_ref[(0.6, 0.5)] = 2
-n_ref[(0.6, 0.75)] = 3
-n_ref[(0.6, 0.9)] = 5
-n_ref[(0.6, 0.95)] = 6
-n_ref[(0.6, 0.98)] = 8
-n_ref[(0.6, 0.99)] = 10
-n_ref[(0.6, 0.999)] = 14
 
-n_ref[(0.65, 0.5)] = 2
-n_ref[(0.65, 0.75)] = 4
-n_ref[(0.65, 0.9)] = 6
-n_ref[(0.65, 0.95)] = 7
-n_ref[(0.65, 0.98)] = 10
-n_ref[(0.65, 0.99)] = 11
-n_ref[(0.65, 0.999)] = 17
-
-n_ref[(0.7, 0.5)] = 2
-n_ref[(0.7, 0.75)] = 4
-n_ref[(0.7, 0.9)] = 7
-n_ref[(0.7, 0.95)] = 9
-n_ref[(0.7, 0.98)] = 11
-n_ref[(0.7, 0.99)] = 13
-n_ref[(0.7, 0.999)] = 20
-
-n_ref[(0.75, 0.5)] = 3
-n_ref[(0.75, 0.75)] = 5
-n_ref[(0.75, 0.9)] = 9
-n_ref[(0.75, 0.95)] = 11
-n_ref[(0.75, 0.98)] = 14
-n_ref[(0.75, 0.99)] = 17
-n_ref[(0.75, 0.999)] = 25
-
-n_ref[(0.8, 0.5)] = 4
-n_ref[(0.8, 0.75)] = 7
-n_ref[(0.8, 0.9)] = 11
-n_ref[(0.8, 0.95)] = 14
-n_ref[(0.8, 0.98)] = 18
-n_ref[(0.8, 0.99)] = 21
-n_ref[(0.8, 0.999)] = 31
-
-n_ref[(0.85, 0.5)] = 5
-n_ref[(0.85, 0.75)] = 9
-n_ref[(0.85, 0.9)] = 15
-n_ref[(0.85, 0.95)] = 19
-n_ref[(0.85, 0.98)] = 25
-n_ref[(0.85, 0.99)] = 29
-n_ref[(0.85, 0.999)] = 43
-
-n_ref[(0.9, 0.5)] = 7
-n_ref[(0.9, 0.75)] = 14
-n_ref[(0.9, 0.9)] = 22
-n_ref[(0.9, 0.95)] = 29
-n_ref[(0.9, 0.98)] = 38
-n_ref[(0.9, 0.99)] = 44
-n_ref[(0.9, 0.999)] = 66
-
-n_ref[(0.95, 0.5)] = 14
-n_ref[(0.95, 0.75)] = 28
-n_ref[(0.95, 0.9)] = 45
-n_ref[(0.95, 0.95)] = 59
-n_ref[(0.95, 0.98)] = 77
-n_ref[(0.95, 0.99)] = 90
-n_ref[(0.95, 0.999)] = 135
-
-n_ref[(0.96, 0.5)] = 17
-n_ref[(0.96, 0.75)] = 34
-n_ref[(0.96, 0.9)] = 57
-n_ref[(0.96, 0.95)] = 74
-n_ref[(0.96, 0.98)] = 96
-n_ref[(0.96, 0.99)] = 113
-n_ref[(0.96, 0.999)] = 170
-
-n_ref[(0.97, 0.5)] = 23
-n_ref[(0.97, 0.75)] = 46
-n_ref[(0.97, 0.9)] = 76
-n_ref[(0.97, 0.95)] = 99
-n_ref[(0.97, 0.98)] = 129
-n_ref[(0.97, 0.99)] = 152
-n_ref[(0.97, 0.999)] = 227
-
-n_ref[(0.98, 0.5)] = 35
-n_ref[(0.98, 0.75)] = 69
-n_ref[(0.98, 0.9)] = 114
-n_ref[(0.98, 0.95)] = 149
-n_ref[(0.98, 0.98)] = 194
-n_ref[(0.98, 0.99)] = 228
-n_ref[(0.98, 0.999)] = 342
-
-n_ref[(0.99, 0.5)] = 69
-n_ref[(0.99, 0.75)] = 138
-n_ref[(0.99, 0.9)] = 230
-n_ref[(0.99, 0.95)] = 299
-n_ref[(0.99, 0.98)] = 390
-n_ref[(0.99, 0.99)] = 459
-n_ref[(0.99, 0.999)] = 688
-
-n_ref[(0.995, 0.5)] = 139
-n_ref[(0.995, 0.75)] = 277
-n_ref[(0.995, 0.9)] = 460
-n_ref[(0.995, 0.95)] = 598
-n_ref[(0.995, 0.98)] = 781
-n_ref[(0.995, 0.99)] = 919
-n_ref[(0.995, 0.999)] = 1379
-
-n_ref[(0.999, 0.5)] = 693
-n_ref[(0.999, 0.75)] = 1386
-n_ref[(0.999, 0.9)] = 2302
-n_ref[(0.999, 0.95)] = 2995
-n_ref[(0.999, 0.98)] = 3911
-n_ref[(0.999, 0.99)] = 4603
-n_ref[(0.999, 0.999)] = 6905
-
-for alpha, beta in n_ref.keys():
-    algo = ot.QuantileConfidence(alpha, beta)
-    n = algo.computeUnilateralMinimumSampleSize(0, True)
-    ref = n_ref[(alpha, beta)]
-    print(f"alpha={alpha} beta={beta} n={n} ref={ref}")
-    assert n == ref
+def check_minimum_unilateral_sample_size():
+    print("check_minimum_unilateral_sample_size ...")
+    n_ref = get_minimum_unilateral_sample_size_ref()
+    for lower_bound in [True, False]:
+        for alpha, beta in n_ref.keys():
+            if lower_bound:
+                algo = ot.QuantileConfidence(1.0 - alpha, beta)
+            else:
+                algo = ot.QuantileConfidence(alpha, beta)
+            n = algo.computeUnilateralMinimumSampleSize(0, lower_bound)
+            ref = n_ref[(alpha, beta)]
+            print(
+                f"lower_bound={lower_bound} "
+                f"alpha={alpha} beta={beta} n={n} ref={ref}"
+            )
+            assert n == ref
 
 
 # asymptotic confidence
-print("asymptotic confidence ...")
-alpha = 0.1
-beta = 0.95
-algo = ot.QuantileConfidence(alpha, beta)
-dist = ot.Gumbel()
-qalpha = dist.computeQuantile(alpha)
-for i in range(3, 7):
-    n = 10**i
-    k1, k2 = algo.computeAsymptoticBilateralRank(n)
-    binom = ot.Binomial(n, alpha)
-    p = binom.computeCDF(k2) - binom.computeCDF(k1)
-    print(f"n={n} ci=[{k1}, {k2}] p={p}")
-    atol = 2.0 * n**-0.5
-    ott.assert_almost_equal(p, beta, 0.0, atol)
-    if n <= 1e4:
-        sample = dist.getSample(n)
-        ci = algo.computeAsymptoticBilateralConfidenceInterval(sample)
-        assert ci.contains(qalpha)
-
-# bilateral ranks bug
-alpha = 0.95
-beta = 0.90
-n = 975
-algo = ot.QuantileConfidence(alpha, beta)
-k1, k2 = algo.computeBilateralRank(n)
-binom = ot.Binomial(n, alpha)
-p = binom.computeCDF(k2) - binom.computeCDF(k1)
-print(f"n={n} k1={k1} k2={k2} p={p}")
-assert (k1, k2) == (910, 935)
-assert p >= beta
-
-alpha = 0.51762756742630334
-beta = 0.95
-n = 674726183
-algo = ot.QuantileConfidence(alpha, beta)
-k1, k2 = algo.computeBilateralRank(n)
-binom = ot.Binomial(n, alpha)
-p = binom.computeCDF(k2) - binom.computeCDF(k1)
-print(f"n={n} k1={k1} k2={k2} p={p}")
-assert p >= beta
-
-# edge cases for computeBilateralRank
-# 1. alpha < 0.5 with CDF(0) underflow (CDF(0) < epsilon)
-for alpha in [0.01, 0.05]:
+def check_asymptotic_confidence():
+    print("check_asymptotic_confidence ...")
+    # asymptotic confidence
+    print("asymptotic confidence ...")
+    alpha = 0.1
     beta = 0.95
     algo = ot.QuantileConfidence(alpha, beta)
-    nMin = algo.computeBilateralMinimumSampleSize()
-    for n in [nMin, nMin + 100, nMin + 1000]:
-        k1, k2 = algo.computeBilateralRank(n)
+    dist = ot.Gumbel()
+    qalpha = dist.computeQuantile(alpha)
+    for i in range(3, 7):
+        n = 10**i
+        k1, k2 = algo.computeAsymptoticBilateralRank(n)
         binom = ot.Binomial(n, alpha)
-        p = binom.computeCDF(k2) - binom.computeCDF(k1)
-        print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
-        assert k2 < n
-        assert k1 < k2
-        assert p >= beta
-        # k1=0 should provide a valid interval at nMin
-        if n == nMin:
-            p0_val = binom.computeCDF(0)
-            k2_zero = binom.computeScalarQuantile(p0_val + beta)
-            if k2_zero < n:
-                p0 = binom.computeCDF(k2_zero) - p0_val
-                assert p0 >= beta
+        p = binom.computeProbability(ot.Interval(k1, k2))
+        print(f"n={n} ci=[{k1}, {k2}] p={p}")
+        atol = 2.0 * n**-0.5
+        ott.assert_almost_equal(p, beta, 0.0, atol)
+        if n <= 1e4:
+            sample = dist.getSample(n)
+            ci = algo.computeAsymptoticBilateralConfidenceInterval(sample)
+            assert ci.contains(qalpha)
 
-# 2. alpha > 0.5 (quantile in upper tail)
-for alpha in [0.95, 0.99]:
+    # Exceptions in computeAsymptoticBilateralConfidenceInterval, dimension > 1
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample(10, 2)
+        ci = algo.computeAsymptoticBilateralConfidenceInterval(sample)
+    # Exceptions in computeAsymptoticBilateralConfidenceInterval, size = 0
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample()
+        ci = algo.computeAsymptoticBilateralConfidenceInterval(sample)
+
+
+# bilateral ranks bug
+def check_bilateral_rank_n_large():
+    print("check_bilateral_rank_n_large...")
+    # Case 1: computeBilateralRank when n is large and alpha > 0.5
+    alpha = 0.95
     beta = 0.90
+    n = 975
     algo = ot.QuantileConfidence(alpha, beta)
-    nMin = algo.computeBilateralMinimumSampleSize()
-    for n in [nMin, nMin + 100, nMin + 1000]:
-        k1, k2 = algo.computeBilateralRank(n)
-        binom = ot.Binomial(n, alpha)
-        p = binom.computeCDF(k2) - binom.computeCDF(k1)
-        print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
-        assert k2 < n
-        assert k1 < k2
-        assert p >= beta
-        if n == nMin:
-            p0_val = binom.computeCDF(0)
-            k2_zero = binom.computeScalarQuantile(p0_val + beta)
-            if k2_zero < n:
-                p0 = binom.computeCDF(k2_zero) - p0_val
-                assert p0 >= beta
+    k1, k2 = algo.computeBilateralRank(n)
+    k1_ref = 910
+    k2_ref = 935
+    assert k1 == k1_ref
+    assert k2 == k2_ref
+    coverage = algo.computeBilateralCoverage(n, k1, k2)
+    assert coverage >= beta
 
-# 3. alpha = 0.5 (symmetric)
-for beta in [0.9, 0.99]:
-    alpha = 0.5
+    # Case 2: Very large n test
+    alpha = 0.51762756742630334
+    beta = 0.95
+    n = 674726183
     algo = ot.QuantileConfidence(alpha, beta)
-    nMin = algo.computeBilateralMinimumSampleSize()
-    for n in [nMin, nMin + 100]:
-        k1, k2 = algo.computeBilateralRank(n)
-        binom = ot.Binomial(n, alpha)
-        p = binom.computeCDF(k2) - binom.computeCDF(k1)
-        print(f"alpha={alpha} beta={beta} n={n} k1={k1} k2={k2} p={p}")
-        assert k2 < n
-        assert k1 < k2
-        assert p >= beta
-
-# 4. beta close to 1
-alpha = 0.05
-for beta in [0.99, 0.999]:
-    algo = ot.QuantileConfidence(alpha, beta)
-    nMin = algo.computeBilateralMinimumSampleSize()
-    for n in [nMin, nMin + 1000]:
-        k1, k2 = algo.computeBilateralRank(n)
-        binom = ot.Binomial(n, alpha)
-        p = binom.computeCDF(k2) - binom.computeCDF(k1)
-        print(f"alpha={alpha} beta={beta} n={n} k1={k1} k2={k2} p={p}")
-        assert k2 < n
-        assert k1 < k2
-        assert p >= beta
-
-# 5. very large n with alpha=0.05 (CDF(0) underflows)
-alpha = 0.05
-beta = 0.95
-algo = ot.QuantileConfidence(alpha, beta)
-for n in [5000, 10000, 100000, 1000000]:
     k1, k2 = algo.computeBilateralRank(n)
     binom = ot.Binomial(n, alpha)
     p = binom.computeCDF(k2) - binom.computeCDF(k1)
-    print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
-    assert k2 < n
-    assert k1 < k2
+    print(f"n={n} k1={k1} k2={k2} p={p}")
     assert p >= beta
 
-# 6. confidence level such that it is exactly equal to the difference of known ranks
-n = int(1e6)
-k1_ref = 49625
-k2_ref = 50533
-alpha = 0.05
-binom = ot.Binomial(n, alpha)
-beta = binom.computeCDF(k2_ref) - binom.computeCDF(k1_ref)
-algo = ot.QuantileConfidence(alpha, beta)
-k1, k2 = algo.computeBilateralRank(n)
-assert k1 == k1_ref
-assert k2 == k2_ref
+
+# edge cases for computeBilateralRank
+def check_bilateral_rank_edge_cases():
+    print("check_bilateral_rank_edge_cases ...")
+    # edge cases for computeBilateralRank
+    # 1. alpha < 0.5 with CDF(0) underflow (CDF(0) < epsilon)
+    for alpha in [0.01, 0.05]:
+        beta = 0.95
+        algo = ot.QuantileConfidence(alpha, beta)
+        nMin = algo.computeBilateralMinimumSampleSize()
+        for n in [nMin, nMin + 100, nMin + 1000]:
+            k1, k2 = algo.computeBilateralRank(n)
+            binom = ot.Binomial(n, alpha)
+            p = binom.computeCDF(k2) - binom.computeCDF(k1)
+            print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
+            assert k2 < n
+            assert k1 < k2
+            assert p >= beta
+            # k1=0 should provide a valid interval at nMin
+            if n == nMin:
+                p0_val = binom.computeCDF(0)
+                k2_zero = binom.computeScalarQuantile(p0_val + beta)
+                if k2_zero < n:
+                    p0 = binom.computeCDF(k2_zero) - p0_val
+                    assert p0 >= beta
+
+    # 2. alpha > 0.5 (quantile in upper tail)
+    for alpha in [0.95, 0.99]:
+        beta = 0.90
+        algo = ot.QuantileConfidence(alpha, beta)
+        nMin = algo.computeBilateralMinimumSampleSize()
+        for n in [nMin, nMin + 100, nMin + 1000]:
+            k1, k2 = algo.computeBilateralRank(n)
+            binom = ot.Binomial(n, alpha)
+            p = binom.computeCDF(k2) - binom.computeCDF(k1)
+            print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
+            assert k2 < n
+            assert k1 < k2
+            assert p >= beta
+            if n == nMin:
+                p0_val = binom.computeCDF(0)
+                k2_zero = binom.computeScalarQuantile(p0_val + beta)
+                if k2_zero < n:
+                    p0 = binom.computeCDF(k2_zero) - p0_val
+                    assert p0 >= beta
+
+    # 3. alpha = 0.5 (symmetric)
+    for beta in [0.9, 0.99]:
+        alpha = 0.5
+        algo = ot.QuantileConfidence(alpha, beta)
+        nMin = algo.computeBilateralMinimumSampleSize()
+        for n in [nMin, nMin + 100]:
+            k1, k2 = algo.computeBilateralRank(n)
+            binom = ot.Binomial(n, alpha)
+            p = binom.computeCDF(k2) - binom.computeCDF(k1)
+            print(f"alpha={alpha} beta={beta} n={n} k1={k1} k2={k2} p={p}")
+            assert k2 < n
+            assert k1 < k2
+            assert p >= beta
+
+    # 4. beta close to 1
+    alpha = 0.05
+    for beta in [0.99, 0.999]:
+        algo = ot.QuantileConfidence(alpha, beta)
+        nMin = algo.computeBilateralMinimumSampleSize()
+        for n in [nMin, nMin + 1000]:
+            k1, k2 = algo.computeBilateralRank(n)
+            binom = ot.Binomial(n, alpha)
+            p = binom.computeCDF(k2) - binom.computeCDF(k1)
+            print(f"alpha={alpha} beta={beta} n={n} k1={k1} k2={k2} p={p}")
+            assert k2 < n
+            assert k1 < k2
+            assert p >= beta
+
+    # 5. very large n with alpha=0.05 (CDF(0) underflows)
+    alpha = 0.05
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    for n in [5000, 10000, 100000, 1000000]:
+        k1, k2 = algo.computeBilateralRank(n)
+        binom = ot.Binomial(n, alpha)
+        p = binom.computeCDF(k2) - binom.computeCDF(k1)
+        print(f"alpha={alpha} n={n} k1={k1} k2={k2} p={p}")
+        assert k2 < n
+        assert k1 < k2
+        assert p >= beta
+
+    # 6. confidence level such that it is exactly equal to the difference of known ranks
+    n = int(1e6)
+    k1_ref = 49625
+    k2_ref = 50533
+    alpha = 0.05
+    binom = ot.Binomial(n, alpha)
+    beta = binom.computeCDF(k2_ref) - binom.computeCDF(k1_ref)
+    algo = ot.QuantileConfidence(alpha, beta)
+    k1, k2 = algo.computeBilateralRank(n)
+    assert k1 == k1_ref
+    assert k2 == k2_ref
+
 
 # random tests
-for _ in range(int(1e2)):
-    alpha = ot.RandomGenerator.Generate()
+def check_bilateral_rank_random(beta=0.95):
+    for _ in range(int(1e2)):
+        alpha = ot.RandomGenerator.Generate()
+        algo = ot.QuantileConfidence(alpha, beta)
+        nMin = algo.computeBilateralMinimumSampleSize()
+        n = nMin + ot.RandomGenerator.IntegerGenerate(int(1e6))
+        k1, k2 = algo.computeBilateralRank(n)
+        binom = ot.Binomial(n, alpha)
+        p = binom.computeCDF(k2) - binom.computeCDF(k1)
+        assert k2 < n
+        assert k1 < k2
+        assert p >= beta
+
+
+def check_interval_coverage_consistency():
+    print("check_interval_coverage_consistency ...")
+    # Check that computeUnilateralConfidenceInterval and
+    # computeUnilateralConfidenceIntervalWithCoverage
+    # produce the same results on a given sample
+    alpha = 0.95
+    beta = 0.90
     algo = ot.QuantileConfidence(alpha, beta)
-    nMin = algo.computeBilateralMinimumSampleSize()
-    n = nMin + ot.RandomGenerator.IntegerGenerate(int(1e6))
-    k1, k2 = algo.computeBilateralRank(n)
-    binom = ot.Binomial(n, alpha)
-    p = binom.computeCDF(k2) - binom.computeCDF(k1)
-    assert k2 < n
-    assert k1 < k2
-    assert p >= beta
+    size = 100
+    distribution = ot.Normal()
+    sample = distribution.getSample(size)
+    interval_upper = algo.computeUnilateralConfidenceInterval(sample)
+    interval_upper_bis, coverage_upper = (
+        algo.computeUnilateralConfidenceIntervalWithCoverage(sample)
+    )
+    interval_lower = algo.computeUnilateralConfidenceInterval(sample, True)
+    interval_lower_bis, coverage_lower = (
+        algo.computeUnilateralConfidenceIntervalWithCoverage(sample, True)
+    )
+    interval_bilateral = algo.computeBilateralConfidenceInterval(sample)
+    interval_bilateral_bis, coverage_bilateral = (
+        algo.computeBilateralConfidenceIntervalWithCoverage(sample)
+    )
+
+    assert interval_upper == interval_upper_bis
+    assert interval_lower == interval_lower_bis
+    assert interval_bilateral == interval_bilateral_bis
+
+    assert coverage_upper >= beta
+    assert coverage_lower >= beta
+    assert coverage_bilateral >= beta
+
+    # The sample is has 2 dimensions, instead of 1
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample(10, 2)
+        interval_upper = algo.computeUnilateralConfidenceInterval(sample)
+    # The sample is empty
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample()
+        interval_upper = algo.computeUnilateralConfidenceInterval(sample)
+    # The sample is has 2 dimensions, instead of 1
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample(10, 2)
+        interval_bilateral = algo.computeBilateralConfidenceInterval(sample)
+    # The sample is empty
+    with ott.assert_raises(TypeError):
+        sample = ot.Sample()
+        interval_bilateral = algo.computeBilateralConfidenceInterval(sample)
+
+
+# Probability of coverage
+def check_empirical_coverage(rtol=1.0e-14):
+    print("check_empirical_coverage ...")
+    # 1. Lower bound test
+    alpha = 0.05
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    size_lower = 300
+    lower_bounded = True
+    rank_lower = algo.computeUnilateralRank(size_lower, lower_bounded)
+    coverage1 = algo.computeUnilateralCoverage(size_lower, rank_lower, lower_bounded)
+    ott.assert_almost_equal(coverage1, 0.9659341864785022, rtol, 0.0)
+
+    # 2. Upper bound test
+    alpha = 0.95
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    size_upper = 300
+    lower_bounded = False
+    rank_upper = algo.computeUnilateralRank(size_upper, lower_bounded)
+    coverage2 = algo.computeUnilateralCoverage(size_upper, rank_upper, lower_bounded)
+    ott.assert_almost_equal(coverage2, 0.9659341864785024, rtol, 0.0)
+
+    # 3. Bilateral test
+    alpha = 0.95
+    beta = 0.95
+    algo = ot.QuantileConfidence(alpha, beta)
+    size_bilateral = 100
+    k1, k2 = algo.computeBilateralRank(size_bilateral)
+    coverage3 = algo.computeBilateralCoverage(size_bilateral, k1, k2)
+    ott.assert_almost_equal(coverage3, 0.9514463806051577, rtol, 0.0)
+
+    # 4. Exceptions in computeUnilateralCoverage, lower case
+    with ott.assert_raises(TypeError):
+        alpha = 0.05
+        beta = 0.95
+        algo = ot.QuantileConfidence(alpha, beta)
+        size_lower = 300
+        rank_lower = size_lower
+        lower_bounded = True
+        coverage1 = algo.computeUnilateralCoverage(
+            size_lower, rank_lower, lower_bounded
+        )
+
+    # 5. Exceptions in computeUnilateralCoverage, upper case
+    with ott.assert_raises(TypeError):
+        alpha = 0.05
+        beta = 0.95
+        algo = ot.QuantileConfidence(alpha, beta)
+        size_lower = 300
+        rank_lower = size_lower
+        lower_bounded = False
+        coverage1 = algo.computeUnilateralCoverage(
+            size_lower, rank_lower, lower_bounded
+        )
+
+    # 6. Exceptions in computeBilateralCoverage: rank1 > rank2
+    with ott.assert_raises(TypeError):
+        alpha = 0.05
+        beta = 0.95
+        algo = ot.QuantileConfidence(alpha, beta)
+        size_bilateral = 300
+        k1 = 20
+        k2 = 19
+        coverage3 = algo.computeBilateralCoverage(size_bilateral, k1, k2)
+
+    # 7. Exceptions in computeBilateralCoverage: rank2 >= size
+    with ott.assert_raises(TypeError):
+        alpha = 0.05
+        beta = 0.95
+        algo = ot.QuantileConfidence(alpha, beta)
+        size_bilateral = 300
+        k1 = 10
+        k2 = 300
+        coverage3 = algo.computeBilateralCoverage(size_bilateral, k1, k2)
+
+
+if __name__ == "__main__":
+    check_basic()
+    check_lower_rank()
+    check_upper_rank()
+    check_bilateral_rank()
+    check_bilateral_rank_n_large()
+    check_interval_coverage_consistency()
+    check_empirical_coverage()
+    check_validate_empirical_coverage()
+    check_minimum_sample_size()
+    check_print_minimum_unilateral_sample_size_meeker()
+    check_minimum_unilateral_sample_size()
+    check_asymptotic_confidence()
+    check_bilateral_rank_edge_cases()
+    check_bilateral_rank_random()


### PR DESCRIPTION
The goal of this PR is to:
- clarify the documentation of the `QuantileConfidence`;
- fix the bug #3178;
- fix the bug #3182;
- provide methods to compute the probability of coverage of a confidence interval of a quantile, given the sample size and the rank.

## Update of the doc

The help for `computeUnilateralConfidenceInterval` states that "_True indicates the interval is bounded by a lower value_". This is confusing because we do not want to bound an interval: we want to bound the quantile. The fact that the method computes a bound of the interval is not relevant here. The correct sentence is: "True indicates the **quantile** is bounded by a lower value". 

In the API help page of `computeUnilateralMinimumSampleSize`, updated the name of the rank parameter, so that it matches the name in the C++ source code. Also, updated the `tail` name in the source code and changed it `lower_bounded` in order to match the name in the doc.

<img width="792" height="506" alt="image" src="https://github.com/user-attachments/assets/ea850f24-2379-4130-98e2-7d355bdbc57e" />

**Figure 1.** The name of the variables in the current API documentation is not consistent with the name of the variables in the C++ source code, which creates confusions.

## Compute the probability of coverage

This PR provides two new methods:
- `computeBilateralCoverage(size, rank1, rank2)`: computes the coverage probability for a two-sided confidence interval;
- `computeUnilateralCoverage(size, rank, lower_bounded)`: computes the coverage probability for a one-sided confidence interval.

The motivation for this development is to provide a direct and efficient way to compute the coverage probability of quantile confidence intervals without requiring an actual dataset. Mathematically, this probability depends solely on the sample size, the selected ranks, and the quantile level; it is entirely independent of the empirical values within a sample. If this direct computation feature is missing, a user is forced to rely on an inefficient workaround to obtain the coverage metric: they must first determine the sample size, generate a dummy sample of that exact size, and then pass this artificial data into the existing interval computation methods merely to extract the probability. By evaluating the underlying Binomial distribution directly, the new implementation eliminates the need to allocate and process dummy samples, making the interface more logical and computationally efficient.

For example, consider the quantile level 5% and the probability of coverage 95%. Assume that we want to compute the probability of coverage of the smallest observation in a sample of size 59, i.e. the probability that the smallest observation in the sample is a lower bound of the quantile. Then the current API forces us to generate a dummy sample of size 59 and use `computeUnilateralConfidenceIntervalWithCoverage()`. With the new `computeUnilateralCoverage()`, we can directly compute the probability of coverage.


The next script is a workaround using the current API based on a dummy sample.
```python
import openturns as ot
import openturns.experimental as otexp

# %%
alpha = 0.05 # 5% quantile
beta = 0.95 # 95% confidence
algo = otexp.QuantileConfidence(alpha, beta)
lower_bounded = True
size = 59

# %%
dummy_sample = ot.Sample(size, 1)  # <- Fake sample
lower_bounded = True
ci, coverage = algo.computeUnilateralConfidenceIntervalWithCoverage(dummy_sample)
print(coverage)  # And ignore ci, which is not used in this case
```
This prints 0.9726281425903597.

The new interface prevents from generating a dummy sample.
```python
rank = 0
lower_bounded = True
coverage = algo.computeUnilateralCoverage(size, rank, lower_bounded)
print(coverage)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public methods to compute unilateral and bilateral coverage probabilities.
  * Added configuration entry QuantileConfidence-ProbabilityEpsilon (default 1.0e-15).

* **Improvements**
  * Stricter input validation with clearer, parameter-specific errors.
  * Renamed boolean convention from "tail" to "lowerBounded" for clarity.
  * Improved bilateral rank search, coverage computation, and asymptotic interval handling.

* **Documentation**
  * Expanded and clarified API docs with updated examples.

* **Tests**
  * Reorganized and extended tests, including empirical coverage checks and minimum-sample-size validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openturns/openturns/pull/3176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->