### PR TITLE
Fix formatting in sensitivity_sobol_from_pce.rst

### DIFF
--- a/python/doc/theory/reliability_sensitivity/sensitivity_sobol_from_pce.rst
+++ b/python/doc/theory/reliability_sensitivity/sensitivity_sobol_from_pce.rst
@@ -40,7 +40,7 @@ and, if necessary, the selection method (e.g. the LARS selection method).
 Let :math:`\metaModel(\standardRV)` be the polynomial chaos expansion:
 
 .. math::
-    \metaModel(\standardRV)
+    \tilde{h}(\standardRV)
     &= \sum_{\idx \in \mathcal{J}_P} a_\idx \psi_\idx(\standardRV)
 
 where :math:`\standardRV` is the standardized input random vector,


### PR DESCRIPTION
Fixes an error alread fixed in #2881, but introduced again in #2883.

The error is this: the input of the metamodel is the physical input random vector **X**, not the standard input random vector **Z**. This is consistent with the model, which input is the physical input random vector **X**. The variance is not changed by an isoprobabilistic transform on the input. This is why the remaining equations, including the Sobol' indices, are ok.