### PR TITLE
Improved LevelSetMesher

### DIFF
--- a/lib/src/Base/Geom/LevelSetMesher.cxx
+++ b/lib/src/Base/Geom/LevelSetMesher.cxx
@@ -114,7 +114,6 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
 {
   const UnsignedInteger dimension = levelSet.getDimension();
   if (discretization_.getSize() != dimension) throw InvalidArgumentException(HERE) << "Error: the mesh factory is for levelSets of dimension=" << discretization_.getSize() << ", here dimension=" << dimension;
-  if (!(dimension <= 3)) throw NotYetImplementedException(HERE) << "In LevelSetMesher::build(const LevelSet & levelSet, const Bool project) const";
   return build(levelSet, Interval(levelSet.getLowerBound(), levelSet.getUpperBound()), project);
 }
 
@@ -125,15 +124,30 @@ Mesh LevelSetMesher::build(const LevelSet & levelSet,
   const UnsignedInteger dimension = levelSet.getDimension();
   if (discretization_.getSize() != dimension) throw InvalidArgumentException(HERE) << "Error: the mesh factory is for levelSets of dimension=" << discretization_.getSize() << ", here dimension=" << dimension;
   if (boundingBox.getDimension() != dimension) throw InvalidArgumentException(HERE) << "Error: the bounding box is of dimension=" << boundingBox.getDimension() << ", expected dimension=" << dimension;
-  // First, mesh the bounding box
   const Mesh boundingMesh(IntervalMesher(discretization_).build(boundingBox));
+  const Function function(levelSet.getFunction());
+  const Field field(boundingMesh, function(boundingMesh.getVertices()));
+  return build(levelSet, field, project);
+}
+
+Mesh LevelSetMesher::build(const LevelSet & levelSet,
+                           const Field & field,
+                           const Bool project) const
+{
+  const UnsignedInteger dimension = levelSet.getDimension();
+  if (discretization_.getSize() != dimension) throw InvalidArgumentException(HERE) << "Error: the mesh factory is for levelSets of dimension=" << discretization_.getSize() << ", here dimension=" << dimension;
+  if (field.getInputDimension() != dimension) throw InvalidArgumentException(HERE) << "Error: the field is of input dimension=" << field.getInputDimension() << ", expected input dimension=" << dimension;
+  if (field.getOutputDimension() != 1) LOGWARN(OSS() << "The field output dimension=" << field.getOutputDimension() << " is different from 1. The function defining the level set will be evaluated over the vertices of the mesh to get the values.");
+  // Extract the mesh and vertices from the field
+  const Mesh boundingMesh(field.getMesh());
   Sample boundingVertices(boundingMesh.getVertices());
   const UnsignedInteger numVertices = boundingVertices.getSize();
   const IndicesCollection boundingSimplices(boundingMesh.getSimplices());
   const UnsignedInteger numSimplices = boundingSimplices.getSize();
   // Second, keep only the simplices with a majority of vertices in the level set
   const Function function(levelSet.getFunction());
-  const Point values(function(boundingVertices).asPoint());
+  // Use field values directly if 1D output (precomputed), otherwise evaluate the level-set function
+  const Point values(field.getOutputDimension() == 1 ? field.getValues().asPoint() : function(boundingVertices).asPoint());
   const Scalar level = levelSet.getLevel();
   const ComparisonOperator comparison(levelSet.getOperator());
   Indices goodSimplices(0);

--- a/lib/src/Base/Geom/openturns/LevelSetMesher.hxx
+++ b/lib/src/Base/Geom/openturns/LevelSetMesher.hxx
@@ -24,6 +24,7 @@
 #include "openturns/LevelSet.hxx"
 #include "openturns/Interval.hxx"
 #include "openturns/Mesh.hxx"
+#include "openturns/Field.hxx"
 #include "openturns/OptimizationAlgorithm.hxx"
 #include "openturns/AbdoRackwitz.hxx"
 
@@ -68,6 +69,9 @@ public:
                      const Bool project = true) const;
   virtual Mesh build(const LevelSet & levelSet,
                      const Interval & boundingBox,
+                     const Bool project = true) const;
+  virtual Mesh build(const LevelSet & levelSet,
+                     const Field & field,
                      const Bool project = true) const;
 
 protected:

--- a/python/src/LevelSetMesher_doc.i
+++ b/python/src/LevelSetMesher_doc.i
@@ -12,19 +12,37 @@ solver : :class:`~openturns.OptimizationAlgorithm`, optional
 
 Notes
 -----
-The meshing algorithm is based on the :class:`~openturns.IntervalMesher` class.
-First, the bounding box of the level set (provided by the user or automatically
-computed) is meshed. Then, all the simplices with all vertices outside of the
-level set are rejected, while the simplices with all vertices inside of the level
-set are kept. The remaining simplices are adapted the following way:
+The meshing algorithm is based either on a :class:`~openturns.Field` or on the
+:class:`~openturns.Interval` class.
 
-  * The mean point of the vertices inside of the level set is computed
+  * Using a field allows one to mesh a level set reusing previously computed
+    values and starting from an arbitrary mesh.
+    If the values of the field are of dimension 1 they are supposed to
+    be the evaluation of the function defining the level set at the vertices of
+    the mesh, otherwise they are recomputed.
 
-  * Each vertex outside of the level set is projected onto the level set using
-    a linear interpolation
+  * Using a bounding box (provided by the user or automatically computed) is a
+    shortcut. The interval is meshed using the :class:`~openturns.Interval` class
+    and the function defining the level set is evaluated at the vertices of the
+    resulting mesh to create a field.
 
-  * If the *project* flag is *True*, then the projection is refined using an
-    optimization solver.
+  * Then, all the simplices with all vertices outside of the level set are
+    rejected, while the simplices with all vertices inside of the level
+    set are kept. The remaining simplices are adapted the following way:
+
+      * The mean point of the vertices inside of the level set is computed
+
+      * Each vertex outside of the level set is projected onto the level set using
+        a linear interpolation
+
+      * If the *project* flag is *True*, then the projection is refined using first
+        a nonlinear equation solver :class:`~openturns.Brent` depending on the
+        `LevelSetMesher-SolveEquation` key in :class:`~openturns.ResourceMap` class.
+        If this key is set to *False* or if the solver fails, then the projection is
+        done using the provided optimization algorithm.
+        If it fails then the :class:`~openturns.Cobyla` optimization algorithm is used.
+
+
 
 Examples
 --------
@@ -38,10 +56,18 @@ Create a mesh:
 >>> mesh = mesher.build(levelSet, ot.Interval([-2.0]*2, [2.0]*2))
 "
 
-// ---------------------------------------------------------------------
+/// ---------------------------------------------------------------------
 
 %feature("docstring") OT::LevelSetMesher::build
 "Build the mesh of level set type.
+
+**Available usages**:
+
+    build(*levelSet, project*)
+
+    build(*levelSet, boundingBox, project*)
+
+    build(*levelSet, field, project*)
 
 Parameters
 ----------
@@ -49,7 +75,10 @@ levelSet : :class:`~openturns.LevelSet`
     The level set to be meshed, of dimension equal to the dimension
     of `discretization`.
 boundingBox : :class:`~openturns.Interval`
-    The bounding box used to mesh the level set.
+    The bounding box used to mesh the level set. It is automatically computed
+    if not provided.
+field : :class:`~openturns.Field`
+    The field used to mesh the level set.
 project : bool
     Flag to tell if the vertices outside of the level set of a simplex partially included into the level set have to be projected onto the level set. Default is *True*.
 
@@ -57,7 +86,7 @@ Returns
 -------
 mesh : :class:`~openturns.Mesh`
     The mesh built."
-
+   
 // ---------------------------------------------------------------------
 
 %feature("docstring") OT::LevelSetMesher::getDiscretization

--- a/python/test/t_LevelSetMesher_std.py
+++ b/python/test/t_LevelSetMesher_std.py
@@ -92,3 +92,17 @@ gGreater = mesh.draw()
 ott.assert_almost_equal(
     gLess.getDrawable(0).getData(), gGreater.getDrawable(0).getData(), 1e-4, 1e-4
 )
+
+# Build based on field
+f = ot.SymbolicFunction(["x", "y"], ["(x-0.5)^3+y^4"])
+levelSet = ot.LevelSet(f, ot.LessOrEqual(), 0.0)
+
+# First case, no values in the field. They will be computed in LevelSetMesher
+mesh1 = ot.LevelSetMesher([16] * 2).build(levelSet, ot.Field(mesh, 0))
+
+# Second case, values are provided.
+values = f(mesh.getVertices())
+mesh2 = ot.LevelSetMesher([16] * 2).build(levelSet, ot.Field(mesh, values))
+
+# Check that the two meshes are identical
+ott.assert_almost_equal(mesh1.getVertices(), mesh2.getVertices(), 1e-4, 1e-4)


### PR DESCRIPTION
Now one can mesh a LevelSet starting from a field. It allows to start from an existing mesh more suited to describe the level set than its bounding box (in particular in high dimension) and it also allows to reuse already computed values if one want to mesh level sets associated to a given function but for different levels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build level-set meshes from a Field input, optionally reusing precomputed per-vertex values.
  * Removed prior dimension restriction so bounding-box meshing flow applies across dimensions.

* **Documentation**
  * Expanded docs describing Field vs bounding-box meshing patterns and projection-refinement fallback behavior.

* **Tests**
  * Added test ensuring field-based mesh construction produces consistent vertex sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->