### PR TITLE
Add more documentation for domination method

### DIFF
--- a/python/doc/bibliography.rst
+++ b/python/doc/bibliography.rst
@@ -230,6 +230,9 @@ Bibliography
 .. [jackson1991] Jackson, J. E. (1991).
     *A user’s guide to principal components.*
     John Wiley & Sons.
+.. [jakeman2019] Jakeman J., Franzelin F., Narayan A., Eldred M., Pflüger D. (2019)
+    *Polynomial chaos expansions for dependent random variables*,
+    Computer Methods in Applied Mechanics and Engineering, 351, pp.643-666.
 .. [janon2014] Janon A., Klein T., Lagnoux-Renaudie A., Prieur C., *Asymptotic
     normality and efficiency of two Sobol index estimators*,
     ESAIM: Probability and Statistics, EDP Sciences, 2014, 18, pp.342-364.

--- a/python/doc/examples/surrogate_modeling/polynomial_chaos/plot_chaos_ishigami_dependent_input.py
+++ b/python/doc/examples/surrogate_modeling/polynomial_chaos/plot_chaos_ishigami_dependent_input.py
@@ -150,7 +150,10 @@ view = otv.View(graph)
 # -------------------------------
 # Now, we want to use the domination method, which means that the basis created by the
 # adaptive strategy is used to project the model. This basis is not orthonormal to
-# :math:`\mu_{\inputRV}`.
+# :math:`\mu_{\inputRV}`. For more information on domination, see, e.g., [jakeman2019]_.
+# Note that domination methods require the basis' measure to be a constant multiple of a density
+# that is greater than the input distributions density---for unbounded domains, this entails
+# choosing a basis orthogonal w.r.t. a density that has appropriate tail decay.
 #
 # We use the :meth:`~openturns.FunctionalChaosAlgorithm.setUseDomination` method.
 # We implement the same steps as before, until the validation graph.

--- a/python/doc/theory/meta_modeling/functional_chaos.rst
+++ b/python/doc/theory/meta_modeling/functional_chaos.rst
@@ -240,14 +240,15 @@ We can also choose **a basis which is not orthonormal with respect to**
 which is orthonormal with respect to an *instrumental measure* :math:`\tilde{p} \neq \mu_{\inputRV}`.
 This instrumental measure is such that:
 
-- the support of :math:`\tilde{p}` is larger than the support of :math:`\mu_{\inputRV}`,
+- if :math:`\mu_{\inputRV}` has bounded support, the support of :math:`\tilde{p}` is larger than the support of :math:`\mu_{\inputRV}`,
+- if :math:`\mu_{\inputRV}` has unbounded support, there exists a constant :math:`C > 0` such that :math:`C \tilde{p} > \mu_{\inputRV}`,
 - :math:`\tilde{p}` has independent components.
 
 This choice is done in the **domination** strategy.
 
 Once the basis has been chosen, the enumeration function helps to enumerate the
 elements of the basis in a specific order
-(see :ref:`enumeration_multivariate_basis` and :ref:`enumeration_strategy` for more
+(see :ref:`enumeration_multivariate_basis` and :ref:`enumeration_strategy` or [jakeman2019]_ for more
 details on this topic).
 
 Which sub-space of approximation?
@@ -407,6 +408,7 @@ more details on this topic.
     - [lemaitre2010]_
     - [sullivan2015]_
     - [xiu2010]_
+    - [jakeman2019]_
     - [soizeghanem2004]_
     - [dahlquist2008]_
     - [rudin1987]_


### PR DESCRIPTION
I found that the `domination` method for the PCE was missing at least one reference, and some important details in the case of unbounded domains. I thought I'd just go ahead and make a PR since it would take less time than to go back-and-forth on an issue. Feel free to warp these contributions in any which way.