### PR TITLE
Building reproducibly in Debian

### DIFF
--- a/distro/debian/patches/build_reproducibility.patch
+++ b/distro/debian/patches/build_reproducibility.patch
@@ -1,0 +1,17 @@
+Description: enhancing build reproducibility: putting the architecture in the
+ system information instead of the kernel version
+Author: Pierre Gruet <pgt@debian.org>
+Forwarded: no
+Last-Update: 2026-06-09
+
+--- a/lib/include/OTconfigure_args.hxx.in
++++ b/lib/include/OTconfigure_args.hxx.in
+@@ -30,7 +30,7 @@
+ static const char CompilerId[]            = "@CMAKE_CXX_COMPILER_ID@";
+ static const char CompilerVersion[]       = "@CMAKE_CXX_COMPILER_VERSION@";
+ static const char SystemName[]            = "@CMAKE_SYSTEM_NAME@";
+-static const char SystemVersion[]         = "@CMAKE_SYSTEM_VERSION@";
++static const char SystemVersion[]         = "@ot_system_version@";
+ static const char SystemProcessor[]       = "@CMAKE_SYSTEM_PROCESSOR@";
+ 
+ END_NAMESPACE_OPENTURNS

--- a/distro/debian/patches/series
+++ b/distro/debian/patches/series
@@ -1,1 +1,1 @@
-build_reproducibly.patch
+build_reproducibility.patch

--- a/distro/debian/patches/series
+++ b/distro/debian/patches/series
@@ -1,0 +1,1 @@
+build_reproducibly.patch

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+# Fixing the locales to build reproducibly.
+export LC_ALL=C.UTF-8
+
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 include /usr/share/dpkg/buildflags.mk
 CFLAGS+=$(CPPFLAGS)

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -41,6 +41,7 @@ override_dh_auto_configure:
             -Dot_configure_date:STRING='$(BUILD_DATE)' \
 	        -Dot_system_version:STRING='Debian $(shell uname -mo)' \
             -DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON \
+            -DCMAKE_BUILD_RPATH_USE_ORIGIN:BOOL=ON \
             -DCMAKE_INSTALL_PREFIX:PATH=/usr \
             -DCMAKE_INSTALL_LIBDIR:PATH=lib/$(DEB_HOST_MULTIARCH) \
             -DOPENTURNS_PYTHON_MODULE_PATH=lib/python3/dist-packages \

--- a/distro/debian/rules
+++ b/distro/debian/rules
@@ -39,6 +39,7 @@ override_dh_auto_configure:
 	dh_auto_configure -Bbuilddir -- \
             $(with_tbb) \
             -Dot_configure_date:STRING='$(BUILD_DATE)' \
+	        -Dot_system_version:STRING='Debian $(shell uname -mo)' \
             -DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON \
             -DCMAKE_INSTALL_PREFIX:PATH=/usr \
             -DCMAKE_INSTALL_LIBDIR:PATH=lib/$(DEB_HOST_MULTIARCH) \


### PR DESCRIPTION
Hello,

Debian recently made it mandatory for its packages to build reproducibly, according to the changes listed on
    https://tests.reproducible-builds.org/debian/index_variations.html

While I trust it is an important achievement for software to build reproducibly, I acknowledge the perspective of packaging is not necessarily the same as the one of openturns as a library to be built from source by its users.

Up to now openturns did not build reproducibly on Debian, I could achieve this by making these changes:
- fixing the locales for the build (the build date is embedded into the .so through the header files, in a way that is sensitive to the locale).
- using "ORIGIN" instead of the build path in the RPATH at build time, to be robust to the directory in which the build is made;
- changing the information in OTconfigure_args.hxx, namely the "system version" which includes the version of the kernel, hence is not robust to a change in the version of the kernel.

I am proposing this pull request which only touches distro/debian, so that you are informed about the changes I did. Maybe you will want to contemplate incorporating them / tweaking them for the main openturns library -- once again, I understand my packaging concerns maybe do not fit yours :)

Best wishes,

Pierre

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Debian build reproducibility by adjusting embedded system version metadata to use the intended build-time value.
  * Enhanced reproducible build locale handling by exporting a consistent UTF-8 locale.
  * Updated Debian CMake configure options related to system version reporting and runtime path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->